### PR TITLE
ci: add extras validation workflow with smoke canaries (10 extras)

### DIFF
--- a/.github/workflows/ci-extras.yml
+++ b/.github/workflows/ci-extras.yml
@@ -64,7 +64,7 @@ jobs:
           - extra: audio
             os: ubuntu-latest
             timeout_minutes: 20  # torch download is large
-            key_import: "import faster_whisper; import mutagen; import tinytag; import torch; print('OK')"
+            key_import: "import faster_whisper; import mutagen; import tinytag; import pydub; import torch; print('OK')"
             smoke: "true"
           # --- Platform/API extras (install + import only) ---
           - extra: cloud

--- a/.github/workflows/ci-extras.yml
+++ b/.github/workflows/ci-extras.yml
@@ -1,0 +1,112 @@
+name: Extras Validation
+
+# Validates that each optional extra can be installed, imported, and (for
+# file-capability extras) passes a minimal smoke canary test.
+#
+# Extras classification:
+#   file-capability (install + import + smoke): audio, video, dedup, archive, scientific, cad
+#   platform/API    (install + import only):    cloud, llama, claude, mlx
+#
+# mlx is Darwin-only and runs on macos-latest.
+# llama/audio may take 5-10 min to install due to large binary wheels (llama-cpp, torch).
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - ".claude/**"
+      - "docs/**"
+      - "*.md"
+  push:
+    branches: [main]
+    paths-ignore:
+      - ".claude/**"
+      - "docs/**"
+
+permissions:
+  contents: read
+
+jobs:
+  extras-validate:
+    name: "Extras [${{ matrix.extra }}]"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: ${{ matrix.timeout_minutes }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # --- File capability extras (install + import + smoke canary) ---
+          - extra: archive
+            os: ubuntu-latest
+            timeout_minutes: 10
+            key_import: "import py7zr; import rarfile; print('OK')"
+            smoke: "true"
+          - extra: scientific
+            os: ubuntu-latest
+            timeout_minutes: 10
+            key_import: "import h5py; import netCDF4; import scipy; print('OK')"
+            smoke: "true"
+          - extra: cad
+            os: ubuntu-latest
+            timeout_minutes: 10
+            key_import: "import ezdxf; print('OK')"
+            smoke: "true"
+          - extra: dedup
+            os: ubuntu-latest
+            timeout_minutes: 15
+            key_import: "import imagededup; import sklearn; print('OK')"
+            smoke: "true"
+          - extra: video
+            os: ubuntu-latest
+            timeout_minutes: 15
+            key_import: "import cv2; import scenedetect; print('OK')"
+            smoke: "true"
+          - extra: audio
+            os: ubuntu-latest
+            timeout_minutes: 20  # torch download is large
+            key_import: "import faster_whisper; import mutagen; import tinytag; print('OK')"
+            smoke: "true"
+          # --- Platform/API extras (install + import only) ---
+          - extra: cloud
+            os: ubuntu-latest
+            timeout_minutes: 10
+            key_import: "import openai; print('OK')"
+            smoke: "false"
+          - extra: claude
+            os: ubuntu-latest
+            timeout_minutes: 10
+            key_import: "import anthropic; print('OK')"
+            smoke: "false"
+          - extra: llama
+            os: ubuntu-latest
+            timeout_minutes: 20  # llama-cpp-python build is large
+            key_import: "import llama_cpp; print('OK')"
+            smoke: "false"
+          - extra: mlx
+            os: macos-latest
+            timeout_minutes: 15
+            key_import: "import mlx_lm; print('OK')"
+            smoke: "false"
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install extra with dev dependencies
+        # .[dev,extra] ensures pytest and repo test toolchain are present for canary runs
+        run: pip install -e ".[dev,${{ matrix.extra }}]"
+
+      - name: Verify key imports
+        run: python -c "${{ matrix.key_import }}"
+
+      - name: Run smoke canary
+        if: matrix.smoke == 'true'
+        run: |
+          pytest tests/extras/test_extras_${{ matrix.extra }}.py \
+            -m "smoke" \
+            -x \
+            -v \
+            --override-ini="addopts="

--- a/.github/workflows/ci-extras.yml
+++ b/.github/workflows/ci-extras.yml
@@ -22,6 +22,7 @@ on:
     paths-ignore:
       - ".claude/**"
       - "docs/**"
+      - "*.md"
 
 permissions:
   contents: read
@@ -54,7 +55,7 @@ jobs:
           - extra: dedup
             os: ubuntu-latest
             timeout_minutes: 15
-            key_import: "import imagededup; import sklearn; print('OK')"
+            key_import: "import imagededup; import sklearn; import pypdf; import striprtf; print('OK')"
             smoke: "true"
           - extra: video
             os: ubuntu-latest

--- a/.github/workflows/ci-extras.yml
+++ b/.github/workflows/ci-extras.yml
@@ -64,7 +64,7 @@ jobs:
           - extra: audio
             os: ubuntu-latest
             timeout_minutes: 20  # torch download is large
-            key_import: "import faster_whisper; import mutagen; import tinytag; print('OK')"
+            key_import: "import faster_whisper; import mutagen; import tinytag; import torch; print('OK')"
             smoke: "true"
           # --- Platform/API extras (install + import only) ---
           - extra: cloud

--- a/docs/internal/xdist-audit-2026-04-15.md
+++ b/docs/internal/xdist-audit-2026-04-15.md
@@ -33,7 +33,7 @@ in the test suite or missing assets; they are out of scope for xdist hardening.
 | Test group | Count | Root cause |
 |------------|-------|-----------|
 | `tests/integration/test_context_menu_macos.py::TestMacOSQuickAction::*` | 12 | `desktop/context-menus/macos/` directory does not exist in repo. Tests lack `@pytest.mark.integration` marker so they are not excluded by the audit filter. |
-| `tests/docs/test_doc_file_paths.py::test_referenced_path_exists[...pr4-extras-*]` | 9 | Plan doc `docs/superpowers/plans/2026-04-15-pr4-extras-validation.md` references files that do not yet exist (`tests/extras/`, `.github/workflows/ci-extras.yml`). |
+| `tests/docs/test_doc_file_paths.py::test_referenced_path_exists[...pr4-extras-*]` | 9 | Plan doc `docs/superpowers/plans/2026-04-15-pr4-extras-validation.md` references files that do not yet exist (`tests/extras/` directory and `ci-extras.yml` workflow). |
 | `tests/ci/test_workflows.py::TestShardCoverage::test_all_test_directories_assigned_to_shard` | 1 | `tests/extras/` directory not assigned to any shard in `scripts/ci_shard_paths.sh`. |
 | `tests/ci/test_md031_ratchet.py::test_no_new_md031_violations_in_changed_files` | 1 | MD031 fenced-code-block violations in plan/spec docs changed on this branch. |
 

--- a/scripts/ci_shard_paths.sh
+++ b/scripts/ci_shard_paths.sh
@@ -78,7 +78,7 @@ case "$SHARD" in
     # Guardrail / unit tests plus the small-to-medium suites that were previously
     # spread across shards 4-6 and under-loaded them.
     # tests/test_*.py expands to the root-level integration / smoke tests.
-    6) PATHS="tests/ci tests/unit tests/utils tests/undo tests/history tests/daemon tests/watcher tests/updater tests/core tests/config tests/docs tests/integrations tests/interfaces tests/test_*.py" ;;
+    6) PATHS="tests/ci tests/unit tests/utils tests/undo tests/history tests/daemon tests/watcher tests/updater tests/core tests/config tests/docs tests/integrations tests/interfaces tests/extras tests/test_*.py" ;;
 
     *)
         echo "Unknown shard: $SHARD (valid: 1-6)" >&2

--- a/tests/extras/test_extras_archive.py
+++ b/tests/extras/test_extras_archive.py
@@ -1,0 +1,40 @@
+"""Smoke canary for the [archive] optional extra (py7zr, rarfile).
+
+Uses a 7z archive — NOT zip, which is core and would not exercise py7zr.
+rarfile can read RAR files but cannot create them, so RAR validation is
+import-only; the 7z path exercises the full read pipeline.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.smoke
+def test_archive_reads_7z_file(tmp_path: Path) -> None:
+    py7zr = pytest.importorskip("py7zr")
+    from file_organizer.utils.readers.archives import read_7z_file
+
+    # Create a minimal 7z archive containing one text file
+    archive_path = tmp_path / "test.7z"
+    content_file = tmp_path / "hello.txt"
+    content_file.write_text("hello from 7z archive")
+
+    with py7zr.SevenZipFile(archive_path, mode="w") as archive:
+        archive.write(content_file, arcname="hello.txt")
+
+    result = read_7z_file(archive_path)
+
+    # read_7z_file returns archive metadata + file listing (not raw file content)
+    assert result is not None
+    assert isinstance(result, str)
+    assert "hello.txt" in result  # archived filename appears in the listing
+
+
+@pytest.mark.smoke
+def test_rarfile_importable() -> None:
+    """rarfile can only read RAR files, not create them.
+    Validate it imports cleanly — creation requires external tooling."""
+    pytest.importorskip("rarfile")
+    import rarfile  # noqa: F401 — import validation only

--- a/tests/extras/test_extras_archive.py
+++ b/tests/extras/test_extras_archive.py
@@ -4,6 +4,7 @@ Uses a 7z archive — NOT zip, which is core and would not exercise py7zr.
 rarfile can read RAR files but cannot create them, so RAR validation is
 import-only; the 7z path exercises the full read pipeline.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -37,4 +38,3 @@ def test_rarfile_importable() -> None:
     """rarfile can only read RAR files, not create them.
     Validate it imports cleanly — creation requires external tooling."""
     pytest.importorskip("rarfile")
-    import rarfile  # noqa: F401 — import validation only

--- a/tests/extras/test_extras_audio.py
+++ b/tests/extras/test_extras_audio.py
@@ -1,0 +1,61 @@
+"""Smoke canary for the [audio] optional extra (faster-whisper, mutagen, tinytag, pydub)."""
+from __future__ import annotations
+
+import struct
+import wave
+from pathlib import Path
+
+import pytest
+
+
+def _make_wav(path: Path) -> None:
+    """Write a 0.1-second 44100 Hz mono WAV file using the stdlib wave module."""
+    num_frames = 4410  # 0.1 s at 44100 Hz
+    with wave.open(str(path), "w") as f:
+        f.setnchannels(1)
+        f.setsampwidth(2)  # 16-bit
+        f.setframerate(44100)
+        f.writeframes(struct.pack("<" + "h" * num_frames, *([0] * num_frames)))
+
+
+@pytest.mark.smoke
+def test_audio_metadata_extractor_reads_wav(tmp_path: Path) -> None:
+    pytest.importorskip("mutagen")
+    from file_organizer.services.audio.metadata_extractor import (
+        AudioMetadata,
+        AudioMetadataExtractor,
+    )
+
+    wav_path = tmp_path / "test.wav"
+    _make_wav(wav_path)
+
+    extractor = AudioMetadataExtractor(use_fallback=True)
+    result = extractor.extract(wav_path)
+
+    assert result is not None
+    assert isinstance(result, AudioMetadata)
+
+
+@pytest.mark.smoke
+def test_tinytag_importable() -> None:
+    pytest.importorskip("tinytag")
+    import tinytag  # noqa: F401
+
+
+@pytest.mark.smoke
+def test_faster_whisper_model_loads(tmp_path: Path) -> None:
+    """Verify faster-whisper can instantiate a WhisperModel (no transcription needed)."""
+    faster_whisper = pytest.importorskip("faster_whisper")
+
+    # Instantiate with the tiny model and cpu device; download is skipped
+    # because we only check that the class is importable and constructable
+    # using a known offline model path.  Pass compute_type="int8" to avoid
+    # needing CUDA drivers on CI runners.
+    model = faster_whisper.WhisperModel.__new__(faster_whisper.WhisperModel)
+    assert model is not None  # class is accessible; full load tested in CI with model cache
+
+
+@pytest.mark.smoke
+def test_pydub_importable() -> None:
+    pytest.importorskip("pydub")
+    import pydub  # noqa: F401

--- a/tests/extras/test_extras_audio.py
+++ b/tests/extras/test_extras_audio.py
@@ -53,4 +53,4 @@ def test_faster_whisper_importable() -> None:
 
 @pytest.mark.smoke
 def test_pydub_importable() -> None:
-    pytest.importorskip("pydub")
+    import pydub  # noqa: F401 — assert the dep is present in the [audio] extra

--- a/tests/extras/test_extras_audio.py
+++ b/tests/extras/test_extras_audio.py
@@ -1,4 +1,5 @@
 """Smoke canary for the [audio] optional extra (faster-whisper, mutagen, tinytag, pydub)."""
+
 from __future__ import annotations
 
 import struct
@@ -34,28 +35,22 @@ def test_audio_metadata_extractor_reads_wav(tmp_path: Path) -> None:
 
     assert result is not None
     assert isinstance(result, AudioMetadata)
+    assert result.sample_rate == 44100
+    assert result.duration == pytest.approx(0.1, abs=0.05)
 
 
 @pytest.mark.smoke
 def test_tinytag_importable() -> None:
     pytest.importorskip("tinytag")
-    import tinytag  # noqa: F401
 
 
 @pytest.mark.smoke
-def test_faster_whisper_model_loads(tmp_path: Path) -> None:
-    """Verify faster-whisper can instantiate a WhisperModel (no transcription needed)."""
+def test_faster_whisper_importable() -> None:
+    """Verify faster-whisper is installed and the WhisperModel class is accessible."""
     faster_whisper = pytest.importorskip("faster_whisper")
-
-    # Instantiate with the tiny model and cpu device; download is skipped
-    # because we only check that the class is importable and constructable
-    # using a known offline model path.  Pass compute_type="int8" to avoid
-    # needing CUDA drivers on CI runners.
-    model = faster_whisper.WhisperModel.__new__(faster_whisper.WhisperModel)
-    assert model is not None  # class is accessible; full load tested in CI with model cache
+    assert hasattr(faster_whisper, "WhisperModel")
 
 
 @pytest.mark.smoke
 def test_pydub_importable() -> None:
     pytest.importorskip("pydub")
-    import pydub  # noqa: F401

--- a/tests/extras/test_extras_audio.py
+++ b/tests/extras/test_extras_audio.py
@@ -53,4 +53,4 @@ def test_faster_whisper_importable() -> None:
 
 @pytest.mark.smoke
 def test_pydub_importable() -> None:
-    import pydub  # noqa: F401 — assert the dep is present in the [audio] extra
+    pytest.importorskip("pydub")

--- a/tests/extras/test_extras_cad.py
+++ b/tests/extras/test_extras_cad.py
@@ -1,4 +1,5 @@
 """Smoke canary for the [cad] optional extra (ezdxf)."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/extras/test_extras_cad.py
+++ b/tests/extras/test_extras_cad.py
@@ -22,6 +22,5 @@ def test_cad_reads_dxf_file(tmp_path: Path) -> None:
     # read_dxf_file returns metadata + layer information, not raw DXF text
     result = read_dxf_file(dxf_path)
 
-    assert result is not None
     assert isinstance(result, str)
-    assert len(result) > 0
+    assert "LINE" in result  # the added LINE entity must appear in entity metadata

--- a/tests/extras/test_extras_cad.py
+++ b/tests/extras/test_extras_cad.py
@@ -1,0 +1,26 @@
+"""Smoke canary for the [cad] optional extra (ezdxf)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.smoke
+def test_cad_reads_dxf_file(tmp_path: Path) -> None:
+    ezdxf = pytest.importorskip("ezdxf")
+    from file_organizer.utils.readers.cad import read_dxf_file
+
+    # Create a minimal DXF file with a single line entity
+    dxf_path = tmp_path / "test.dxf"
+    doc = ezdxf.new(dxfversion="R2010")
+    msp = doc.modelspace()
+    msp.add_line((0, 0), (10, 10))
+    doc.saveas(dxf_path)
+
+    # read_dxf_file returns metadata + layer information, not raw DXF text
+    result = read_dxf_file(dxf_path)
+
+    assert result is not None
+    assert isinstance(result, str)
+    assert len(result) > 0

--- a/tests/extras/test_extras_dedup.py
+++ b/tests/extras/test_extras_dedup.py
@@ -1,0 +1,30 @@
+"""Smoke canary for the [dedup] optional extra (imagededup, scikit-learn)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.smoke
+def test_image_deduplicator_finds_identical_images(tmp_path: Path) -> None:
+    pytest.importorskip("imagededup")
+    from PIL import Image  # Pillow is a dep of imagededup
+    from file_organizer.services.deduplication.image_dedup import ImageDeduplicator
+
+    # Create two identical small images — deduplicator should flag them
+    img = Image.new("RGB", (64, 64), color=(128, 64, 32))
+    img.save(tmp_path / "img1.jpg")
+    img.save(tmp_path / "img2.jpg")
+
+    deduplicator = ImageDeduplicator()
+    result = deduplicator.find_duplicates(tmp_path)
+
+    assert result is not None
+    assert isinstance(result, dict)
+
+
+@pytest.mark.smoke
+def test_sklearn_importable() -> None:
+    pytest.importorskip("sklearn")
+    import sklearn  # noqa: F401

--- a/tests/extras/test_extras_dedup.py
+++ b/tests/extras/test_extras_dedup.py
@@ -1,4 +1,5 @@
 """Smoke canary for the [dedup] optional extra (imagededup, scikit-learn)."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -10,6 +11,7 @@ import pytest
 def test_image_deduplicator_finds_identical_images(tmp_path: Path) -> None:
     pytest.importorskip("imagededup")
     from PIL import Image  # Pillow is a dep of imagededup
+
     from file_organizer.services.deduplication.image_dedup import ImageDeduplicator
 
     # Create two identical small images — deduplicator should flag them
@@ -22,9 +24,9 @@ def test_image_deduplicator_finds_identical_images(tmp_path: Path) -> None:
 
     assert result is not None
     assert isinstance(result, dict)
+    assert len(result) >= 1  # at least one duplicate group found from identical images
 
 
 @pytest.mark.smoke
 def test_sklearn_importable() -> None:
     pytest.importorskip("sklearn")
-    import sklearn  # noqa: F401

--- a/tests/extras/test_extras_dedup.py
+++ b/tests/extras/test_extras_dedup.py
@@ -14,17 +14,18 @@ def test_image_deduplicator_finds_identical_images(tmp_path: Path) -> None:
 
     from file_organizer.services.deduplication.image_dedup import ImageDeduplicator
 
-    # Create two identical small images — deduplicator should flag them
+    # Use PNG (lossless) so both saves produce bit-identical files and the
+    # perceptual hash distance is guaranteed to be 0.  threshold=0 requires
+    # exact hash match, making the assertion deterministic.
     img = Image.new("RGB", (64, 64), color=(128, 64, 32))
-    img.save(tmp_path / "img1.jpg")
-    img.save(tmp_path / "img2.jpg")
+    img.save(tmp_path / "img1.png")
+    img.save(tmp_path / "img2.png")
 
-    deduplicator = ImageDeduplicator()
+    deduplicator = ImageDeduplicator(threshold=0)
     result = deduplicator.find_duplicates(tmp_path)
 
-    assert result is not None
     assert isinstance(result, dict)
-    assert len(result) >= 1  # at least one duplicate group found from identical images
+    assert len(result) >= 1  # identical PNGs must produce a duplicate group
 
 
 @pytest.mark.smoke

--- a/tests/extras/test_extras_dedup.py
+++ b/tests/extras/test_extras_dedup.py
@@ -9,7 +9,11 @@ import pytest
 
 @pytest.mark.smoke
 def test_image_deduplicator_finds_identical_images(tmp_path: Path) -> None:
-    pytest.importorskip("imagededup")
+    imagededup = pytest.importorskip("imagededup")
+    # Guard against sys.modules mock injection from test_image_dedup.py under
+    # xdist: if imagededup is a bare ModuleType mock it won't have __version__.
+    if not hasattr(imagededup, "__version__"):
+        pytest.skip("imagededup is mocked by unit tests — real package not installed")
     from PIL import Image  # Pillow is a dep of imagededup
 
     from file_organizer.services.deduplication.image_dedup import ImageDeduplicator

--- a/tests/extras/test_extras_dedup.py
+++ b/tests/extras/test_extras_dedup.py
@@ -15,17 +15,21 @@ def test_image_deduplicator_finds_identical_images(tmp_path: Path) -> None:
     from file_organizer.services.deduplication.image_dedup import ImageDeduplicator
 
     # Use PNG (lossless) so both saves produce bit-identical files and the
-    # perceptual hash distance is guaranteed to be 0.  threshold=0 requires
-    # exact hash match, making the assertion deterministic.
+    # perceptual hash distance is guaranteed to be 0.
+    # Use cluster_by_similarity (direct Hamming distance, <= comparison) rather
+    # than find_duplicates (delegates to imagededup whose threshold semantics
+    # vary by version) to keep the assertion deterministic.
     img = Image.new("RGB", (64, 64), color=(128, 64, 32))
     img.save(tmp_path / "img1.png")
     img.save(tmp_path / "img2.png")
 
     deduplicator = ImageDeduplicator(threshold=0)
-    result = deduplicator.find_duplicates(tmp_path)
+    clusters = deduplicator.cluster_by_similarity(
+        [tmp_path / "img1.png", tmp_path / "img2.png"]
+    )
 
-    assert isinstance(result, dict)
-    assert len(result) >= 1  # identical PNGs must produce a duplicate group
+    assert len(clusters) == 1  # identical PNGs must form exactly one cluster
+    assert len(clusters[0]) == 2  # both images in the cluster
 
 
 @pytest.mark.smoke

--- a/tests/extras/test_extras_scientific.py
+++ b/tests/extras/test_extras_scientific.py
@@ -23,9 +23,8 @@ def test_scientific_reads_hdf5_file(tmp_path: Path) -> None:
     # read_hdf5_file returns HDF5 structure metadata, not raw dataset values
     result = read_hdf5_file(hdf5_path)
 
-    assert result is not None
     assert isinstance(result, str)
-    assert len(result) > 0
+    assert "measurements" in result  # dataset name must appear in HDF5 structure output
 
 
 @pytest.mark.smoke

--- a/tests/extras/test_extras_scientific.py
+++ b/tests/extras/test_extras_scientific.py
@@ -1,4 +1,5 @@
 """Smoke canary for the [scientific] optional extra (h5py, netCDF4, scipy)."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -10,6 +11,7 @@ import pytest
 def test_scientific_reads_hdf5_file(tmp_path: Path) -> None:
     h5py = pytest.importorskip("h5py")
     import numpy as np  # numpy is a transitive dep of h5py
+
     from file_organizer.utils.readers.scientific import read_hdf5_file
 
     # Create a minimal HDF5 file with one dataset and one attribute
@@ -29,10 +31,8 @@ def test_scientific_reads_hdf5_file(tmp_path: Path) -> None:
 @pytest.mark.smoke
 def test_scipy_importable() -> None:
     pytest.importorskip("scipy")
-    import scipy  # noqa: F401
 
 
 @pytest.mark.smoke
 def test_netcdf4_importable() -> None:
     pytest.importorskip("netCDF4")
-    import netCDF4  # noqa: F401

--- a/tests/extras/test_extras_scientific.py
+++ b/tests/extras/test_extras_scientific.py
@@ -1,0 +1,38 @@
+"""Smoke canary for the [scientific] optional extra (h5py, netCDF4, scipy)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.smoke
+def test_scientific_reads_hdf5_file(tmp_path: Path) -> None:
+    h5py = pytest.importorskip("h5py")
+    import numpy as np  # numpy is a transitive dep of h5py
+    from file_organizer.utils.readers.scientific import read_hdf5_file
+
+    # Create a minimal HDF5 file with one dataset and one attribute
+    hdf5_path = tmp_path / "test.h5"
+    with h5py.File(hdf5_path, "w") as f:
+        f.create_dataset("measurements", data=np.array([1.0, 2.5, 3.7]))
+        f.attrs["description"] = "canary dataset"
+
+    # read_hdf5_file returns HDF5 structure metadata, not raw dataset values
+    result = read_hdf5_file(hdf5_path)
+
+    assert result is not None
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+@pytest.mark.smoke
+def test_scipy_importable() -> None:
+    pytest.importorskip("scipy")
+    import scipy  # noqa: F401
+
+
+@pytest.mark.smoke
+def test_netcdf4_importable() -> None:
+    pytest.importorskip("netCDF4")
+    import netCDF4  # noqa: F401

--- a/tests/extras/test_extras_video.py
+++ b/tests/extras/test_extras_video.py
@@ -1,4 +1,5 @@
 """Smoke canary for the [video] optional extra (opencv-python, scenedetect)."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -63,4 +64,5 @@ def test_scenedetect_detects_scenes(tmp_path: Path) -> None:
     scene_manager.add_detector(scenedetect.ContentDetector())
     scene_manager.detect_scenes(video)
     scenes = scene_manager.get_scene_list()
-    assert isinstance(scenes, list)  # may be empty — that is fine for a canary
+    assert isinstance(scenes, list)
+    assert len(scenes) == 0  # uniform black frames produce no scene cuts

--- a/tests/extras/test_extras_video.py
+++ b/tests/extras/test_extras_video.py
@@ -1,0 +1,66 @@
+"""Smoke canary for the [video] optional extra (opencv-python, scenedetect)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.smoke
+def test_opencv_read_write_cycle(tmp_path: Path) -> None:
+    """Validate the opencv-python install end-to-end without going through ffprobe."""
+    cv2 = pytest.importorskip("cv2")
+    import numpy as np  # numpy is a transitive dep of opencv-python
+
+    # Write a minimal video using cv2 (not ffprobe)
+    video_path = tmp_path / "test.mp4"
+    out = cv2.VideoWriter(
+        str(video_path),
+        cv2.VideoWriter_fourcc(*"mp4v"),
+        1,  # fps
+        (64, 64),  # width x height
+    )
+    frame = np.zeros((64, 64, 3), dtype=np.uint8)
+    for _ in range(5):
+        out.write(frame)
+    out.release()
+
+    # Read it back with cv2 — exercises the full opencv install path, not ffprobe
+    cap = cv2.VideoCapture(str(video_path))
+    assert cap.isOpened(), "cv2 could not open the written video"
+    frame_count = 0
+    while True:
+        ret, _ = cap.read()
+        if not ret:
+            break
+        frame_count += 1
+    cap.release()
+    assert frame_count >= 1
+
+
+@pytest.mark.smoke
+def test_scenedetect_detects_scenes(tmp_path: Path) -> None:
+    """Validate scenedetect performs actual scene detection (not just an import check)."""
+    cv2 = pytest.importorskip("cv2")
+    scenedetect = pytest.importorskip("scenedetect")
+    import numpy as np
+
+    # Write a minimal video for scenedetect to process
+    video_path = tmp_path / "scenes.mp4"
+    out = cv2.VideoWriter(
+        str(video_path),
+        cv2.VideoWriter_fourcc(*"mp4v"),
+        10,  # fps (scenedetect needs > 1 fps to resolve timecodes)
+        (64, 64),
+    )
+    frame = np.zeros((64, 64, 3), dtype=np.uint8)
+    for _ in range(30):
+        out.write(frame)
+    out.release()
+
+    video = scenedetect.open_video(str(video_path))
+    scene_manager = scenedetect.SceneManager()
+    scene_manager.add_detector(scenedetect.ContentDetector())
+    scene_manager.detect_scenes(video)
+    scenes = scene_manager.get_scene_list()
+    assert isinstance(scenes, list)  # may be empty — that is fine for a canary

--- a/tests/services/deduplication/test_image_dedup.py
+++ b/tests/services/deduplication/test_image_dedup.py
@@ -37,6 +37,22 @@ _imagededup_methods_mod.AHash = _mock_ahash_cls  # type: ignore[attr-defined]
 sys.modules.setdefault("imagededup", _imagededup_mod)
 sys.modules.setdefault("imagededup.methods", _imagededup_methods_mod)
 
+
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_imagededup_sys_modules() -> None:
+    """Remove injected imagededup mocks from sys.modules after the session.
+
+    The module-level setdefault() calls above inject mock modules when imagededup
+    is not installed.  Without cleanup, the mock persists across xdist workers
+    in the same process, causing smoke-canary tests to receive mock PHash
+    instances instead of being skipped via pytest.importorskip.
+    """
+    yield  # type: ignore[misc]
+    if sys.modules.get("imagededup") is _imagededup_mod:
+        del sys.modules["imagededup"]
+    if sys.modules.get("imagededup.methods") is _imagededup_methods_mod:
+        del sys.modules["imagededup.methods"]
+
 # Now import the module under test – the mocked modules will satisfy the
 # ``from imagededup.methods import …`` statement.
 import file_organizer.services.deduplication.image_dedup as _image_dedup_module  # noqa: E402


### PR DESCRIPTION
## Summary

- New `.github/workflows/ci-extras.yml` validates 10 optional extras on every PR push and main push via a matrix job
- **6 file-capability extras** (archive, scientific, cad, dedup, video, audio): `pip install -e ".[dev,extra]"` + key import check + smoke canary test in `tests/extras/`
- **4 platform/API extras** (cloud, llama, claude, mlx): install + import only (no external calls in CI); mlx runs on `macos-latest`
- Smoke canary tests use `tmp_path` fixture files — no network, no external calls
- Archive canary uses a 7z fixture (not ZIP, which is core)
- Video canary uses `cv2.VideoCapture` end-to-end (bypasses ffprobe path) and actual `SceneManager + ContentDetector` scene detection
- Audio canary uses `WhisperModel` attribute check (no model download)

Closes workstream 4 of curdriceaurora/fo-core#92.

## Test plan

- [ ] `ci-extras.yml` YAML valid
- [ ] 14 smoke tests pass locally: `pytest tests/extras/ -m "smoke" -v --override-ini="addopts="`  (archive×2 + scientific×3 + cad×1 + dedup×2 + video×2 + audio×4)
- [ ] All 6 canary files use `pytest.importorskip` (no bare optional dep imports at module level)
- [ ] `fail-fast: false` in matrix so all extras are validated independently
- [ ] Pre-commit validation passes (242 CI guardrails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive smoke tests for optional audio, archive, CAD, deduplication, scientific, and video features to ensure proper installation and basic functionality of dependencies.

* **Chores**
  * Introduced new GitHub Actions workflow for automated validation of optional extras across multiple operating systems.
  * Updated CI configuration to include extras test coverage in the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->