### PR TITLE
ci: run PR integration tests on every push (fix #84)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,16 +128,18 @@ jobs:
   test:
     # Per-commit fast gate for pull requests.
     #
-    # Three-tier CI strategy:
+    # Four-tier CI strategy:
     #   1. This job (per-commit)  — runs tests marked `ci`, ~2 min, every push to a PR branch.
     #   2. pr-integration.yml     — runs `integration`-marked tests, ~3–5 min, on every push
-    #                               to the PR branch (bounded by cancel-in-progress concurrency).
+    #                               to the PR branch (own cancel-in-progress concurrency group).
     #   3. test-full (push only)  — runs the non-benchmark/non-e2e suite across 6 shards × 2 pythons after merge.
+    #   4. ci-full.yml (nightly)  — full matrix (Linux + macOS + Windows) at 06:00 UTC.
     #
     # Why integration tests are NOT in this job:
     #   Adding `integration` to this filter would run ~140 extra test files on every fixup
-    #   commit without cancellation. pr-integration.yml handles this with cancel-in-progress
-    #   so only the latest push in a PR runs integration tests — keeping feedback timely and cost-bounded.
+    #   commit, increasing per-commit latency and CI spend. pr-integration.yml keeps this
+    #   workload isolated (with its own cancel-in-progress), so only the latest PR push
+    #   completes integration tests — keeping the per-commit job lean and fast.
     name: "Test PR suite (py${{ matrix.python-version }})"
     needs: changes
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,14 +130,14 @@ jobs:
     #
     # Three-tier CI strategy:
     #   1. This job (per-commit)  — runs tests marked `ci`, ~2 min, every push to a PR branch.
-    #   2. pr-integration.yml     — runs `integration`-marked tests, ~3–5 min, once per PR
-    #                               lifecycle event (opened / reopened / ready_for_review) — NOT every push.
+    #   2. pr-integration.yml     — runs `integration`-marked tests, ~3–5 min, on every push
+    #                               to the PR branch (bounded by cancel-in-progress concurrency).
     #   3. test-full (push only)  — runs the non-benchmark/non-e2e suite across 6 shards × 2 pythons after merge.
     #
     # Why integration tests are NOT in this job:
     #   Adding `integration` to this filter would run ~140 extra test files on every fixup
-    #   commit, which adds 3–5 min to each push. pr-integration.yml gives integration
-    #   feedback at PR open, reopened, and ready-for-review gates without taxing every commit.
+    #   commit without cancellation. pr-integration.yml handles this with cancel-in-progress
+    #   so only the latest push in a PR runs integration tests — keeping feedback timely and cost-bounded.
     name: "Test PR suite (py${{ matrix.python-version }})"
     needs: changes
     if: github.event_name == 'pull_request'

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -1,25 +1,26 @@
 name: PR Integration Tests
 
-# Runs the full integration test suite once per PR lifecycle event:
+# Runs the full integration test suite on every push to an open PR.
+# Triggered on:
 #   opened          — first feedback when the PR is created
 #   reopened        — re-validation after a PR is un-closed
 #   ready_for_review — final gate before requesting reviewers (draft → ready)
+#   synchronize     — re-validation on every push to the PR (fixup commits, code updates)
 #
-# Intentionally NOT triggered on every push (synchronize) — the fast ci-suite
-# in ci.yml already covers every commit via `-m "ci and not benchmark"`.
-# Integration tests are expensive (~3–5 min with -n=auto) and add value at
-# the PR open/ready gates, not on every fixup commit.
+# Cost is bounded by concurrency.cancel-in-progress: true, which cancels any
+# in-flight run when a new push arrives. This ensures only the latest commit
+# on the PR runs integration tests, preventing stale results from blocking merge.
 #
 # Relationship to other jobs:
-#   ci.yml test         → per-commit fast gate  (ci-marked tests, ~2 min)
-#   pr-integration.yml  → per-PR-lifecycle gate  (integration tests, ~3–5 min)
-#   ci.yml test-full    → post-merge full suite   (6 shards × 2 pythons, main push)
-#   ci-full.yml         → nightly full matrix     (Linux + macOS + Windows)
+#   ci.yml test         → per-commit fast gate        (ci-marked tests, ~2 min)
+#   pr-integration.yml  → on every push to open PR    (integration tests, ~3–5 min, bounded by concurrency)
+#   ci.yml test-full    → post-merge full suite       (6 shards × 2 pythons, main push)
+#   ci-full.yml         → nightly full matrix         (Linux + macOS + Windows)
 
 on:
   pull_request:
     branches: [main]
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
     paths-ignore:
       - ".claude/**"
       - "docs/**"

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -4,7 +4,7 @@ name: PR Integration Tests
 # Triggered on:
 #   opened          — first feedback when the PR is created
 #   reopened        — re-validation after a PR is un-closed
-#   ready_for_review — final gate before requesting reviewers (draft → ready)
+#   ready_for_review — re-validation when a draft PR transitions to ready
 #   synchronize     — re-validation on every push to the PR (fixup commits, code updates)
 #
 # Cost is bounded by concurrency.cancel-in-progress: true, which cancels any

--- a/docs/testing/testing-strategy.md
+++ b/docs/testing/testing-strategy.md
@@ -5,7 +5,7 @@
 | Tier | Workflow | Trigger | Marker filter | Approx time |
 |------|----------|---------|--------------|-------------|
 | Per-commit (fast) | `ci.yml` `test` job | Every push to PR branch | `ci and not benchmark` | ~2 min |
-| Per-PR lifecycle | `pr-integration.yml` | Every push to PR branch (opened / reopened / ready-for-review / synchronize) | `integration and not benchmark` | ~3–5 min |
+| Per-push integration | `pr-integration.yml` | Every push to PR branch (opened / reopened / ready-for-review / synchronize) | `integration and not benchmark` | ~3–5 min |
 | Post-merge full | `ci.yml` `test-full` | Push to main | non-benchmark/non-e2e (6 shards × py3.11+3.12) | ~2–3 min/shard |
 | Nightly matrix | `ci-full.yml` | Daily 06:00 UTC | Linux: full-suite (6 shards, py3.11+3.12); macOS + Windows: `ci/smoke` subset | ~15 min |
 

--- a/docs/testing/testing-strategy.md
+++ b/docs/testing/testing-strategy.md
@@ -5,14 +5,14 @@
 | Tier | Workflow | Trigger | Marker filter | Approx time |
 |------|----------|---------|--------------|-------------|
 | Per-commit (fast) | `ci.yml` `test` job | Every push to PR branch | `ci and not benchmark` | ~2 min |
-| Per-PR lifecycle | `pr-integration.yml` | PR opened / reopened / ready-for-review | `integration and not benchmark` | ~3–5 min |
+| Per-PR lifecycle | `pr-integration.yml` | Every push to PR branch (opened / reopened / ready-for-review / synchronize) | `integration and not benchmark` | ~3–5 min |
 | Post-merge full | `ci.yml` `test-full` | Push to main | non-benchmark/non-e2e (6 shards × py3.11+3.12) | ~2–3 min/shard |
 | Nightly matrix | `ci-full.yml` | Daily 06:00 UTC | Linux: full-suite (6 shards, py3.11+3.12); macOS + Windows: `ci/smoke` subset | ~15 min |
 
 **Marker rules for new tests:**
 
 - `@pytest.mark.ci` — runs on every PR push. Use for fast unit-style tests (no I/O, no external deps).
-- `@pytest.mark.integration` — runs at PR open/reopened/ready-for-review gates and on main push. Use when the test
+- `@pytest.mark.integration` — runs on every push to an open PR and on main push. Use when the test
   touches real files, DB, or service interactions. No need to also add `ci`; the integration
   workflow picks these up automatically.
 - Dual-tagging `ci + integration` is **not required** and was a historical artefact — the

--- a/tests/services/deduplication/test_dedup_embedder.py
+++ b/tests/services/deduplication/test_dedup_embedder.py
@@ -52,27 +52,22 @@ def embedder(mock_vectorizer):
     from file_organizer.services.deduplication.embedder import DocumentEmbedder
 
     # DocumentEmbedder defers sklearn import to __init__
-    # Mock the import at instantiation by patching sys.modules temporarily
+    # Mock the import at instantiation using patch.dict so ALL three entries are
+    # restored on exit (the manual try/finally approach only restored "sklearn",
+    # leaving "sklearn.feature_extraction.text" pointing at the mock, which
+    # caused cross-test contamination in xdist workers).
     mock_sklearn = MagicMock()
     mock_sklearn.feature_extraction.text.TfidfVectorizer = MagicMock(return_value=mock_vectorizer)
 
-    # Temporarily mock sklearn before instantiation
-    saved_sklearn = sys.modules.get("sklearn")
-    try:
-        sys.modules["sklearn"] = mock_sklearn
-        sys.modules["sklearn.feature_extraction"] = mock_sklearn.feature_extraction
-        sys.modules["sklearn.feature_extraction.text"] = mock_sklearn.feature_extraction.text
+    mock_modules = {
+        "sklearn": mock_sklearn,
+        "sklearn.feature_extraction": mock_sklearn.feature_extraction,
+        "sklearn.feature_extraction.text": mock_sklearn.feature_extraction.text,
+    }
 
+    with unittest.mock.patch.dict(sys.modules, mock_modules):
         emb = DocumentEmbedder(max_features=100, ngram_range=(1, 2))
         emb.vectorizer = mock_vectorizer
-    finally:
-        # Restore original sklearn state
-        if saved_sklearn is None:
-            sys.modules.pop("sklearn", None)
-            sys.modules.pop("sklearn.feature_extraction", None)
-            sys.modules.pop("sklearn.feature_extraction.text", None)
-        else:
-            sys.modules["sklearn"] = saved_sklearn
 
     return emb
 

--- a/tests/services/deduplication/test_viewer_branches.py
+++ b/tests/services/deduplication/test_viewer_branches.py
@@ -468,6 +468,38 @@ class TestGenerateAsciiPreviewIntegration:
         lines = result.split("\n")
         assert len(lines) == 5
 
+    def test_get_flattened_data_branch_executed(self, tmp_path: Path) -> None:
+        """Force the callable get_flattened_data branch used by some Pillow builds."""
+        viewer = ComparisonViewer(console=_silent_console())
+        img_path = _make_png(tmp_path, "flattened.png", (20, 20))
+
+        resized = MagicMock()
+        resized.width = 10
+        resized.height = 5
+        resized.get_flattened_data.return_value = [128] * 50
+
+        fake_img = MagicMock()
+        fake_img.width = 20
+        fake_img.height = 20
+        fake_img.convert.return_value = fake_img
+        fake_img.resize.return_value = resized
+
+        mock_cm = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=fake_img)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+
+        with patch(
+            "file_organizer.services.deduplication.viewer.Image.open",
+            return_value=mock_cm,
+        ):
+            result = viewer._generate_ascii_preview(img_path, max_width=10, max_height=5)
+
+        resized.get_flattened_data.assert_called_once_with()
+        resized.getdata.assert_not_called()
+        assert result is not None
+        lines = result.split("\n")
+        assert len(lines) == 5
+
     def test_nonexistent_file_returns_none(self, tmp_path: Path) -> None:
         """_generate_ascii_preview returns None when the image path does not exist."""
         viewer = ComparisonViewer(console=_silent_console())


### PR DESCRIPTION
## Summary

- Adds `synchronize` to the `pull_request` trigger types in `pr-integration.yml` so integration tests re-run on every push to an open PR, not just at lifecycle events (opened/reopened/ready-for-review)
- Cost is bounded by the existing `concurrency.cancel-in-progress: true` — a new push cancels any in-flight run
- Fixes stale comments in `ci.yml` and `docs/testing/testing-strategy.md` that incorrectly described the integration gate as running only at lifecycle events

## Test Plan

- [ ] Push a fixup commit to any open PR and verify `PR Integration Tests` workflow triggers
- [ ] Verify a second push cancels the first run (concurrency cancel-in-progress)
- [ ] Confirm `ci.yml` and `docs/testing/testing-strategy.md` accurately describe the new cadence

Closes #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing strategy documentation to clarify when and how integration tests run during pull request development

* **Tests**
  * Added new integration test case for image preview branch execution scenarios

* **Chores**
  * Updated CI workflow configuration to execute integration tests on all pull request updates for faster feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->