### PR TITLE
test: restore main integration coverage floors

### DIFF
--- a/tests/integration/test_audio_video_services_batch4.py
+++ b/tests/integration/test_audio_video_services_batch4.py
@@ -1030,7 +1030,7 @@ class TestVideoMetadataExtractor:
         assert metadata.height == 360
         assert metadata.fps == 24.0
         assert metadata.duration == 10.0
-        cap.release.assert_called_once()
+        cap.release.assert_called_once_with()
 
     def test_try_opencv_returns_false_when_capture_not_opened(self, tmp_path: Path) -> None:
         from file_organizer.services.video.metadata_extractor import (
@@ -1050,7 +1050,7 @@ class TestVideoMetadataExtractor:
             ok = VideoMetadataExtractor()._try_opencv(fp, metadata)
 
         assert ok is False
-        cap.release.assert_called_once()
+        cap.release.assert_called_once_with()
 
     def test_try_opencv_exception_returns_false(self, tmp_path: Path) -> None:
         from file_organizer.services.video.metadata_extractor import (
@@ -1077,7 +1077,7 @@ class TestVideoMetadataExtractor:
             ok = VideoMetadataExtractor()._try_opencv(fp, metadata)
 
         assert ok is False
-        cap.release.assert_called_once()
+        cap.release.assert_called_once_with()
 
     def test_safe_float_invalid_returns_none(self) -> None:
         from file_organizer.services.video.metadata_extractor import _safe_float

--- a/tests/integration/test_audio_video_services_batch4.py
+++ b/tests/integration/test_audio_video_services_batch4.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -958,6 +959,130 @@ class TestVideoMetadataExtractor:
         assert metadata.creation_date is not None
         assert metadata.creation_date.year == 2024
         assert metadata.creation_date.month == 6
+
+    def test_extract_ffprobe_uses_format_duration_when_stream_duration_missing(
+        self, tmp_path: Path
+    ) -> None:
+        import json
+
+        from file_organizer.services.video.metadata_extractor import VideoMetadataExtractor
+
+        fp = tmp_path / "format-duration.mp4"
+        fp.write_bytes(b"\x00" * 2048)
+
+        probe_data = {
+            "streams": [
+                {
+                    "codec_type": "video",
+                    "width": 1280,
+                    "height": 720,
+                    "codec_name": "h265",
+                    "r_frame_rate": "not-a-fraction",
+                }
+            ],
+            "format": {
+                "duration": "42.5",
+                "bit_rate": "2500000",
+                "tags": {"date": "2024-06-15"},
+            },
+        }
+
+        mock_result = MagicMock(returncode=0, stdout=json.dumps(probe_data))
+
+        with patch("subprocess.run", return_value=mock_result):
+            metadata = VideoMetadataExtractor().extract(fp)
+
+        assert metadata.duration == 42.5
+        assert metadata.fps is None
+        assert metadata.creation_date is not None
+        assert metadata.creation_date.tzinfo == UTC
+
+    def test_extract_uses_opencv_when_ffprobe_fails(self, tmp_path: Path) -> None:
+        from file_organizer.services.video.metadata_extractor import VideoMetadataExtractor
+
+        fp = tmp_path / "opencv.mp4"
+        fp.write_bytes(b"\x00" * 1024)
+
+        cap = MagicMock()
+        cap.isOpened.return_value = True
+        cap.get.side_effect = lambda prop: {
+            3: 640,
+            4: 360,
+            5: 24.0,
+            7: 240.0,
+        }[prop]
+
+        fake_cv2 = SimpleNamespace(
+            CAP_PROP_FRAME_WIDTH=3,
+            CAP_PROP_FRAME_HEIGHT=4,
+            CAP_PROP_FPS=5,
+            CAP_PROP_FRAME_COUNT=7,
+            VideoCapture=MagicMock(return_value=cap),
+        )
+
+        with (
+            patch("subprocess.run", return_value=MagicMock(returncode=1)),
+            patch.dict("sys.modules", {"cv2": fake_cv2}),
+        ):
+            metadata = VideoMetadataExtractor().extract(fp)
+
+        assert metadata.width == 640
+        assert metadata.height == 360
+        assert metadata.fps == 24.0
+        assert metadata.duration == 10.0
+        cap.release.assert_called_once()
+
+    def test_try_opencv_returns_false_when_capture_not_opened(self, tmp_path: Path) -> None:
+        from file_organizer.services.video.metadata_extractor import (
+            VideoMetadata,
+            VideoMetadataExtractor,
+        )
+
+        fp = tmp_path / "closed.mp4"
+        fp.write_bytes(b"\x00")
+        metadata = VideoMetadata(file_path=fp, file_size=1, format="mp4")
+
+        cap = MagicMock()
+        cap.isOpened.return_value = False
+        fake_cv2 = SimpleNamespace(VideoCapture=MagicMock(return_value=cap))
+
+        with patch.dict("sys.modules", {"cv2": fake_cv2}):
+            ok = VideoMetadataExtractor()._try_opencv(fp, metadata)
+
+        assert ok is False
+        cap.release.assert_called_once()
+
+    def test_try_opencv_exception_returns_false(self, tmp_path: Path) -> None:
+        from file_organizer.services.video.metadata_extractor import (
+            VideoMetadata,
+            VideoMetadataExtractor,
+        )
+
+        fp = tmp_path / "broken.mp4"
+        fp.write_bytes(b"\x00")
+        metadata = VideoMetadata(file_path=fp, file_size=1, format="mp4")
+
+        cap = MagicMock()
+        cap.isOpened.return_value = True
+        cap.get.side_effect = RuntimeError("capture failed")
+        fake_cv2 = SimpleNamespace(
+            CAP_PROP_FRAME_WIDTH=3,
+            CAP_PROP_FRAME_HEIGHT=4,
+            CAP_PROP_FPS=5,
+            CAP_PROP_FRAME_COUNT=7,
+            VideoCapture=MagicMock(return_value=cap),
+        )
+
+        with patch.dict("sys.modules", {"cv2": fake_cv2}):
+            ok = VideoMetadataExtractor()._try_opencv(fp, metadata)
+
+        assert ok is False
+        cap.release.assert_called_once()
+
+    def test_safe_float_invalid_returns_none(self) -> None:
+        from file_organizer.services.video.metadata_extractor import _safe_float
+
+        assert _safe_float("not-a-float") is None
 
     def test_resolution_label_4k(self) -> None:
         from file_organizer.services.video.metadata_extractor import resolution_label

--- a/tests/integration/test_copilot_executor.py
+++ b/tests/integration/test_copilot_executor.py
@@ -7,6 +7,7 @@ Covers:
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -225,3 +226,29 @@ class TestCommandExecutorExecute:
         )
         result = executor.execute(intent)
         assert isinstance(result, ExecutionResult)
+
+    def test_execute_find_retriever_setup_index_error_falls_back(
+        self, executor: CommandExecutor, tmp_path: Path
+    ) -> None:
+        alpha = tmp_path / "alpha.txt"
+        alpha.write_text("hello", encoding="utf-8")
+
+        with patch.object(
+            executor,
+            "_build_retriever_for_root",
+            side_effect=IndexError("boom"),
+        ) as mock_build:
+            result = executor.execute(
+                Intent(
+                    intent_type=IntentType.FIND,
+                    confidence=0.9,
+                    parameters={"query": "alpha", "paths": [str(tmp_path)]},
+                )
+            )
+
+        mock_build.assert_called_once_with(tmp_path)
+        assert result == ExecutionResult(
+            success=True,
+            message=f"Found 1 file(s) matching 'alpha':\n  - {alpha}",
+            affected_files=[str(alpha)],
+        )

--- a/tests/integration/test_dedup_backup.py
+++ b/tests/integration/test_dedup_backup.py
@@ -102,7 +102,7 @@ class TestBackupManagerCreate:
     def test_create_backup_directory_path_raises(
         self, backup_mgr: BackupManager, tmp_path: Path
     ) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Path is not a file"):
             backup_mgr.create_backup(tmp_path)
 
 
@@ -279,8 +279,9 @@ class TestBackupManagerManifest:
         manifest[str(backup_path)]["backup_time"] = "2000-01-01T00:00:00Z"
         backup_mgr.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
-        with patch.object(Path, "unlink", side_effect=OSError("busy")):
+        with patch.object(Path, "unlink", side_effect=OSError("busy")) as mock_unlink:
             removed = backup_mgr.cleanup_old_backups(max_age_days=1)
 
+        mock_unlink.assert_called_once_with()
         assert removed == []
         assert backup_mgr._load_manifest() == {}

--- a/tests/integration/test_dedup_backup.py
+++ b/tests/integration/test_dedup_backup.py
@@ -6,7 +6,9 @@ Covers:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -90,6 +92,18 @@ class TestBackupManagerCreate:
         # Should create two separate backups
         assert b1.exists()
         assert b2.exists()
+
+    def test_create_backup_missing_source_raises(
+        self, backup_mgr: BackupManager, tmp_path: Path
+    ) -> None:
+        with pytest.raises(FileNotFoundError):
+            backup_mgr.create_backup(tmp_path / "missing.txt")
+
+    def test_create_backup_directory_path_raises(
+        self, backup_mgr: BackupManager, tmp_path: Path
+    ) -> None:
+        with pytest.raises(ValueError):
+            backup_mgr.create_backup(tmp_path)
 
 
 # ---------------------------------------------------------------------------
@@ -190,6 +204,22 @@ class TestBackupManagerVerify:
         # Healthy backups should produce empty list (no errors)
         assert result == []
 
+    def test_verify_reports_missing_and_size_mismatch(
+        self, backup_mgr: BackupManager, tmp_path: Path
+    ) -> None:
+        first = _make_file(tmp_path / "first.txt", b"one")
+        second = _make_file(tmp_path / "second.txt", b"two")
+        first_backup = backup_mgr.create_backup(first)
+        second_backup = backup_mgr.create_backup(second)
+
+        first_backup.unlink()
+        second_backup.write_bytes(b"changed-size")
+
+        issues = backup_mgr.verify_backups()
+
+        assert any("Missing:" in issue for issue in issues)
+        assert any("Size mismatch:" in issue for issue in issues)
+
 
 # ---------------------------------------------------------------------------
 # BackupManager — get_statistics
@@ -232,3 +262,25 @@ class TestBackupManagerCleanup:
         removed = backup_mgr.cleanup_old_backups(max_age_days=365)
         # Recent backups should not be removed
         assert len(removed) == 0
+
+
+class TestBackupManagerManifest:
+    def test_load_manifest_corrupt_json_returns_empty(self, backup_mgr: BackupManager) -> None:
+        backup_mgr.manifest_path.write_text("{not-json", encoding="utf-8")
+
+        assert backup_mgr._load_manifest() == {}
+
+    def test_cleanup_old_backups_ignores_unlink_errors(
+        self, backup_mgr: BackupManager, tmp_path: Path
+    ) -> None:
+        source = _make_file(tmp_path / "old.txt", b"stale")
+        backup_path = backup_mgr.create_backup(source)
+        manifest = backup_mgr._load_manifest()
+        manifest[str(backup_path)]["backup_time"] = "2000-01-01T00:00:00Z"
+        backup_mgr.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        with patch.object(Path, "unlink", side_effect=OSError("busy")):
+            removed = backup_mgr.cleanup_old_backups(max_age_days=1)
+
+        assert removed == []
+        assert backup_mgr._load_manifest() == {}

--- a/tests/integration/test_dedup_viewer.py
+++ b/tests/integration/test_dedup_viewer.py
@@ -47,6 +47,26 @@ def test_comparison_viewer_interactive_select_specific(
 
 
 @patch("file_organizer.services.deduplication.viewer.Prompt.ask")
+def test_comparison_viewer_interactive_select_ignores_invalid_entries(
+    mock_ask: MagicMock, duplicate_images: list[Path]
+) -> None:
+    mock_ask.return_value = "1,invalid,9"
+    viewer = ComparisonViewer()
+    selected = viewer.interactive_select(duplicate_images)
+    assert selected == [duplicate_images[0]]
+
+
+@patch("file_organizer.services.deduplication.viewer.Prompt.ask")
+def test_comparison_viewer_interactive_select_none(
+    mock_ask: MagicMock, duplicate_images: list[Path]
+) -> None:
+    mock_ask.return_value = "none"
+    viewer = ComparisonViewer()
+    selected = viewer.interactive_select(duplicate_images)
+    assert selected == []
+
+
+@patch("file_organizer.services.deduplication.viewer.Prompt.ask")
 def test_comparison_viewer_show_comparison_auto(
     mock_ask: MagicMock, duplicate_images: list[Path]
 ) -> None:

--- a/tests/integration/test_dedup_viewer.py
+++ b/tests/integration/test_dedup_viewer.py
@@ -54,6 +54,7 @@ def test_comparison_viewer_interactive_select_ignores_invalid_entries(
     viewer = ComparisonViewer()
     selected = viewer.interactive_select(duplicate_images)
     assert selected == [duplicate_images[0]]
+    mock_ask.assert_called_once_with("Your selection", default="all")
 
 
 @patch("file_organizer.services.deduplication.viewer.Prompt.ask")
@@ -64,6 +65,7 @@ def test_comparison_viewer_interactive_select_none(
     viewer = ComparisonViewer()
     selected = viewer.interactive_select(duplicate_images)
     assert selected == []
+    mock_ask.assert_called_once_with("Your selection", default="all")
 
 
 @patch("file_organizer.services.deduplication.viewer.Prompt.ask")

--- a/tests/integration/test_optimization_core.py
+++ b/tests/integration/test_optimization_core.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
@@ -956,6 +957,63 @@ class TestMemoryLimiter:
         limiter = MemoryLimiter(max_memory_mb=999_999, action=LimitAction.WARN)
         limiter.enforce()
         assert limiter.violation_count == 0
+
+    def test_guarded_context_manager_raises_on_exit(self) -> None:
+        from file_organizer.optimization.memory_limiter import (
+            LimitAction,
+            MemoryLimiter,
+            MemoryLimitError,
+        )
+
+        limiter = MemoryLimiter(max_memory_mb=1, action=LimitAction.RAISE)
+        rss_values = iter([0, 2 * 1024 * 1024])
+
+        with patch.object(type(limiter), "_get_rss", staticmethod(lambda: next(rss_values))):
+            with pytest.raises(MemoryLimitError):
+                with limiter.guarded():
+                    pass
+
+    def test_get_rss_reads_proc_status(self) -> None:
+        from file_organizer.optimization.memory_limiter import MemoryLimiter
+
+        with patch("builtins.open", mock_open(read_data="VmRSS:\t2048 kB\n")):
+            rss = MemoryLimiter._get_rss()
+
+        assert rss == 2048 * 1024
+
+    def test_get_rss_uses_resource_module_on_darwin(self) -> None:
+        from file_organizer.optimization.memory_limiter import MemoryLimiter
+
+        fake_usage = SimpleNamespace(ru_maxrss=4096)
+        fake_resource = SimpleNamespace(RUSAGE_SELF=1, getrusage=MagicMock(return_value=fake_usage))
+
+        with (
+            patch("builtins.open", side_effect=FileNotFoundError),
+            patch("sys.platform", "darwin"),
+            patch.dict("sys.modules", {"resource": fake_resource}),
+        ):
+            rss = MemoryLimiter._get_rss()
+
+        assert rss == 4096
+
+    def test_get_rss_returns_zero_when_proc_and_resource_unavailable(self) -> None:
+        from file_organizer.optimization.memory_limiter import MemoryLimiter
+
+        import_error = ImportError("no resource")
+        original_import = __import__
+
+        def _import_side_effect(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "resource":
+                raise import_error
+            return original_import(name, *args, **kwargs)
+
+        with (
+            patch("builtins.open", side_effect=FileNotFoundError),
+            patch("builtins.__import__", side_effect=_import_side_effect),
+        ):
+            rss = MemoryLimiter._get_rss()
+
+        assert rss == 0
 
 
 # ===========================================================================

--- a/tests/integration/test_optimization_core.py
+++ b/tests/integration/test_optimization_core.py
@@ -995,6 +995,7 @@ class TestMemoryLimiter:
             rss = MemoryLimiter._get_rss()
 
         assert rss == 4096
+        fake_resource.getrusage.assert_called_once_with(fake_resource.RUSAGE_SELF)
 
     def test_get_rss_returns_zero_when_proc_and_resource_unavailable(self) -> None:
         from file_organizer.optimization.memory_limiter import MemoryLimiter
@@ -1002,7 +1003,7 @@ class TestMemoryLimiter:
         import_error = ImportError("no resource")
         original_import = __import__
 
-        def _import_side_effect(name: str, *args: Any, **kwargs: Any) -> Any:
+        def _import_side_effect(name: str, *args: object, **kwargs: object) -> Any:
             if name == "resource":
                 raise import_error
             return original_import(name, *args, **kwargs)

--- a/tests/integration/test_services_search.py
+++ b/tests/integration/test_services_search.py
@@ -14,7 +14,7 @@ Covers:
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -205,6 +205,22 @@ class TestHybridRetriever:
         results = r.retrieve("quick fox", top_k=5)
         assert isinstance(results, list)
         assert all(isinstance(p, Path) and isinstance(s, float) for p, s in results)
+
+    def test_vector_index_value_error_falls_back_to_bm25_only(self, tmp_path: Path) -> None:
+        r = self._make_retriever()
+        docs = ["finance budget report", "meeting summary notes"]
+        paths = [tmp_path / "finance.txt", tmp_path / "meeting.txt"]
+
+        with patch(
+            "file_organizer.services.search.hybrid_retriever.VectorIndex.index",
+            side_effect=ValueError("vectorizer rejected corpus"),
+        ):
+            r.index(docs, paths)
+
+        assert r.is_initialized is True
+        assert r.corpus_size == 2
+        assert r._vector.size == 0
+        assert r._bm25.size == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_services_search.py
+++ b/tests/integration/test_services_search.py
@@ -214,13 +214,14 @@ class TestHybridRetriever:
         with patch(
             "file_organizer.services.search.hybrid_retriever.VectorIndex.index",
             side_effect=ValueError("vectorizer rejected corpus"),
-        ):
+        ) as mock_vector_index:
             r.index(docs, paths)
 
         assert r.is_initialized is True
         assert r.corpus_size == 2
         assert r._vector.size == 0
         assert r._bm25.size == 2
+        mock_vector_index.assert_called_once_with(docs, paths)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_watcher_updater_core_daemon.py
+++ b/tests/integration/test_watcher_updater_core_daemon.py
@@ -10,6 +10,7 @@ import io
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1515,11 +1516,18 @@ class TestDetectHardware:
 
         assert cores == 12
 
-    def test_get_system_ram_returns_non_negative(self) -> None:
+    def test_get_system_ram_uses_psutil_when_available(self) -> None:
         from file_organizer.core.hardware_profile import _get_system_ram
 
-        ram = _get_system_ram()
-        assert ram >= 0
+        fake_psutil = SimpleNamespace(
+            virtual_memory=MagicMock(return_value=SimpleNamespace(total=32 * 1024**3))
+        )
+
+        with patch.dict("sys.modules", {"psutil": fake_psutil}):
+            ram = _get_system_ram()
+
+        assert ram == 32 * 1024**3
+        fake_psutil.virtual_memory.assert_called_once_with()
 
     def test_get_system_ram_darwin_fallback_uses_sysctl(self) -> None:
         from file_organizer.core.hardware_profile import _get_system_ram
@@ -1581,6 +1589,9 @@ class TestDetectHardware:
                 return_value=("Apple M2 Pro", 32 * 1024**3),
             ),
             patch(
+                "file_organizer.core.hardware_profile._detect_amd", return_value=("unused", 1)
+            ) as mock_detect_amd,
+            patch(
                 "file_organizer.core.hardware_profile._get_system_ram", return_value=32 * 1024**3
             ),
             patch("file_organizer.core.hardware_profile._get_cpu_cores", return_value=10),
@@ -1591,6 +1602,8 @@ class TestDetectHardware:
 
         assert profile.gpu_type == GpuType.APPLE_MPS
         assert profile.gpu_name == "Apple M2 Pro"
+        assert profile.vram_bytes == 32 * 1024**3
+        mock_detect_amd.assert_not_called()
 
     def test_detect_hardware_amd_detected(self) -> None:
         from file_organizer.core.hardware_profile import GpuType, detect_hardware
@@ -1601,7 +1614,7 @@ class TestDetectHardware:
             patch(
                 "file_organizer.core.hardware_profile._detect_amd",
                 return_value=("Radeon 7900", 24 * 1024**3),
-            ),
+            ) as mock_detect_amd,
             patch(
                 "file_organizer.core.hardware_profile._get_system_ram", return_value=64 * 1024**3
             ),
@@ -1613,6 +1626,8 @@ class TestDetectHardware:
 
         assert profile.gpu_type == GpuType.AMD
         assert profile.gpu_name == "Radeon 7900"
+        assert profile.vram_bytes == 24 * 1024**3
+        mock_detect_amd.assert_called_once_with()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_watcher_updater_core_daemon.py
+++ b/tests/integration/test_watcher_updater_core_daemon.py
@@ -6,6 +6,7 @@ Target: ≥80% integration coverage for each module.
 
 from __future__ import annotations
 
+import io
 import threading
 import time
 from pathlib import Path
@@ -1459,17 +1460,159 @@ class TestDetectHardware:
 
         assert name is None
 
+    def test_detect_apple_mps_darwin_apple_chip_returns_unified_memory(self) -> None:
+        from file_organizer.core.hardware_profile import _detect_apple_mps
+
+        brand_result = MagicMock(returncode=0, stdout="Apple M3 Max")
+        mem_result = MagicMock(returncode=0, stdout="68719476736")
+
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch("subprocess.run", side_effect=[brand_result, mem_result]),
+        ):
+            name, vram = _detect_apple_mps()
+
+        assert name == "Apple M3 Max"
+        assert vram == 68719476736
+
+    def test_detect_apple_mps_darwin_subprocess_error_returns_none(self) -> None:
+        from file_organizer.core.hardware_profile import _detect_apple_mps
+
+        with (
+            patch("platform.system", return_value="Darwin"),
+            patch("subprocess.run", side_effect=FileNotFoundError("sysctl missing")),
+        ):
+            name, vram = _detect_apple_mps()
+
+        assert name is None
+        assert vram == 0
+
+    def test_detect_nvidia_malformed_output_returns_none(self) -> None:
+        from file_organizer.core.hardware_profile import _detect_nvidia
+
+        malformed = MagicMock(returncode=0, stdout="Tesla T4 only")
+
+        with patch("subprocess.run", return_value=malformed):
+            name, vram = _detect_nvidia()
+
+        assert name is None
+        assert vram == 0
+
     def test_get_cpu_cores_returns_positive(self) -> None:
         from file_organizer.core.hardware_profile import _get_cpu_cores
 
         cores = _get_cpu_cores()
         assert cores >= 1
 
+    def test_get_cpu_cores_importerror_falls_back_to_os_cpu_count(self) -> None:
+        from file_organizer.core.hardware_profile import _get_cpu_cores
+
+        with (
+            patch.dict("sys.modules", {"psutil": None}),
+            patch("os.cpu_count", return_value=12),
+        ):
+            cores = _get_cpu_cores()
+
+        assert cores == 12
+
     def test_get_system_ram_returns_non_negative(self) -> None:
         from file_organizer.core.hardware_profile import _get_system_ram
 
         ram = _get_system_ram()
         assert ram >= 0
+
+    def test_get_system_ram_darwin_fallback_uses_sysctl(self) -> None:
+        from file_organizer.core.hardware_profile import _get_system_ram
+
+        sysctl_result = MagicMock(returncode=0, stdout="17179869184")
+
+        with (
+            patch.dict("sys.modules", {"psutil": None}),
+            patch("platform.system", return_value="Darwin"),
+            patch("subprocess.run", return_value=sysctl_result),
+        ):
+            ram = _get_system_ram()
+
+        assert ram == 17179869184
+
+    def test_get_system_ram_linux_proc_meminfo_fallback(self) -> None:
+        from file_organizer.core.hardware_profile import _get_system_ram
+
+        with (
+            patch.dict("sys.modules", {"psutil": None}),
+            patch("platform.system", return_value="Linux"),
+            patch("builtins.open", return_value=io.StringIO("MemTotal: 2048 kB\n")),
+        ):
+            ram = _get_system_ram()
+
+        assert ram == 2048 * 1024
+
+    def test_detect_amd_default_name_with_missing_rows(self) -> None:
+        from file_organizer.core.hardware_profile import _detect_amd
+
+        name_result = MagicMock(returncode=0, stdout="GPU,Name\n")
+        mem_result = MagicMock(returncode=0, stdout="VRAM\n")
+
+        with patch("subprocess.run", side_effect=[name_result, mem_result]):
+            name, vram = _detect_amd()
+
+        assert name == "AMD GPU"
+        assert vram == 0
+
+    def test_detect_amd_invalid_vram_keeps_name_and_zero_vram(self) -> None:
+        from file_organizer.core.hardware_profile import _detect_amd
+
+        name_result = MagicMock(returncode=0, stdout="GPU,Name\nRadeon Pro,foo\n")
+        mem_result = MagicMock(returncode=0, stdout="VRAM\nnot-a-number,foo\n")
+
+        with patch("subprocess.run", side_effect=[name_result, mem_result]):
+            name, vram = _detect_amd()
+
+        assert name == "Radeon Pro"
+        assert vram == 0
+
+    def test_detect_hardware_apple_mps_detected(self) -> None:
+        from file_organizer.core.hardware_profile import GpuType, detect_hardware
+
+        with (
+            patch("file_organizer.core.hardware_profile._detect_nvidia", return_value=(None, 0)),
+            patch(
+                "file_organizer.core.hardware_profile._detect_apple_mps",
+                return_value=("Apple M2 Pro", 32 * 1024**3),
+            ),
+            patch(
+                "file_organizer.core.hardware_profile._get_system_ram", return_value=32 * 1024**3
+            ),
+            patch("file_organizer.core.hardware_profile._get_cpu_cores", return_value=10),
+            patch("platform.system", return_value="Darwin"),
+            patch("platform.machine", return_value="arm64"),
+        ):
+            profile = detect_hardware()
+
+        assert profile.gpu_type == GpuType.APPLE_MPS
+        assert profile.gpu_name == "Apple M2 Pro"
+
+    def test_detect_hardware_amd_detected(self) -> None:
+        from file_organizer.core.hardware_profile import GpuType, detect_hardware
+
+        with (
+            patch("file_organizer.core.hardware_profile._detect_nvidia", return_value=(None, 0)),
+            patch("file_organizer.core.hardware_profile._detect_apple_mps", return_value=(None, 0)),
+            patch(
+                "file_organizer.core.hardware_profile._detect_amd",
+                return_value=("Radeon 7900", 24 * 1024**3),
+            ),
+            patch(
+                "file_organizer.core.hardware_profile._get_system_ram", return_value=64 * 1024**3
+            ),
+            patch("file_organizer.core.hardware_profile._get_cpu_cores", return_value=16),
+            patch("platform.system", return_value="Linux"),
+            patch("platform.machine", return_value="x86_64"),
+        ):
+            profile = detect_hardware()
+
+        assert profile.gpu_type == GpuType.AMD
+        assert profile.gpu_name == "Radeon 7900"
 
 
 # ---------------------------------------------------------------------------
@@ -1623,6 +1766,17 @@ class TestDaemonSchedulerRunning:
 
         scheduler = DaemonScheduler()
         assert scheduler.task_names == []
+
+    def test_tick_skips_task_when_interval_not_elapsed(self) -> None:
+        from file_organizer.daemon.scheduler import DaemonScheduler
+
+        callback = MagicMock()
+        scheduler = DaemonScheduler()
+        scheduler.schedule_task("later", 60.0, callback)
+        scheduler._tasks["later"].last_run = time.monotonic()
+        scheduler._tick()
+
+        callback.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/utils/readers/test_archives_reader.py
+++ b/tests/integration/utils/readers/test_archives_reader.py
@@ -16,7 +16,7 @@ import tarfile
 import zipfile
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -265,7 +265,7 @@ class TestRead7zMockedPaths:
         try:
             archives.PY7ZR_AVAILABLE = True
             archives.py7zr = SimpleNamespace(
-                SevenZipFile=lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("bad 7z"))
+                SevenZipFile=MagicMock(side_effect=OSError("bad 7z")),
             )
             with pytest.raises(FileReadError):
                 read_7z_file(path)

--- a/tests/integration/utils/readers/test_archives_reader.py
+++ b/tests/integration/utils/readers/test_archives_reader.py
@@ -232,9 +232,10 @@ class TestRead7zMockedPaths:
         sentinel = object()
         original_py7zr = getattr(archives, "py7zr", sentinel)
         original_available = archives.PY7ZR_AVAILABLE
+        seven_zip_ctor = MagicMock(return_value=FakeArchive())
         try:
             archives.PY7ZR_AVAILABLE = True
-            archives.py7zr = SimpleNamespace(SevenZipFile=lambda *_args, **_kwargs: FakeArchive())
+            archives.py7zr = SimpleNamespace(SevenZipFile=seven_zip_ctor)
             result = read_7z_file(path, max_files=2)
         finally:
             archives.PY7ZR_AVAILABLE = original_available
@@ -243,6 +244,7 @@ class TestRead7zMockedPaths:
             else:
                 archives.py7zr = original_py7zr
 
+        seven_zip_ctor.assert_called_once_with(path, "r")
         assert "7Z Archive: mocked.7z" in result
         assert "Encrypted: Yes" in result
         assert "a.txt" in result
@@ -262,11 +264,10 @@ class TestRead7zMockedPaths:
         sentinel = object()
         original_py7zr = getattr(archives, "py7zr", sentinel)
         original_available = archives.PY7ZR_AVAILABLE
+        seven_zip_ctor = MagicMock(side_effect=OSError("bad 7z"))
         try:
             archives.PY7ZR_AVAILABLE = True
-            archives.py7zr = SimpleNamespace(
-                SevenZipFile=MagicMock(side_effect=OSError("bad 7z")),
-            )
+            archives.py7zr = SimpleNamespace(SevenZipFile=seven_zip_ctor)
             with pytest.raises(FileReadError):
                 read_7z_file(path)
         finally:
@@ -275,6 +276,8 @@ class TestRead7zMockedPaths:
                 del archives.py7zr
             else:
                 archives.py7zr = original_py7zr
+
+        seven_zip_ctor.assert_called_once_with(path, "r")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/utils/readers/test_archives_reader.py
+++ b/tests/integration/utils/readers/test_archives_reader.py
@@ -15,6 +15,7 @@ import io
 import tarfile
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -194,6 +195,86 @@ class TestRead7zImportError:
         with patch.object(archives, "PY7ZR_AVAILABLE", False):
             with pytest.raises(ImportError, match="py7zr"):
                 read_7z_file(tmp_path / "dummy.7z")
+
+
+class TestRead7zMockedPaths:
+    def test_mocked_success_without_py7zr_dependency(self, tmp_path: Path) -> None:
+        from file_organizer.utils.readers import archives
+        from file_organizer.utils.readers.archives import read_7z_file
+
+        path = tmp_path / "mocked.7z"
+        path.write_bytes(b"7z placeholder")
+
+        class FakeEntry:
+            def __init__(
+                self, filename: str, compressed: int | None, uncompressed: int | None
+            ) -> None:
+                self.filename = filename
+                self.compressed = compressed
+                self.uncompressed = uncompressed
+
+        class FakeArchive:
+            password_protected = True
+
+            def __enter__(self) -> FakeArchive:
+                return self
+
+            def __exit__(self, exc_type, exc, tb) -> bool:
+                return False
+
+            def list(self) -> list[FakeEntry]:
+                return [
+                    FakeEntry("a.txt", 100, 200),
+                    FakeEntry("b.txt", None, 300),
+                    FakeEntry("c.txt", 50, None),
+                ]
+
+        sentinel = object()
+        original_py7zr = getattr(archives, "py7zr", sentinel)
+        original_available = archives.PY7ZR_AVAILABLE
+        try:
+            archives.PY7ZR_AVAILABLE = True
+            archives.py7zr = SimpleNamespace(SevenZipFile=lambda *_args, **_kwargs: FakeArchive())
+            result = read_7z_file(path, max_files=2)
+        finally:
+            archives.PY7ZR_AVAILABLE = original_available
+            if original_py7zr is sentinel:
+                del archives.py7zr
+            else:
+                archives.py7zr = original_py7zr
+
+        assert "7Z Archive: mocked.7z" in result
+        assert "Encrypted: Yes" in result
+        assert "a.txt" in result
+        assert "b.txt" in result
+        assert "and 1 more files" in result
+
+    def test_mocked_error_without_py7zr_dependency_raises_file_read_error(
+        self, tmp_path: Path
+    ) -> None:
+        from file_organizer.utils.readers import archives
+        from file_organizer.utils.readers._base import FileReadError
+        from file_organizer.utils.readers.archives import read_7z_file
+
+        path = tmp_path / "broken.7z"
+        path.write_bytes(b"7z placeholder")
+
+        sentinel = object()
+        original_py7zr = getattr(archives, "py7zr", sentinel)
+        original_available = archives.PY7ZR_AVAILABLE
+        try:
+            archives.PY7ZR_AVAILABLE = True
+            archives.py7zr = SimpleNamespace(
+                SevenZipFile=lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("bad 7z"))
+            )
+            with pytest.raises(FileReadError):
+                read_7z_file(path)
+        finally:
+            archives.PY7ZR_AVAILABLE = original_available
+            if original_py7zr is sentinel:
+                del archives.py7zr
+            else:
+                archives.py7zr = original_py7zr
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/utils/readers/test_cad_reader.py
+++ b/tests/integration/utils/readers/test_cad_reader.py
@@ -14,7 +14,8 @@ Covers:
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -322,9 +323,6 @@ class TestReadDxfFile:
         """Exercise read_dxf_file using a fully mocked ezdxf document."""
         from file_organizer.utils.readers import cad as cad_module
 
-        if not cad_module.EZDXF_AVAILABLE:
-            pytest.skip("ezdxf not installed")
-
         path = tmp_path / "mocked.dxf"
         path.write_text("placeholder")
 
@@ -346,17 +344,79 @@ class TestReadDxfFile:
         mock_doc.modelspace.return_value = [mock_entity]
         mock_doc.blocks = []
 
+        sentinel = object()
+        original_ezdxf = getattr(cad_module, "ezdxf", sentinel)
         original = cad_module.EZDXF_AVAILABLE
         try:
             cad_module.EZDXF_AVAILABLE = True
-            with patch.object(cad_module.ezdxf, "readfile", return_value=mock_doc):
-                result = cad_module.read_dxf_file(path)
+            cad_module.ezdxf = SimpleNamespace(readfile=MagicMock(return_value=mock_doc))
+            result = cad_module.read_dxf_file(path, max_layers=1)
         finally:
             cad_module.EZDXF_AVAILABLE = original
+            if original_ezdxf is sentinel:
+                del cad_module.ezdxf
+            else:
+                cad_module.ezdxf = original_ezdxf
 
-        assert "DXF Version" in result
-        assert "AC1015" in result
-        assert "LINE" in result
+        assert "=== DXF Document Metadata ===" in result
+        assert "Title: Test Drawing" in result
+        assert "Author: TestUser" in result
+        assert "=== Layers (1 total) ===" in result
+        assert "Layer: 0 (Color: 7)" in result
+        assert "=== Entities ===" in result
+        assert "Total entities: 1" in result
+        assert "LINE: 1" in result
+
+    def test_dxf_mocked_blocks_and_layer_truncation_without_ezdxf_dependency(
+        self, tmp_path: Path
+    ) -> None:
+        from file_organizer.utils.readers import cad as cad_module
+
+        path = tmp_path / "mocked_blocks.dxf"
+        path.write_text("placeholder")
+
+        mock_layers = []
+        for idx in range(3):
+            layer = MagicMock()
+            layer.dxf.name = f"Layer{idx}"
+            layer.dxf.color = idx + 1
+            mock_layers.append(layer)
+
+        mock_entities = [MagicMock(), MagicMock()]
+        mock_entities[0].dxftype.return_value = "LINE"
+        mock_entities[1].dxftype.return_value = "CIRCLE"
+
+        user_block = MagicMock()
+        user_block.name = "TitleBlock"
+        internal_block = MagicMock()
+        internal_block.name = "*Model_Space"
+
+        mock_doc = MagicMock()
+        mock_doc.dxfversion = "AC1018"
+        mock_doc.header.get.side_effect = lambda key, default="": {"$TITLE": ""}.get(key, default)
+        mock_doc.layers = mock_layers
+        mock_doc.modelspace.return_value = mock_entities
+        mock_doc.blocks = [user_block, internal_block]
+
+        sentinel = object()
+        original_ezdxf = getattr(cad_module, "ezdxf", sentinel)
+        original_available = cad_module.EZDXF_AVAILABLE
+        try:
+            cad_module.EZDXF_AVAILABLE = True
+            cad_module.ezdxf = SimpleNamespace(readfile=MagicMock(return_value=mock_doc))
+            result = cad_module.read_dxf_file(path, max_layers=2)
+        finally:
+            cad_module.EZDXF_AVAILABLE = original_available
+            if original_ezdxf is sentinel:
+                del cad_module.ezdxf
+            else:
+                cad_module.ezdxf = original_ezdxf
+
+        assert "DXF Version: AC1018" in result
+        assert "... and 1 more layers" in result
+        assert "LINE: 1" in result
+        assert "CIRCLE: 1" in result
+        assert "Block definitions: 1" in result
 
 
 # ---------------------------------------------------------------------------
@@ -382,23 +442,24 @@ class TestReadDwgFile:
         """When ezdxf cannot parse the DWG, fallback metadata is returned."""
         from file_organizer.utils.readers import cad as cad_module
 
-        if not cad_module.EZDXF_AVAILABLE:
-            pytest.skip("ezdxf not installed")
-
         path = tmp_path / "unknown.dwg"
         path.write_bytes(b"NOT A REAL DWG FILE CONTENT")
 
+        sentinel = object()
+        original_ezdxf = getattr(cad_module, "ezdxf", sentinel)
         original = cad_module.EZDXF_AVAILABLE
         try:
             cad_module.EZDXF_AVAILABLE = True
-            with patch.object(
-                cad_module.ezdxf,
-                "readfile",
-                side_effect=Exception("Cannot parse DWG"),
-            ):
-                result = cad_module.read_dwg_file(path)
+            cad_module.ezdxf = SimpleNamespace(
+                readfile=MagicMock(side_effect=Exception("Cannot parse DWG"))
+            )
+            result = cad_module.read_dwg_file(path)
         finally:
             cad_module.EZDXF_AVAILABLE = original
+            if original_ezdxf is sentinel:
+                del cad_module.ezdxf
+            else:
+                cad_module.ezdxf = original_ezdxf
 
         assert "DWG File Information" in result
         assert "unknown.dwg" in result
@@ -409,23 +470,70 @@ class TestReadDwgFile:
         from file_organizer.utils.readers import cad as cad_module
         from file_organizer.utils.readers._base import FileReadError
 
-        if not cad_module.EZDXF_AVAILABLE:
-            pytest.skip("ezdxf not installed")
-
         path = tmp_path / "ghost.dwg"
 
+        sentinel = object()
+        original_ezdxf = getattr(cad_module, "ezdxf", sentinel)
         original = cad_module.EZDXF_AVAILABLE
         try:
             cad_module.EZDXF_AVAILABLE = True
-            with patch.object(
-                cad_module.ezdxf,
-                "readfile",
-                side_effect=Exception("Cannot parse"),
-            ):
-                with pytest.raises(FileReadError):
-                    cad_module.read_dwg_file(path)
+            cad_module.ezdxf = SimpleNamespace(
+                readfile=MagicMock(side_effect=Exception("Cannot parse"))
+            )
+            with pytest.raises(FileReadError):
+                cad_module.read_dwg_file(path)
         finally:
             cad_module.EZDXF_AVAILABLE = original
+            if original_ezdxf is sentinel:
+                del cad_module.ezdxf
+            else:
+                cad_module.ezdxf = original_ezdxf
+
+    def test_dwg_mocked_ezdxf_success_without_dependency(self, tmp_path: Path) -> None:
+        from file_organizer.utils.readers import cad as cad_module
+
+        path = tmp_path / "mocked.dwg"
+        path.write_bytes(b"dwg-placeholder")
+
+        layer = MagicMock()
+        layer.dxf.name = "Model"
+        layer.dxf.color = 2
+
+        entity = MagicMock()
+        entity.dxftype.return_value = "ARC"
+
+        block = MagicMock()
+        block.name = "Detail"
+
+        mock_doc = MagicMock()
+        mock_doc.dxfversion = "AC1024"
+        mock_doc.header.get.side_effect = lambda key, default="": {
+            "$TITLE": "DWG Mock",
+            "$AUTHOR": "CADUser",
+        }.get(key, default)
+        mock_doc.layers = [layer]
+        mock_doc.modelspace.return_value = [entity]
+        mock_doc.blocks = [block]
+
+        sentinel = object()
+        original_ezdxf = getattr(cad_module, "ezdxf", sentinel)
+        original_available = cad_module.EZDXF_AVAILABLE
+        try:
+            cad_module.EZDXF_AVAILABLE = True
+            cad_module.ezdxf = SimpleNamespace(readfile=MagicMock(return_value=mock_doc))
+            result = cad_module.read_dwg_file(path)
+        finally:
+            cad_module.EZDXF_AVAILABLE = original_available
+            if original_ezdxf is sentinel:
+                del cad_module.ezdxf
+            else:
+                cad_module.ezdxf = original_ezdxf
+
+        assert "Title: DWG Mock" in result
+        assert "Author: CADUser" in result
+        assert "DXF Version: AC1024" in result
+        assert "ARC: 1" in result
+        assert "Block definitions: 1" in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/utils/readers/test_scientific_reader.py
+++ b/tests/integration/utils/readers/test_scientific_reader.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -220,7 +221,7 @@ class TestReadHdf5File:
         try:
             sci_module.H5PY_AVAILABLE = True
             sci_module.h5py = SimpleNamespace(
-                File=lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("bad hdf5")),
+                File=MagicMock(side_effect=OSError("bad hdf5")),
                 Dataset=object,
                 Group=object,
             )
@@ -417,7 +418,7 @@ class TestReadNetcdfFile:
         try:
             sci_module.NETCDF4_AVAILABLE = True
             sci_module.netCDF4 = SimpleNamespace(
-                Dataset=lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("bad netcdf"))
+                Dataset=MagicMock(side_effect=OSError("bad netcdf"))
             )
             with pytest.raises(FileReadError):
                 sci_module.read_netcdf_file(path)
@@ -536,9 +537,7 @@ class TestReadMatFile:
         original_available = sci_module.SCIPY_AVAILABLE
         try:
             sci_module.SCIPY_AVAILABLE = True
-            sci_module.loadmat = lambda *_args, **_kwargs: (_ for _ in ()).throw(
-                ValueError("bad mat")
-            )
+            sci_module.loadmat = MagicMock(side_effect=ValueError("bad mat"))
             with pytest.raises(FileReadError):
                 sci_module.read_mat_file(path)
         finally:

--- a/tests/integration/utils/readers/test_scientific_reader.py
+++ b/tests/integration/utils/readers/test_scientific_reader.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -72,10 +73,6 @@ def _make_mat(tmp_path: Path, name: str = "test.mat") -> Path:
 
 
 class TestReadHdf5File:
-    @pytest.fixture(autouse=True)
-    def _require_h5py(self) -> None:
-        pytest.importorskip("h5py")
-
     def test_valid_hdf5_returns_string(self, tmp_path: Path) -> None:
         from file_organizer.utils.readers.scientific import read_hdf5_file
 
@@ -129,7 +126,7 @@ class TestReadHdf5File:
 
     def test_hdf5_max_datasets_truncation(self, tmp_path: Path) -> None:
         """max_datasets=1 causes truncation notice."""
-        import h5py
+        h5py = pytest.importorskip("h5py")
         import numpy as np
 
         from file_organizer.utils.readers.scientific import read_hdf5_file
@@ -142,14 +139,99 @@ class TestReadHdf5File:
         result = read_hdf5_file(path, max_datasets=1)
         assert "showing first 1" in result
 
+    def test_hdf5_mocked_success_without_h5py_dependency(self, tmp_path: Path) -> None:
+        from file_organizer.utils.readers import scientific as sci_module
+
+        path = tmp_path / "mocked.h5"
+        path.write_text("placeholder", encoding="utf-8")
+
+        class FakeDataset:
+            def __init__(
+                self,
+                shape: tuple[int, ...],
+                nbytes: int,
+                dtype: str,
+                attrs: dict[str, str],
+            ) -> None:
+                self.shape = shape
+                self.nbytes = nbytes
+                self.dtype = dtype
+                self.attrs = attrs
+
+        class FakeGroup:
+            pass
+
+        class FakeFile:
+            def __enter__(self) -> FakeFile:
+                return self
+
+            def __exit__(self, exc_type, exc, tb) -> bool:
+                return False
+
+            def keys(self) -> list[str]:
+                return ["measurements"]
+
+            def visititems(self, callback) -> None:
+                callback("measurements", FakeGroup())
+                callback(
+                    "measurements/temperature",
+                    FakeDataset((3, 2), 2048, "float64", {"units": "Celsius"}),
+                )
+                callback(
+                    "measurements/pressure",
+                    FakeDataset((1,), 128, "int32", {}),
+                )
+
+        sentinel = object()
+        original_h5py = getattr(sci_module, "h5py", sentinel)
+        original_available = sci_module.H5PY_AVAILABLE
+        try:
+            sci_module.H5PY_AVAILABLE = True
+            sci_module.h5py = SimpleNamespace(
+                File=lambda *_args, **_kwargs: FakeFile(),
+                Dataset=FakeDataset,
+                Group=FakeGroup,
+            )
+
+            result = sci_module.read_hdf5_file(path, max_datasets=1)
+        finally:
+            sci_module.H5PY_AVAILABLE = original_available
+            if original_h5py is sentinel:
+                del sci_module.h5py
+            else:
+                sci_module.h5py = original_h5py
+
+        assert "HDF5 File: mocked.h5" in result
+        assert "Group: measurements/" in result
+        assert "Dataset: measurements/temperature [float64] 3x2" in result
+        assert "units: Celsius" in result
+        assert "showing first 1 datasets" in result
+
     def test_hdf5_file_read_error_on_corrupt_file(self, tmp_path: Path) -> None:
+        from file_organizer.utils.readers import scientific as sci_module
         from file_organizer.utils.readers._base import FileReadError
-        from file_organizer.utils.readers.scientific import read_hdf5_file
 
         path = tmp_path / "corrupt.h5"
         path.write_bytes(b"\x00\x01NOT AN HDF5 FILE\xff\xfe")
-        with pytest.raises(FileReadError):
-            read_hdf5_file(path)
+
+        sentinel = object()
+        original_h5py = getattr(sci_module, "h5py", sentinel)
+        original_available = sci_module.H5PY_AVAILABLE
+        try:
+            sci_module.H5PY_AVAILABLE = True
+            sci_module.h5py = SimpleNamespace(
+                File=lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("bad hdf5")),
+                Dataset=object,
+                Group=object,
+            )
+            with pytest.raises(FileReadError):
+                sci_module.read_hdf5_file(path)
+        finally:
+            sci_module.H5PY_AVAILABLE = original_available
+            if original_h5py is sentinel:
+                del sci_module.h5py
+            else:
+                sci_module.h5py = original_h5py
 
     def test_hdf5_raises_import_error_when_h5py_unavailable(self, tmp_path: Path) -> None:
         from file_organizer.utils.readers import scientific as sci_module
@@ -171,10 +253,6 @@ class TestReadHdf5File:
 
 
 class TestReadNetcdfFile:
-    @pytest.fixture(autouse=True)
-    def _require_netcdf4(self) -> None:
-        pytest.importorskip("netCDF4")
-
     def test_valid_netcdf_returns_string(self, tmp_path: Path) -> None:
         from file_organizer.utils.readers.scientific import read_netcdf_file
 
@@ -234,14 +312,121 @@ class TestReadNetcdfFile:
         assert "Global Attributes" in result
         assert "title" in result
 
+    def test_netcdf_mocked_success_without_netcdf_dependency(self, tmp_path: Path) -> None:
+        from file_organizer.utils.readers import scientific as sci_module
+
+        path = tmp_path / "mocked.nc"
+        path.write_text("placeholder", encoding="utf-8")
+
+        class FakeDimension:
+            def __init__(self, size: int, unlimited: bool = False) -> None:
+                self._size = size
+                self._unlimited = unlimited
+
+            def isunlimited(self) -> bool:
+                return self._unlimited
+
+            def __len__(self) -> int:
+                return self._size
+
+        class FakeVariable:
+            def __init__(
+                self,
+                shape: tuple[int, ...],
+                dtype: str,
+                *,
+                units: str | None = None,
+                long_name: str | None = None,
+            ) -> None:
+                self.shape = shape
+                self.dtype = dtype
+                if units is not None:
+                    self.units = units
+                if long_name is not None:
+                    self.long_name = long_name
+
+        class FakeDataset:
+            data_model = "NETCDF4"
+
+            def __init__(self) -> None:
+                self.dimensions = {
+                    "time": FakeDimension(3),
+                    "lat": FakeDimension(4),
+                    "sample": FakeDimension(0, unlimited=True),
+                }
+                self.variables = {
+                    "temperature": FakeVariable(
+                        (3, 4),
+                        "f4",
+                        units="K",
+                        long_name="Air Temperature",
+                    ),
+                    **{f"extra_{i}": FakeVariable((i + 1,), "i4") for i in range(20)},
+                }
+                self._attrs = {
+                    "title": "Test dataset",
+                    "institution": "fo-core tests",
+                }
+
+            def __enter__(self) -> FakeDataset:
+                return self
+
+            def __exit__(self, exc_type, exc, tb) -> bool:
+                return False
+
+            def ncattrs(self) -> list[str]:
+                return list(self._attrs.keys())
+
+            def getncattr(self, name: str) -> str:
+                return self._attrs[name]
+
+        sentinel = object()
+        original_netcdf4 = getattr(sci_module, "netCDF4", sentinel)
+        original_available = sci_module.NETCDF4_AVAILABLE
+        try:
+            sci_module.NETCDF4_AVAILABLE = True
+            sci_module.netCDF4 = SimpleNamespace(Dataset=lambda *_args, **_kwargs: FakeDataset())
+
+            result = sci_module.read_netcdf_file(path)
+        finally:
+            sci_module.NETCDF4_AVAILABLE = original_available
+            if original_netcdf4 is sentinel:
+                del sci_module.netCDF4
+            else:
+                sci_module.netCDF4 = original_netcdf4
+
+        assert "NetCDF File: mocked.nc" in result
+        assert "time: 3" in result
+        assert "sample: unlimited" in result
+        assert "temperature (f4): 3x4" in result
+        assert "units: K" in result
+        assert "long_name: Air Temperature" in result
+        assert "... and 1 more variables" in result
+        assert "Global Attributes" in result
+
     def test_netcdf_file_read_error_on_corrupt_file(self, tmp_path: Path) -> None:
+        from file_organizer.utils.readers import scientific as sci_module
         from file_organizer.utils.readers._base import FileReadError
-        from file_organizer.utils.readers.scientific import read_netcdf_file
 
         path = tmp_path / "corrupt.nc"
         path.write_bytes(b"\x89NOT A NETCDF FILE\x00\x01")
-        with pytest.raises(FileReadError):
-            read_netcdf_file(path)
+
+        sentinel = object()
+        original_netcdf4 = getattr(sci_module, "netCDF4", sentinel)
+        original_available = sci_module.NETCDF4_AVAILABLE
+        try:
+            sci_module.NETCDF4_AVAILABLE = True
+            sci_module.netCDF4 = SimpleNamespace(
+                Dataset=lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("bad netcdf"))
+            )
+            with pytest.raises(FileReadError):
+                sci_module.read_netcdf_file(path)
+        finally:
+            sci_module.NETCDF4_AVAILABLE = original_available
+            if original_netcdf4 is sentinel:
+                del sci_module.netCDF4
+            else:
+                sci_module.netCDF4 = original_netcdf4
 
     def test_netcdf_raises_import_error_when_unavailable(self, tmp_path: Path) -> None:
         from file_organizer.utils.readers import scientific as sci_module
@@ -263,10 +448,6 @@ class TestReadNetcdfFile:
 
 
 class TestReadMatFile:
-    @pytest.fixture(autouse=True)
-    def _require_scipy(self) -> None:
-        pytest.importorskip("scipy")
-
     def test_valid_mat_returns_string(self, tmp_path: Path) -> None:
         from file_organizer.utils.readers.scientific import read_mat_file
 
@@ -305,14 +486,67 @@ class TestReadMatFile:
         # y is a 2x2 matrix; shape info should appear in output as "2x2"
         assert "2x2" in result
 
+    def test_mat_mocked_success_without_scipy_dependency(self, tmp_path: Path) -> None:
+        from file_organizer.utils.readers import scientific as sci_module
+
+        path = tmp_path / "mocked.mat"
+        path.write_text("placeholder", encoding="utf-8")
+
+        class FakeArray:
+            def __init__(self, shape: tuple[int, ...]) -> None:
+                self.shape = shape
+
+        sentinel = object()
+        original_loadmat = getattr(sci_module, "loadmat", sentinel)
+        original_available = sci_module.SCIPY_AVAILABLE
+        try:
+            sci_module.SCIPY_AVAILABLE = True
+            sci_module.loadmat = lambda *_args, **_kwargs: {
+                "__header__": "ignored",
+                "x": FakeArray((3,)),
+                "y": FakeArray((2, 2)),
+                "scalar": 7,
+                **{f"var_{i}": FakeArray((1,)) for i in range(32)},
+            }
+
+            result = sci_module.read_mat_file(path)
+        finally:
+            sci_module.SCIPY_AVAILABLE = original_available
+            if original_loadmat is sentinel:
+                del sci_module.loadmat
+            else:
+                sci_module.loadmat = original_loadmat
+
+        assert "MATLAB File: mocked.mat" in result
+        assert "Variables" in result
+        assert "x (FakeArray): 3" in result
+        assert "y (FakeArray): 2x2" in result
+        assert "scalar (int)" in result
+        assert "more variables" in result
+
     def test_mat_file_read_error_on_corrupt_file(self, tmp_path: Path) -> None:
+        from file_organizer.utils.readers import scientific as sci_module
         from file_organizer.utils.readers._base import FileReadError
-        from file_organizer.utils.readers.scientific import read_mat_file
 
         path = tmp_path / "corrupt.mat"
         path.write_bytes(b"\x00\x01NOT A MAT FILE\xff\xfe")
-        with pytest.raises(FileReadError):
-            read_mat_file(path)
+
+        sentinel = object()
+        original_loadmat = getattr(sci_module, "loadmat", sentinel)
+        original_available = sci_module.SCIPY_AVAILABLE
+        try:
+            sci_module.SCIPY_AVAILABLE = True
+            sci_module.loadmat = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                ValueError("bad mat")
+            )
+            with pytest.raises(FileReadError):
+                sci_module.read_mat_file(path)
+        finally:
+            sci_module.SCIPY_AVAILABLE = original_available
+            if original_loadmat is sentinel:
+                del sci_module.loadmat
+            else:
+                sci_module.loadmat = original_loadmat
 
     def test_mat_raises_import_error_when_scipy_unavailable(self, tmp_path: Path) -> None:
         from file_organizer.utils.readers import scientific as sci_module

--- a/tests/integration/utils/readers/test_scientific_reader.py
+++ b/tests/integration/utils/readers/test_scientific_reader.py
@@ -11,6 +11,7 @@ Covers:
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -66,6 +67,29 @@ def _make_mat(tmp_path: Path, name: str = "test.mat") -> Path:
     path = tmp_path / name
     savemat(str(path), {"x": np.array([1.0, 2.0, 3.0]), "y": np.array([[1, 2], [3, 4]])})
     return path
+
+
+@contextmanager
+def _patched_optional_dependency(
+    module: object,
+    availability_attr: str,
+    dependency_attr: str,
+    dependency_value: object,
+):
+    """Temporarily install an optional-dependency shim on a reader module."""
+    sentinel = object()
+    original_dependency = getattr(module, dependency_attr, sentinel)
+    original_available = getattr(module, availability_attr)
+    try:
+        setattr(module, availability_attr, True)
+        setattr(module, dependency_attr, dependency_value)
+        yield
+    finally:
+        setattr(module, availability_attr, original_available)
+        if original_dependency is sentinel:
+            delattr(module, dependency_attr)
+        else:
+            setattr(module, dependency_attr, original_dependency)
 
 
 # ---------------------------------------------------------------------------
@@ -183,24 +207,17 @@ class TestReadHdf5File:
                     FakeDataset((1,), 128, "int32", {}),
                 )
 
-        sentinel = object()
-        original_h5py = getattr(sci_module, "h5py", sentinel)
-        original_available = sci_module.H5PY_AVAILABLE
-        try:
-            sci_module.H5PY_AVAILABLE = True
-            sci_module.h5py = SimpleNamespace(
+        with _patched_optional_dependency(
+            sci_module,
+            "H5PY_AVAILABLE",
+            "h5py",
+            SimpleNamespace(
                 File=lambda *_args, **_kwargs: FakeFile(),
                 Dataset=FakeDataset,
                 Group=FakeGroup,
-            )
-
+            ),
+        ):
             result = sci_module.read_hdf5_file(path, max_datasets=1)
-        finally:
-            sci_module.H5PY_AVAILABLE = original_available
-            if original_h5py is sentinel:
-                del sci_module.h5py
-            else:
-                sci_module.h5py = original_h5py
 
         assert "HDF5 File: mocked.h5" in result
         assert "Group: measurements/" in result
@@ -215,24 +232,18 @@ class TestReadHdf5File:
         path = tmp_path / "corrupt.h5"
         path.write_bytes(b"\x00\x01NOT AN HDF5 FILE\xff\xfe")
 
-        sentinel = object()
-        original_h5py = getattr(sci_module, "h5py", sentinel)
-        original_available = sci_module.H5PY_AVAILABLE
-        try:
-            sci_module.H5PY_AVAILABLE = True
-            sci_module.h5py = SimpleNamespace(
+        with _patched_optional_dependency(
+            sci_module,
+            "H5PY_AVAILABLE",
+            "h5py",
+            SimpleNamespace(
                 File=MagicMock(side_effect=OSError("bad hdf5")),
                 Dataset=object,
                 Group=object,
-            )
+            ),
+        ):
             with pytest.raises(FileReadError):
                 sci_module.read_hdf5_file(path)
-        finally:
-            sci_module.H5PY_AVAILABLE = original_available
-            if original_h5py is sentinel:
-                del sci_module.h5py
-            else:
-                sci_module.h5py = original_h5py
 
     def test_hdf5_raises_import_error_when_h5py_unavailable(self, tmp_path: Path) -> None:
         from file_organizer.utils.readers import scientific as sci_module
@@ -381,20 +392,13 @@ class TestReadNetcdfFile:
             def getncattr(self, name: str) -> str:
                 return self._attrs[name]
 
-        sentinel = object()
-        original_netcdf4 = getattr(sci_module, "netCDF4", sentinel)
-        original_available = sci_module.NETCDF4_AVAILABLE
-        try:
-            sci_module.NETCDF4_AVAILABLE = True
-            sci_module.netCDF4 = SimpleNamespace(Dataset=lambda *_args, **_kwargs: FakeDataset())
-
+        with _patched_optional_dependency(
+            sci_module,
+            "NETCDF4_AVAILABLE",
+            "netCDF4",
+            SimpleNamespace(Dataset=lambda *_args, **_kwargs: FakeDataset()),
+        ):
             result = sci_module.read_netcdf_file(path)
-        finally:
-            sci_module.NETCDF4_AVAILABLE = original_available
-            if original_netcdf4 is sentinel:
-                del sci_module.netCDF4
-            else:
-                sci_module.netCDF4 = original_netcdf4
 
         assert "NetCDF File: mocked.nc" in result
         assert "time: 3" in result
@@ -412,22 +416,14 @@ class TestReadNetcdfFile:
         path = tmp_path / "corrupt.nc"
         path.write_bytes(b"\x89NOT A NETCDF FILE\x00\x01")
 
-        sentinel = object()
-        original_netcdf4 = getattr(sci_module, "netCDF4", sentinel)
-        original_available = sci_module.NETCDF4_AVAILABLE
-        try:
-            sci_module.NETCDF4_AVAILABLE = True
-            sci_module.netCDF4 = SimpleNamespace(
-                Dataset=MagicMock(side_effect=OSError("bad netcdf"))
-            )
+        with _patched_optional_dependency(
+            sci_module,
+            "NETCDF4_AVAILABLE",
+            "netCDF4",
+            SimpleNamespace(Dataset=MagicMock(side_effect=OSError("bad netcdf"))),
+        ):
             with pytest.raises(FileReadError):
                 sci_module.read_netcdf_file(path)
-        finally:
-            sci_module.NETCDF4_AVAILABLE = original_available
-            if original_netcdf4 is sentinel:
-                del sci_module.netCDF4
-            else:
-                sci_module.netCDF4 = original_netcdf4
 
     def test_netcdf_raises_import_error_when_unavailable(self, tmp_path: Path) -> None:
         from file_organizer.utils.readers import scientific as sci_module
@@ -497,26 +493,19 @@ class TestReadMatFile:
             def __init__(self, shape: tuple[int, ...]) -> None:
                 self.shape = shape
 
-        sentinel = object()
-        original_loadmat = getattr(sci_module, "loadmat", sentinel)
-        original_available = sci_module.SCIPY_AVAILABLE
-        try:
-            sci_module.SCIPY_AVAILABLE = True
-            sci_module.loadmat = lambda *_args, **_kwargs: {
+        with _patched_optional_dependency(
+            sci_module,
+            "SCIPY_AVAILABLE",
+            "loadmat",
+            lambda *_args, **_kwargs: {
                 "__header__": "ignored",
                 "x": FakeArray((3,)),
                 "y": FakeArray((2, 2)),
                 "scalar": 7,
                 **{f"var_{i}": FakeArray((1,)) for i in range(32)},
-            }
-
+            },
+        ):
             result = sci_module.read_mat_file(path)
-        finally:
-            sci_module.SCIPY_AVAILABLE = original_available
-            if original_loadmat is sentinel:
-                del sci_module.loadmat
-            else:
-                sci_module.loadmat = original_loadmat
 
         assert "MATLAB File: mocked.mat" in result
         assert "Variables" in result
@@ -532,20 +521,14 @@ class TestReadMatFile:
         path = tmp_path / "corrupt.mat"
         path.write_bytes(b"\x00\x01NOT A MAT FILE\xff\xfe")
 
-        sentinel = object()
-        original_loadmat = getattr(sci_module, "loadmat", sentinel)
-        original_available = sci_module.SCIPY_AVAILABLE
-        try:
-            sci_module.SCIPY_AVAILABLE = True
-            sci_module.loadmat = MagicMock(side_effect=ValueError("bad mat"))
+        with _patched_optional_dependency(
+            sci_module,
+            "SCIPY_AVAILABLE",
+            "loadmat",
+            MagicMock(side_effect=ValueError("bad mat")),
+        ):
             with pytest.raises(FileReadError):
                 sci_module.read_mat_file(path)
-        finally:
-            sci_module.SCIPY_AVAILABLE = original_available
-            if original_loadmat is sentinel:
-                del sci_module.loadmat
-            else:
-                sci_module.loadmat = original_loadmat
 
     def test_mat_raises_import_error_when_scipy_unavailable(self, tmp_path: Path) -> None:
         from file_organizer.utils.readers import scientific as sci_module
@@ -562,6 +545,7 @@ class TestReadMatFile:
 
     def test_mat_many_variables_truncated(self, tmp_path: Path) -> None:
         """Files with more than 30 variables produce truncation notice."""
+        pytest.importorskip("scipy")
         import numpy as np
         from scipy.io import savemat
 

--- a/tests/integration/utils/readers/test_scientific_reader.py
+++ b/tests/integration/utils/readers/test_scientific_reader.py
@@ -320,7 +320,7 @@ class TestReadNetcdfFile:
         path.write_text("placeholder", encoding="utf-8")
 
         class FakeDimension:
-            def __init__(self, size: int, unlimited: bool = False) -> None:
+            def __init__(self, size: int, *, unlimited: bool = False) -> None:
                 self._size = size
                 self._unlimited = unlimited
 


### PR DESCRIPTION
## Summary
- restore integration coverage in the modules that regressed on `main` after the NLTK fix
- replace optional-dependency-skipping reader tests with mocked integration paths so CI still covers scientific, CAD, and 7z readers
- add targeted integration coverage for hardware detection, video metadata fallbacks, memory limiter RSS branches, retriever fallback, backup/viewer, scheduler, and copilot find fallback

## Verification
- `pre-commit run --files tests/integration/test_watcher_updater_core_daemon.py tests/integration/test_audio_video_services_batch4.py tests/integration/test_optimization_core.py tests/integration/test_services_search.py tests/integration/utils/readers/test_scientific_reader.py tests/integration/utils/readers/test_cad_reader.py tests/integration/utils/readers/test_archives_reader.py tests/integration/test_copilot_executor.py tests/integration/test_dedup_backup.py tests/integration/test_dedup_viewer.py`
- `/Users/rahul/.pyenv/versions/3.11.15/bin/python -m pytest tests/integration/test_watcher_updater_core_daemon.py tests/integration/test_audio_video_services_batch4.py tests/integration/test_services_search.py tests/integration/utils/readers/test_scientific_reader.py tests/integration/utils/readers/test_cad_reader.py tests/integration/utils/readers/test_archives_reader.py tests/integration/test_copilot_executor.py tests/integration/test_dedup_backup.py tests/integration/test_dedup_viewer.py -q --override-ini="addopts="`
- `/Users/rahul/.pyenv/versions/3.11.15/bin/python -m pytest tests/integration/test_optimization_core.py -k "TestMemoryLimiter" -q --override-ini="addopts="`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded integration tests to improve reliability of media metadata extraction and fallbacks, backup creation/verification, search/retrieval fallback behavior, memory limiting, hardware detection, and various file readers (archives, CAD, scientific formats), reducing risk of runtime failures and improving error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->