### PR TITLE
chore: remove dead deps and deptry ignores for deleted surfaces

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
     labels:
       - "dependencies"
     ignore:
-      - dependency-name: "aiofiles"
       - dependency-name: "diff-cover"
       - dependency-name: "numpy"
       - dependency-name: "Pillow"
@@ -22,7 +21,6 @@ updates:
       - dependency-name: "pytest-cov"
       - dependency-name: "pytest-randomly"
       - dependency-name: "rich"
-      - dependency-name: "textual"
       - dependency-name: "tinytag"
       - dependency-name: "watchdog"
     groups:
@@ -35,8 +33,6 @@ updates:
           - "coverage"
       security:
         patterns:
-          - "bcrypt"
-          - "python-jose"
           - "cryptography"
 
   - package-ecosystem: "github-actions"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,12 @@ jobs:
           if [ "${{ matrix.platform }}" = "windows" ]; then
             cli_exe=$(find dist -name "file-organizer-*.exe" -type f | head -1)
           else
-            cli_exe=$(find dist -maxdepth 1 -type f -name "file-organizer-*" -not -name "*.AppImage" -perm /111 | head -1)
+            cli_exe=$(find dist -maxdepth 1 -type f -name "file-organizer-*" -perm /111 \
+              -not -name "*.AppImage" \
+              -not -name "*.tar.gz" \
+              -not -name "*.zip" \
+              -not -name "*.sha256" \
+              -not -name "*.txt" | head -1)
           fi
 
           if [ -z "$cli_exe" ]; then
@@ -84,6 +89,16 @@ jobs:
             exit 1
           fi
           echo "CLI executable: $cli_exe ($(du -h "$cli_exe" | cut -f1))"
+
+          if [ "${{ matrix.platform }}" = "linux" ]; then
+            appimage=$(find dist -maxdepth 1 -type f -name "*.AppImage" | head -1)
+            if [ -z "$appimage" ]; then
+              echo "ERROR: No AppImage found in dist/ after Linux AppImage build"
+              ls -la dist/
+              exit 1
+            fi
+            echo "AppImage: $appimage ($(du -h "$appimage" | cut -f1))"
+          fi
 
           "$cli_exe" --help || true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,21 +44,16 @@ jobs:
           python-version: '3.12'
           cache: 'pip'
 
-      - name: Install pywebview Linux build dependencies
+      - name: Install Linux AppImage dependencies
         if: matrix.platform == 'linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y \
-            libgirepository1.0-dev \
-            libcairo2-dev \
-            gir1.2-webkit2-4.1 \
-            fuse \
-            libfuse2
+          sudo apt-get install -y fuse libfuse2
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[desktop,dev]"
+          pip install -e ".[dev]"
           pip install pyinstaller
 
       - name: Run tests
@@ -69,10 +64,6 @@ jobs:
         run: |
           python scripts/build.py --clean
 
-      - name: Build Desktop executable
-        run: |
-          python scripts/build.py --desktop
-
       - name: Build AppImage
         if: matrix.platform == 'linux'
         run: |
@@ -81,13 +72,10 @@ jobs:
       - name: Verify executables
         shell: bash
         run: |
-          # Find CLI executable
           if [ "${{ matrix.platform }}" = "windows" ]; then
-            cli_exe=$(find dist -name "file-organizer-*" -not -name "*desktop*" -name "*.exe" -type f | head -1)
-            desktop_exe=$(find dist -name "file-organizer-desktop-*.exe" -type f | head -1)
+            cli_exe=$(find dist -name "file-organizer-*.exe" -type f | head -1)
           else
-            cli_exe=$(find dist -maxdepth 1 -type f -name "file-organizer-*" -not -name "*desktop*" -perm /111 | head -1)
-            desktop_exe=$(find dist -maxdepth 1 -type f -name "file-organizer-desktop-*" -perm /111 | head -1)
+            cli_exe=$(find dist -maxdepth 1 -type f -name "file-organizer-*" -perm /111 | head -1)
           fi
 
           if [ -z "$cli_exe" ]; then
@@ -97,14 +85,6 @@ jobs:
           fi
           echo "CLI executable: $cli_exe ($(du -h "$cli_exe" | cut -f1))"
 
-          if [ -z "$desktop_exe" ]; then
-            echo "ERROR: No desktop executable found in dist/"
-            ls -la dist/
-            exit 1
-          fi
-          echo "Desktop executable: $desktop_exe ($(du -h "$desktop_exe" | cut -f1))"
-
-          # Basic smoke test for CLI
           "$cli_exe" --help || true
 
       - name: Upload artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
           if [ "${{ matrix.platform }}" = "windows" ]; then
             cli_exe=$(find dist -name "file-organizer-*.exe" -type f | head -1)
           else
-            cli_exe=$(find dist -maxdepth 1 -type f -name "file-organizer-*" -perm /111 | head -1)
+            cli_exe=$(find dist -maxdepth 1 -type f -name "file-organizer-*" -not -name "*.AppImage" -perm /111 | head -1)
           fi
 
           if [ -z "$cli_exe" ]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -353,7 +353,6 @@ pep621_dev_dependency_groups = ["dev", "docs", "build"]
 "python-pptx" = "pptx"
 "beautifulsoup4" = "bs4"
 "pyyaml" = "yaml"
-"python-jose" = "jose"
 "scikit-learn" = "sklearn"
 "opencv-python" = "cv2"
 "pydantic-settings" = "pydantic_settings"
@@ -361,44 +360,27 @@ pep621_dev_dependency_groups = ["dev", "docs", "build"]
 "striprtf" = "striprtf"
 "llama-cpp-python" = "llama_cpp"
 "mlx-lm" = "mlx_lm"
-"pywebview" = "webview"
 [tool.deptry.per_rule_ignores]
 # netCDF4: in scientific optional group; deptry has mixed-case matching issues
 # redis: optional import via try/except in events/stream.py
 DEP001 = ["netCDF4", "redis"]
-# aiofiles: Starlette StaticFiles uses it for async file serving (no direct import)
-# python-multipart: FastAPI uses it for file uploads (no direct import)
 # lxml: used as bs4 parser string "lxml" (not imported directly)
-# email-validator: pydantic uses it for EmailStr (not imported directly)
-# websockets: starlette WebSocket support (must be installed, not imported)
 # python-dotenv: pydantic-settings reads .env files via this package
-# jinja2: fastapi.templating wraps it (not imported directly)
 # alembic: used as CLI migration tool (not imported in application code)
 # openpyxl: pandas uses it for Excel I/O (not imported directly)
 # fo-core: self-reference in the [all] optional group
 DEP002 = [
-    "aiofiles",
-    "python-multipart",
     "lxml",
-    "email-validator",
-    "websockets",
     "python-dotenv",
-    "jinja2",
     "alembic",
     "openpyxl",
     "fo-core",
     # pydantic-settings: pydantic's BaseSettings uses it internally; no direct import needed
     "pydantic-settings",
-    # PyQt6: GUI-only dep; GUI application lives outside src/file_organizer/
-    "PyQt6",
     # netCDF4: mixed-case name causes deptry matching issues; used in scientific.py
     "netCDF4",
-    # ecdsa: transitive via python-jose; pinned for CVE-2026-33936
-    "ecdsa",
-    # Pygments: transitive via rich/textual; pinned for CVE-2026-4539
+    # Pygments: transitive via rich; pinned for CVE-2026-4539
     "Pygments",
-    # pywebview: desktop GUI wrapper; import name is 'webview' (mapped above); used in desktop/app.py
-    "pywebview",
     # sqlalchemy: used by alembic migrations and undo/history at runtime; no direct src/ import
     "sqlalchemy",
     # pydantic: used transitively by pydantic-settings; no direct src/ import after refactor

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -63,20 +63,6 @@ fi
 echo "    Found: ${EXECUTABLE}"
 
 # ---------------------------------------------------------------------------
-# Detect whether we're packaging the CLI or the pywebview desktop executable.
-# If a desktop-specific binary exists in dist/, prefer it for the AppImage.
-# ---------------------------------------------------------------------------
-DESKTOP_EXECUTABLE=$(find "${DIST_DIR}" -maxdepth 1 -name "file-organizer-desktop-*" \
-    -not -name "*.AppImage" -not -name "*.sha256" -not -name "*.tar.gz" -not -name "*.dmg" \
-    -type f 2>/dev/null | head -1)
-IS_DESKTOP=false
-if [[ -n "$DESKTOP_EXECUTABLE" ]]; then
-    EXECUTABLE="${DESKTOP_EXECUTABLE}"
-    IS_DESKTOP=true
-    echo "==> Desktop executable detected: ${EXECUTABLE}"
-fi
-
-# ---------------------------------------------------------------------------
 # Download appimagetool if needed
 # ---------------------------------------------------------------------------
 APPIMAGETOOL="${BUILD_DIR}/appimagetool-${APPIMAGE_ARCH}"
@@ -121,11 +107,7 @@ mkdir -p "${APPDIR}/usr/share/icons/hicolor/256x256/apps"
 cp "${EXECUTABLE}" "${APPDIR}/usr/bin/file-organizer"
 chmod +x "${APPDIR}/usr/bin/file-organizer"
 
-# Create .desktop file (Terminal=false for pywebview desktop app; true for CLI)
-TERMINAL_FLAG="true"
-if [[ "$IS_DESKTOP" == "true" ]]; then
-    TERMINAL_FLAG="false"
-fi
+# Create .desktop file
 cat > "${APPDIR}/usr/share/applications/${APP_NAME}.desktop" << DESKTOP
 [Desktop Entry]
 Type=Application
@@ -134,7 +116,7 @@ Comment=AI-powered local file management
 Exec=file-organizer
 Icon=file-organizer
 Categories=Utility;FileManager;
-Terminal=${TERMINAL_FLAG}
+Terminal=true
 DESKTOP
 
 # Copy desktop file to root (required by AppImage spec)

--- a/scripts/ci_shard_paths.sh
+++ b/scripts/ci_shard_paths.sh
@@ -9,10 +9,7 @@
 # file; both pipelines will pick up the change automatically.
 #
 # Shard sizing goal: ~3 000-4 500 test functions per shard, keeping runtime
-# balanced without over-fragmenting the matrix. After fixing the websocket
-# queue-task cleanup in tests/api/test_realtime.py, the async-heavy API and web
-# suites can run safely under xdist again, so the emergency micro-shards are no
-# longer needed.
+# balanced without over-fragmenting the matrix.
 
 set -euo pipefail
 
@@ -23,12 +20,12 @@ if [[ -z "$SHARD" ]]; then
 fi
 
 case "$SHARD" in
-    1) PATHS="tests/integration tests/e2e" ;;
+    1) PATHS="tests/integration" ;;
     2) PATHS="tests/services tests/models tests/events tests/optimization" ;;
-    3) PATHS="tests/api" ;;
-    4) PATHS="tests/cli tests/methodologies tests/ci tests/unit tests/plugins tests/tui tests/parallel tests/pipeline" ;;
-    5) PATHS="tests/utils tests/undo tests/history tests/daemon tests/deploy tests/watcher tests/updater tests/core tests/config tests/client tests/docs tests/desktop tests/integrations tests/interfaces tests/test_*.py" ;;
-    6) PATHS="tests/web" ;;
+    3) PATHS="tests/cli tests/methodologies tests/parallel tests/pipeline" ;;
+    4) PATHS="tests/ci tests/unit" ;;
+    5) PATHS="tests/utils tests/undo tests/history tests/daemon tests/watcher tests/updater tests/test_*.py" ;;
+    6) PATHS="tests/core tests/config tests/docs tests/integrations tests/interfaces" ;;
     *)
         echo "Unknown shard: $SHARD (valid: 1-6)" >&2
         exit 1

--- a/tests/ci/test_build_workflow.py
+++ b/tests/ci/test_build_workflow.py
@@ -1,4 +1,4 @@
-"""Tests for build.yml CI/CD pipeline (pywebview desktop build pipeline)."""
+"""Tests for build.yml CI/CD pipeline (CLI-only build pipeline)."""
 
 from __future__ import annotations
 
@@ -75,51 +75,11 @@ class TestNoRustOrTauriSteps:
         assert "combined-artifacts" not in raw
 
 
-class TestDesktopBuildStep:
-    def test_desktop_build_step_present(self) -> None:
-        """A step building the pywebview desktop executable must exist."""
-        names = _build_step_names()
-        assert any("Desktop" in name or "desktop" in name for name in names), (
-            f"No desktop build step found in: {names}"
-        )
-
-    def test_desktop_build_uses_desktop_flag(self) -> None:
-        """The desktop build step must invoke build.py with --desktop."""
-        run_text = _build_step_run_text()
-        assert "--desktop" in run_text
-
+class TestCLIBuildStep:
     def test_cli_build_step_present(self) -> None:
-        """A step building the CLI executable must also exist."""
+        """A step building the CLI executable must exist."""
         run_text = _build_step_run_text()
         assert "python scripts/build.py --clean" in run_text
-
-
-class TestPywebviewLinuxDeps:
-    def test_pywebview_linux_deps_step(self) -> None:
-        """A Linux-conditional step must install GTK/WebKit pywebview deps."""
-        jobs = _load_workflow().get("jobs", {})
-        steps = jobs.get("build", {}).get("steps", [])
-        linux_dep_steps = [
-            s
-            for s in steps
-            if "libgirepository" in s.get("run", "") or "gir1.2-webkit2" in s.get("run", "")
-        ]
-        assert linux_dep_steps, "No pywebview GTK/WebKit Linux dependency step found"
-
-    def test_linux_deps_are_platform_conditional(self) -> None:
-        """The GTK/WebKit dep step must be guarded by a linux platform condition."""
-        jobs = _load_workflow().get("jobs", {})
-        steps = jobs.get("build", {}).get("steps", [])
-        found = False
-        for step in steps:
-            if "libgirepository" in step.get("run", "") or "gir1.2-webkit2" in step.get("run", ""):
-                found = True
-                cond = step.get("if", "")
-                assert "linux" in cond, (
-                    f"GTK/WebKit dep step must be linux-conditional, got if: {cond!r}"
-                )
-                break
-        assert found, "GTK/WebKit dep step not found"
 
 
 class TestArtifactUpload:

--- a/tests/ci/test_build_workflow.py
+++ b/tests/ci/test_build_workflow.py
@@ -91,7 +91,7 @@ class TestCLIBuildStep:
     def test_linux_verification_avoids_appimage_and_checks_appimage_exists(self) -> None:
         """Linux verification should target CLI binary and separately assert AppImage output."""
         run_text = _build_step_run_text()
-        assert "-not -name \"*.AppImage\"" in run_text
+        assert '-not -name "*.AppImage"' in run_text
         assert "No AppImage found in dist/" in run_text
 
 

--- a/tests/ci/test_build_workflow.py
+++ b/tests/ci/test_build_workflow.py
@@ -81,6 +81,19 @@ class TestCLIBuildStep:
         run_text = _build_step_run_text()
         assert "python scripts/build.py --clean" in run_text
 
+    def test_no_desktop_runtime_dependencies(self) -> None:
+        """CLI-only workflow should not install desktop GUI runtime deps."""
+        run_text = _build_step_run_text()
+        assert "pywebview" not in run_text
+        assert "libwebkit2gtk" not in run_text
+        assert "gir1.2-webkit2" not in run_text
+
+    def test_linux_verification_avoids_appimage_and_checks_appimage_exists(self) -> None:
+        """Linux verification should target CLI binary and separately assert AppImage output."""
+        run_text = _build_step_run_text()
+        assert "-not -name \"*.AppImage\"" in run_text
+        assert "No AppImage found in dist/" in run_text
+
 
 class TestArtifactUpload:
     def test_artifacts_from_dist(self) -> None:


### PR DESCRIPTION
## Summary

Closes #16

Removes dead dependency references and deptry ignores left behind after the CLI-only streamline (PR #15).

- Remove 7 dead DEP002 ignores from `pyproject.toml`: `aiofiles`, `python-multipart`, `email-validator`, `websockets`, `jinja2`, `PyQt6`, `pywebview`, `ecdsa`
- Remove stale comments referencing FastAPI/Starlette/desktop
- Remove dead module name mappings (`pywebview`, `python-jose`)
- Strip desktop build steps from `.github/workflows/build.yml`
- Clean dead entries from `.github/dependabot.yml`
- Remove desktop executable detection from `scripts/build_linux.sh`
- Remove deleted test directory references from `scripts/ci_shard_paths.sh`

## Test plan

- [ ] `ruff check src/` passes
- [ ] `deptry .` runs clean (no new violations)
- [ ] CI green
- [ ] `build.yml` workflow still builds CLI executable correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)