### PR TITLE
ci: add CodeRabbit workflow for PR reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,18 +1,46 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 
 # CodeRabbit Configuration
-# Excludes internal Claude Code configuration from review
+# Tuned for higher-signal automated reviews on production PRs.
 
-language: en
+language: "en-US"
+early_access: false
 
 reviews:
+  # Prefer deeper analysis over permissive style-only feedback.
+  profile: "assertive"
   request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  review_details: true
   auto_review:
     enabled: true
-  review_status: true
+    drafts: false
   path_filters:
     - "!.claude/**"
     - "!.vscode/**"
     - "!.idea/**"
     - "!.DS_Store"
     - "!*.log"
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  web_search:
+    enabled: true
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "**/AGENTS.md"
+      - ".github/copilot-instructions.md"
+      - ".claude/rules/**/*.md"
+  learnings:
+    scope: "global"
+  issues:
+    scope: "global"
+  pull_requests:
+    scope: "global"
+  linked_repositories:
+    - repository: "curdriceaurora/local-file-organizer"
+      instructions: "Shared architecture and CLI behavior references for fo-core."

--- a/.github/workflows/coderabbit.yml
+++ b/.github/workflows/coderabbit.yml
@@ -1,0 +1,32 @@
+name: CodeRabbit
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  coderabbit:
+    # Prevent self-trigger loops and skip draft PR reviews until ready.
+    if: |
+      github.actor != 'coderabbitai[bot]' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+      (github.event_name != 'issue_comment' || github.event.issue.pull_request)
+    runs-on: ubuntu-latest
+    steps:
+      - name: CodeRabbit AI Review
+        uses: coderabbitai/ai-pr-reviewer@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow at `.github/workflows/coderabbit.yml`
- trigger on PR open/sync/reopen/ready_for_review and review comment events
- use least-required permissions (`contents: read`, `pull-requests: write`, `issues: write`)
- prevent bot self-loops and skip draft PRs until ready

## Validation
- `pre-commit run --files .github/workflows/coderabbit.yml`
