### PR TITLE
fix: isolate config edit persistence test from xdist races

### DIFF
--- a/tests/integration/test_cli_config.py
+++ b/tests/integration/test_cli_config.py
@@ -6,6 +6,8 @@ Covers: config show, config list (empty / with profiles), config edit
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from typer.testing import CliRunner
 
@@ -156,8 +158,15 @@ class TestConfigEdit:
         assert result.exit_code == 0
         assert "saved" in result.output.lower()
 
-    def test_config_edit_persists_text_model(self) -> None:
-        """After editing, config show reflects the updated text model."""
+    def test_config_edit_persists_text_model(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """After editing, config show reflects the updated text model.
+
+        Uses an isolated config dir via monkeypatch to avoid races with other
+        tests that write to the shared default profile under xdist parallelism.
+        """
+        monkeypatch.setattr("file_organizer.config.manager.DEFAULT_CONFIG_DIR", tmp_path)
         runner.invoke(app, ["config", "edit", "--text-model", "llama3.2:3b"])
         result = runner.invoke(app, ["config", "show"])
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary

- `test_config_edit_persists_text_model` was writing to the real user config directory with no isolation
- Under xdist parallelism, `test_config_edit_multiple_fields_at_once` (on a different worker) could overwrite `llama3.2:3b` with `qwen2.5:7b` between the edit and show calls, producing a deterministic-looking but worker-order-dependent failure
- Fix: `monkeypatch.setattr("file_organizer.config.manager.DEFAULT_CONFIG_DIR", tmp_path)` redirects `ConfigManager()` to an isolated temp dir for the duration of the test

Fixes the flaky failure reported from the main CI run:
```
AssertionError: assert 'llama3.2:3b' in '...Text model: qwen2.5:7b...'
```

## Test plan

- [x] `pytest tests/integration/test_cli_config.py -m integration --override-ini="addopts=" -n 4` — 26 passed
- [x] `pytest tests/integration/test_cli_config.py::TestConfigEdit::test_config_edit_persists_text_model -xvs --override-ini="addopts="` — 1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)