### PR TITLE
fix(ci): restore GitHub Pages docs workflow with preflight check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,76 @@
+name: Build and Deploy Documentation
+on:
+  push:
+    branches: [main, develop]
+    paths: ['docs/**', 'mkdocs.yml', '.github/workflows/docs.yml']
+  pull_request:
+    branches: [main]
+    paths: ['docs/**', 'mkdocs.yml', '.github/workflows/docs.yml']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - run: pip install -e .[docs] mkdocs-minify-plugin
+      - run: mkdocs build --strict
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: documentation
+          path: site/
+          retention-days: 30
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Check GitHub Pages is enabled
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          status=$(gh api repos/${{ github.repository }}/pages --jq '.status' 2>/dev/null || echo "disabled")
+          if [ "$status" = "disabled" ] || [ "$status" = "null" ]; then
+            echo "❌ GitHub Pages is not enabled."
+            echo "   Go to Settings → Pages → Source: GitHub Actions"
+            echo "   Then re-run this workflow."
+            exit 1
+          fi
+          echo "✅ GitHub Pages is enabled (status: $status)"
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: documentation
+          path: ./site
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b  # v4.0.0
+        with:
+          path: ./site
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0
+
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - run: pip install -e .[docs] mkdocs-minify-plugin
+      - run: mkdocs build --strict

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     permissions:
       contents: read
     steps:
@@ -20,7 +21,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-      - run: pip install -e .[docs] mkdocs-minify-plugin
+      - run: pip install -e ".[docs]"
       - run: mkdocs build --strict
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
@@ -72,5 +73,5 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-      - run: pip install -e .[docs] mkdocs-minify-plugin
+      - run: pip install -e ".[docs]"
       - run: mkdocs build --strict


### PR DESCRIPTION
## Summary

- Restores `.github/workflows/docs.yml` that was deleted in PR #15 ("Strip to CLI-only surface")
- Adds a preflight check step in the `deploy` job that emits a human-readable error if GitHub Pages is disabled, instead of failing silently with a 404 from `deploy-pages`
- GitHub Pages has been enabled on the fork via the API (`build_type=workflow`) as part of this fix

## Changes

- **`build` job**: Checks out repo, builds mkdocs docs, uploads `site/` as artifact (30-day retention)
- **`deploy` job**: Runs on `push` to `main` only — preflight check verifies Pages is enabled, then deploys the artifact via `upload-pages-artifact` + `deploy-pages`
- **`test` job**: Runs on PRs only — verifies `mkdocs build --strict` succeeds without deploying

## Test plan

- [ ] Verify CI passes on this PR (triggers `test` job via `pull_request`)
- [ ] After merge, verify `deploy` job runs and publishes to https://curdriceaurora.github.io/fo-core/
- [ ] Manually disable Pages and re-run workflow to confirm preflight check emits the human-readable error and exits 1

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)