### PR TITLE
fix: convert hasattr st_birthtime guards to try/except AttributeError

### DIFF
--- a/src/file_organizer/methodologies/para/ai/feature_extractor.py
+++ b/src/file_organizer/methodologies/para/ai/feature_extractor.py
@@ -318,12 +318,13 @@ class FeatureExtractor:
         #   macOS  → st_birthtime (true birth time)
         #   Windows → st_ctime    (creation time on NTFS)
         #   Linux  → st_mtime     (st_ctime is inode-change time, not creation)
-        if hasattr(stat, "st_birthtime"):  # macOS
-            creation_ref = stat.st_birthtime
-        elif os.name == "nt":  # Windows
-            creation_ref = getattr(stat, "st_ctime", stat.st_mtime)
-        else:  # Linux — use mtime as best available proxy
-            creation_ref = stat.st_mtime
+        try:
+            creation_ref = stat.st_birthtime  # macOS — true birth time
+        except AttributeError:
+            if os.name == "nt":  # Windows — NTFS creation time
+                creation_ref = getattr(stat, "st_ctime", stat.st_mtime)
+            else:  # Linux — use mtime as best available proxy
+                creation_ref = stat.st_mtime
 
         # Convert timestamps to datetime
         creation_date = datetime.fromtimestamp(creation_ref, tz=UTC)

--- a/src/file_organizer/methodologies/para/detection/heuristics.py
+++ b/src/file_organizer/methodologies/para/detection/heuristics.py
@@ -144,12 +144,13 @@ class TemporalHeuristic(Heuristic):
         days_since_accessed = (now - stat.st_atime) / 86400
         # Cross-platform file age: use birth time if available (macOS/Windows),
         # fall back to modification time on Linux (st_ctime is inode change time, not creation).
-        if hasattr(stat, "st_birthtime"):  # macOS
-            ref_time = stat.st_birthtime
-        elif os.name == "nt":  # Windows
-            ref_time = getattr(stat, "st_ctime", stat.st_mtime)
-        else:  # Linux — use mtime as best proxy for "last active"
-            ref_time = stat.st_mtime
+        try:
+            ref_time = stat.st_birthtime  # macOS — true birth time
+        except AttributeError:
+            if os.name == "nt":  # Windows
+                ref_time = getattr(stat, "st_ctime", stat.st_mtime)
+            else:  # Linux — use mtime as best proxy for "last active"
+                ref_time = stat.st_mtime
         days_since_created = (now - ref_time) / 86400
 
         # Check for old year patterns in path (e.g., "/Projects/2020/...")

--- a/tests/methodologies/para/test_ai_heuristic.py
+++ b/tests/methodologies/para/test_ai_heuristic.py
@@ -1364,10 +1364,39 @@ class TestAIHeuristicEnsureClientEdgeCases:
 class TestPlatformSpecificBranches:
     """Tests to cover platform-specific code branches."""
 
+    def test_macos_platform_stat_birthtime(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """macOS branch uses st_birthtime (try succeeds — no AttributeError)."""
+        import time
+
+        from file_organizer.methodologies.para.detection.heuristics import TemporalHeuristic
+
+        f = tmp_path / "test.txt"
+        f.write_text("test")
+        real_mode = f.stat().st_mode
+
+        now = time.time()
+
+        class MockStat:
+            st_mtime = now - (5 * 86400)
+            st_atime = now - (2 * 86400)
+            st_ctime = now - (5 * 86400)
+            st_birthtime = now - (5 * 86400)  # macOS — true birth time present
+            st_mode = real_mode
+
+        monkeypatch.setattr(Path, "stat", lambda _self, *args, **kwargs: MockStat())
+
+        h = TemporalHeuristic(weight=0.25)
+        result = h.evaluate(f)
+
+        # File was modified 5 days ago — recently_modified signal expected
+        assert "recently_modified" in result.scores[PARACategory.PROJECT].signals
+
     def test_windows_platform_stat_ctime(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Windows branch uses st_ctime when no st_birthtime."""
+        """Windows branch uses st_ctime when no st_birthtime (AttributeError → Windows branch)."""
 
         from file_organizer.methodologies.para.detection.heuristics import TemporalHeuristic
 
@@ -1398,7 +1427,7 @@ class TestPlatformSpecificBranches:
     def test_linux_platform_stat_mtime_fallback(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Linux branch uses st_mtime as creation time proxy."""
+        """Linux branch uses st_mtime as creation time proxy (no st_birthtime → AttributeError)."""
 
         from file_organizer.methodologies.para.detection.heuristics import TemporalHeuristic
 

--- a/tests/methodologies/para/test_ai_heuristic.py
+++ b/tests/methodologies/para/test_ai_heuristic.py
@@ -1279,7 +1279,7 @@ class TestPlatformSpecificPaths:
         # Simulate Windows platform
         monkeypatch.setattr(os, "name", "nt")
         now = time.time()
-        monkeypatch.setattr(Path, "stat", lambda _self, *args, **kwargs: MockStat(now=now))
+        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat(now=now))
 
         h = TemporalHeuristic(weight=0.25)
         f = tmp_path / "test.txt"
@@ -1306,7 +1306,7 @@ class TestPlatformSpecificPaths:
         # Simulate Linux platform
         monkeypatch.setattr(os, "name", "posix")
         now = time.time()
-        monkeypatch.setattr(Path, "stat", lambda _self, *args, **kwargs: MockStat(now=now))
+        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat(now=now))
 
         h = TemporalHeuristic(weight=0.25)
         f = tmp_path / "test.txt"
@@ -1385,7 +1385,7 @@ class TestPlatformSpecificBranches:
             st_birthtime = now - (5 * 86400)  # macOS — true birth time present
             st_mode = real_mode
 
-        monkeypatch.setattr(Path, "stat", lambda _self, *args, **kwargs: MockStat())
+        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat())
 
         h = TemporalHeuristic(weight=0.25)
         result = h.evaluate(f)
@@ -1416,7 +1416,7 @@ class TestPlatformSpecificBranches:
 
         # Monkeypatch both os.name and Path.stat
         monkeypatch.setattr(os, "name", "nt")
-        monkeypatch.setattr(Path, "stat", lambda _self, *args, **kwargs: MockStat())
+        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat())
 
         h = TemporalHeuristic(weight=0.25)
         result = h.evaluate(f)
@@ -1447,7 +1447,7 @@ class TestPlatformSpecificBranches:
 
         # Monkeypatch both os.name and Path.stat
         monkeypatch.setattr(os, "name", "posix")
-        monkeypatch.setattr(Path, "stat", lambda _self, *args, **kwargs: MockStat())
+        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat())
 
         h = TemporalHeuristic(weight=0.25)
         result = h.evaluate(f)
@@ -1484,7 +1484,7 @@ class TestPlatformSpecificBranches:
             st_birthtime = birthtime_120_days_ago
             st_mode = real_mode  # required by Path.is_dir() via pathlib internals
 
-        monkeypatch.setattr(Path, "stat", lambda _self, *args, **kwargs: MockStat())
+        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat())
 
         h = TemporalHeuristic(weight=0.25)
         result = h.evaluate(f)

--- a/tests/methodologies/para/test_feature_extractor.py
+++ b/tests/methodologies/para/test_feature_extractor.py
@@ -562,6 +562,7 @@ class TestEdgeCasesAndErrorHandling:
         assert len(features.action_items) >= 1
         assert "TODO" in features.action_items[0]
 
+    @pytest.mark.ci
     def test_metadata_macos_platform_creation_time(
         self,
         extractor: FeatureExtractor,
@@ -592,6 +593,7 @@ class TestEdgeCasesAndErrorHandling:
         assert features.days_since_created == pytest.approx(5.0)
         assert features.file_size == 7
 
+    @pytest.mark.ci
     def test_metadata_windows_platform_creation_time(
         self,
         extractor: FeatureExtractor,
@@ -622,6 +624,7 @@ class TestEdgeCasesAndErrorHandling:
         assert features.days_since_created == pytest.approx(1.0)
         assert features.file_size == 7
 
+    @pytest.mark.ci
     def test_metadata_linux_platform_creation_time(
         self,
         extractor: FeatureExtractor,

--- a/tests/methodologies/para/test_feature_extractor.py
+++ b/tests/methodologies/para/test_feature_extractor.py
@@ -562,15 +562,43 @@ class TestEdgeCasesAndErrorHandling:
         assert len(features.action_items) >= 1
         assert "TODO" in features.action_items[0]
 
+    def test_metadata_macos_platform_creation_time(
+        self,
+        extractor: FeatureExtractor,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Should use st_birthtime on macOS platform (try/except AttributeError path)."""
+        import file_organizer.methodologies.para.ai.feature_extractor as fe_module
+
+        class MockStat:
+            def __init__(self, *, now: float) -> None:
+                self.st_size = 7
+                self.st_atime = now - (2 * 86400)
+                self.st_ctime = now - 86400
+                self.st_mtime = now - (10 * 86400)
+                self.st_birthtime = now - (5 * 86400)  # macOS birth time
+                self.st_mode = 0o100644  # regular file — required by Path.is_dir()
+
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("content")
+        now = 2_000_000_000.0
+
+        monkeypatch.setattr(fe_module.time, "time", lambda: now)
+        monkeypatch.setattr(Path, "stat", lambda _self, *args, **kwargs: MockStat(now=now))
+
+        features = extractor.extract_metadata_features(test_file)
+        # st_birthtime is 5 days ago → days_since_created ≈ 5.0
+        assert features.days_since_created == pytest.approx(5.0)
+        assert features.file_size == 7
+
     def test_metadata_windows_platform_creation_time(
         self,
         extractor: FeatureExtractor,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Should use st_ctime on Windows platform."""
-        import builtins
-
+        """Should use st_ctime on Windows platform (no st_birthtime → AttributeError)."""
         import file_organizer.methodologies.para.ai.feature_extractor as fe_module
 
         class MockStat:
@@ -580,25 +608,15 @@ class TestEdgeCasesAndErrorHandling:
                 self.st_ctime = now - 86400
                 self.st_mtime = now - (10 * 86400)
                 self.st_mode = 0o100644  # regular file — required by Path.is_dir()
+                # no st_birthtime — triggers AttributeError → Windows branch
 
         test_file = tmp_path / "test.txt"
         test_file.write_text("content")
         now = 2_000_000_000.0
 
-        # Mock os module in the feature_extractor namespace
         monkeypatch.setattr(fe_module.os, "name", "nt")
         monkeypatch.setattr(fe_module.time, "time", lambda: now)
         monkeypatch.setattr(Path, "stat", lambda _self, *args, **kwargs: MockStat(now=now))
-
-        # Mock hasattr to return False for st_birthtime
-        original_hasattr = builtins.hasattr
-
-        def mock_hasattr(obj: object, name: str) -> bool:
-            if name == "st_birthtime":
-                return False
-            return original_hasattr(obj, name)
-
-        monkeypatch.setattr(builtins, "hasattr", mock_hasattr)
 
         features = extractor.extract_metadata_features(test_file)
         assert features.days_since_created == pytest.approx(1.0)
@@ -610,9 +628,7 @@ class TestEdgeCasesAndErrorHandling:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Should use st_mtime on Linux platform."""
-        import builtins
-
+        """Should use st_mtime on Linux platform (no st_birthtime → AttributeError)."""
         import file_organizer.methodologies.para.ai.feature_extractor as fe_module
 
         class MockStat:
@@ -622,25 +638,15 @@ class TestEdgeCasesAndErrorHandling:
                 self.st_ctime = now - 86400
                 self.st_mtime = now - (10 * 86400)
                 self.st_mode = 0o100644  # regular file — required by Path.is_dir()
+                # no st_birthtime — triggers AttributeError → Linux branch
 
         test_file = tmp_path / "test.txt"
         test_file.write_text("content")
         now = 2_000_000_000.0
 
-        # Mock os module in the feature_extractor namespace
         monkeypatch.setattr(fe_module.os, "name", "posix")
         monkeypatch.setattr(fe_module.time, "time", lambda: now)
         monkeypatch.setattr(Path, "stat", lambda _self, *args, **kwargs: MockStat(now=now))
-
-        # Mock hasattr to return False for st_birthtime
-        original_hasattr = builtins.hasattr
-
-        def mock_hasattr(obj: object, name: str) -> bool:
-            if name == "st_birthtime":
-                return False
-            return original_hasattr(obj, name)
-
-        monkeypatch.setattr(builtins, "hasattr", mock_hasattr)
 
         features = extractor.extract_metadata_features(test_file)
         assert features.days_since_created == pytest.approx(10.0)

--- a/tests/methodologies/para/test_feature_extractor.py
+++ b/tests/methodologies/para/test_feature_extractor.py
@@ -585,7 +585,7 @@ class TestEdgeCasesAndErrorHandling:
         now = 2_000_000_000.0
 
         monkeypatch.setattr(fe_module.time, "time", lambda: now)
-        monkeypatch.setattr(Path, "stat", lambda _self, *args, **kwargs: MockStat(now=now))
+        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat(now=now))
 
         features = extractor.extract_metadata_features(test_file)
         # st_birthtime is 5 days ago → days_since_created ≈ 5.0
@@ -616,7 +616,7 @@ class TestEdgeCasesAndErrorHandling:
 
         monkeypatch.setattr(fe_module.os, "name", "nt")
         monkeypatch.setattr(fe_module.time, "time", lambda: now)
-        monkeypatch.setattr(Path, "stat", lambda _self, *args, **kwargs: MockStat(now=now))
+        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat(now=now))
 
         features = extractor.extract_metadata_features(test_file)
         assert features.days_since_created == pytest.approx(1.0)
@@ -646,7 +646,7 @@ class TestEdgeCasesAndErrorHandling:
 
         monkeypatch.setattr(fe_module.os, "name", "posix")
         monkeypatch.setattr(fe_module.time, "time", lambda: now)
-        monkeypatch.setattr(Path, "stat", lambda _self, *args, **kwargs: MockStat(now=now))
+        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat(now=now))
 
         features = extractor.extract_metadata_features(test_file)
         assert features.days_since_created == pytest.approx(10.0)


### PR DESCRIPTION
## Summary

- Fixes Pyre PYRE-ERROR-16 false positives in `feature_extractor.py` (line 322) and `heuristics.py` (line 148) where `stat.st_birthtime` was flagged as an undefined attribute
- Replaces `if hasattr(stat, "st_birthtime") / elif / else` blocks with `try: stat.st_birthtime / except AttributeError: if/else` — Pyre accepts unconditional attribute access, no suppression annotation needed
- Cross-platform behaviour is identical: macOS gets `st_birthtime`, Windows gets `st_ctime`/`st_mtime`, Linux gets `st_mtime`

## Files modified

- `src/file_organizer/methodologies/para/ai/feature_extractor.py` — convert hasattr guard → try/except
- `src/file_organizer/methodologies/para/detection/heuristics.py` — convert hasattr guard → try/except
- `tests/methodologies/para/test_feature_extractor.py` — drop `builtins.hasattr` monkey-patch (no longer needed); add macOS path test
- `tests/methodologies/para/test_ai_heuristic.py` — add macOS path test (`st_birthtime` present → try succeeds)

## Test plan

- [ ] `pytest tests/methodologies/para/test_feature_extractor.py` — 48 passed
- [ ] `pytest tests/methodologies/para/test_ai_heuristic.py` — 70 passed
- [ ] `bash .claude/scripts/pre-commit-validation.sh` — all gates pass, diff coverage 90%

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated documentation build and deployment via GitHub Actions—docs are now built and deployed to GitHub Pages on changes to `main` and tested on pull requests.

* **Chores**
  * Improved file metadata detection reliability by refining timestamp and file stat handling across platform-specific implementations.
  * Enhanced code quality with type-checking annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->