### PR TITLE
feat: add --update-baseline flag to check_module_coverage_floor.py

### DIFF
--- a/scripts/check_module_coverage_floor.py
+++ b/scripts/check_module_coverage_floor.py
@@ -10,6 +10,25 @@ Why this exists:
 Expected report format is pytest-cov's table output (``--cov-report=term-missing``),
 for rows like:
     src/file_organizer/foo.py   123   10   20   4   88%   12-18, 44
+
+--update-baseline mode
+----------------------
+Pass ``--update-baseline`` to write the current report's coverage values back to
+the baseline file instead of running the gate check::
+
+    pytest ... | tee /tmp/report.txt
+    python scripts/check_module_coverage_floor.py \\
+      --report-path /tmp/report.txt \\
+      --baseline-path scripts/coverage/integration_module_floor_baseline.json \\
+      --update-baseline
+
+Behaviour:
+- Existing modules: floor is set to actual (floors are a ratchet — never lowered)
+- New modules: added with floor = actual
+- Deleted modules (in baseline but not in report and not on disk): removed
+- ``generated_at_utc`` and ``source`` block updated with current timestamp
+- Exits 0; does not run the gate check
+- Add ``--dry-run`` to print the diff without writing
 """
 
 from __future__ import annotations
@@ -17,6 +36,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -90,6 +110,22 @@ def parse_args() -> argparse.Namespace:
             "Repository root for checking whether baseline modules still exist on disk. "
             "Defaults to the script-anchored repository root."
         ),
+    )
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        default=False,
+        help=(
+            "Write current coverage values back to the baseline file (ratchet mode). "
+            "Floors are never lowered; new modules are added; deleted modules are removed. "
+            "Exits 0 without running the gate check."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="With --update-baseline: print the diff without writing the file.",
     )
     return parser.parse_args()
 
@@ -219,6 +255,117 @@ def _resolve_policy(
     return new_module_min, tolerance
 
 
+def _compute_baseline_delta(
+    report_modules: dict[str, float],
+    existing: dict[str, float],
+    repo_root: Path,
+) -> tuple[dict[str, float], list[tuple[str, float, float]], list[tuple[str, float]], list[str]]:
+    """Compute the ratcheted module map and the three change lists.
+
+    Returns:
+        (new_modules, raised, added, removed) where:
+        - new_modules: updated module -> floor mapping
+        - raised: (module, old_floor, new_floor) for improved modules
+        - added: (module, actual) for brand-new modules
+        - removed: module names that were deleted from disk
+    """
+    raised: list[tuple[str, float, float]] = []
+    added: list[tuple[str, float]] = []
+    removed: list[str] = []
+    new_modules: dict[str, float] = {}
+
+    for module, actual in sorted(report_modules.items()):
+        if module in existing:
+            old_floor = existing[module]
+            new_floor = max(old_floor, actual)
+            new_modules[module] = new_floor
+            if new_floor > old_floor:
+                raised.append((module, old_floor, new_floor))
+        else:
+            new_modules[module] = actual
+            added.append((module, actual))
+
+    for module in existing:
+        if module not in report_modules:
+            if not (repo_root / module).exists():
+                removed.append(module)
+            else:
+                new_modules[module] = existing[module]
+
+    return new_modules, raised, added, removed
+
+
+def _print_baseline_diff(
+    raised: list[tuple[str, float, float]],
+    added: list[tuple[str, float]],
+    removed: list[str],
+) -> None:
+    if raised:
+        print(f"Raising {len(raised)} floor(s):")
+        for module, old, new in raised:
+            print(f"  {module}: {old:.1f}% → {new:.1f}%")
+    if added:
+        print(f"Adding {len(added)} new module(s):")
+        for module, actual in added:
+            print(f"  {module}: {actual:.1f}%")
+    if removed:
+        print(f"Removing {len(removed)} deleted module(s):")
+        for module in removed:
+            print(f"  {module}")
+    if not raised and not added and not removed:
+        print("No changes — baseline is already up-to-date.")
+
+
+def update_baseline(
+    report_modules: dict[str, float],
+    baseline: dict[str, Any],
+    *,
+    repo_root: Path,
+    dry_run: bool,
+    baseline_path: Path,
+) -> int:
+    """Ratchet baseline floors up to current coverage values and write the result.
+
+    Args:
+        report_modules: Module -> actual coverage % from the current run.
+        baseline: Full parsed baseline document (mutated in-place before serialisation).
+        repo_root: Repository root used to decide whether a missing module was deleted.
+        dry_run: When True, print the diff without writing.
+        baseline_path: Path to the baseline JSON file to (over)write.
+
+    Returns:
+        0 on success, 2 on write failure.
+    """
+    existing: dict[str, float] = {
+        module: float(floor) for module, floor in baseline.get("modules", {}).items()
+    }
+
+    new_modules, raised, added, removed = _compute_baseline_delta(
+        report_modules, existing, repo_root
+    )
+    _print_baseline_diff(raised, added, removed)
+
+    if dry_run:
+        print("(dry-run: baseline not written)")
+        return 0
+
+    baseline["modules"] = new_modules
+    baseline["generated_at_utc"] = datetime.now(tz=UTC).isoformat()
+    baseline["source"] = {"workflow_run_id": None, "job_id": None, "commit": None}
+
+    try:
+        baseline_path.write_text(
+            json.dumps(baseline, indent=2, sort_keys=False) + "\n",
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        print(f"ERROR: failed to write baseline file {baseline_path}: {exc}")
+        return 2
+
+    print(f"Baseline written to {baseline_path}")
+    return 0
+
+
 def main() -> int:
     args = parse_args()
     input_status = validate_inputs(args)
@@ -234,6 +381,23 @@ def main() -> int:
     if baseline is None:
         return 2
 
+    repo_root = args.repo_root.resolve() if args.repo_root else _default_repo_root()
+
+    if args.update_baseline:
+        if args.dry_run:
+            print("--update-baseline --dry-run: showing changes without writing")
+        return update_baseline(
+            report_modules,
+            baseline,
+            repo_root=repo_root,
+            dry_run=args.dry_run,
+            baseline_path=args.baseline_path,
+        )
+
+    if args.dry_run:
+        print("ERROR: --dry-run requires --update-baseline")
+        return 2
+
     policy = _resolve_policy(baseline, args)
     if policy is None:
         return 2
@@ -246,8 +410,6 @@ def main() -> int:
     except (TypeError, ValueError) as exc:
         print(f"ERROR: invalid module floor value in baseline: {exc}")
         return 2
-
-    repo_root = args.repo_root.resolve() if args.repo_root else _default_repo_root()
 
     regressions, low_new_modules, missing_from_report = evaluate(
         report_modules,

--- a/scripts/coverage/README.md
+++ b/scripts/coverage/README.md
@@ -17,8 +17,39 @@ This makes coverage improvements durable and prevents hidden regressions in low-
 
 ## How to ratchet floors upward
 
+### Automated (recommended)
+
+Run the integration suite and pipe the output to the script with `--update-baseline`:
+
+```bash
+bash scripts/measure-integration-coverage.sh | tee /tmp/integration-report.txt
+
+python3 scripts/check_module_coverage_floor.py \
+  --report-path /tmp/integration-report.txt \
+  --baseline-path scripts/coverage/integration_module_floor_baseline.json \
+  --update-baseline
+```
+
+The script will:
+
+- **Raise** floors for modules whose coverage has improved (never lowered — ratchet behaviour).
+- **Add** new modules with their actual coverage as the floor.
+- **Remove** modules that have been deleted from disk.
+- Update `generated_at_utc` in the baseline JSON.
+
+Preview changes first with `--dry-run` (prints the diff without writing):
+
+```bash
+python3 scripts/check_module_coverage_floor.py \
+  --report-path /tmp/integration-report.txt \
+  --baseline-path scripts/coverage/integration_module_floor_baseline.json \
+  --update-baseline --dry-run
+```
+
+### Manual
+
 1. Improve integration tests for target modules.
-2. Run the integration coverage command locally and capture term output.
-3. Regenerate module floors from that run, then review and commit the updated JSON.
+2. Run `bash scripts/measure-integration-coverage.sh | tee /tmp/report.txt`.
+3. Edit `integration_module_floor_baseline.json` by hand, then commit.
 
 When coverage improves materially, update the baseline in the same PR so future changes cannot regress.

--- a/tests/ci/test_module_coverage_floor.py
+++ b/tests/ci/test_module_coverage_floor.py
@@ -435,6 +435,306 @@ def test_main_anchors_repo_root_to_script_location(
     assert module_path in captured
 
 
+def _make_baseline(tmp_path: Path, modules: dict[str, float]) -> Path:
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                "generated_at_utc": "2026-01-01T00:00:00+00:00",
+                "source": {"workflow_run_id": 1, "job_id": 2, "commit": "abc"},
+                "policy": {"new_module_min_percent": 71.9, "tolerance_percent": 0.5},
+                "modules": modules,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return baseline
+
+
+def test_update_baseline_raises_floor_when_coverage_improves(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_module()
+
+    report = tmp_path / "report.txt"
+    _write_report(report, ["src/file_organizer/cli/update.py  100  5  40  2  95%"])
+
+    baseline = _make_baseline(tmp_path, {"src/file_organizer/cli/update.py": 80.0})
+
+    rc = _run_main(
+        module,
+        monkeypatch,
+        [
+            "--report-path",
+            str(report),
+            "--baseline-path",
+            str(baseline),
+            "--update-baseline",
+            "--repo-root",
+            str(tmp_path),
+        ],
+    )
+
+    assert rc == 0
+    data = json.loads(baseline.read_text(encoding="utf-8"))
+    assert data["modules"]["src/file_organizer/cli/update.py"] == 95.0
+    captured = capsys.readouterr().out
+    assert "80.0% → 95.0%" in captured
+
+
+def test_update_baseline_ratchet_does_not_lower_floor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When actual coverage drops below the existing floor, the floor must not be lowered."""
+    module = _load_module()
+
+    report = tmp_path / "report.txt"
+    _write_report(report, ["src/file_organizer/cli/update.py  100  30  40  10  70%"])
+
+    baseline = _make_baseline(tmp_path, {"src/file_organizer/cli/update.py": 80.0})
+
+    rc = _run_main(
+        module,
+        monkeypatch,
+        [
+            "--report-path",
+            str(report),
+            "--baseline-path",
+            str(baseline),
+            "--update-baseline",
+            "--repo-root",
+            str(tmp_path),
+        ],
+    )
+
+    assert rc == 0
+    data = json.loads(baseline.read_text(encoding="utf-8"))
+    assert data["modules"]["src/file_organizer/cli/update.py"] == 80.0
+
+
+def test_update_baseline_adds_new_module(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_module()
+
+    report = tmp_path / "report.txt"
+    _write_report(report, ["src/file_organizer/new_module.py  50  5  10  1  88%"])
+
+    baseline = _make_baseline(tmp_path, {})
+
+    rc = _run_main(
+        module,
+        monkeypatch,
+        [
+            "--report-path",
+            str(report),
+            "--baseline-path",
+            str(baseline),
+            "--update-baseline",
+            "--repo-root",
+            str(tmp_path),
+        ],
+    )
+
+    assert rc == 0
+    data = json.loads(baseline.read_text(encoding="utf-8"))
+    assert data["modules"]["src/file_organizer/new_module.py"] == 88.0
+    captured = capsys.readouterr().out
+    assert "Adding 1 new module" in captured
+    assert "src/file_organizer/new_module.py: 88.0%" in captured
+
+
+def test_update_baseline_removes_deleted_module(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Modules in baseline but absent from report AND disk should be removed."""
+    module = _load_module()
+
+    report = tmp_path / "report.txt"
+    _write_report(report, ["src/file_organizer/kept.py  10  0  0  0  100%"])
+
+    baseline = _make_baseline(
+        tmp_path,
+        {
+            "src/file_organizer/kept.py": 100.0,
+            "src/file_organizer/deleted.py": 50.0,  # not on disk, not in report
+        },
+    )
+
+    rc = _run_main(
+        module,
+        monkeypatch,
+        [
+            "--report-path",
+            str(report),
+            "--baseline-path",
+            str(baseline),
+            "--update-baseline",
+            "--repo-root",
+            str(tmp_path),
+        ],
+    )
+
+    assert rc == 0
+    data = json.loads(baseline.read_text(encoding="utf-8"))
+    assert "src/file_organizer/deleted.py" not in data["modules"]
+    assert "src/file_organizer/kept.py" in data["modules"]
+    captured = capsys.readouterr().out
+    assert "Removing 1 deleted module" in captured
+
+
+def test_update_baseline_keeps_floor_for_module_still_on_disk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Module missing from report but still on disk should keep its floor (not removed)."""
+    module = _load_module()
+
+    on_disk = tmp_path / "src" / "file_organizer" / "missing_from_report.py"
+    on_disk.parent.mkdir(parents=True, exist_ok=True)
+    on_disk.write_text("# placeholder", encoding="utf-8")
+
+    report = tmp_path / "report.txt"
+    _write_report(report, ["src/file_organizer/present.py  10  0  0  0  100%"])
+
+    baseline = _make_baseline(
+        tmp_path,
+        {
+            "src/file_organizer/present.py": 100.0,
+            "src/file_organizer/missing_from_report.py": 75.0,
+        },
+    )
+
+    rc = _run_main(
+        module,
+        monkeypatch,
+        [
+            "--report-path",
+            str(report),
+            "--baseline-path",
+            str(baseline),
+            "--update-baseline",
+            "--repo-root",
+            str(tmp_path),
+        ],
+    )
+
+    assert rc == 0
+    data = json.loads(baseline.read_text(encoding="utf-8"))
+    assert data["modules"]["src/file_organizer/missing_from_report.py"] == 75.0
+
+
+def test_update_baseline_dry_run_does_not_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_module()
+
+    report = tmp_path / "report.txt"
+    _write_report(report, ["src/file_organizer/cli/update.py  100  5  40  2  95%"])
+
+    original_content = json.dumps(
+        {
+            "generated_at_utc": "2026-01-01T00:00:00+00:00",
+            "source": {"workflow_run_id": 1, "job_id": 2, "commit": "abc"},
+            "policy": {"new_module_min_percent": 71.9, "tolerance_percent": 0.5},
+            "modules": {"src/file_organizer/cli/update.py": 80.0},
+        }
+    )
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(original_content, encoding="utf-8")
+
+    rc = _run_main(
+        module,
+        monkeypatch,
+        [
+            "--report-path",
+            str(report),
+            "--baseline-path",
+            str(baseline),
+            "--update-baseline",
+            "--dry-run",
+            "--repo-root",
+            str(tmp_path),
+        ],
+    )
+
+    assert rc == 0
+    assert baseline.read_text(encoding="utf-8") == original_content
+    captured = capsys.readouterr().out
+    assert "dry-run" in captured.lower()
+
+
+def test_update_baseline_updates_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _load_module()
+
+    report = tmp_path / "report.txt"
+    _write_report(report, ["src/file_organizer/cli/update.py  10  0  0  0  100%"])
+
+    baseline = _make_baseline(tmp_path, {"src/file_organizer/cli/update.py": 100.0})
+
+    rc = _run_main(
+        module,
+        monkeypatch,
+        [
+            "--report-path",
+            str(report),
+            "--baseline-path",
+            str(baseline),
+            "--update-baseline",
+            "--repo-root",
+            str(tmp_path),
+        ],
+    )
+
+    assert rc == 0
+    data = json.loads(baseline.read_text(encoding="utf-8"))
+    assert "generated_at_utc" in data
+    assert data["generated_at_utc"] != "2026-01-01T00:00:00+00:00"
+    assert data["source"]["workflow_run_id"] is None
+
+
+def test_dry_run_without_update_baseline_returns_2(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_module()
+
+    report = tmp_path / "report.txt"
+    _write_report(report, ["src/file_organizer/cli/update.py  10  0  0  0  100%"])
+
+    baseline = _make_baseline(tmp_path, {"src/file_organizer/cli/update.py": 100.0})
+
+    rc = _run_main(
+        module,
+        monkeypatch,
+        [
+            "--report-path",
+            str(report),
+            "--baseline-path",
+            str(baseline),
+            "--dry-run",
+        ],
+    )
+
+    assert rc == 2
+    captured = capsys.readouterr().out
+    assert "ERROR" in captured
+    assert "--update-baseline" in captured
+
+
 def test_print_report_shows_effective_thresholds_and_guidance(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
## Summary

- Adds `--update-baseline` flag to `scripts/check_module_coverage_floor.py` that writes current coverage values back to the baseline JSON using ratchet semantics (floors are never lowered)
- Adds `--dry-run` flag to preview changes without writing
- Updates `scripts/coverage/README.md` with the new automated workflow

## Behaviour

- **Existing modules**: floor raised to `actual` if `actual > floor`; never lowered (ratchet)
- **New modules**: added with `floor = actual`
- **Deleted modules** (in baseline, not in report, not on disk): removed
- `generated_at_utc` and `source` block updated; CI-specific IDs set to `null`
- `--update-baseline` exits 0 and skips the gate check
- `--dry-run` without `--update-baseline` returns 2 with an error message

## Test plan

- [x] `test_update_baseline_raises_floor_when_coverage_improves`
- [x] `test_update_baseline_ratchet_does_not_lower_floor`
- [x] `test_update_baseline_adds_new_module`
- [x] `test_update_baseline_removes_deleted_module`
- [x] `test_update_baseline_keeps_floor_for_module_still_on_disk`
- [x] `test_update_baseline_dry_run_does_not_write`
- [x] `test_update_baseline_updates_metadata`
- [x] `test_dry_run_without_update_baseline_returns_2`
- [x] All 25 tests in `tests/ci/test_module_coverage_floor.py` pass
- [x] Pre-commit validation passes (ruff, pymarkdown, diff-cover, docstring coverage)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated workflow to continuously measure and update code coverage baselines
  * Introduced `--update-baseline` flag to automatically ratchet per-module coverage floors upward while preventing floors from lowering
  * Added `--dry-run` flag to preview baseline changes without writing to disk

* **Documentation**
  * Updated coverage workflow documentation with new automated process and flag usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->