### PR TITLE
fix: revert FileOrganizer path to full repo-relative path

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -205,7 +205,7 @@ class CustomModel(BaseModel):
 | **Pipeline Stages** | Preprocessor/Analyzer/Postprocessor/Writer | `pipeline/stages/` | Active |
 | **TextProcessor** | Text file pipeline | `services/text_processor.py` | Active |
 | **VisionProcessor** | Image/video pipeline | `services/vision_processor.py` | Active |
-| **FileOrganizer** | Main orchestrator | `core/organizer.py` | Active |
+| **FileOrganizer** | Main orchestrator | `src/file_organizer/core/organizer.py` | Active |
 | **PatternAnalyzer** | Naming pattern detection | `services/pattern_analyzer.py` | Active |
 | **SuggestionEngine** | Placement suggestions | `services/smart_suggestions.py` | Active |
 | **Intelligence** | User preference learning | `services/intelligence/` | Active |


### PR DESCRIPTION
## Summary

- Reverts `core/organizer.py` → `src/file_organizer/core/organizer.py` in the Component Registry table in `docs/developer/architecture.md`

## Root cause

`test_doc_file_paths.py` validates that backtick paths in docs resolve from the repo root. `core/organizer.py` does not exist there; `src/file_organizer/core/organizer.py` does. The CodeRabbit suggestion to shorten it (applied in #55) was incorrect — the other table entries using module-relative paths (`models/base.py` etc.) are not path-existence-checked by that test, but the FileOrganizer entry was.

## Test

`tests/docs/test_doc_file_paths.py::test_referenced_path_exists[docs/developer/architecture.md-src/file_organizer/core/organizer.py]` will pass; the previous failure was `core/organizer.py` not found at repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation references to reflect current component organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->