### PR TITLE
chore(scripts): harden .claude/scripts portability and add mypy-changed hook

### DIFF
--- a/.claude/scripts/check-stale-doc-refs.sh
+++ b/.claude/scripts/check-stale-doc-refs.sh
@@ -17,12 +17,8 @@ fi
 if $STAGED_ONLY; then
   MD_FILES=$(git diff --cached --name-only --diff-filter=ACM -- '*.md' || true)
 else
-  MD_FILES=$(find "$REPO_ROOT" -name '*.md' \
-    -not -path '*/node_modules/*' \
-    -not -path '*/.git/*' \
-    -not -path '*/docs/plans/*' \
-    -not -path '*/.claude/worktrees/*' \
-    | sed "s|^$REPO_ROOT/||")
+  MD_FILES=$(git -C "$REPO_ROOT" ls-files '*.md' \
+    | grep -v -E '^(docs/plans/|\.claude/worktrees/)')
 fi
 
 if [[ -z "$MD_FILES" ]]; then

--- a/.claude/scripts/cherry-pick-to-pr.sh
+++ b/.claude/scripts/cherry-pick-to-pr.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# cherry-pick-to-pr.sh — Cherry-pick one or more commits onto a new branch from
+# main, push it, and create a GitHub PR.
+#
+# Usage:
+#   bash .claude/scripts/cherry-pick-to-pr.sh \
+#     <new-branch> <pr-title> <pr-body-file> <commit> [<commit> ...]
+#
+# Example:
+#   bash .claude/scripts/cherry-pick-to-pr.sh \
+#     coverage/59-buckets-b-through-e \
+#     "test(integration): Buckets B-E coverage uplift" \
+#     /tmp/pr_body.md \
+#     a960988
+set -euo pipefail
+
+if ! command -v gh &>/dev/null; then
+    echo "Error: gh CLI not found. Install it from https://cli.github.com" >&2
+    exit 1
+fi
+
+NEW_BRANCH="${1:?Usage: cherry-pick-to-pr.sh <new-branch> <pr-title> <pr-body-file> <commit>...}"
+PR_TITLE="${2:?Missing PR title}"
+PR_BODY_FILE="${3:?Missing PR body file}"
+shift 3
+COMMITS=("$@")
+
+if [ "${#COMMITS[@]}" -eq 0 ]; then
+    echo "Error: at least one commit SHA is required" >&2
+    exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CURRENT_BRANCH="$(git branch --show-current)"
+
+if git show-ref --verify --quiet "refs/heads/$NEW_BRANCH"; then
+    echo "Error: branch '$NEW_BRANCH' already exists locally." >&2
+    echo "  Delete it first: git branch -D $NEW_BRANCH" >&2
+    exit 1
+fi
+
+git fetch origin main
+git checkout origin/main -b "$NEW_BRANCH"
+
+for sha in "${COMMITS[@]}"; do
+    git cherry-pick "$sha"
+done
+
+git push -u origin "$NEW_BRANCH"
+
+gh pr create \
+    --repo "$(gh repo view --json nameWithOwner -q '.nameWithOwner')" \
+    --head "$NEW_BRANCH" \
+    --base main \
+    --title "$PR_TITLE" \
+    --body-file "$PR_BODY_FILE"
+
+git checkout "$CURRENT_BRANCH"

--- a/.claude/scripts/gh-graphql.sh
+++ b/.claude/scripts/gh-graphql.sh
@@ -29,6 +29,12 @@
 
 set -euo pipefail
 
+# Verify required tools
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq not found. Install it (e.g. brew install jq) to use gh-graphql.sh." >&2
+    exit 1
+fi
+
 # Derive repo owner/name from git remote
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
 if [[ -z "$REPO" ]]; then

--- a/.claude/scripts/pr-merge-safe.sh
+++ b/.claude/scripts/pr-merge-safe.sh
@@ -57,7 +57,8 @@ REVIEW_DECISION=$(echo "$DATA" | jq -r '.reviewDecision // "NONE"')
 BASE_REF=$(echo "$DATA" | jq -r '.baseRefName')
 PR_BASE_OID=$(echo "$DATA" | jq -r '.baseRefOid[0:8]')
 
-MAIN_HEAD=$(git log "$BASE_REF" --oneline -1 2>/dev/null | awk '{print $1}' || echo "unknown")
+git fetch origin "$BASE_REF" --quiet 2>/dev/null || true
+MAIN_HEAD=$(git log "origin/$BASE_REF" --oneline -1 2>/dev/null | awk '{print $1}' || echo "unknown")
 
 # Step 2: Handle stale branch
 if [[ "$PR_BASE_OID" != "$MAIN_HEAD" && "$MAIN_HEAD" != "unknown" ]]; then

--- a/.claude/scripts/pre-commit-validation.sh
+++ b/.claude/scripts/pre-commit-validation.sh
@@ -39,12 +39,16 @@ collect_changed_files() {
   local untracked_files=()
 
   if git diff --cached --quiet; then
-    mapfile -t tracked_files < <(git diff --name-only --diff-filter=ACMR HEAD 2>/dev/null || true)
-    mapfile -t untracked_files < <(git ls-files --others --exclude-standard)
-    changed_files=("${tracked_files[@]}" "${untracked_files[@]}")
+    while IFS= read -r line; do [[ -n "$line" ]] && tracked_files+=("$line"); done \
+      < <(git diff --name-only --diff-filter=ACMR HEAD 2>/dev/null || true)
+    while IFS= read -r line; do [[ -n "$line" ]] && untracked_files+=("$line"); done \
+      < <(git ls-files --others --exclude-standard)
+    changed_files=("${tracked_files[@]+"${tracked_files[@]}"}" "${untracked_files[@]+"${untracked_files[@]}"}")
     changed_mode="working tree vs HEAD + untracked"
   else
-    mapfile -t changed_files < <(git diff --cached --name-only --diff-filter=ACMR)
+    changed_files=()
+    while IFS= read -r line; do [[ -n "$line" ]] && changed_files+=("$line"); done \
+      < <(git diff --cached --name-only --diff-filter=ACMR)
     changed_mode="staged diff"
   fi
 }

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # Ephemeral context checkpoint (session state, not project code)
 .claude/context/checkpoint.md
 
+# Claude Code scheduled-task process lock (runtime state, cleaned up on exit)
+.claude/scheduled_tasks.lock
+
 # Byte-compiled Python files
 __pycache__/
 *.py[cod]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,6 +127,16 @@ repos:
         pass_filenames: false
 
       # ----------------------------------------------------------------
+      # Type checking on models (scoped mypy gate)
+      # ----------------------------------------------------------------
+      - id: mypy-changed
+        name: mypy (changed models files)
+        entry: bash scripts/run-mypy-changed.sh
+        language: system
+        files: ^src/file_organizer/models/.*\.py$
+        pass_filenames: true
+
+      # ----------------------------------------------------------------
       # PyPI version validation
       # ----------------------------------------------------------------
       - id: pypi-version-check

--- a/scripts/run-mypy-changed.sh
+++ b/scripts/run-mypy-changed.sh
@@ -8,4 +8,11 @@ if [[ $# -eq 0 ]]; then
     exit 0
 fi
 
-exec mypy "$@"
+if [[ -x .venv/bin/mypy ]]; then
+    exec .venv/bin/mypy "$@"
+elif command -v mypy &>/dev/null; then
+    exec mypy "$@"
+else
+    echo "error: mypy not found — run 'pip install mypy' or activate your venv" >&2
+    exit 1
+fi

--- a/scripts/run-mypy-changed.sh
+++ b/scripts/run-mypy-changed.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# run-mypy-changed.sh — Run mypy on the files passed as arguments.
+# Invoked by the mypy-changed pre-commit hook with pass_filenames: true.
+# mypy reads strict settings from pyproject.toml automatically.
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+    exit 0
+fi
+
+exec mypy "$@"


### PR DESCRIPTION
## Summary

- **`pre-commit-validation.sh`**: replace `mapfile` with `while`-`read` loops — `mapfile` requires Bash 4+, macOS ships Bash 3.2
- **`cherry-pick-to-pr.sh`**: gate on `gh` CLI existence at startup; abort if target branch already exists locally
- **`pr-merge-safe.sh`**: `git fetch origin` before staleness comparison so `MAIN_HEAD` is current, not a stale local ref
- **`check-stale-doc-refs.sh`**: replace `find` with `git ls-files` in non-staged mode — respects `.gitignore`, skips editor temp files
- **`gh-graphql.sh`**: add `jq` existence check at startup with a clear install hint
- **`.pre-commit-config.yaml` + `scripts/run-mypy-changed.sh`**: add `mypy-changed` hook (scoped to `models/`) synced from [Local-File-Organizer](https://github.com/curdriceaurora/Local-File-Organizer/blob/main/.pre-commit-config.yaml); web-only hooks (`pytest-websocket`, `pytest-web-ui`, `pytest-csrf-guardrails`) skipped as fo-core is CLI-only

## Test plan

- [ ] Run `bash .claude/scripts/pre-commit-validation.sh` on macOS (Bash 3.2) — should no longer fail with `mapfile: command not found`
- [ ] Run `bash .claude/scripts/cherry-pick-to-pr.sh existing-branch ...` — should abort before touching git state
- [ ] Verify `pre-commit run mypy-changed` fires only when `src/file_organizer/models/*.py` is staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added commit-time type-checking to run mypy on changed model files, improving pre-commit quality gates.
  * Included a small helper script to invoke mypy reliably in developer environments.
  * Updated ignore rules to exclude a runtime lock file used by scheduled tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->