### PR TITLE
fix(tests): harden ollama-unavailable tests against xdist mock leaks (py3.12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,7 @@ site/
 
 # Backup files and directories
 *.bak
-.file_organizer_backups/
+.fo_backups/
 
 # Logs
 logs/
@@ -140,4 +140,3 @@ coverage.json
 # Superpowers scaffolding (implementation artifacts, not permanent docs)
 docs/superpowers/plans/
 docs/superpowers/specs/
-.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ coverage.json
 # Superpowers scaffolding (implementation artifacts, not permanent docs)
 docs/superpowers/plans/
 docs/superpowers/specs/
+.worktrees/

--- a/tests/integration/test_methodologies_para_ai_rules_heuristics.py
+++ b/tests/integration/test_methodologies_para_ai_rules_heuristics.py
@@ -1317,8 +1317,8 @@ class TestAIHeuristicHelpers:
         # Patch both OLLAMA_AVAILABLE and ollama to prevent any real or leaked
         # mock client from reaching _parse_response (xdist isolation defence).
         with (
-            patch.object(_mod, "OLLAMA_AVAILABLE", False),
-            patch.object(_mod, "ollama", None),
+            patch.object(_mod, "OLLAMA_AVAILABLE", new=False),
+            patch.object(_mod, "ollama", new=None),
         ):
             result = h.evaluate(f)
         assert result.abstained is True

--- a/tests/integration/test_methodologies_para_ai_rules_heuristics.py
+++ b/tests/integration/test_methodologies_para_ai_rules_heuristics.py
@@ -1314,7 +1314,12 @@ class TestAIHeuristicHelpers:
 
         f = _make_file(tmp_path, "doc.txt")
         h = AIHeuristic()
-        with patch.object(_mod, "OLLAMA_AVAILABLE", False):
+        # Patch both OLLAMA_AVAILABLE and ollama to prevent any real or leaked
+        # mock client from reaching _parse_response (xdist isolation defence).
+        with (
+            patch.object(_mod, "OLLAMA_AVAILABLE", False),
+            patch.object(_mod, "ollama", None),
+        ):
             result = h.evaluate(f)
         assert result.abstained is True
 

--- a/tests/methodologies/para/test_ai_heuristic.py
+++ b/tests/methodologies/para/test_ai_heuristic.py
@@ -62,7 +62,12 @@ class TestAIHeuristicUnavailable:
         test_file = tmp_path / "notes.txt"
         test_file.write_text("project deadline tomorrow")
 
-        with patch(f"{_HEURISTICS_MODULE}.OLLAMA_AVAILABLE", False):
+        # Patch both OLLAMA_AVAILABLE and ollama to prevent any real or leaked
+        # mock client from reaching _parse_response (xdist isolation defence).
+        with (
+            patch(f"{_HEURISTICS_MODULE}.OLLAMA_AVAILABLE", False),
+            patch(f"{_HEURISTICS_MODULE}.ollama", None),
+        ):
             result = h.evaluate(test_file)
 
         assert result.overall_confidence == 0.0

--- a/tests/methodologies/para/test_ai_heuristic.py
+++ b/tests/methodologies/para/test_ai_heuristic.py
@@ -65,8 +65,8 @@ class TestAIHeuristicUnavailable:
         # Patch both OLLAMA_AVAILABLE and ollama to prevent any real or leaked
         # mock client from reaching _parse_response (xdist isolation defence).
         with (
-            patch(f"{_HEURISTICS_MODULE}.OLLAMA_AVAILABLE", False),
-            patch(f"{_HEURISTICS_MODULE}.ollama", None),
+            patch(f"{_HEURISTICS_MODULE}.OLLAMA_AVAILABLE", new=False),
+            patch(f"{_HEURISTICS_MODULE}.ollama", new=None),
         ):
             result = h.evaluate(test_file)
 


### PR DESCRIPTION
## Summary

- Patches both `OLLAMA_AVAILABLE` **and** `ollama` (sets to `None`) in two tests that assert graceful degradation when Ollama is not installed
- Fixes the single test failure in the **"Test full suite (py3.12)"** CI job

## Root Cause

Under `-n auto` (xdist), a mock from another worker can overwrite the module-level `ollama` reference. When that happens, `_ensure_client()` succeeds (mock client, no errors), and `evaluate()` calls `generate()` → the response text is a `MagicMock`.

In `_parse_response`, the line `if start == -1 or end == -1 or end <= start:` compares two `MagicMock` values. In **Python 3.11** this returned a truthy mock (test accidentally passed). In **Python 3.12**, `MagicMock() <= MagicMock()` raises `TypeError` — causing the one failure.

## Fix

Adding `patch(target, "ollama", None)` ensures that even if `OLLAMA_AVAILABLE` leaks as a truthy mock, `_ensure_client()` hits `AttributeError` on `None.Client(...)`, which is caught by the `except Exception:` handler → `_available=False` → `evaluate()` returns early with `abstained=True`.

## Test Plan

- [ ] py3.12 CI passes for `TestAIHeuristicHelpers::test_evaluate_ollama_not_available`
- [ ] py3.12 CI passes for `TestAIHeuristicUnavailable::test_ollama_not_installed`
- [ ] No other tests broken by these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test isolation for AI evaluation logic to prevent external dependencies from interfering with test execution.

* **Chores**
  * Updated ignore configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->