### PR TITLE
fix: address CodeRabbit findings from PR #50

### DIFF
--- a/scripts/check_module_coverage_floor.py
+++ b/scripts/check_module_coverage_floor.py
@@ -35,7 +35,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
+import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -53,6 +55,7 @@ ROW_RE = re.compile(
 
 
 def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes from *text*."""
     return ANSI_RE.sub("", text)
 
 
@@ -73,6 +76,13 @@ def parse_report(report_path: Path) -> dict[str, float]:
 
 
 def load_baseline(path: Path) -> dict[str, Any]:
+    """Load and minimally validate the baseline JSON file.
+
+    Raises:
+        json.JSONDecodeError: If the file is not valid JSON.
+        ValueError: If the top-level structure is missing required keys.
+        OSError: If the file cannot be read.
+    """
     data = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise ValueError(f"Invalid baseline file {path}: expected top-level JSON object")
@@ -82,11 +92,13 @@ def load_baseline(path: Path) -> dict[str, Any]:
 
 
 def _default_repo_root() -> Path:
+    """Return the repository root derived from this script's location."""
     # Script lives at <repo>/scripts/check_module_coverage_floor.py.
     return Path(__file__).resolve().parents[1]
 
 
 def parse_args() -> argparse.Namespace:
+    """Build and return the argument parser namespace."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--report-path", type=Path, required=True)
     parser.add_argument("--baseline-path", type=Path, required=True)
@@ -131,6 +143,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def validate_inputs(args: argparse.Namespace) -> int:
+    """Return 2 with an error message if required input files do not exist, else 0."""
     if not args.report_path.exists():
         print(f"ERROR: report not found: {args.report_path}")
         return 2
@@ -148,6 +161,12 @@ def evaluate(
     new_module_min: float,
     repo_root: Path,
 ) -> tuple[list[tuple[str, float, float]], list[tuple[str, float]], list[str]]:
+    """Compare report coverage against baseline floors and return gate findings.
+
+    Returns:
+        (regressions, low_new_modules, missing_from_report) where each entry is
+        a tuple describing a gate violation.
+    """
     regressions: list[tuple[str, float, float]] = []
     low_new_modules: list[tuple[str, float]] = []
     missing_from_report: list[str] = []
@@ -180,6 +199,7 @@ def print_report(
     tolerance: float,
     baseline_path: Path,
 ) -> None:
+    """Print a human-readable gate result to stdout."""
     print(
         f"Per-module coverage check: {len(report_modules)} modules parsed, "
         f"{len(regressions)} regressions, {len(low_new_modules)} low new modules"
@@ -220,6 +240,7 @@ def print_report(
 
 
 def _parse_baseline(path: Path) -> dict[str, Any] | None:
+    """Load the baseline file, printing a user-friendly error and returning None on failure."""
     try:
         return load_baseline(path)
     except json.JSONDecodeError as exc:
@@ -236,6 +257,7 @@ def _parse_baseline(path: Path) -> dict[str, Any] | None:
 def _resolve_policy(
     baseline: dict[str, Any], args: argparse.Namespace
 ) -> tuple[float, float] | None:
+    """Resolve (new_module_min, tolerance) from CLI args then baseline policy, or None on error."""
     policy = baseline.get("policy", {})
     if policy is None or not isinstance(policy, dict):
         policy = {}
@@ -300,6 +322,7 @@ def _print_baseline_diff(
     added: list[tuple[str, float]],
     removed: list[str],
 ) -> None:
+    """Print a human-readable summary of pending baseline changes to stdout."""
     if raised:
         print(f"Raising {len(raised)} floor(s):")
         for module, old, new in raised:
@@ -334,11 +357,15 @@ def update_baseline(
         baseline_path: Path to the baseline JSON file to (over)write.
 
     Returns:
-        0 on success, 2 on write failure.
+        0 on success, 2 on any failure (invalid baseline floor values or write errors).
     """
-    existing: dict[str, float] = {
-        module: float(floor) for module, floor in baseline.get("modules", {}).items()
-    }
+    try:
+        existing: dict[str, float] = {
+            module: float(floor) for module, floor in baseline.get("modules", {}).items()
+        }
+    except (TypeError, ValueError) as exc:
+        print(f"ERROR: invalid module floor value in baseline: {exc}")
+        return 2
 
     new_modules, raised, added, removed = _compute_baseline_delta(
         report_modules, existing, repo_root
@@ -353,13 +380,27 @@ def update_baseline(
     baseline["generated_at_utc"] = datetime.now(tz=UTC).isoformat()
     baseline["source"] = {"workflow_run_id": None, "job_id": None, "commit": None}
 
+    payload = json.dumps(baseline, indent=2, sort_keys=False) + "\n"
+    tmp_fd: int | None = None
+    tmp_name: str | None = None
     try:
-        baseline_path.write_text(
-            json.dumps(baseline, indent=2, sort_keys=False) + "\n",
-            encoding="utf-8",
-        )
+        tmp_fd, tmp_name = tempfile.mkstemp(dir=baseline_path.parent, suffix=".tmp", text=True)
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+            tmp_fd = None  # fdopen takes ownership; don't double-close on error
+            fh.write(payload)
+        os.replace(tmp_name, baseline_path)
     except OSError as exc:
         print(f"ERROR: failed to write baseline file {baseline_path}: {exc}")
+        if tmp_fd is not None:
+            try:
+                os.close(tmp_fd)
+            except OSError:
+                pass
+        if tmp_name is not None:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
         return 2
 
     print(f"Baseline written to {baseline_path}")
@@ -367,6 +408,7 @@ def update_baseline(
 
 
 def main() -> int:
+    """Entry point: parse args, run gate check or baseline update, return exit code."""
     args = parse_args()
     input_status = validate_inputs(args)
     if input_status:

--- a/scripts/coverage/README.md
+++ b/scripts/coverage/README.md
@@ -22,7 +22,7 @@ This makes coverage improvements durable and prevents hidden regressions in low-
 Run the integration suite and pipe the output to the script with `--update-baseline`:
 
 ```bash
-bash scripts/measure-integration-coverage.sh | tee /tmp/integration-report.txt
+bash .claude/scripts/measure-integration-coverage.sh | tee /tmp/integration-report.txt
 
 python3 scripts/check_module_coverage_floor.py \
   --report-path /tmp/integration-report.txt \
@@ -49,7 +49,7 @@ python3 scripts/check_module_coverage_floor.py \
 ### Manual
 
 1. Improve integration tests for target modules.
-2. Run `bash scripts/measure-integration-coverage.sh | tee /tmp/report.txt`.
+2. Run `bash .claude/scripts/measure-integration-coverage.sh | tee /tmp/report.txt`.
 3. Edit `integration_module_floor_baseline.json` by hand, then commit.
 
 When coverage improves materially, update the baseline in the same PR so future changes cannot regress.


### PR DESCRIPTION
Follow-up to #50 — fixes three CodeRabbit findings that were not addressed before merge.

## Changes

- **Invalid-floor guard** (`scripts/check_module_coverage_floor.py`): wrap the `float()` conversion of existing baseline floors in `update_baseline()` with `try/except (TypeError, ValueError)` so a malformed value exits with code 2 instead of an unhandled traceback (matching the gate path behaviour)
- **Atomic write** (`scripts/check_module_coverage_floor.py`): replace `baseline_path.write_text(...)` with `tempfile.mkstemp` + `os.replace()` to prevent a partial write from corrupting the baseline JSON on interruption (pattern F3 / S6)
- **README script path** (`scripts/coverage/README.md`): both examples now call `.claude/scripts/measure-integration-coverage.sh` (which erases `.coverage` first) instead of `scripts/measure-integration-coverage.sh`, per C7 guidance

## Test plan

- [x] All 25 existing tests in `tests/ci/test_module_coverage_floor.py` pass
- [x] Pre-commit validation passes (ruff, pymarkdown, diff-cover, docstring coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for baseline module floor parsing to properly detect and report invalid data with appropriate exit codes.
  * Implemented atomic file write operations for baseline file updates to ensure data integrity and prevent corruption.

* **Documentation**
  * Updated integration coverage script command references to reflect correct file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->