### PR TITLE
feat: triage policy, coverage ratchet, CLI smoke tests, organizer refactor (#85–#88)

### DIFF
--- a/.claude/scripts/pr-comments-complete.sh
+++ b/.claude/scripts/pr-comments-complete.sh
@@ -4,8 +4,11 @@
 # pr-comments-complete: Fetch all PR comments including review comments
 #
 # This script works around limitations in the built-in /pr-comments skill
-# by fetching PR-level comments, review comments, and reviews in a single
+# by fetching PR-level comments and reviews (with inline comments) in a single
 # GraphQL query for efficiency.
+#
+# Note: reviewComments is a REST-only concept. Inline review comments are
+# available under reviews.nodes[].comments.nodes[] in GraphQL.
 #
 # Usage:
 #   bash .claude/scripts/pr-comments-complete.sh [PR_NUMBER]
@@ -51,24 +54,16 @@ query($owner: String!, $repo: String!, $number: Int!) {
           body
         }
       }
-      reviewComments(first: 100) {
-        nodes {
-          author { login }
-          path
-          line
-          diffHunk
-          body
-          createdAt
-        }
-      }
       reviews(first: 100) {
         nodes {
+          id
           author { login }
           state
           submittedAt
           body
           comments(first: 100) {
             nodes {
+              id
               path
               line
               diffHunk
@@ -83,11 +78,22 @@ query($owner: String!, $repo: String!, $number: Int!) {
 QUERY
 
 # Execute GraphQL query (pass PR_NUMBER as integer, not string)
-RESPONSE=$(gh api graphql \
+RAW_RESPONSE=$(gh api graphql \
   --field owner="$OWNER" \
   --field repo="$REPO_NAME" \
   --field number="$PR_NUMBER" \
   --raw-field query="$GRAPHQL_QUERY" 2>/dev/null || echo '{"errors":[{"message":"GraphQL query failed"}]}')
+
+# Sanitize control characters that CodeRabbit injects in review bodies.
+# Python's json.loads(strict=False) accepts them; json.dumps() re-encodes safely.
+RESPONSE=$(echo "$RAW_RESPONSE" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin, strict=False)
+    print(json.dumps(data))
+except Exception as e:
+    print(json.dumps({'errors': [{'message': str(e)}]}))
+")
 
 ##############################################################################
 # Section 1: PR-Level Comments
@@ -106,31 +112,18 @@ fi
 echo ""
 
 ##############################################################################
-# Section 2: Review Comments (Inline Code Comments)
+# Section 2: Reviews (Summary + Inline Comments)
+#
+# Inline code comments are nested under reviews in GitHub's GraphQL schema.
+# They are presented here grouped by review so context is preserved.
 ##############################################################################
 
-echo "### Review Comments (Inline)"
-echo ""
-
-if echo "$RESPONSE" | jq -e '.data.repository.pullRequest.reviewComments.nodes | length > 0' >/dev/null 2>&1; then
-  echo "$RESPONSE" | jq -r '.data.repository.pullRequest.reviewComments.nodes[] |
-    "**@\(.author.login)** - \(.path)#L\(.line)\n\n```diff\n\(.diffHunk)\n```\n\n> \(.body)\n\n---\n"'
-else
-  echo "No inline review comments found."
-fi
-
-echo ""
-
-##############################################################################
-# Section 3: Review Summary (by reviewer and state)
-##############################################################################
-
-echo "### Review Summary"
+echo "### Reviews (with Inline Comments)"
 echo ""
 
 if echo "$RESPONSE" | jq -e '.data.repository.pullRequest.reviews.nodes | length > 0' >/dev/null 2>&1; then
   echo "$RESPONSE" | jq -r '.data.repository.pullRequest.reviews.nodes[] |
-    "**\(.state)** - @\(.author.login) (\(.submittedAt | sub("T.*"; "")))\n\n\(.body // "(no summary body)")\n\nReview comments:\n\(.comments.nodes | if length > 0 then (.[] | "  - \(.path)#L\(.line): \(.body)") | join("\n") else "(no inline comments in this review)" end)\n\n---\n"'
+    "**\(.state)** - @\(.author.login) (\(.submittedAt | sub("T.*"; "")))\n\nReview ID: \(.id)\n\n\(.body // "(no summary body)")\n\nInline comments:\n\(.comments.nodes | if length > 0 then [.[] | "  [\(.id)] \(.path)#L\(.line)\n  Diff:\n\(.diffHunk | split("\n") | .[:4] | map("    " + .) | join("\n"))\n  Comment: \(.body)"] | join("\n\n") else "  (no inline comments in this review)" end)\n\n---\n"'
 else
   echo "No reviews found."
 fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,6 +163,9 @@ ruff check src/
 
 # Type check
 mypy src/file_organizer/ --strict
+
+# Ratchet integration coverage baseline (after improving integration tests)
+bash scripts/coverage/ratchet.sh update
 ```
 
 ### Full CI in Docker with `act` (ubuntu-latest parity)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -387,6 +387,10 @@ For details, see `.claude/rules/code-quality-validation.md` and `.claude/rules/d
 
 ## Pull Requests
 
+> **Test cleanup issues**: before opening a PR for test-only cleanup work,
+> see [Triage Policy](docs/developer/triage-policy.md) for the decision
+> tree on bundling, standalone PRs, or closing.
+
 1. Create a feature branch from `main`: `git checkout -b feature/description`
 2. Make changes with tests
 3. Run quality gates (in order):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,9 @@ ruff check src/
 # Type check
 mypy src/file_organizer/ --strict
 
-# Ratchet integration coverage baseline (after improving integration tests)
+# Validate integration coverage against current baseline
+bash scripts/coverage/ratchet.sh check
+# Ratchet baseline upward (only after improving integration tests)
 bash scripts/coverage/ratchet.sh update
 ```
 

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -37,6 +37,7 @@ ollama pull qwen2.5vl:7b-q4_K_M
 - Unit and integration testing
 - Code style and standards (see [Contributing](contributing.md))
 - [Guardrail Workflow](guardrails.md) - Where guardrails belong and how to add them
+- [Triage Policy](triage-policy.md) — When to bundle, standalone-PR, or close cleanup-only test issues
 
 ## Architecture
 

--- a/docs/developer/triage-policy.md
+++ b/docs/developer/triage-policy.md
@@ -1,0 +1,59 @@
+# Triage Policy for Cleanup-Only Test Work
+
+This policy applies to issues whose primary content is: removing dead assertions,
+deduplicating overlapping test cases, fixing obsolete mocks, or adding trivial
+happy-path coverage with no `src/` delta. It does **not** apply to test work that
+accompanies a feature or bug fix — that follows the normal PR process.
+
+## What Qualifies as Cleanup-Only
+
+A test work item is cleanup-only when **all three** of the following are true:
+
+1. No `src/` change (or only comments/docstrings are touched)
+2. No new assertion surface — the paths being exercised are already covered by
+   equivalent assertions in existing tests
+3. Coverage delta is less than 1%
+
+If any condition is false, treat the item as a normal feature or fix.
+
+## Decision Tree
+
+```text
+Is the test work already covered by an in-flight PR or issue?
+├── Yes → Close as Duplicate: link the in-flight item, label `duplicate`
+└── No
+    ↓
+Does it fit cleanly into a nearby src/ change landing this sprint (<10 test lines)?
+├── Yes → Bundle: add as a commit on that branch, reference this issue in the PR body
+└── No
+    ↓
+Is the cleanup genuinely valuable (removes confusing tests, improves readability)?
+├── No  → Close as Won't Fix: add label `wontfix`, leave a one-line explanation
+└── Yes → Standalone PR: branch cleanup/test-<slug>, title prefix "test:"
+```
+
+## Standalone PR Rules
+
+When the decision is "Standalone PR":
+
+- Branch name: `cleanup/test-<short-slug>`
+- PR title must start with `test:`
+- PR body must state which metric (if any) improves and by how much
+- CI must pass; no new `# noqa` suppressions allowed
+
+## Closing Stale Cleanup Threads
+
+A cleanup issue is stale when it has had **no activity for 60 days** and no open
+PR references it. Close with:
+
+1. Add label: `stale`
+2. Post this comment:
+
+   > Closing as stale — no activity in 60 days and no in-flight PR.
+   > If this is still relevant, please reopen with a PR draft attached.
+
+## What Does Not Belong Here
+
+- Issues touching `src/` beyond comments → normal review process applies
+- Coverage ratchet updates (see `scripts/coverage/README.md`)
+- Issues with failing CI → fix the failures first, then triage

--- a/docs/developer/triage-policy.md
+++ b/docs/developer/triage-policy.md
@@ -24,7 +24,7 @@ Is the test work already covered by an in-flight PR or issue?
 └── No
     ↓
 Does it fit cleanly into a nearby src/ change landing this sprint (<10 test lines)?
-├── Yes → Bundle: add as a commit on that branch, reference this issue in the PR body
+├── Yes → Bundle: commit on that branch, reference this issue in the PR body
 └── No
     ↓
 Is the cleanup genuinely valuable (removes confusing tests, improves readability)?

--- a/docs/developer/triage-policy.md
+++ b/docs/developer/triage-policy.md
@@ -23,7 +23,7 @@ Is the test work already covered by an in-flight PR or issue?
 ├── Yes → Close as Duplicate: link the in-flight item, label `duplicate`
 └── No
     ↓
-Does it fit cleanly into a nearby src/ change landing this sprint (<10 test lines)?
+Is there an open branch/PR touching related src/ code? (<10 test lines)
 ├── Yes → Bundle: commit on that branch, reference this issue in the PR body
 └── No
     ↓
@@ -55,5 +55,5 @@ PR references it. Close with:
 ## What Does Not Belong Here
 
 - Issues touching `src/` beyond comments → normal review process applies
-- Coverage ratchet updates (see `scripts/coverage/README.md`)
+- Coverage ratchet updates (see `scripts/coverage/README.md` at repo root)
 - Issues with failing CI → fix the failures first, then triage

--- a/docs/developer/triage-policy.md
+++ b/docs/developer/triage-policy.md
@@ -23,13 +23,13 @@ Is the test work already covered by an in-flight PR or issue?
 ├── Yes → Close as Duplicate: link the in-flight item, label `duplicate`
 └── No
     ↓
-Is there an open branch/PR touching related src/ code? (<10 test lines)
+Is there an open branch/PR touching related src/ code? (fewer than 10 test lines changed)
 ├── Yes → Bundle: commit on that branch, reference this issue in the PR body
 └── No
     ↓
 Is the cleanup genuinely valuable (removes confusing tests, improves readability)?
 ├── No  → Close as Won't Fix: add label `wontfix`, leave a one-line explanation
-└── Yes → Standalone PR: branch cleanup/test-<slug>, title prefix "test:"
+└── Yes → Standalone PR: branch cleanup/test-<short-slug>, title prefix "test:"
 ```
 
 ## Standalone PR Rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,11 +233,6 @@ convention = "google"
 "tests/**/*.py" = ["D"]
 "scripts/**/*.py" = ["D"]
 "scripts/docker_utils.py" = ["D", "C901"]
-# C901 ratchet baseline — functions exceeding complexity 15 (2026-02-28)
-# Each entry allows existing complex functions; new ones must stay under 15.
-# Note: 9 files refactored in 2026-03 (task 005), 3 more in issue #1022.
-# Remaining files with complexity > 15:
-"src/file_organizer/core/organizer.py" = ["C901"]  # organize: 33
 
 # MyPy configuration (type checking)
 [tool.mypy]

--- a/scripts/coverage/README.md
+++ b/scripts/coverage/README.md
@@ -17,17 +17,14 @@ This makes coverage improvements durable and prevents hidden regressions in low-
 
 ## How to ratchet floors upward
 
-### Automated (recommended)
+### Single command (recommended)
 
-Run the integration suite and pipe the output to the script with `--update-baseline`:
+Run from the repository root:
 
 ```bash
-bash .claude/scripts/measure-integration-coverage.sh | tee /tmp/integration-report.txt
-
-python3 scripts/check_module_coverage_floor.py \
-  --report-path /tmp/integration-report.txt \
-  --baseline-path scripts/coverage/integration_module_floor_baseline.json \
-  --update-baseline
+bash scripts/coverage/ratchet.sh check    # gate-check (mirrors CI)
+bash scripts/coverage/ratchet.sh update   # ratchet baseline upward
+bash scripts/coverage/ratchet.sh dry-run  # preview changes without writing
 ```
 
 The script will:
@@ -37,14 +34,7 @@ The script will:
 - **Remove** modules that have been deleted from disk.
 - Update `generated_at_utc` in the baseline JSON.
 
-Preview changes first with `--dry-run` (prints the diff without writing):
-
-```bash
-python3 scripts/check_module_coverage_floor.py \
-  --report-path /tmp/integration-report.txt \
-  --baseline-path scripts/coverage/integration_module_floor_baseline.json \
-  --update-baseline --dry-run
-```
+After improving tests, run `update` and commit the updated baseline file.
 
 ### Manual
 

--- a/scripts/coverage/ratchet.sh
+++ b/scripts/coverage/ratchet.sh
@@ -14,6 +14,12 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MEASURE_SCRIPT="${REPO_ROOT}/.claude/scripts/measure-integration-coverage.sh"
 CHECKER="${REPO_ROOT}/scripts/check_module_coverage_floor.py"
 BASELINE="${REPO_ROOT}/scripts/coverage/integration_module_floor_baseline.json"
+if [[ "$#" -gt 1 ]]; then
+  echo "ERROR: too many arguments" >&2
+  echo "Usage: bash scripts/coverage/ratchet.sh [check|update|dry-run]" >&2
+  exit 2
+fi
+
 MODE="${1:-check}"
 
 case "${MODE}" in

--- a/scripts/coverage/ratchet.sh
+++ b/scripts/coverage/ratchet.sh
@@ -25,7 +25,7 @@ case "${MODE}" in
     ;;
 esac
 
-REPORT="$(mktemp /tmp/integration-coverage-report.XXXXXX.txt)"
+REPORT="$(mktemp "${TMPDIR:-/tmp}/integration-coverage-report.XXXXXX.txt")"
 trap 'rm -f "${REPORT}"' EXIT
 
 echo "==> [1/2] Measuring integration coverage (mode: ${MODE})..."

--- a/scripts/coverage/ratchet.sh
+++ b/scripts/coverage/ratchet.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# scripts/coverage/ratchet.sh — one-command integration coverage ratchet
+#
+# Usage (from repo root):
+#   bash scripts/coverage/ratchet.sh [check|update|dry-run]
+#
+#   check    Measure then gate-check against baseline (mirrors CI). DEFAULT.
+#   update   Measure then ratchet baseline floors upward (never lowers).
+#   dry-run  Measure then preview changes without writing.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MEASURE_SCRIPT="${REPO_ROOT}/.claude/scripts/measure-integration-coverage.sh"
+CHECKER="${REPO_ROOT}/scripts/check_module_coverage_floor.py"
+BASELINE="${REPO_ROOT}/scripts/coverage/integration_module_floor_baseline.json"
+MODE="${1:-check}"
+
+case "${MODE}" in
+  check|update|dry-run) ;;
+  *)
+    echo "ERROR: unknown mode '${MODE}'" >&2
+    echo "Usage: bash scripts/coverage/ratchet.sh [check|update|dry-run]" >&2
+    exit 2
+    ;;
+esac
+
+REPORT="$(mktemp /tmp/integration-coverage-report.XXXXXX.txt)"
+trap 'rm -f "${REPORT}"' EXIT
+
+echo "==> [1/2] Measuring integration coverage (mode: ${MODE})..."
+bash "${MEASURE_SCRIPT}" | tee "${REPORT}"
+
+echo ""
+echo "==> [2/2] Evaluating coverage floors..."
+
+case "${MODE}" in
+  check)
+    python3 "${CHECKER}" --report-path "${REPORT}" --baseline-path "${BASELINE}"
+    ;;
+  update)
+    python3 "${CHECKER}" --report-path "${REPORT}" --baseline-path "${BASELINE}" --update-baseline
+    echo ""
+    echo "==> Baseline updated. Commit ${BASELINE} with your PR."
+    ;;
+  dry-run)
+    python3 "${CHECKER}" --report-path "${REPORT}" --baseline-path "${BASELINE}" --update-baseline --dry-run
+    ;;
+esac

--- a/src/file_organizer/core/organizer.py
+++ b/src/file_organizer/core/organizer.py
@@ -380,7 +380,7 @@ class FileOrganizer:
                 seen_hashes[file_hash] = pf
                 deduped.append(pf)
             else:
-                logger.info(f"Duplicate file detected by content: {pf.file_path.name}, skipping.")
+                logger.info("Duplicate file detected by content: {}, skipping.", pf.file_path.name)
                 result.deduplicated_files += 1
         return deduped
 
@@ -458,9 +458,11 @@ class FileOrganizer:
     # ------------------------------------------------------------------
 
     def _collect_files(self, path: Path) -> list[Path]:
+        """Collect all files under *path* recursively (delegates to file_ops)."""
         return file_ops.collect_files(path, self.console)
 
     def _fallback_by_extension(self, files: list[Path]) -> list[ProcessedFile]:
+        """Classify *files* by extension when AI processing is unavailable."""
         return file_ops.fallback_by_extension(files)
 
     def _organize_files(
@@ -469,6 +471,7 @@ class FileOrganizer:
         output_path: Path,
         skip_existing: bool,
     ) -> dict[str, list[str]]:
+        """Copy/move processed files into *output_path*, respecting undo history."""
         return file_ops.organize_files(
             processed,
             output_path,
@@ -483,12 +486,15 @@ class FileOrganizer:
         processed: list[ProcessedFile | ProcessedImage],
         output_path: Path,
     ) -> dict[str, list[str]]:
+        """Simulate organization without writing any files (dry-run helper)."""
         return file_ops.simulate_organization(processed, output_path)
 
     def _cleanup_empty_dirs(self, root: Path) -> None:
+        """Remove empty directories left behind after organization under *root*."""
         file_ops.cleanup_empty_dirs(root)
 
     def _init_text_processor(self) -> None:
+        """Initialize the text processor; sets ``self.text_processor`` or leaves it None."""
         self.text_processor = initializer.init_text_processor(
             self.text_model_config,
             self.console,
@@ -496,6 +502,7 @@ class FileOrganizer:
         )
 
     def _init_vision_processor(self) -> None:
+        """Initialize the vision processor; sets ``self.vision_processor`` or leaves it None."""
         self.vision_processor = initializer.init_vision_processor(
             self.vision_model_config,
             self.console,
@@ -503,19 +510,23 @@ class FileOrganizer:
         )
 
     def _process_text_files(self, files: list[Path]) -> list[ProcessedFile]:
+        """Dispatch *files* to the initialized text processor."""
         assert self.text_processor is not None
         return dispatcher.process_text_files(
             files, self.text_processor, self.parallel_processor, self.console
         )
 
     def _process_image_files(self, files: list[Path]) -> list[ProcessedImage]:
+        """Dispatch *files* to the initialized vision processor."""
         assert self.vision_processor is not None
         return dispatcher.process_image_files(
             files, self.vision_processor, self.parallel_processor, self.console
         )
 
     def _process_audio_files(self, files: list[Path]) -> list[ProcessedFile]:
+        """Extract metadata from audio *files* and return processed results."""
         return dispatcher.process_audio_files(files, extractor_cls=AudioMetadataExtractor)
 
     def _process_video_files(self, files: list[Path]) -> list[ProcessedFile]:
+        """Extract metadata from video *files* and return processed results."""
         return dispatcher.process_video_files(files, extractor_cls=VideoMetadataExtractor)

--- a/src/file_organizer/core/organizer.py
+++ b/src/file_organizer/core/organizer.py
@@ -210,7 +210,7 @@ class FileOrganizer:
 
         if all_processed:
             all_processed = self._deduplicate_processed(all_processed, result)
-            failed_cnt = len([p for p in all_processed if p.error])
+            failed_cnt = sum(1 for p in all_processed if p.error)
             result.processed_files = len(all_processed) - failed_cnt
             result.failed_files = failed_cnt
             self._execute_organization(
@@ -364,7 +364,7 @@ class FileOrganizer:
 
         Mutates ``result.deduplicated_files``. Returns the deduplicated list.
         """
-        seen_hashes: dict[str, ProcessedFile | ProcessedImage] = {}
+        seen_hashes: set[str] = set()
         deduped: list[ProcessedFile | ProcessedImage] = []
         for pf in all_processed:
             try:
@@ -377,7 +377,7 @@ class FileOrganizer:
                 deduped.append(pf)
                 continue
             if file_hash not in seen_hashes:
-                seen_hashes[file_hash] = pf
+                seen_hashes.add(file_hash)
                 deduped.append(pf)
             else:
                 logger.info("Duplicate file detected by content: {}, skipping.", pf.file_path.name)

--- a/src/file_organizer/core/organizer.py
+++ b/src/file_organizer/core/organizer.py
@@ -12,6 +12,7 @@ delegates to extracted modules for specific concerns:
 
 from __future__ import annotations
 
+import hashlib
 import time
 from pathlib import Path
 from typing import ClassVar
@@ -363,8 +364,6 @@ class FileOrganizer:
 
         Mutates ``result.deduplicated_files``. Returns the deduplicated list.
         """
-        import hashlib
-
         seen_hashes: dict[str, ProcessedFile | ProcessedImage] = {}
         deduped: list[ProcessedFile | ProcessedImage] = []
         for pf in all_processed:

--- a/src/file_organizer/core/organizer.py
+++ b/src/file_organizer/core/organizer.py
@@ -189,7 +189,58 @@ class FileOrganizer:
             self.console.print("[yellow]No files found to organize[/yellow]")
             return result
 
-        # Categorize files (single pass)
+        text_files, image_files, video_files, audio_files, cad_files, other_files = (
+            self._categorize_files(files)
+        )
+
+        display.show_file_breakdown(
+            self.console,
+            text_files=text_files,
+            image_files=image_files,
+            video_files=video_files,
+            audio_files=audio_files,
+            cad_files=cad_files,
+            other_files=other_files,
+        )
+
+        all_processed = self._process_all_file_types(
+            text_files, image_files, video_files, audio_files, cad_files
+        )
+
+        if all_processed:
+            all_processed = self._deduplicate_processed(all_processed, result)
+            failed_cnt = len([p for p in all_processed if p.error])
+            result.processed_files = len(all_processed) - failed_cnt
+            result.failed_files = failed_cnt
+            self._execute_organization(
+                all_processed, input_path, output_path, skip_existing, result
+            )
+
+        # Skipped files
+        if other_files:
+            result.skipped_files = len(other_files)
+            self.console.print("\n[bold yellow]Skipped Files:[/bold yellow]")
+            for f in other_files:
+                self.console.print(f"  [yellow]•[/yellow] {f.name} (unsupported type)")
+            self.console.print("\n  [dim]These file types are not yet supported[/dim]")
+
+        result.processing_time = time.time() - start_time
+        display.show_summary(self.console, result, output_path, dry_run=self.dry_run)
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Private helpers extracted from organize()
+    # ------------------------------------------------------------------
+
+    def _categorize_files(
+        self, files: list[Path]
+    ) -> tuple[list[Path], list[Path], list[Path], list[Path], list[Path], list[Path]]:
+        """Categorize files by type using extension sets.
+
+        Returns:
+            Six lists: (text, image, video, audio, cad, other)
+        """
         text_files: list[Path] = []
         image_files: list[Path] = []
         video_files: list[Path] = []
@@ -212,23 +263,44 @@ class FileOrganizer:
             else:
                 other_files.append(f)
 
-        display.show_file_breakdown(
-            self.console,
-            text_files=text_files,
-            image_files=image_files,
-            video_files=video_files,
-            audio_files=audio_files,
-            cad_files=cad_files,
-            other_files=other_files,
-        )
+        return text_files, image_files, video_files, audio_files, cad_files, other_files
 
-        # Process each file type
+    def _process_image_type(self, image_files: list[Path]) -> list[ProcessedFile | ProcessedImage]:
+        """Process image files, using vision model if available and enabled."""
+        self.console.print(f"\n[bold blue]Processing {len(image_files)} images...[/bold blue]")
+        if self.enable_vision:
+            self._init_vision_processor()
+            vision_ready = (
+                self.vision_processor is not None
+                and self.vision_processor.vision_model.is_initialized
+            )
+            if vision_ready:
+                return list(self._process_image_files(image_files))
+            return list(self._fallback_by_extension(image_files))
+        self.console.print(
+            "[yellow]⚠ Vision processing disabled (--no-vision/--text-only): "
+            "using extension-based organization for images[/yellow]"
+        )
+        return list(self._fallback_by_extension(image_files))
+
+    def _process_all_file_types(
+        self,
+        text_files: list[Path],
+        image_files: list[Path],
+        video_files: list[Path],
+        audio_files: list[Path],
+        cad_files: list[Path],
+    ) -> list[ProcessedFile | ProcessedImage]:
+        """Initialize processors and process all file type groups.
+
+        Manages VRAM hand-off between text and vision models and ensures
+        cleanup on success or failure.
+        """
         all_processed: list[ProcessedFile | ProcessedImage] = []
         self.text_processor = None
         self.vision_processor = None
 
         try:
-            # Text + CAD
             if text_files or cad_files:
                 self._init_text_processor()
 
@@ -259,36 +331,15 @@ class FileOrganizer:
                 self.text_processor.cleanup()
                 self.text_processor = None
 
-            # Images
             if image_files:
-                self.console.print(
-                    f"\n[bold blue]Processing {len(image_files)} images...[/bold blue]"
-                )
-                if self.enable_vision:
-                    self._init_vision_processor()
-                    vision_ready = (
-                        self.vision_processor is not None
-                        and self.vision_processor.vision_model.is_initialized
-                    )
-                    if vision_ready:
-                        all_processed.extend(self._process_image_files(image_files))
-                    else:
-                        all_processed.extend(self._fallback_by_extension(image_files))
-                else:
-                    self.console.print(
-                        "[yellow]⚠ Vision processing disabled (--no-vision/--text-only): "
-                        "using extension-based organization for images[/yellow]"
-                    )
-                    all_processed.extend(self._fallback_by_extension(image_files))
+                all_processed.extend(self._process_image_type(image_files))
 
-            # Audio
             if audio_files:
                 self.console.print(
                     f"\n[bold blue]Processing {len(audio_files)} audio files...[/bold blue]"
                 )
                 all_processed.extend(self._process_audio_files(audio_files))
 
-            # Video
             if video_files:
                 self.console.print(
                     f"\n[bold blue]Processing {len(video_files)} videos...[/bold blue]"
@@ -301,88 +352,84 @@ class FileOrganizer:
             if self.vision_processor:
                 self.vision_processor.cleanup()
 
-        # Organize
-        # Content‑based deduplication: remove duplicate files based on file content hash
-        if all_processed:
-            import hashlib
+        return all_processed
 
-            seen_hashes: dict[str, ProcessedFile | ProcessedImage] = {}
-            deduped_processed: list[ProcessedFile | ProcessedImage] = []
-            for pf in all_processed:
-                try:
-                    hasher = hashlib.sha256()
-                    with pf.file_path.open("rb") as f:
-                        for chunk in iter(lambda: f.read(65536), b""):
-                            hasher.update(chunk)
-                    file_hash = hasher.hexdigest()
-                except OSError:
-                    # If we cannot read the file, keep it (it will be handled later)
-                    deduped_processed.append(pf)
-                    continue
-                if file_hash not in seen_hashes:
-                    seen_hashes[file_hash] = pf
-                    deduped_processed.append(pf)
-                else:
-                    # Duplicate detected – skip this file
-                    logger.info(
-                        f"Duplicate file detected by content: {pf.file_path.name}, skipping."
-                    )
-                    result.deduplicated_files += 1
-            all_processed = deduped_processed
-            failed_cnt = len([p for p in all_processed if p.error])
-            result.processed_files = len(all_processed) - failed_cnt
-            result.failed_files = failed_cnt
+    def _deduplicate_processed(
+        self,
+        all_processed: list[ProcessedFile | ProcessedImage],
+        result: OrganizationResult,
+    ) -> list[ProcessedFile | ProcessedImage]:
+        """Remove duplicate files based on SHA-256 content hash.
 
-            if not self.dry_run:
-                self.console.print("\n[bold blue]Organizing files...[/bold blue]")
-                if self._undo_manager is None:
-                    self._undo_manager = UndoManager()
-                self._last_transaction_id = self._undo_manager.history.start_transaction(
-                    metadata={"input_path": str(input_path), "output_path": str(output_path)}
-                )
-                self._last_output_path = output_path
+        Mutates ``result.deduplicated_files``. Returns the deduplicated list.
+        """
+        import hashlib
 
-                try:
-                    organized = file_ops.organize_files(
-                        all_processed,
-                        output_path,
-                        skip_existing,
-                        use_hardlinks=self.use_hardlinks,
-                        undo_manager=self._undo_manager,
-                        transaction_id=self._last_transaction_id,
-                    )
-                except (OSError, RuntimeError):
-                    logger.exception(
-                        "Error while organizing files; leaving transaction {} uncommitted",
-                        self._last_transaction_id,
-                    )
-                    raise
-                else:
-                    undo_manager = self._undo_manager
-                    assert undo_manager is not None
-                    history = undo_manager.history
-                    history.commit_transaction(self._last_transaction_id)
-                    result.organized_structure = organized
+        seen_hashes: dict[str, ProcessedFile | ProcessedImage] = {}
+        deduped: list[ProcessedFile | ProcessedImage] = []
+        for pf in all_processed:
+            try:
+                hasher = hashlib.sha256()
+                with pf.file_path.open("rb") as f:
+                    for chunk in iter(lambda: f.read(65536), b""):
+                        hasher.update(chunk)
+                file_hash = hasher.hexdigest()
+            except OSError:
+                deduped.append(pf)
+                continue
+            if file_hash not in seen_hashes:
+                seen_hashes[file_hash] = pf
+                deduped.append(pf)
             else:
-                self.console.print(
-                    "\n[bold yellow]DRY RUN - Simulating organization...[/bold yellow]"
+                logger.info(f"Duplicate file detected by content: {pf.file_path.name}, skipping.")
+                result.deduplicated_files += 1
+        return deduped
+
+    def _execute_organization(
+        self,
+        all_processed: list[ProcessedFile | ProcessedImage],
+        input_path: Path,
+        output_path: Path,
+        skip_existing: bool,
+        result: OrganizationResult,
+    ) -> None:
+        """Execute file organization or dry-run simulation.
+
+        Mutates ``result.organized_structure``.
+        """
+        if not self.dry_run:
+            self.console.print("\n[bold blue]Organizing files...[/bold blue]")
+            if self._undo_manager is None:
+                self._undo_manager = UndoManager()
+            self._last_transaction_id = self._undo_manager.history.start_transaction(
+                metadata={"input_path": str(input_path), "output_path": str(output_path)}
+            )
+            self._last_output_path = output_path
+
+            try:
+                organized = file_ops.organize_files(
+                    all_processed,
+                    output_path,
+                    skip_existing,
+                    use_hardlinks=self.use_hardlinks,
+                    undo_manager=self._undo_manager,
+                    transaction_id=self._last_transaction_id,
                 )
-                result.organized_structure = file_ops.simulate_organization(
-                    all_processed, output_path
+            except (OSError, RuntimeError):
+                logger.exception(
+                    "Error while organizing files; leaving transaction {} uncommitted",
+                    self._last_transaction_id,
                 )
-
-        # Skipped files
-        if other_files:
-            result.skipped_files = len(other_files)
-            self.console.print("\n[bold yellow]Skipped Files:[/bold yellow]")
-            for f in other_files:
-                self.console.print(f"  [yellow]•[/yellow] {f.name} (unsupported type)")
-            self.console.print("\n  [dim]These file types are not yet supported[/dim]")
-
-        result.processing_time = time.time() - start_time
-        display.show_summary(self.console, result, output_path, dry_run=self.dry_run)
-
-        return result
+                raise
+            else:
+                undo_manager = self._undo_manager
+                assert undo_manager is not None
+                history = undo_manager.history
+                history.commit_transaction(self._last_transaction_id)
+                result.organized_structure = organized
+        else:
+            self.console.print("\n[bold yellow]DRY RUN - Simulating organization...[/bold yellow]")
+            result.organized_structure = file_ops.simulate_organization(all_processed, output_path)
 
     # ------------------------------------------------------------------
     # Undo / Redo

--- a/tests/cli/test_cli_smoke.py
+++ b/tests/cli/test_cli_smoke.py
@@ -1,0 +1,102 @@
+"""Smoke tests for high-traffic CLI commands.
+
+Markers: smoke + ci + unit. Runtime target: <30s.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from file_organizer.cli.main import app
+
+pytestmark = [pytest.mark.smoke, pytest.mark.ci, pytest.mark.unit]
+runner = CliRunner()
+_SETUP_PATCH = "file_organizer.cli.organize._check_setup_completed"
+
+
+class TestOrganizeSmoke:
+    """fo organize --dry-run exits 0 and reports processed count."""
+
+    @patch("file_organizer.core.organizer.FileOrganizer")
+    @patch(_SETUP_PATCH, return_value=True)
+    def test_organize_dry_run_exits_zero(
+        self, _setup: MagicMock, mock_cls: MagicMock, tmp_path: object
+    ) -> None:
+        import pathlib
+
+        input_dir = pathlib.Path(str(tmp_path)) / "input"
+        output_dir = pathlib.Path(str(tmp_path)) / "output"
+        input_dir.mkdir()
+        output_dir.mkdir()
+        for name in ("a.txt", "b.md", "c.csv"):
+            (input_dir / name).write_text("x")
+
+        mock_org = MagicMock()
+        mock_cls.return_value = mock_org
+        result_obj = MagicMock()
+        result_obj.total_files = 3
+        result_obj.processed_files = 3
+        result_obj.skipped_files = 0
+        result_obj.failed_files = 0
+        mock_org.organize.return_value = result_obj
+
+        result = runner.invoke(
+            app,
+            ["organize", str(input_dir), str(output_dir), "--dry-run"],
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_cls.assert_called_once_with(
+            dry_run=True,
+            parallel_workers=None,
+            prefetch_depth=2,
+            enable_vision=True,
+            no_prefetch=False,
+        )
+
+
+class TestSearchSmoke:
+    """fo search glob exits 0 and names at least one match."""
+
+    def test_search_glob_exits_zero(self, tmp_path: object) -> None:
+        import pathlib
+
+        d = pathlib.Path(str(tmp_path))
+        (d / "report.txt").write_text("hello")
+        (d / "notes.txt").write_text("world")
+
+        result = runner.invoke(app, ["search", "*.txt", str(d)])
+
+        assert result.exit_code == 0, result.output
+        assert "report.txt" in result.output or "notes.txt" in result.output
+
+
+class TestDedupeScanSmoke:
+    """fo dedupe scan exits 0 and reports no duplicates."""
+
+    @patch("file_organizer.cli.dedupe_v2._get_detector")
+    def test_dedupe_scan_no_duplicates(
+        self, mock_get_detector: MagicMock, tmp_path: object
+    ) -> None:
+        mock_det = MagicMock()
+        mock_get_detector.return_value = mock_det
+        mock_det.get_duplicate_groups.return_value = {}
+
+        result = runner.invoke(app, ["dedupe", "scan", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert "No duplicates" in result.output
+        mock_det.scan_directory.assert_called_once()
+
+
+class TestCopilotStatusSmoke:
+    """fo copilot status exits 0 and prints ready (Ollama optional)."""
+
+    def test_copilot_status_exits_zero(self) -> None:
+        result = runner.invoke(app, ["copilot", "status"])
+
+        assert result.exit_code == 0, result.output
+        assert "Copilot" in result.output
+        assert "ready" in result.output

--- a/tests/cli/test_cli_smoke.py
+++ b/tests/cli/test_cli_smoke.py
@@ -26,12 +26,10 @@ class TestOrganizeSmoke:
     @patch("file_organizer.core.organizer.FileOrganizer")
     @patch(_SETUP_PATCH, return_value=True)
     def test_organize_dry_run_exits_zero(
-        self, _setup: MagicMock, mock_cls: MagicMock, tmp_path: object
+        self, _setup: MagicMock, mock_cls: MagicMock, tmp_path: Path
     ) -> None:
-        import pathlib
-
-        input_dir = pathlib.Path(str(tmp_path)) / "input"
-        output_dir = pathlib.Path(str(tmp_path)) / "output"
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
         input_dir.mkdir()
         output_dir.mkdir()
         for name in ("a.txt", "b.md", "c.csv"):

--- a/tests/cli/test_cli_smoke.py
+++ b/tests/cli/test_cli_smoke.py
@@ -23,11 +23,10 @@ class TestOrganizeSmoke:
 
     # FileOrganizer is lazy-imported inside organize(); patching at definition
     # site because cli.organize holds no module-level reference to the class.
+    # _SETUP_PATCH uses new= so its mock is not injected as a parameter (PT019).
     @patch("file_organizer.core.organizer.FileOrganizer")
-    @patch(_SETUP_PATCH, return_value=True)
-    def test_organize_dry_run_exits_zero(
-        self, _setup: MagicMock, mock_cls: MagicMock, tmp_path: Path
-    ) -> None:
+    @patch(_SETUP_PATCH, new=MagicMock(return_value=True))
+    def test_organize_dry_run_exits_zero(self, mock_cls: MagicMock, tmp_path: Path) -> None:
         input_dir = tmp_path / "input"
         output_dir = tmp_path / "output"
         input_dir.mkdir()

--- a/tests/cli/test_cli_smoke.py
+++ b/tests/cli/test_cli_smoke.py
@@ -2,6 +2,7 @@
 
 Markers: smoke + ci + unit. Runtime target: <30s.
 """
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/cli/test_cli_smoke.py
+++ b/tests/cli/test_cli_smoke.py
@@ -61,14 +61,11 @@ class TestOrganizeSmoke:
 class TestSearchSmoke:
     """fo search glob exits 0 and names at least one match."""
 
-    def test_search_glob_exits_zero(self, tmp_path: object) -> None:
-        import pathlib
+    def test_search_glob_exits_zero(self, tmp_path: Path) -> None:
+        (tmp_path / "report.txt").write_text("hello")
+        (tmp_path / "notes.txt").write_text("world")
 
-        d = pathlib.Path(str(tmp_path))
-        (d / "report.txt").write_text("hello")
-        (d / "notes.txt").write_text("world")
-
-        result = runner.invoke(app, ["search", "*.txt", str(d)])
+        result = runner.invoke(app, ["search", "*.txt", str(tmp_path)])
 
         assert result.exit_code == 0, result.output
         assert "report.txt" in result.output or "notes.txt" in result.output
@@ -78,9 +75,7 @@ class TestDedupeScanSmoke:
     """fo dedupe scan exits 0 and reports no duplicates."""
 
     @patch("file_organizer.cli.dedupe_v2._get_detector")
-    def test_dedupe_scan_no_duplicates(
-        self, mock_get_detector: MagicMock, tmp_path: object
-    ) -> None:
+    def test_dedupe_scan_no_duplicates(self, mock_get_detector: MagicMock, tmp_path: Path) -> None:
         mock_det = MagicMock()
         mock_get_detector.return_value = mock_det
         mock_det.get_duplicate_groups.return_value = {}
@@ -89,7 +84,7 @@ class TestDedupeScanSmoke:
 
         assert result.exit_code == 0, result.output
         assert "No duplicates" in result.output
-        mock_det.scan_directory.assert_called_once_with(Path(str(tmp_path)), ANY)
+        mock_det.scan_directory.assert_called_once_with(tmp_path, ANY)
 
 
 class TestCopilotStatusSmoke:

--- a/tests/cli/test_cli_smoke.py
+++ b/tests/cli/test_cli_smoke.py
@@ -4,7 +4,8 @@ Markers: smoke + ci + unit. Runtime target: <30s.
 """
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from pathlib import Path
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
@@ -19,6 +20,8 @@ _SETUP_PATCH = "file_organizer.cli.organize._check_setup_completed"
 class TestOrganizeSmoke:
     """fo organize --dry-run exits 0 and reports processed count."""
 
+    # FileOrganizer is lazy-imported inside organize(); patching at definition
+    # site because cli.organize holds no module-level reference to the class.
     @patch("file_organizer.core.organizer.FileOrganizer")
     @patch(_SETUP_PATCH, return_value=True)
     def test_organize_dry_run_exits_zero(
@@ -88,7 +91,7 @@ class TestDedupeScanSmoke:
 
         assert result.exit_code == 0, result.output
         assert "No duplicates" in result.output
-        mock_det.scan_directory.assert_called_once()
+        mock_det.scan_directory.assert_called_once_with(Path(str(tmp_path)), ANY)
 
 
 class TestCopilotStatusSmoke:

--- a/tests/core/test_organizer.py
+++ b/tests/core/test_organizer.py
@@ -192,7 +192,10 @@ class TestFileOps:
         out_path = tmp_path / "out"
         structure = simulate_organization([p1, p2, p3, err], out_path)
 
-        assert structure == {"docs": ["file_1.txt", "file_2.txt"], "images": ["img_1.jpg"]}
+        assert structure == {
+            "docs": ["file_1.txt", "file_2.txt"],
+            "images": ["img_1.jpg"],
+        }
         assert not out_path.exists()
 
     @patch("file_organizer.core.file_ops.shutil.copy2")
@@ -539,3 +542,63 @@ class TestDeduplicateProcessed:
 
         assert len(deduped) == 1
         assert result.deduplicated_files == 0
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestProcessImageType:
+    """Unit tests for FileOrganizer._process_image_type()."""
+
+    def _make_organizer(self, enable_vision: bool = True) -> FileOrganizer:
+        organizer = FileOrganizer.__new__(FileOrganizer)
+        organizer.console = MagicMock()
+        organizer.enable_vision = enable_vision
+        organizer.vision_processor = None
+        return organizer
+
+    def test_vision_disabled_uses_fallback(self, tmp_path: Path) -> None:
+        """When enable_vision is False, _fallback_by_extension is called."""
+        organizer = self._make_organizer(enable_vision=False)
+        fallback_result = [ProcessedFile(tmp_path / "a.jpg", "", "image", "a")]
+
+        with patch.object(
+            organizer, "_fallback_by_extension", return_value=fallback_result
+        ) as mock_fb:
+            result = organizer._process_image_type([tmp_path / "a.jpg"])
+
+        mock_fb.assert_called_once_with([tmp_path / "a.jpg"])
+        assert result == fallback_result
+
+    def test_vision_enabled_not_initialized_uses_fallback(self, tmp_path: Path) -> None:
+        """When vision is enabled but processor fails to init, falls back to extension."""
+        organizer = self._make_organizer(enable_vision=True)
+        fallback_result = [ProcessedFile(tmp_path / "a.jpg", "", "image", "a")]
+
+        # _init_vision_processor sets vision_processor = None (init failed)
+        with patch.object(organizer, "_init_vision_processor"):
+            organizer.vision_processor = None  # not initialized
+            with patch.object(
+                organizer, "_fallback_by_extension", return_value=fallback_result
+            ) as mock_fb:
+                result = organizer._process_image_type([tmp_path / "a.jpg"])
+
+        mock_fb.assert_called_once_with([tmp_path / "a.jpg"])
+        assert result == fallback_result
+
+    def test_vision_enabled_and_ready_uses_vision_pipeline(self, tmp_path: Path) -> None:
+        """When vision processor is ready, _process_image_files is called."""
+        organizer = self._make_organizer(enable_vision=True)
+        image_results = [MagicMock(spec=ProcessedImage)]
+
+        mock_processor = MagicMock()
+        mock_processor.vision_model.is_initialized = True
+
+        with patch.object(organizer, "_init_vision_processor"):
+            organizer.vision_processor = mock_processor
+            with patch.object(
+                organizer, "_process_image_files", return_value=image_results
+            ) as mock_pif:
+                result = organizer._process_image_type([tmp_path / "a.jpg"])
+
+        mock_pif.assert_called_once_with([tmp_path / "a.jpg"])
+        assert result == image_results

--- a/tests/core/test_organizer.py
+++ b/tests/core/test_organizer.py
@@ -416,8 +416,6 @@ class TestInitializer:
 class TestCategorizeFiles:
     """Unit tests for FileOrganizer._categorize_files()."""
 
-    @pytest.mark.unit
-    @pytest.mark.ci
     def test_routes_by_extension(self, tmp_path: Path) -> None:
         """Files are routed to the correct bucket based on extension."""
         organizer = FileOrganizer.__new__(FileOrganizer)
@@ -436,8 +434,6 @@ class TestCategorizeFiles:
         assert cad == []
         assert other == []
 
-    @pytest.mark.unit
-    @pytest.mark.ci
     def test_unknown_goes_to_other(self, tmp_path: Path) -> None:
         """Files with unrecognized extensions go to the other bucket."""
         organizer = FileOrganizer.__new__(FileOrganizer)
@@ -449,20 +445,16 @@ class TestCategorizeFiles:
         assert len(other) == 1
         assert other[0].name == "mystery.xyz"
 
-    @pytest.mark.unit
-    @pytest.mark.ci
     def test_cad_extension(self, tmp_path: Path) -> None:
         """DWG files are categorized as CAD."""
         organizer = FileOrganizer.__new__(FileOrganizer)
         f = tmp_path / "drawing.dwg"
 
-        text, image, video, audio, cad, other = organizer._categorize_files([f])
+        _text, _image, _video, _audio, cad, _other = organizer._categorize_files([f])
 
         assert len(cad) == 1
         assert cad[0].name == "drawing.dwg"
 
-    @pytest.mark.unit
-    @pytest.mark.ci
     def test_empty_returns_empty_buckets(self) -> None:
         """Empty input yields six empty lists."""
         organizer = FileOrganizer.__new__(FileOrganizer)
@@ -487,8 +479,6 @@ class TestDeduplicateProcessed:
         organizer.console = MagicMock()
         return organizer
 
-    @pytest.mark.unit
-    @pytest.mark.ci
     def test_identical_content_deduplicated(self, tmp_path: Path) -> None:
         """Two files with identical content: only the first is kept."""
         organizer = self._make_organizer()
@@ -507,8 +497,6 @@ class TestDeduplicateProcessed:
         assert len(deduped) == 1
         assert result.deduplicated_files == 1
 
-    @pytest.mark.unit
-    @pytest.mark.ci
     def test_unique_content_all_kept(self, tmp_path: Path) -> None:
         """Files with distinct content are all retained."""
         organizer = self._make_organizer()
@@ -527,8 +515,6 @@ class TestDeduplicateProcessed:
         assert len(deduped) == 2
         assert result.deduplicated_files == 0
 
-    @pytest.mark.unit
-    @pytest.mark.ci
     def test_unreadable_file_kept(self, tmp_path: Path) -> None:
         """A file that raises OSError on read is kept (handled downstream)."""
         organizer = self._make_organizer()

--- a/tests/core/test_organizer.py
+++ b/tests/core/test_organizer.py
@@ -401,3 +401,141 @@ class TestInitializer:
         result = init_vision_processor(config, console)
 
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _categorize_files tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestCategorizeFiles:
+    """Unit tests for FileOrganizer._categorize_files()."""
+
+    @pytest.mark.unit
+    @pytest.mark.ci
+    def test_routes_by_extension(self, tmp_path: Path) -> None:
+        """Files are routed to the correct bucket based on extension."""
+        organizer = FileOrganizer.__new__(FileOrganizer)
+
+        text, image, video, audio, cad, other = organizer._categorize_files(
+            [tmp_path / "doc.txt", tmp_path / "photo.jpg", tmp_path / "movie.mp4"]
+        )
+
+        assert len(text) == 1
+        assert text[0].name == "doc.txt"
+        assert len(image) == 1
+        assert image[0].name == "photo.jpg"
+        assert len(video) == 1
+        assert video[0].name == "movie.mp4"
+        assert audio == []
+        assert cad == []
+        assert other == []
+
+    @pytest.mark.unit
+    @pytest.mark.ci
+    def test_unknown_goes_to_other(self, tmp_path: Path) -> None:
+        """Files with unrecognized extensions go to the other bucket."""
+        organizer = FileOrganizer.__new__(FileOrganizer)
+        f = tmp_path / "mystery.xyz"
+
+        text, image, video, audio, cad, other = organizer._categorize_files([f])
+
+        assert text == image == video == audio == cad == []
+        assert len(other) == 1
+        assert other[0].name == "mystery.xyz"
+
+    @pytest.mark.unit
+    @pytest.mark.ci
+    def test_cad_extension(self, tmp_path: Path) -> None:
+        """DWG files are categorized as CAD."""
+        organizer = FileOrganizer.__new__(FileOrganizer)
+        f = tmp_path / "drawing.dwg"
+
+        text, image, video, audio, cad, other = organizer._categorize_files([f])
+
+        assert len(cad) == 1
+        assert cad[0].name == "drawing.dwg"
+
+    @pytest.mark.unit
+    @pytest.mark.ci
+    def test_empty_returns_empty_buckets(self) -> None:
+        """Empty input yields six empty lists."""
+        organizer = FileOrganizer.__new__(FileOrganizer)
+
+        result = organizer._categorize_files([])
+
+        assert all(lst == [] for lst in result)
+
+
+# ---------------------------------------------------------------------------
+# _deduplicate_processed tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestDeduplicateProcessed:
+    """Unit tests for FileOrganizer._deduplicate_processed()."""
+
+    def _make_organizer(self) -> FileOrganizer:
+        organizer = FileOrganizer.__new__(FileOrganizer)
+        organizer.console = MagicMock()
+        return organizer
+
+    @pytest.mark.unit
+    @pytest.mark.ci
+    def test_identical_content_deduplicated(self, tmp_path: Path) -> None:
+        """Two files with identical content: only the first is kept."""
+        organizer = self._make_organizer()
+        result = OrganizationResult(total_files=2)
+
+        f1 = tmp_path / "a.txt"
+        f2 = tmp_path / "b.txt"
+        f1.write_bytes(b"same content")
+        f2.write_bytes(b"same content")
+
+        pf1 = ProcessedFile(f1, "", "document", "a")
+        pf2 = ProcessedFile(f2, "", "document", "b")
+
+        deduped = organizer._deduplicate_processed([pf1, pf2], result)
+
+        assert len(deduped) == 1
+        assert result.deduplicated_files == 1
+
+    @pytest.mark.unit
+    @pytest.mark.ci
+    def test_unique_content_all_kept(self, tmp_path: Path) -> None:
+        """Files with distinct content are all retained."""
+        organizer = self._make_organizer()
+        result = OrganizationResult(total_files=2)
+
+        f1 = tmp_path / "a.txt"
+        f2 = tmp_path / "b.txt"
+        f1.write_bytes(b"content A")
+        f2.write_bytes(b"content B")
+
+        pf1 = ProcessedFile(f1, "", "document", "a")
+        pf2 = ProcessedFile(f2, "", "document", "b")
+
+        deduped = organizer._deduplicate_processed([pf1, pf2], result)
+
+        assert len(deduped) == 2
+        assert result.deduplicated_files == 0
+
+    @pytest.mark.unit
+    @pytest.mark.ci
+    def test_unreadable_file_kept(self, tmp_path: Path) -> None:
+        """A file that raises OSError on read is kept (handled downstream)."""
+        organizer = self._make_organizer()
+        result = OrganizationResult(total_files=1)
+
+        # Point to a nonexistent path — open() raises OSError
+        f = tmp_path / "ghost.txt"
+        pf = ProcessedFile(f, "", "document", "ghost")
+
+        deduped = organizer._deduplicate_processed([pf], result)
+
+        assert len(deduped) == 1
+        assert result.deduplicated_files == 0


### PR DESCRIPTION
## Summary

Four independent improvements delivered as a single PR from \`codex/issues-85-88\`:

- **#88 — Triage policy doc**: New \`docs/developer/triage-policy.md\` with decision tree for cleanup-only test work. Added pointer in \`CONTRIBUTING.md\` and \`docs/developer/index.md\`.
- **#85 — One-command coverage ratchet**: New \`scripts/coverage/ratchet.sh\` wrapping the 3-step integration coverage flow into \`check\` / \`update\` / \`dry-run\` modes. Updated \`scripts/coverage/README.md\` and \`CONTRIBUTING.md\`.
- **#87 — CLI smoke tests**: New \`tests/cli/test_cli_smoke.py\` with 4 smoke tests (\`fo organize\`, \`fo search\`, \`fo dedupe scan\`, \`fo copilot status\`). All marked \`smoke + ci + unit\`, run in 1.25s.
- **#86 — Organizer refactor (C901 removal)**: Extracted 5 private methods from \`organize()\` (complexity 33 → ≤15): \`_categorize_files\`, \`_process_image_type\`, \`_process_all_file_types\`, \`_deduplicate_processed\`, \`_execute_organization\`. Removed C901 exemption from \`pyproject.toml\`. Added \`TestCategorizeFiles\` (4 tests), \`TestDeduplicateProcessed\` (3 tests), \`TestProcessImageType\` (3 tests).

## Closes

Closes #85
Closes #86
Closes #87
Closes #88

## Test plan

- [x] \`pymarkdown scan docs/developer/triage-policy.md\` → 0 violations
- [x] \`bash scripts/coverage/ratchet.sh unknown_mode\` → exits 2 with usage message
- [x] \`bash scripts/coverage/ratchet.sh check\` → validates baseline; \`update\` ratchets upward; \`dry-run\` previews changes
- [x] \`pytest -m smoke tests/cli/test_cli_smoke.py -q --override-ini="addopts="\` → 4 passed
- [x] \`ruff check --select C901 src/file_organizer/core/organizer.py\` → no violations
- [x] \`pytest tests/core/test_organizer.py -q --override-ini="addopts="\` → 33 passed
- [x] Pre-commit hooks: all pass
- [x] CI: Test PR suite (py3.11) → SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)