### PR TITLE
feat(mypy): expand strict gate to services/ and collapse to full-src CI (#93)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,26 +87,8 @@ jobs:
           python-version: "3.12"
           cache: pip
       - run: pip install -e ".[dev]"
-      - name: Run mypy on gated modules
-        run: |
-          mypy \
-            src/file_organizer/models/ \
-            src/file_organizer/optimization/ \
-            src/file_organizer/parallel/ \
-            src/file_organizer/events/ \
-            src/file_organizer/daemon/ \
-            src/file_organizer/undo/ \
-            src/file_organizer/history/ \
-            src/file_organizer/interfaces/ \
-            src/file_organizer/updater/ \
-            src/file_organizer/pipeline/ \
-            src/file_organizer/methodologies/ \
-            src/file_organizer/integrations/ \
-            src/file_organizer/utils/ \
-            src/file_organizer/config/ \
-            src/file_organizer/core/ \
-            src/file_organizer/cli/ \
-            src/file_organizer/watcher/
+      - name: Run mypy on all source modules
+        run: python -m mypy --config-file pyproject.toml src/
 
   link-integrity:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,10 @@ jobs:
             src/file_organizer/methodologies/ \
             src/file_organizer/integrations/ \
             src/file_organizer/utils/ \
-            src/file_organizer/config/
+            src/file_organizer/config/ \
+            src/file_organizer/core/ \
+            src/file_organizer/cli/ \
+            src/file_organizer/watcher/
 
   link-integrity:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ coverage.json
 # Superpowers scaffolding (implementation artifacts, not permanent docs)
 docs/superpowers/plans/
 docs/superpowers/specs/
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,3 @@ coverage.json
 # Superpowers scaffolding (implementation artifacts, not permanent docs)
 docs/superpowers/plans/
 docs/superpowers/specs/
-.worktrees/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,7 +127,7 @@ repos:
         pass_filenames: false
 
       # ----------------------------------------------------------------
-      # Strict mypy gate: 14 gated packages (Tier 1 + Tier 2)
+      # Strict mypy gate: 17 gated packages (Tier 1 + Tier 2 + Tier 3)
       # ----------------------------------------------------------------
       - id: mypy-changed
         name: mypy (gated packages — 17 pkgs, 208 files)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -130,10 +130,10 @@ repos:
       # Strict mypy gate: 14 gated packages (Tier 1 + Tier 2)
       # ----------------------------------------------------------------
       - id: mypy-changed
-        name: mypy (gated packages — 14 pkgs, 164 files)
+        name: mypy (gated packages — 17 pkgs, 208 files)
         entry: bash scripts/run-mypy-changed.sh
         language: system
-        files: ^src/file_organizer/(models|optimization|parallel|events|daemon|undo|history|interfaces|updater|pipeline|methodologies|integrations|utils|config)/.*\.py$
+        files: ^src/file_organizer/(models|optimization|parallel|events|daemon|undo|history|interfaces|updater|pipeline|methodologies|integrations|utils|config|core|cli|watcher)/.*\.py$
         pass_filenames: true
 
       # ----------------------------------------------------------------

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,13 +127,13 @@ repos:
         pass_filenames: false
 
       # ----------------------------------------------------------------
-      # Strict mypy gate: 17 gated packages (Tier 1 + Tier 2 + Tier 3)
+      # Strict mypy gate: all source packages (src/)
       # ----------------------------------------------------------------
       - id: mypy-changed
-        name: mypy (gated packages — 17 pkgs, 208 files)
+        name: mypy (all source — strict mode)
         entry: bash scripts/run-mypy-changed.sh
         language: system
-        files: ^src/file_organizer/(models|optimization|parallel|events|daemon|undo|history|interfaces|updater|pipeline|methodologies|integrations|utils|config|core|cli|watcher)/.*\.py$
+        files: ^src/file_organizer/.*\.py$
         pass_filenames: true
 
       # ----------------------------------------------------------------

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -178,8 +178,7 @@ def test_my_feature():
 ```bash
 ruff check .              # Linting
 black .                   # Formatting
-pre-commit run mypy-changed --all-files   # Type checking (gated packages)
-# Authoritative package list: .github/workflows/ci.yml → "Run mypy on gated modules"
+pre-commit run mypy-changed --all-files   # Type checking (all source)
 pytest                    # Tests
 ```
 

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -178,7 +178,8 @@ def test_my_feature():
 ```bash
 ruff check .              # Linting
 black .                   # Formatting
-mypy .                    # Type checking
+pre-commit run mypy-changed --all-files   # Type checking (gated packages)
+# Authoritative package list: .github/workflows/ci.yml → "Run mypy on gated modules"
 pytest                    # Tests
 ```
 

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -273,7 +273,7 @@ GitHub Actions runs automated checks on every PR and push to main:
 
 - `pytest -m "ci"` test subset runs (selected critical tests)
 - Linting checks (ruff for Python, markdownlint for docs)
-- Type checking (mypy strict, gated packages only — see `.github/workflows/ci.yml`)
+- Type checking (mypy strict on entire src/ tree — see `.github/workflows/ci.yml`)
 - No coverage threshold enforced
 
 **Main Branch Pushes:**
@@ -281,7 +281,7 @@ GitHub Actions runs automated checks on every PR and push to main:
 - Full test suite passes (`pytest`)
 - Coverage must be >= 95% (code) and >= 95% (docstrings) -- both gates must pass
 - Linting must pass (ruff and markdownlint)
-- Type checking must pass (mypy strict on all gated packages — `core`, `cli`, `watcher` + 14 others)
+- Type checking must pass (mypy strict on all source packages — entire `src/` tree)
 
 See `.github/workflows/` for CI configuration.
 

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -273,7 +273,7 @@ GitHub Actions runs automated checks on every PR and push to main:
 
 - `pytest -m "ci"` test subset runs (selected critical tests)
 - Linting checks (ruff for Python, markdownlint for docs)
-- Type checking (mypy)
+- Type checking (mypy strict, gated packages only — see `.github/workflows/ci.yml`)
 - No coverage threshold enforced
 
 **Main Branch Pushes:**
@@ -281,7 +281,7 @@ GitHub Actions runs automated checks on every PR and push to main:
 - Full test suite passes (`pytest`)
 - Coverage must be >= 95% (code) and >= 95% (docstrings) -- both gates must pass
 - Linting must pass (ruff and markdownlint)
-- Type checking must pass (mypy)
+- Type checking must pass (mypy strict on all gated packages — `core`, `cli`, `watcher` + 14 others)
 
 See `.github/workflows/` for CI configuration.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -264,6 +264,20 @@ module = [
 ]
 ignore_errors = true
 
+# Optional-dep modules: mutagen, ezdxf, redis stubs are only available when
+# the corresponding extras are installed (audio, cad, cloud).  Without the extra,
+# the type: ignore comments that suppress attr-defined / assignment errors become
+# "unused" and trigger warn_unused_ignores.  Disable that check per-module so
+# both CI (no extras) and local dev (with extras) pass mypy cleanly.
+[[tool.mypy.overrides]]
+module = [
+    "file_organizer.services.audio.metadata_extractor",
+    "file_organizer.utils.readers.cad",
+    "file_organizer.events.stream",
+    "file_organizer.services.deduplication.extractor",
+]
+warn_unused_ignores = false
+
 # Pytest configuration
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/src/file_organizer/cli/benchmark.py
+++ b/src/file_organizer/cli/benchmark.py
@@ -992,7 +992,7 @@ def run(
         if json_output:
             empty_outcome = _SuiteIterationOutcome(processed_count=0)
             classification = classifier([], empty_outcome)
-            output: dict[str, Any] = {
+            empty_output: dict[str, Any] = {
                 "suite": suite,
                 "effective_suite": classification.effective_suite,
                 "degraded": classification.degraded,
@@ -1002,15 +1002,15 @@ def run(
                 "hardware_profile": _detect_hardware_profile(),
                 "results": compute_stats([], 0),
             }
-            validate_benchmark_payload(output)
-            output = _maybe_attach_comparison_output(
-                output=output,
+            validate_benchmark_payload(empty_output)
+            empty_output = _maybe_attach_comparison_output(
+                output=empty_output,
                 compare_path=compare_path,
                 suite=suite,
                 console=console,
                 json_output=json_output,
             )
-            console.print(json.dumps(output, indent=2))
+            console.print(json.dumps(empty_output, indent=2))
         else:
             console.print("[yellow]No files found in the specified path.[/yellow]")
         return

--- a/src/file_organizer/cli/dedupe_hash.py
+++ b/src/file_organizer/cli/dedupe_hash.py
@@ -52,6 +52,7 @@ class ProgressTracker:
 
         if self.progress_bar is None:
             self.progress_bar = self.tqdm(total=total, desc="Hashing files", unit="files")
+        assert self.progress_bar is not None
         self.progress_bar.update(1)
 
     def close(self) -> None:

--- a/src/file_organizer/cli/rules.py
+++ b/src/file_organizer/cli/rules.py
@@ -208,7 +208,7 @@ def rules_export(
     output: Path | None = typer.Option(None, "--output", "-o", help="Output file path."),
 ) -> None:
     """Export a rule set to YAML."""
-    import yaml  # type: ignore[import-untyped]
+    import yaml
 
     from file_organizer.services.copilot.rules import RuleManager
 

--- a/src/file_organizer/core/__init__.py
+++ b/src/file_organizer/core/__init__.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from file_organizer.core.organizer import FileOrganizer, OrganizationResult
+from file_organizer.core.organizer import FileOrganizer
+from file_organizer.core.types import OrganizationResult
 
 __all__ = [
     "FileOrganizer",

--- a/src/file_organizer/core/backend_detector.py
+++ b/src/file_organizer/core/backend_detector.py
@@ -170,7 +170,7 @@ def list_installed_models() -> list[InstalledModel]:
                 # ollama.Model dataclass
                 models.append(
                     InstalledModel(
-                        name=model_data.model,
+                        name=model_data.model or "",
                         size=getattr(model_data, "size", None),
                         modified=str(getattr(model_data, "modified_at", None)),
                     )
@@ -205,11 +205,11 @@ def list_installed_models() -> list[InstalledModel]:
             return _parse_ollama_list_text()
 
         data = json.loads(result.stdout)
-        models: list[InstalledModel] = []
+        cli_models: list[InstalledModel] = []
 
         if isinstance(data, dict) and "models" in data:
             for model_data in data["models"]:
-                models.append(
+                cli_models.append(
                     InstalledModel(
                         name=model_data.get("name", ""),
                         size=model_data.get("size"),
@@ -218,7 +218,7 @@ def list_installed_models() -> list[InstalledModel]:
                 )
         elif isinstance(data, list):
             for model_data in data:
-                models.append(
+                cli_models.append(
                     InstalledModel(
                         name=model_data.get("name", ""),
                         size=model_data.get("size"),
@@ -226,8 +226,8 @@ def list_installed_models() -> list[InstalledModel]:
                     )
                 )
 
-        logger.debug("Found {} installed models via Ollama CLI", len(models))
-        return models
+        logger.debug("Found {} installed models via Ollama CLI", len(cli_models))
+        return cli_models
 
     except FileNotFoundError:
         logger.debug("Ollama CLI not found")

--- a/src/file_organizer/events/stream.py
+++ b/src/file_organizer/events/stream.py
@@ -16,7 +16,7 @@ from typing import Any
 try:
     import redis
 except ImportError:  # pragma: no cover
-    redis = None
+    redis = None  # type: ignore[assignment]
 
 from file_organizer.events.config import EventConfig
 

--- a/src/file_organizer/methodologies/para/ai/feature_extractor.py
+++ b/src/file_organizer/methodologies/para/ai/feature_extractor.py
@@ -319,7 +319,7 @@ class FeatureExtractor:
         #   Windows → st_ctime    (creation time on NTFS)
         #   Linux  → st_mtime     (st_ctime is inode-change time, not creation)
         try:
-            creation_ref = stat.st_birthtime  # type: ignore[attr-defined]  # macOS — true birth time
+            creation_ref = stat.st_birthtime  # macOS — true birth time
         except AttributeError:
             if os.name == "nt":  # Windows — NTFS creation time
                 creation_ref = getattr(stat, "st_ctime", stat.st_mtime)

--- a/src/file_organizer/methodologies/para/ai/feature_extractor.py
+++ b/src/file_organizer/methodologies/para/ai/feature_extractor.py
@@ -318,13 +318,10 @@ class FeatureExtractor:
         #   macOS  → st_birthtime (true birth time)
         #   Windows → st_ctime    (creation time on NTFS)
         #   Linux  → st_mtime     (st_ctime is inode-change time, not creation)
-        try:
-            creation_ref = stat.st_birthtime  # macOS — true birth time
-        except AttributeError:
-            if os.name == "nt":  # Windows — NTFS creation time
-                creation_ref = getattr(stat, "st_ctime", stat.st_mtime)
-            else:  # Linux — use mtime as best available proxy
-                creation_ref = stat.st_mtime
+        # macOS: st_birthtime (true birth time); Linux: not present (use mtime); Windows: st_ctime
+        creation_ref = getattr(stat, "st_birthtime", stat.st_mtime)
+        if os.name == "nt" and not hasattr(stat, "st_birthtime"):  # Windows fallback
+            creation_ref = getattr(stat, "st_ctime", stat.st_mtime)
 
         # Convert timestamps to datetime
         creation_date = datetime.fromtimestamp(creation_ref, tz=UTC)

--- a/src/file_organizer/methodologies/para/detection/heuristics.py
+++ b/src/file_organizer/methodologies/para/detection/heuristics.py
@@ -145,7 +145,7 @@ class TemporalHeuristic(Heuristic):
         # Cross-platform file age: use birth time if available (macOS/Windows),
         # fall back to modification time on Linux (st_ctime is inode change time, not creation).
         try:
-            ref_time = stat.st_birthtime  # type: ignore[attr-defined]  # macOS — true birth time
+            ref_time = stat.st_birthtime  # macOS — true birth time
         except AttributeError:
             if os.name == "nt":  # Windows
                 ref_time = getattr(stat, "st_ctime", stat.st_mtime)

--- a/src/file_organizer/methodologies/para/detection/heuristics.py
+++ b/src/file_organizer/methodologies/para/detection/heuristics.py
@@ -144,13 +144,10 @@ class TemporalHeuristic(Heuristic):
         days_since_accessed = (now - stat.st_atime) / 86400
         # Cross-platform file age: use birth time if available (macOS/Windows),
         # fall back to modification time on Linux (st_ctime is inode change time, not creation).
-        try:
-            ref_time = stat.st_birthtime  # macOS — true birth time
-        except AttributeError:
-            if os.name == "nt":  # Windows
-                ref_time = getattr(stat, "st_ctime", stat.st_mtime)
-            else:  # Linux — use mtime as best proxy for "last active"
-                ref_time = stat.st_mtime
+        # macOS: st_birthtime (true birth time); Linux: not present (use mtime); Windows: st_ctime
+        ref_time = getattr(stat, "st_birthtime", stat.st_mtime)
+        if os.name == "nt" and not hasattr(stat, "st_birthtime"):  # Windows fallback
+            ref_time = getattr(stat, "st_ctime", stat.st_mtime)
         days_since_created = (now - ref_time) / 86400
 
         # Check for old year patterns in path (e.g., "/Projects/2020/...")

--- a/src/file_organizer/services/audio/metadata_extractor.py
+++ b/src/file_organizer/services/audio/metadata_extractor.py
@@ -111,7 +111,7 @@ class AudioMetadataExtractor:
     def _extract_with_mutagen(self, audio_path: Path) -> AudioMetadata:
         """Extract metadata using mutagen library."""
         try:
-            from mutagen import File as MutagenFile
+            from mutagen import File as MutagenFile  # type: ignore[attr-defined]
         except ImportError as e:
             raise ImportError(
                 "mutagen is required for audio metadata extraction. "

--- a/src/file_organizer/services/audio/transcriber.py
+++ b/src/file_organizer/services/audio/transcriber.py
@@ -24,7 +24,7 @@ try:
 
     _FASTER_WHISPER_AVAILABLE = True  # pragma: no cover
 except ImportError:  # pragma: no cover
-    WhisperModel = None  # type: ignore[assignment, misc]
+    WhisperModel = None
     _FASTER_WHISPER_AVAILABLE = False
 
 logger = logging.getLogger(__name__)

--- a/src/file_organizer/services/audio/utils.py
+++ b/src/file_organizer/services/audio/utils.py
@@ -15,7 +15,7 @@ try:
     from pydub.exceptions import PydubException
 except ImportError:  # pragma: no cover - optional dependency
 
-    class PydubException(Exception):
+    class PydubException(Exception):  # type: ignore[no-redef]
         """Fallback when pydub is unavailable."""
 
 
@@ -23,7 +23,7 @@ try:
     from tinytag import TinyTagException  # pyre-ignore[21]
 except ImportError:  # pragma: no cover - optional dependency
 
-    class TinyTagException(Exception):
+    class TinyTagException(Exception):  # type: ignore[no-redef]
         """Fallback when tinytag is unavailable."""
 
 

--- a/src/file_organizer/services/copilot/rules/rule_manager.py
+++ b/src/file_organizer/services/copilot/rules/rule_manager.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 from loguru import logger
 
 from file_organizer.config.path_manager import get_config_dir

--- a/src/file_organizer/services/deduplication/embedder.py
+++ b/src/file_organizer/services/deduplication/embedder.py
@@ -9,8 +9,10 @@ import logging
 import pickle
 import threading
 from pathlib import Path
+from typing import Any
 
 import numpy as np
+from numpy.typing import NDArray
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +64,7 @@ class DocumentEmbedder:
         self.is_fitted = False
 
         # Cache for embeddings {document_hash: embedding}
-        self.embedding_cache: dict[str, np.ndarray] = {}
+        self.embedding_cache: dict[str, NDArray[Any]] = {}
         self._cache_lock = threading.Lock()
 
         # Load cache if available
@@ -73,7 +75,7 @@ class DocumentEmbedder:
             f"DocumentEmbedder initialized: max_features={max_features}, ngram_range={ngram_range}"
         )
 
-    def fit_transform(self, documents: list[str]) -> np.ndarray:
+    def fit_transform(self, documents: list[str]) -> NDArray[Any]:
         """Fit the vectorizer and transform documents to embeddings.
 
         Two corpus-size guards are applied before calling sklearn:
@@ -150,7 +152,7 @@ class DocumentEmbedder:
             logger.exception("Error during fit_transform")
             raise
 
-    def transform(self, document: str) -> np.ndarray:
+    def transform(self, document: str) -> NDArray[Any]:
         """Transform a single document to embedding.
 
         Args:
@@ -173,7 +175,7 @@ class DocumentEmbedder:
                 return self.embedding_cache[doc_hash]
 
         # Transform
-        embedding: np.ndarray = np.asarray(self.vectorizer.transform([document]).toarray()[0])
+        embedding: NDArray[Any] = np.asarray(self.vectorizer.transform([document]).toarray()[0])
 
         # Cache the embedding
         with self._cache_lock:
@@ -181,7 +183,7 @@ class DocumentEmbedder:
 
         return embedding
 
-    def transform_batch(self, documents: list[str]) -> np.ndarray:
+    def transform_batch(self, documents: list[str]) -> NDArray[Any]:
         """Transform multiple documents to embeddings.
 
         Args:
@@ -193,7 +195,7 @@ class DocumentEmbedder:
         if not self.is_fitted:
             raise RuntimeError("Vectorizer not fitted. Call fit_transform() first.")
 
-        embeddings: np.ndarray = np.asarray(self.vectorizer.transform(documents).toarray())
+        embeddings: NDArray[Any] = np.asarray(self.vectorizer.transform(documents).toarray())
 
         logger.debug(f"Transformed {len(documents)} documents")
 
@@ -229,7 +231,7 @@ class DocumentEmbedder:
 
         return {k: int(v) for k, v in self.vectorizer.vocabulary_.items()}
 
-    def get_top_terms(self, embedding: np.ndarray, top_n: int = 10) -> list[tuple[str, float]]:
+    def get_top_terms(self, embedding: NDArray[Any], top_n: int = 10) -> list[tuple[str, float]]:
         """Get top N terms from an embedding by weight.
 
         Args:

--- a/src/file_organizer/services/deduplication/extractor.py
+++ b/src/file_organizer/services/deduplication/extractor.py
@@ -127,7 +127,7 @@ class DocumentExtractor:
             try:
                 from pypdf.errors import PyPdfError
             except (ImportError, AttributeError):
-                PyPdfError = Exception
+                PyPdfError = Exception  # type: ignore[misc,assignment]  # fallback when pypdf.errors unavailable
 
             text_parts = []
 

--- a/src/file_organizer/services/deduplication/image_utils.py
+++ b/src/file_organizer/services/deduplication/image_utils.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from PIL import Image, UnidentifiedImageError
 from PIL.Image import DecompressionBombError
@@ -130,7 +130,7 @@ def get_image_dimensions(image_path: Path) -> tuple[int, int] | None:
     """
     try:
         with Image.open(image_path) as img:
-            return img.size
+            return cast(tuple[int, int], img.size)
     except (OSError, ValueError) as e:
         logger.warning(f"Could not get dimensions for {image_path}: {e}")
         return None
@@ -147,7 +147,7 @@ def get_image_format(image_path: Path) -> str | None:
     """
     try:
         with Image.open(image_path) as img:
-            return img.format
+            return cast("str | None", img.format)
     except (OSError, ValueError) as e:
         logger.warning(f"Could not determine format for {image_path}: {e}")
         return None

--- a/src/file_organizer/services/deduplication/semantic.py
+++ b/src/file_organizer/services/deduplication/semantic.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+from numpy.typing import NDArray
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +34,7 @@ class SemanticAnalyzer:
         self.threshold = threshold
         logger.info(f"SemanticAnalyzer initialized with threshold={threshold}")
 
-    def compute_similarity(self, doc1_vector: np.ndarray, doc2_vector: np.ndarray) -> float:
+    def compute_similarity(self, doc1_vector: NDArray[Any], doc2_vector: NDArray[Any]) -> float:
         """Compute cosine similarity between two document vectors.
 
         Args:
@@ -58,7 +59,7 @@ class SemanticAnalyzer:
         return float(np.clip(similarity, 0.0, 1.0))
 
     def find_similar_documents(
-        self, embeddings: np.ndarray, paths: list[Path], min_similarity: float | None = None
+        self, embeddings: NDArray[Any], paths: list[Path], min_similarity: float | None = None
     ) -> dict[Path, list[tuple[Path, float]]]:
         """Find similar documents based on embeddings.
 
@@ -106,8 +107,8 @@ class SemanticAnalyzer:
 
     def find_similar_to_query(
         self,
-        query_embedding: np.ndarray,
-        document_embeddings: np.ndarray,
+        query_embedding: NDArray[Any],
+        document_embeddings: NDArray[Any],
         paths: list[Path],
         top_k: int | None = None,
         min_similarity: float | None = None,
@@ -188,7 +189,7 @@ class SemanticAnalyzer:
 
         return clusters
 
-    def compute_similarity_matrix(self, embeddings: np.ndarray) -> np.ndarray:
+    def compute_similarity_matrix(self, embeddings: NDArray[Any]) -> NDArray[Any]:
         """Compute full pairwise similarity matrix.
 
         Args:
@@ -213,7 +214,7 @@ class SemanticAnalyzer:
         return np.asarray(similarity_matrix)
 
     def get_duplicate_groups(
-        self, embeddings: np.ndarray, paths: list[Path], min_similarity: float | None = None
+        self, embeddings: NDArray[Any], paths: list[Path], min_similarity: float | None = None
     ) -> list[dict[str, Any]]:
         """Get groups of duplicate/similar documents with metadata.
 
@@ -279,7 +280,7 @@ class SemanticAnalyzer:
         self.threshold = threshold
         logger.info(f"Updated similarity threshold to {threshold}")
 
-    def get_statistics(self, similarity_matrix: np.ndarray) -> dict[str, Any]:
+    def get_statistics(self, similarity_matrix: NDArray[Any]) -> dict[str, Any]:
         """Compute statistics from similarity matrix.
 
         Args:

--- a/src/file_organizer/services/intelligence/profile_importer.py
+++ b/src/file_organizer/services/intelligence/profile_importer.py
@@ -17,7 +17,7 @@ import json
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from file_organizer.services.intelligence.profile_manager import Profile, ProfileManager
 
@@ -125,7 +125,7 @@ class ProfileImporter:
         """Load and parse JSON file."""
         try:
             with open(file_path, encoding="utf-8") as f:
-                return json.load(f)
+                return cast(dict[str, Any], json.load(f))
         except json.JSONDecodeError as e:
             errors.append(f"Invalid JSON format: {e}")
             return None

--- a/src/file_organizer/services/search/bm25_index.py
+++ b/src/file_organizer/services/search/bm25_index.py
@@ -22,7 +22,7 @@ try:
 
     _BM25_AVAILABLE = True
 except ImportError as _exc:  # pragma: no cover
-    BM25Okapi = None  # type: ignore[assignment, misc]
+    BM25Okapi = None
     _BM25_AVAILABLE = False
     _BM25_IMPORT_ERROR = _exc
 

--- a/src/file_organizer/services/search/embedding_cache.py
+++ b/src/file_organizer/services/search/embedding_cache.py
@@ -33,6 +33,7 @@ from typing import Any
 
 import numpy as np
 from loguru import logger
+from numpy.typing import NDArray
 
 from file_organizer.interfaces.search import EmbeddingCacheProtocol
 
@@ -51,14 +52,15 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def _array_to_blob(arr: np.ndarray) -> bytes:
+def _array_to_blob(arr: NDArray[Any]) -> bytes:
     buf = io.BytesIO()
     np.save(buf, arr, allow_pickle=False)
     return buf.getvalue()
 
 
-def _blob_to_array(blob: bytes) -> np.ndarray:
-    return np.load(io.BytesIO(blob), allow_pickle=False)
+def _blob_to_array(blob: bytes) -> NDArray[Any]:
+    result: NDArray[Any] = np.load(io.BytesIO(blob), allow_pickle=False)
+    return result
 
 
 class EmbeddingCache:
@@ -111,8 +113,8 @@ class EmbeddingCache:
         self,
         path: Path,
         /,
-        compute: Callable[[str], np.ndarray],
-    ) -> np.ndarray:
+        compute: Callable[[str], NDArray[Any]],
+    ) -> NDArray[Any]:
         """Return a cached embedding for *path*, computing it if necessary.
 
         The cache entry is invalidated when:

--- a/src/file_organizer/services/search/vector_index.py
+++ b/src/file_organizer/services/search/vector_index.py
@@ -13,9 +13,10 @@ the class remains usable in environments without a running Ollama instance.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
-import numpy as np
 from loguru import logger
+from numpy.typing import NDArray
 
 from file_organizer.services.deduplication.embedder import DocumentEmbedder
 from file_organizer.services.deduplication.semantic import SemanticAnalyzer
@@ -47,7 +48,7 @@ class VectorIndex:
         self._embedder = DocumentEmbedder()
         self._analyzer = SemanticAnalyzer(threshold=max(similarity_threshold, 0.0))
         self._paths: list[Path] = []
-        self._matrix: np.ndarray | None = None  # shape (n_docs, n_features)
+        self._matrix: NDArray[Any] | None = None  # shape (n_docs, n_features)
 
     # ------------------------------------------------------------------
     # IndexProtocol

--- a/src/file_organizer/utils/readers/cad.py
+++ b/src/file_organizer/utils/readers/cad.py
@@ -122,7 +122,7 @@ def read_dxf_file(file_path: str | Path, max_layers: int = 20) -> str:
     file_path = Path(file_path)
     _check_file_size(file_path)
     try:
-        doc = ezdxf.readfile(file_path)
+        doc = ezdxf.readfile(file_path)  # type: ignore[attr-defined]  # ezdxf stubs incomplete
         return _process_dxf_doc(doc, file_path, max_layers)
     except Exception as e:  # Intentional catch-all: ezdxf raises library-specific errors
         raise FileReadError(f"Failed to read DXF file {file_path}: {e}") from e
@@ -153,7 +153,7 @@ def read_dwg_file(file_path: str | Path) -> str:
     try:
         # Try to read with ezdxf (limited support).
         # Capture the returned document and pass it through to avoid re-opening the file.
-        doc = ezdxf.readfile(file_path)
+        doc = ezdxf.readfile(file_path)  # type: ignore[attr-defined]  # ezdxf stubs incomplete
         return _process_dxf_doc(doc, file_path)
 
     except Exception as e:  # Intentional catch-all: ezdxf raises library-specific errors

--- a/src/file_organizer/watcher/monitor.py
+++ b/src/file_organizer/watcher/monitor.py
@@ -89,7 +89,7 @@ class FileMonitor:
                     e,
                     exc_info=True,
                 )
-                self._observer = PollingObserver(timeout=1.0)
+                self._observer = PollingObserver(timeout=1.0)  # type: ignore[no-untyped-call]
                 self._observer_type = "polling"
                 logger.info("Using polling observer for file system monitoring")
 
@@ -101,7 +101,7 @@ class FileMonitor:
             for directory in self.config.watch_directories:
                 self._schedule_directory(directory, self.config.recursive)
 
-            observer.start()
+            observer.start()  # type: ignore[no-untyped-call]
             self._running = True
             logger.info(
                 "FileMonitor started (%s observer), watching %d directories",
@@ -120,7 +120,7 @@ class FileMonitor:
                 return
 
             observer = self._observer
-            observer.stop()
+            observer.stop()  # type: ignore[no-untyped-call]
             observer.join(timeout=5.0)
             self._observer = None
             self._watches.clear()
@@ -177,7 +177,7 @@ class FileMonitor:
                 watch = self._watches[path_key]
                 observer = self._observer
                 assert observer is not None
-                observer.unschedule(watch)
+                observer.unschedule(watch)  # type: ignore[no-untyped-call]
 
             del self._watches[path_key]
 
@@ -298,7 +298,7 @@ class FileMonitor:
             raise FileNotFoundError(f"Watch directory does not exist: {path}")
 
         if self._observer is not None:
-            watch: ObservedWatch = self._observer.schedule(
+            watch: ObservedWatch = self._observer.schedule(  # type: ignore[no-untyped-call]
                 self.handler, str(path), recursive=recursive
             )
             self._watches[path_key] = watch

--- a/tests/ci/test_mypy_gate.py
+++ b/tests/ci/test_mypy_gate.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
+
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+# Read at import time: intentional — these are required config files; missing files
+# should cause immediate, loud failure rather than a confusing assertion error.
 _CI_YML = (PROJECT_ROOT / ".github" / "workflows" / "ci.yml").read_text()
 _PRECOMMIT = (PROJECT_ROOT / ".pre-commit-config.yaml").read_text()
 
@@ -22,7 +26,10 @@ def _mypy_step_body() -> str:
         _CI_YML,
         re.DOTALL,
     )
-    assert m, "Step 'Run mypy on all source modules' not found in ci.yml"
+    assert m, (
+        "Step 'Run mypy on all source modules' not found in ci.yml. "
+        "If the step was renamed, update both the CI workflow and this test."
+    )
     return m.group()
 
 
@@ -39,6 +46,7 @@ def _mypy_hook_files_value() -> str:
     return files_m.group(1)
 
 
+@pytest.mark.ci
 class TestFullSrcMypyGate:
     """Full-src gate: CI step and pre-commit hook must target src/ not per-package paths."""
 

--- a/tests/ci/test_mypy_gate.py
+++ b/tests/ci/test_mypy_gate.py
@@ -1,0 +1,61 @@
+"""Guardrail tests asserting mypy gate configuration matches expectations.
+
+These tests read ci.yml and .pre-commit-config.yaml as text and assert
+structural properties. They fail when the gate drifts from what was
+agreed in issue #93.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_CI_YML = (PROJECT_ROOT / ".github" / "workflows" / "ci.yml").read_text()
+_PRECOMMIT = (PROJECT_ROOT / ".pre-commit-config.yaml").read_text()
+
+
+def _mypy_step_body() -> str:
+    """Extract the body of the 'Run mypy on gated modules' step."""
+    m = re.search(
+        r"Run mypy on gated modules.*?(?=\n      - name|\n  \w|\Z)",
+        _CI_YML,
+        re.DOTALL,
+    )
+    assert m, "Step 'Run mypy on gated modules' not found in ci.yml"
+    return m.group()
+
+
+def _mypy_hook_files_value() -> str:
+    """Extract the files: value from the mypy-changed pre-commit hook."""
+    hook_m = re.search(
+        r"id: mypy-changed.*?(?=\n      - id:|\n  - repo:|\Z)",
+        _PRECOMMIT,
+        re.DOTALL,
+    )
+    assert hook_m, "mypy-changed hook not found in .pre-commit-config.yaml"
+    files_m = re.search(r"files:\s*(\S+)", hook_m.group())
+    assert files_m, "files: line not found in mypy-changed hook"
+    return files_m.group(1)
+
+
+class TestTier3MypyGate:
+    """PR 1: core, cli, watcher must be in the gate."""
+
+    def test_core_in_ci_mypy_step(self) -> None:
+        assert "src/file_organizer/core/" in _mypy_step_body()
+
+    def test_cli_in_ci_mypy_step(self) -> None:
+        assert "src/file_organizer/cli/" in _mypy_step_body()
+
+    def test_watcher_in_ci_mypy_step(self) -> None:
+        assert "src/file_organizer/watcher/" in _mypy_step_body()
+
+    def test_core_in_precommit_hook_regex(self) -> None:
+        assert "core" in _mypy_hook_files_value()
+
+    def test_cli_in_precommit_hook_regex(self) -> None:
+        assert "cli" in _mypy_hook_files_value()
+
+    def test_watcher_in_precommit_hook_regex(self) -> None:
+        assert "watcher" in _mypy_hook_files_value()

--- a/tests/ci/test_mypy_gate.py
+++ b/tests/ci/test_mypy_gate.py
@@ -1,8 +1,8 @@
 """Guardrail tests asserting mypy gate configuration matches expectations.
 
 These tests read ci.yml and .pre-commit-config.yaml as text and assert
-structural properties. They fail when the gate drifts from what was
-agreed in issue #93.
+structural properties. They fail when the gate drifts from the full-src
+invocation agreed in issue #93 (tier-3 expansion).
 """
 
 from __future__ import annotations
@@ -16,13 +16,13 @@ _PRECOMMIT = (PROJECT_ROOT / ".pre-commit-config.yaml").read_text()
 
 
 def _mypy_step_body() -> str:
-    """Extract the body of the 'Run mypy on gated modules' step."""
+    """Extract the body of the 'Run mypy on all source modules' step."""
     m = re.search(
-        r"Run mypy on gated modules.*?(?=\n      - name|\n  \w|\Z)",
+        r"Run mypy on all source modules.*?(?=\n      - name|\n  \w|\Z)",
         _CI_YML,
         re.DOTALL,
     )
-    assert m, "Step 'Run mypy on gated modules' not found in ci.yml"
+    assert m, "Step 'Run mypy on all source modules' not found in ci.yml"
     return m.group()
 
 
@@ -39,23 +39,38 @@ def _mypy_hook_files_value() -> str:
     return files_m.group(1)
 
 
-class TestTier3MypyGate:
-    """PR 1: core, cli, watcher must be in the gate."""
+class TestFullSrcMypyGate:
+    """Full-src gate: CI step and pre-commit hook must target src/ not per-package paths."""
 
-    def test_core_in_ci_mypy_step(self) -> None:
-        assert "src/file_organizer/core/" in _mypy_step_body()
+    def test_ci_step_uses_full_src_path(self) -> None:
+        """CI step must target src/ not individual packages."""
+        assert "src/" in _mypy_step_body()
 
-    def test_cli_in_ci_mypy_step(self) -> None:
-        assert "src/file_organizer/cli/" in _mypy_step_body()
+    def test_ci_step_not_per_package(self) -> None:
+        """CI step must not list individual packages (regression guard)."""
+        body = _mypy_step_body()
+        assert "src/file_organizer/core/" not in body
+        assert "src/file_organizer/cli/" not in body
+        assert "src/file_organizer/watcher/" not in body
 
-    def test_watcher_in_ci_mypy_step(self) -> None:
-        assert "src/file_organizer/watcher/" in _mypy_step_body()
+    def test_precommit_hook_covers_all_source(self) -> None:
+        """Pre-commit hook files: regex must cover all src/file_organizer/ files."""
+        regex = _mypy_hook_files_value()
+        assert regex.startswith("^src/file_organizer/")
 
-    def test_core_in_precommit_hook_regex(self) -> None:
-        assert "core" in _mypy_hook_files_value()
+    def test_precommit_hook_not_per_package(self) -> None:
+        """Pre-commit hook must not use per-package alternation (regression guard)."""
+        regex = _mypy_hook_files_value()
+        assert "|core|" not in regex
+        assert "|cli|" not in regex
+        assert "|watcher|" not in regex
 
-    def test_cli_in_precommit_hook_regex(self) -> None:
-        assert "cli" in _mypy_hook_files_value()
-
-    def test_watcher_in_precommit_hook_regex(self) -> None:
-        assert "watcher" in _mypy_hook_files_value()
+    def test_precommit_hook_name_reflects_full_src(self) -> None:
+        """Pre-commit hook name must reflect full-src coverage."""
+        hook_m = re.search(
+            r"id: mypy-changed.*?(?=\n      - id:|\n  - repo:|\Z)",
+            _PRECOMMIT,
+            re.DOTALL,
+        )
+        assert hook_m, "mypy-changed hook not found"
+        assert "all source" in hook_m.group()

--- a/tests/ci/test_mypy_gate.py
+++ b/tests/ci/test_mypy_gate.py
@@ -51,8 +51,15 @@ class TestFullSrcMypyGate:
     """Full-src gate: CI step and pre-commit hook must target src/ not per-package paths."""
 
     def test_ci_step_uses_full_src_path(self) -> None:
-        """CI step must target src/ not individual packages."""
-        assert "src/" in _mypy_step_body()
+        """CI step must invoke mypy with bare src/ not a per-package subpath."""
+        body = _mypy_step_body()
+        # Require the standalone src/ token: must not be followed by file_organizer/
+        assert re.search(r"\bsrc/\s", body) or body.rstrip().endswith("src/"), (
+            "mypy step does not invoke bare 'src/'; found: " + body
+        )
+        assert "src/file_organizer/" not in body, (
+            "mypy step uses a per-package subpath instead of bare src/"
+        )
 
     def test_ci_step_not_per_package(self) -> None:
         """CI step must not list individual packages (regression guard)."""
@@ -69,9 +76,11 @@ class TestFullSrcMypyGate:
     def test_precommit_hook_not_per_package(self) -> None:
         """Pre-commit hook must not use per-package alternation (regression guard)."""
         regex = _mypy_hook_files_value()
-        assert "|core|" not in regex
-        assert "|cli|" not in regex
-        assert "|watcher|" not in regex
+        # The full-src regex (^src/file_organizer/.*\.py$) never needs alternation.
+        # Any '|' in the value indicates a per-package list, which is a regression.
+        assert "|" not in regex, (
+            f"pre-commit hook files regex contains alternation (per-package list): {regex!r}"
+        )
 
     def test_precommit_hook_name_reflects_full_src(self) -> None:
         """Pre-commit hook name must reflect full-src coverage."""

--- a/tests/watcher/test_monitor.py
+++ b/tests/watcher/test_monitor.py
@@ -99,6 +99,7 @@ def _drain_startup_events(monitor: FileMonitor) -> None:
 class TestFileMonitorLifecycle:
     """Tests for start/stop lifecycle."""
 
+    @pytest.mark.ci
     def test_start_and_stop(self, monitor: FileMonitor) -> None:
         """Test basic start and stop cycle."""
         assert monitor.is_running is False
@@ -314,6 +315,7 @@ class TestFileMonitorFileDetection:
 class TestFileMonitorDynamicDirectories:
     """Tests for dynamically adding/removing watch directories."""
 
+    @pytest.mark.ci
     def test_add_directory_while_running(self, monitor: FileMonitor, tmp_path: Path) -> None:
         """Test adding a new directory to a running monitor."""
         monitor.start()
@@ -359,6 +361,7 @@ class TestFileMonitorDynamicDirectories:
         with pytest.raises(FileNotFoundError):
             monitor.add_directory(tmp_path / "nope")
 
+    @pytest.mark.ci
     def test_remove_directory(self, monitor: FileMonitor, watch_dir: Path) -> None:
         """Test removing a directory from monitoring."""
         monitor.start()
@@ -533,6 +536,7 @@ class TestFileMonitorObserverFallback:
         # Type is preserved after stop
         assert monitor.observer_type in ("native", "polling")
 
+    @pytest.mark.ci
     def test_fallback_to_polling_observer(self, watch_dir: Path) -> None:
         """Test that monitor falls back to PollingObserver when native fails.
 


### PR DESCRIPTION
## Summary

Closes #93. Expands the mypy strict gate from 17 packages to all of \`src/\` in a single PR covering both phases (originally planned as two separate PRs; combined here since all work landed cleanly on one branch with green CI).

### Phase 1 (commit \`b5ede55\`): Add core, cli, watcher to strict gate

- Fix 28 mypy errors in \`core/\`, \`cli/\`, \`watcher/\`
- Fix 2 stale \`type: ignore[attr-defined]\` in \`methodologies/\` (stale \`st_birthtime\` ignores)
- Fix pre-existing \`events/stream.py\` redis assignment ignore
- Add \`core\`, \`cli\`, \`watcher\` to CI mypy step and pre-commit hook regex
- Add \`tests/ci/test_mypy_gate.py\`: 6 guardrail tests verifying Tier 3 gate configuration

### Phase 2 (commit \`f5aebaf\`): Add services/ and collapse to full-src gate

- Fix 31 mypy errors across \`services/\` packages:
  - \`deduplication/\`: 18 errors (NDArray annotations, cast fixes)
  - \`search/\`: 8 errors (NDArray, no-any-return, stale ignores)
  - \`copilot/\`: 1 stale ignore
  - \`audio/\`: 3 errors (no-redef, attr-defined, stale ignore)
  - \`intelligence/\`: 1 no-any-return
- Fix optional-extra errors in \`utils/readers/cad.py\` (ezdxf stubs incomplete)
- Collapse CI mypy step from 17-package listing to single \`src/\` invocation
- Update pre-commit hook regex to \`^src/file_organizer/.*\.py$\` (auto-covers future packages)
- Update guardrail tests to verify full-src configuration (5 tests)
- Update \`docs/developer/\` to reflect full-src coverage

### Follow-up fixes (later commits)

- Fix 7 CI environment-mismatch mypy errors (Linux \`st_birthtime\` attr-defined, optional-extra \`warn_unused_ignores\`)
- Add \`@pytest.mark.ci\` to watcher tests to hit diff-cover 80% gate
- Address CodeRabbit review findings (gitignore dedup, test_mypy_gate.py improvements)
- Defer two outside-diff findings to issues #100 and #101

## Test plan

- [x] \`python -m mypy --config-file pyproject.toml src/\` → 0 errors
- [x] \`pytest tests/ci/test_mypy_gate.py -v\` → 5 tests pass
- [x] Pre-commit validation passes
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)