### PR TITLE
fix(tests): fix 3 ci-full daily matrix failures (Windows + py3.11 xdist)

### DIFF
--- a/tests/cli/test_cli_dedupe.py
+++ b/tests/cli/test_cli_dedupe.py
@@ -533,8 +533,10 @@ class TestDisplayDuplicateGroup:
         output = console.export_text()
         assert "Duplicate Group 1/3" in output
         assert "abc123def4567890..." in output
-        assert "/a/file1.txt" in output
-        assert "/a/file2.txt" in output
+        # Use str(path) to match what display_duplicate_group renders — on Windows
+        # Path() uses backslashes, so hardcoded "/" strings fail cross-platform.
+        assert str(files[0]["path"]) in output
+        assert str(files[1]["path"]) in output
         assert "Potential space savings: 1.0 KB" in output
 
     def test_displays_group_no_keep(self, capsys):
@@ -552,8 +554,8 @@ class TestDisplayDuplicateGroup:
         )
         output = console.export_text()
         assert "Duplicate Group 2/5" in output
-        assert "/x/y.txt" in output
-        assert "/x/z.txt" in output
+        assert str(files[0]["path"]) in output
+        assert str(files[1]["path"]) in output
         assert "Potential space savings: 500.0 B" in output
 
 

--- a/tests/integration/test_methodologies_para_ai_rules_heuristics.py
+++ b/tests/integration/test_methodologies_para_ai_rules_heuristics.py
@@ -1313,13 +1313,15 @@ class TestAIHeuristicHelpers:
         from methodologies.para.detection.heuristics import AIHeuristic
 
         f = _make_file(tmp_path, "doc.txt")
-        h = AIHeuristic()
-        # Patch both OLLAMA_AVAILABLE and ollama to prevent any real or leaked
-        # mock client from reaching _parse_response (xdist isolation defence).
+        # Create the instance INSIDE the patch context so that _available is never
+        # seeded by a leaked MagicMock client from another xdist worker that
+        # set sys.modules["ollama"] = MagicMock() (e.g. test_backend_detector.py).
+        # Patch both OLLAMA_AVAILABLE and ollama for defence-in-depth.
         with (
             patch.object(_mod, "OLLAMA_AVAILABLE", new=False),
             patch.object(_mod, "ollama", new=None),
         ):
+            h = AIHeuristic()
             result = h.evaluate(f)
         assert result.abstained is True
 

--- a/tests/updater/test_installer.py
+++ b/tests/updater/test_installer.py
@@ -210,7 +210,10 @@ class TestRollback:
 
     def test_rollback_success(self, tmp_path):
         inst = UpdateInstaller(install_dir=tmp_path)
-        backup = tmp_path / "test-app.bak"
+        # Derive backup path the same way _resolve_target does — on Windows the
+        # target gets a .exe suffix, so the backup is "test-app.exe.bak" not "test-app.bak".
+        target = inst._resolve_target("test-app")
+        backup = target.with_name(f"{target.name}.bak")
         backup.write_bytes(b"old binary")
 
         assert inst.rollback("test-app") is True
@@ -221,7 +224,8 @@ class TestRollback:
 
     def test_rollback_failure(self, tmp_path):
         inst = UpdateInstaller(install_dir=tmp_path)
-        backup = tmp_path / "test-app.bak"
+        target = inst._resolve_target("test-app")
+        backup = target.with_name(f"{target.name}.bak")
         backup.write_bytes(b"old binary")
 
         with patch("shutil.move", side_effect=OSError("fail")):


### PR DESCRIPTION
## Summary

Fixes the three failures that have been making `CI Full Matrix` (daily 06:00 UTC) red for the past week.

### 1. `test_rollback_success` / `test_rollback_failure` — Windows

`_resolve_target("test-app")` returns `test-app.exe` on Windows, so `rollback()` looks for `test-app.exe.bak`. The tests were creating `test-app.bak`, which was never found → `rollback()` returned False.

**Fix:** derive the backup path via `inst._resolve_target()` instead of hardcoding the stem.

### 2. `TestDisplayDuplicateGroup` — Windows

`display_duplicate_group` renders paths with `str(path)`, which uses backslashes on Windows. Tests asserted hardcoded Unix strings (`"/a/file1.txt"`).

**Fix:** assert `str(files[N]["path"]) in output` — matches whatever the platform renders.

### 3. `test_evaluate_ollama_not_available` — Linux py3.11 xdist

`test_backend_detector.py` injects `sys.modules["ollama"] = MagicMock()` at module level (needed because `ollama` lacks `socksio` in the base env). In the same xdist worker, when `methodologies.para.detection.heuristics` is imported, `OLLAMA_AVAILABLE` becomes `True` and `_ensure_client()` creates a Mock client. If `h = AIHeuristic()` was constructed *before* entering the `patch.object` context, `_available` could be seeded to `True` before `OLLAMA_AVAILABLE` was patched — causing `evaluate()` to reach `_parse_response` with a `MagicMock` `response_text` → `TypeError: '<=' not supported between instances of 'MagicMock' and 'MagicMock'`.

**Fix:** move `h = AIHeuristic()` *inside* the `patch.object` context manager so `_available` is always `None` when `evaluate()` reads the patched `OLLAMA_AVAILABLE=False`.

## Test plan

- [ ] `ci-full` Linux py3.11 job passes
- [ ] `ci-full` Linux py3.12 job passes
- [ ] `ci-full` Windows job passes
- [ ] `ci-full` macOS job passes (no change here, but shouldn't regress)
- [ ] `tests/core/test_backend_detector.py` still fully passes (verify the sys.modules change didn't break anything)

🤖 Generated with [Claude Code](https://claude.com/claude-code)