### PR TITLE
fix(ci): resolve 5 failure groups from most recent main CI run

### DIFF
--- a/src/file_organizer/cli/daemon.py
+++ b/src/file_organizer/cli/daemon.py
@@ -160,7 +160,7 @@ def watch(
             for event in events:
                 event_type = getattr(event, "event_type", "unknown")
                 event_path = getattr(event, "path", getattr(event, "src_path", "?"))
-                console.print(f"  [{event_type}] {event_path}")
+                console.print(f"  [{event_type}] {event_path}", markup=False)
     except KeyboardInterrupt:
         console.print("\n[dim]Stopped watching.[/dim]")
     finally:

--- a/src/file_organizer/cli/models_cli.py
+++ b/src/file_organizer/cli/models_cli.py
@@ -33,7 +33,7 @@ def model_pull(
     from file_organizer.models.model_manager import ModelManager
 
     mgr = ModelManager(console=console)
-    success = mgr.pull_model(name)
+    success = mgr.pull_model(name=name)
     if not success:
         raise typer.Exit(code=1)
 

--- a/src/file_organizer/services/deduplication/embedder.py
+++ b/src/file_organizer/services/deduplication/embedder.py
@@ -82,9 +82,22 @@ class DocumentEmbedder:
     def fit_transform(self, documents: list[str]) -> np.ndarray:
         """Fit the vectorizer and transform documents to embeddings.
 
-        For very small corpora where ``len(documents) * max_df < 1``, ``max_df``
-        is temporarily set to 1.0 for this call only and restored afterwards, so
-        the configured value is preserved for subsequent calls on the same instance.
+        Two corpus-size guards are applied before calling sklearn:
+
+        1. *Fraction rounding*: when ``max_df`` is a float and
+           ``len(documents) * max_df < 1``, ``max_df`` is temporarily set to
+           1.0 so that sklearn's internal threshold rounds to at least one
+           document.
+        2. *All-terms-pruned retry*: if sklearn still raises
+           ``ValueError("After pruning, no terms remain …")`` (every remaining
+           term appeared in every document and was pruned by ``max_df``), the
+           call is retried once with ``max_df=1.0``.  Any other ``ValueError``
+           (bad tokenizer params, mismatched vocabulary, etc.) is **not**
+           caught and propagates to the caller.
+
+        In both cases the original ``max_df`` value is restored by a
+        ``finally`` block, so subsequent calls on the same instance use the
+        configured value.
 
         Args:
             documents: List of document texts
@@ -111,13 +124,17 @@ class DocumentEmbedder:
 
             try:
                 embeddings = self.vectorizer.fit_transform(documents)
-            except ValueError:
-                # All terms exceeded max_df threshold (every term appears in every doc).
-                # Retry with max_df=1.0 so no terms are pruned.
+            except ValueError as _exc:
+                # Only retry for the sklearn pruning error: every term appeared
+                # in every document and was pruned by max_df.  Any other
+                # ValueError (bad params, tokenizer errors, etc.) propagates.
+                _PRUNING_MSG = "After pruning, no terms remain"
+                if _PRUNING_MSG not in str(_exc):
+                    raise
                 logger.warning(
-                    "fit_transform raised ValueError (all terms pruned by max_df=%.2f); "
-                    "retrying with max_df=1.0",
+                    "fit_transform: all terms pruned by max_df=%.2f; retrying with max_df=1.0",
                     self.vectorizer.max_df,
+                    exc_info=True,
                 )
                 self.vectorizer.max_df = 1.0
                 embeddings = self.vectorizer.fit_transform(documents)
@@ -135,8 +152,8 @@ class DocumentEmbedder:
 
             return np.asarray(dense_embeddings)
 
-        except ValueError as e:
-            logger.error(f"Error during fit_transform: {e}")
+        except ValueError:
+            logger.error("Error during fit_transform", exc_info=True)
             raise
 
     def transform(self, document: str) -> np.ndarray:

--- a/src/file_organizer/services/deduplication/embedder.py
+++ b/src/file_organizer/services/deduplication/embedder.py
@@ -111,6 +111,16 @@ class DocumentEmbedder:
 
             try:
                 embeddings = self.vectorizer.fit_transform(documents)
+            except ValueError:
+                # All terms exceeded max_df threshold (every term appears in every doc).
+                # Retry with max_df=1.0 so no terms are pruned.
+                logger.warning(
+                    "fit_transform raised ValueError (all terms pruned by max_df=%.2f); "
+                    "retrying with max_df=1.0",
+                    self.vectorizer.max_df,
+                )
+                self.vectorizer.max_df = 1.0
+                embeddings = self.vectorizer.fit_transform(documents)
             finally:
                 self.vectorizer.max_df = _original_max_df
             self.is_fitted = True
@@ -206,7 +216,7 @@ class DocumentEmbedder:
         if not self.is_fitted:
             raise RuntimeError("Vectorizer not fitted. Call fit_transform() first.")
 
-        return dict(self.vectorizer.vocabulary_)
+        return {k: int(v) for k, v in self.vectorizer.vocabulary_.items()}
 
     def get_top_terms(self, embedding: np.ndarray, top_n: int = 10) -> list[tuple[str, float]]:
         """Get top N terms from an embedding by weight.

--- a/src/file_organizer/services/deduplication/embedder.py
+++ b/src/file_organizer/services/deduplication/embedder.py
@@ -153,7 +153,7 @@ class DocumentEmbedder:
             return np.asarray(dense_embeddings)
 
         except ValueError:
-            logger.error("Error during fit_transform", exc_info=True)
+            logger.exception("Error during fit_transform")
             raise
 
     def transform(self, document: str) -> np.ndarray:

--- a/tests/integration/test_coverage_gap_supplements.py
+++ b/tests/integration/test_coverage_gap_supplements.py
@@ -375,7 +375,12 @@ class TestTextProcessingNLTKPaths:
     def test_sanitize_filename_length_truncation(self) -> None:
         from file_organizer.utils.text_processing import sanitize_filename
 
-        long_name = "very_long_filename_that_exceeds_fifty_characters_definitely"
+        # Use space-separated words so clean_text tokenizes them individually.
+        # Underscore-joined words fail isalpha() and are entirely pruned → "untitled".
+        # The five words produce "jungle_kingdom_laurel_mansion_nautical" (37 chars);
+        # truncated at 20: "jungle_kingdom_laure" — last char is 'e', not '_',
+        # so rstrip("_") is a no-op and len is exactly 20.
+        long_name = "jungle kingdom laurel mansion nautical octopus paradise quantum"
         result = sanitize_filename(long_name, max_length=20)
         assert len(result) == 20
 

--- a/tests/integration/test_coverage_gap_supplements.py
+++ b/tests/integration/test_coverage_gap_supplements.py
@@ -382,7 +382,8 @@ class TestTextProcessingNLTKPaths:
         # so rstrip("_") is a no-op and len is exactly 20.
         long_name = "jungle kingdom laurel mansion nautical octopus paradise quantum"
         result = sanitize_filename(long_name, max_length=20)
-        assert len(result) == 20
+        assert result == "jungle_kingdom_laure"
+        assert result[-1] != "_"
 
     def test_get_unwanted_words_includes_stopwords(self) -> None:
         from file_organizer.utils.text_processing import get_unwanted_words

--- a/tests/integration/test_events_monitor_consumer_bus.py
+++ b/tests/integration/test_events_monitor_consumer_bus.py
@@ -276,6 +276,10 @@ class TestEventMonitorConnected:
 class TestRedisStreamManagerConnect:
     """RedisStreamManager connection and disconnect lifecycle."""
 
+    @pytest.fixture(autouse=True)
+    def _require_redis(self) -> None:
+        pytest.importorskip("redis")
+
     def test_connect_calls_ping_and_sets_connected(self) -> None:
         mock_redis = MagicMock()
         mock_redis.ping.return_value = True

--- a/tests/integration/test_services_dedup_embedder_extractor_hasher_detector.py
+++ b/tests/integration/test_services_dedup_embedder_extractor_hasher_detector.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.integration
 
 
 def _require_sklearn() -> None:
-    pytest.importorskip("sklearn")
+    pytest.importorskip("sklearn.feature_extraction.text")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes all 5 failure groups identified in the most recent main CI run via root cause analysis.

### Group A — Missing `redis` import guard
- **`test_events_monitor_consumer_bus.py`**: Added class-level `autouse` fixture calling `pytest.importorskip("redis")` to `TestRedisStreamManagerConnect`. Without it the entire test class fails with `ImportError` when `redis` is not installed (T8 pattern).

### Group B — sklearn / `DocumentEmbedder` failures (3 fixes)
- **`embedder.py` `get_vocabulary()`**: Cast `numpy.int64` values to `int` — sklearn's `vocabulary_` returns `dict[str, numpy.int64]`, but the method's return type is `dict[str, int]` and test assertions used `isinstance(v, int)` which fails on numpy scalars.
- **`embedder.py` `fit_transform()`**: Added `except ValueError` inside the small-corpus guard to catch the case where all terms are pruned by `max_df` (every term appears in every document). Retries with `max_df=1.0`; `finally` always restores the original value.
- **`test_services_dedup_embedder_extractor_hasher_detector.py`**: Changed `pytest.importorskip("sklearn")` → `pytest.importorskip("sklearn.feature_extraction.text")` to target the exact subpackage used, matching the guard in `embedder.py` itself.

### Group C — Rich markup stripping event type strings
- **`daemon.py`**: Added `markup=False` to `console.print(f"  [{event_type}] {event_path}")`. Rich silently discards unrecognised tags like `[created]`, so the event type was never shown in `watch` output.

### Group D — `sanitize_filename` truncation test broken by NLTK filtering
- **`test_coverage_gap_supplements.py`**: The original input `"very_long_filename_that_exceeds_fifty_characters_definitely"` is treated as a single token by NLTK's tokenizer; `isalpha()` rejects it (contains `_`) → `clean_text` returns `""` → `sanitize_filename` returns `"untitled"` (8 chars) → `assert len(result) == 20` fails. Fixed by using space-separated non-stopwords that produce a 37-char joined string, truncated to exactly 20 chars at a non-underscore boundary.

### Group E — `pull_model` positional vs keyword argument mismatch
- **`models_cli.py`**: Changed `mgr.pull_model(name)` → `mgr.pull_model(name=name)` to match both the `ModelManager.pull_model(name: str)` signature and the test's `assert_called_once_with(name="llama3:8b")` expectation.

## Test plan

- [ ] CI passes on Python 3.11 and 3.12 (integration tests exercise Groups A–C and E)
- [ ] `test_cache_path_loaded_on_init` no longer raises `ValueError` (Group B corpus fix)
- [ ] `test_get_vocabulary` passes with `isinstance(v, int)` assertion (Group B numpy cast)
- [ ] `test_sanitize_filename_length_truncation` returns a result of exactly 20 chars (Group D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Console output now avoids unintended markup interpretation for special characters.
  * Embeddings processing is more robust when text pruning would remove all terms (automatic retry) and normalizes vocabulary IDs to integers.

* **Tests**
  * Improved filename-sanitization test inputs and stricter truncation assertions.
  * Tests now skip when optional runtime packages or specific submodules aren’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->