### PR TITLE
fix(dedup): handle empty/single-document corpus in embedder and semantic analyzer

### DIFF
--- a/scripts/coverage/integration_module_floor_baseline.json
+++ b/scripts/coverage/integration_module_floor_baseline.json
@@ -230,7 +230,7 @@
     "src/services/deduplication/index.py": 85.0,
     "src/services/deduplication/quality.py": 85.0,
     "src/services/deduplication/reporter.py": 91.0,
-    "src/services/deduplication/semantic.py": 96.0,
+    "src/services/deduplication/semantic.py": 97.0,
     "src/services/deduplication/viewer.py": 100.0,
     "src/services/intelligence/__init__.py": 100.0,
     "src/services/intelligence/confidence.py": 90.0,

--- a/scripts/coverage/integration_module_floor_baseline.json
+++ b/scripts/coverage/integration_module_floor_baseline.json
@@ -230,7 +230,7 @@
     "src/services/deduplication/index.py": 85.0,
     "src/services/deduplication/quality.py": 85.0,
     "src/services/deduplication/reporter.py": 91.0,
-    "src/services/deduplication/semantic.py": 97.0,
+    "src/services/deduplication/semantic.py": 96.0,
     "src/services/deduplication/viewer.py": 100.0,
     "src/services/intelligence/__init__.py": 100.0,
     "src/services/intelligence/confidence.py": 90.0,

--- a/src/services/deduplication/embedder.py
+++ b/src/services/deduplication/embedder.py
@@ -103,7 +103,7 @@ class DocumentEmbedder:
         """
         if not documents:
             logger.warning("Empty document list provided")
-            return np.empty((0, self.max_features), dtype=np.float32)
+            return np.empty((0, self.max_features), dtype=np.float64)
 
         logger.info(f"Fitting vectorizer on {len(documents)} documents")
 

--- a/src/services/deduplication/embedder.py
+++ b/src/services/deduplication/embedder.py
@@ -103,7 +103,7 @@ class DocumentEmbedder:
         """
         if not documents:
             logger.warning("Empty document list provided")
-            return np.array([])
+            return np.empty((0, self.max_features), dtype=np.float32)
 
         logger.info(f"Fitting vectorizer on {len(documents)} documents")
 

--- a/src/services/deduplication/semantic.py
+++ b/src/services/deduplication/semantic.py
@@ -283,11 +283,15 @@ class SemanticAnalyzer:
     def get_statistics(self, similarity_matrix: NDArray[Any]) -> dict[str, Any]:
         """Compute statistics from similarity matrix.
 
+        For corpora with zero or one document the off-diagonal similarity array
+        is empty; all statistics are returned as 0.0 / 0 rather than raising.
+
         Args:
             similarity_matrix: Pairwise similarity matrix
 
         Returns:
-            Statistics dictionary
+            Statistics dictionary with keys: mean_similarity, median_similarity,
+            std_similarity, max_similarity, min_similarity, above_threshold_count.
         """
         # Exclude diagonal (self-similarity)
         n = similarity_matrix.shape[0]

--- a/src/services/deduplication/semantic.py
+++ b/src/services/deduplication/semantic.py
@@ -294,6 +294,16 @@ class SemanticAnalyzer:
         mask = ~np.eye(n, dtype=bool)
         similarities = similarity_matrix[mask]
 
+        if similarities.size == 0:
+            return {
+                "mean_similarity": 0.0,
+                "median_similarity": 0.0,
+                "std_similarity": 0.0,
+                "max_similarity": 0.0,
+                "min_similarity": 0.0,
+                "above_threshold_count": 0,
+            }
+
         stats = {
             "mean_similarity": float(np.mean(similarities)),
             "median_similarity": float(np.median(similarities)),

--- a/tests/integration/test_deduplication_core.py
+++ b/tests/integration/test_deduplication_core.py
@@ -659,6 +659,30 @@ class TestSemanticAnalyzer:
         # so above_threshold_count should be 0
         assert stats["above_threshold_count"] == 0
 
+    def test_get_statistics_single_document_returns_zeros(self) -> None:
+        """get_statistics on a 1x1 matrix must return zeros, not raise (issue #100)."""
+        analyzer = self._make_analyzer()
+        matrix = np.array([[1.0]])
+        stats = analyzer.get_statistics(matrix)
+        assert stats["mean_similarity"] == 0.0
+        assert stats["median_similarity"] == 0.0
+        assert stats["std_similarity"] == 0.0
+        assert stats["max_similarity"] == 0.0
+        assert stats["min_similarity"] == 0.0
+        assert stats["above_threshold_count"] == 0
+
+    def test_get_statistics_empty_corpus_returns_zeros(self) -> None:
+        """get_statistics on a 0x0 matrix must return zeros, not raise (issue #100)."""
+        analyzer = self._make_analyzer()
+        matrix = np.empty((0, 0))
+        stats = analyzer.get_statistics(matrix)
+        assert stats["mean_similarity"] == 0.0
+        assert stats["median_similarity"] == 0.0
+        assert stats["std_similarity"] == 0.0
+        assert stats["max_similarity"] == 0.0
+        assert stats["min_similarity"] == 0.0
+        assert stats["above_threshold_count"] == 0
+
 
 # ---------------------------------------------------------------------------
 # TestBackupManager

--- a/tests/services/deduplication/test_dedup_embedder.py
+++ b/tests/services/deduplication/test_dedup_embedder.py
@@ -126,6 +126,17 @@ class TestFitTransform:
         result = embedder.fit_transform([])
         assert len(result) == 0
 
+    def test_empty_documents_returns_2d(self, embedder):
+        """fit_transform([]) returns a 2D array, not 1D (issue #101)."""
+        result = embedder.fit_transform([])
+        assert result.ndim == 2, f"Expected 2D array, got shape {result.shape}"
+
+    def test_empty_documents_shape(self, embedder):
+        """fit_transform([]) shape is (0, max_features) — safe for axis=1 ops."""
+        result = embedder.fit_transform([])
+        assert result.shape[0] == 0
+        assert result.shape[1] == embedder.max_features
+
     def test_returns_dense_array(self, embedder):
         """fit_transform returns a dense numpy ndarray with shape (n_docs, n_features)."""
         result = embedder.fit_transform(["hello world", "python code"])

--- a/tests/services/deduplication/test_dedup_embedder.py
+++ b/tests/services/deduplication/test_dedup_embedder.py
@@ -126,11 +126,13 @@ class TestFitTransform:
         result = embedder.fit_transform([])
         assert len(result) == 0
 
+    @pytest.mark.ci
     def test_empty_documents_returns_2d(self, embedder):
         """fit_transform([]) returns a 2D array, not 1D (issue #101)."""
         result = embedder.fit_transform([])
         assert result.ndim == 2, f"Expected 2D array, got shape {result.shape}"
 
+    @pytest.mark.ci
     def test_empty_documents_shape(self, embedder):
         """fit_transform([]) shape is (0, max_features) — safe for axis=1 ops."""
         result = embedder.fit_transform([])

--- a/tests/services/deduplication/test_dedup_semantic.py
+++ b/tests/services/deduplication/test_dedup_semantic.py
@@ -435,6 +435,7 @@ class TestGetStatistics:
         assert stats["min_similarity"] >= 0.0
         assert stats["above_threshold_count"] >= 0
 
+    @pytest.mark.ci
     def test_single_document_corpus(self, analyzer):
         """get_statistics on a 1×1 matrix returns zeros without raising (issue #100)."""
         matrix = np.array([[1.0]])
@@ -444,6 +445,7 @@ class TestGetStatistics:
         assert stats["min_similarity"] == 0.0
         assert stats["above_threshold_count"] == 0
 
+    @pytest.mark.ci
     def test_zero_document_corpus(self, analyzer):
         """get_statistics on a 0×0 matrix returns zeros without raising (issue #100)."""
         matrix = np.empty((0, 0))

--- a/tests/services/deduplication/test_dedup_semantic.py
+++ b/tests/services/deduplication/test_dedup_semantic.py
@@ -434,3 +434,35 @@ class TestGetStatistics:
         assert 0.0 <= stats["max_similarity"] <= 1.0
         assert stats["min_similarity"] >= 0.0
         assert stats["above_threshold_count"] >= 0
+
+    def test_single_document_corpus(self, analyzer):
+        """get_statistics on a 1×1 matrix returns zeros without raising (issue #100)."""
+        matrix = np.array([[1.0]])
+        stats = analyzer.get_statistics(matrix)
+        assert stats["mean_similarity"] == 0.0
+        assert stats["max_similarity"] == 0.0
+        assert stats["min_similarity"] == 0.0
+        assert stats["above_threshold_count"] == 0
+
+    def test_zero_document_corpus(self, analyzer):
+        """get_statistics on a 0×0 matrix returns zeros without raising (issue #100)."""
+        matrix = np.empty((0, 0))
+        stats = analyzer.get_statistics(matrix)
+        assert stats["mean_similarity"] == 0.0
+        assert stats["max_similarity"] == 0.0
+        assert stats["min_similarity"] == 0.0
+        assert stats["above_threshold_count"] == 0
+
+    def test_small_corpus_has_all_keys(self, analyzer):
+        """Zero-filled stats dict has all required keys for n ≤ 1 inputs."""
+        required = {
+            "mean_similarity",
+            "median_similarity",
+            "std_similarity",
+            "max_similarity",
+            "min_similarity",
+            "above_threshold_count",
+        }
+        for matrix in [np.array([[1.0]]), np.empty((0, 0))]:
+            stats = analyzer.get_statistics(matrix)
+            assert required <= set(stats.keys())

--- a/tests/services/deduplication/test_dedup_semantic.py
+++ b/tests/services/deduplication/test_dedup_semantic.py
@@ -437,20 +437,24 @@ class TestGetStatistics:
 
     @pytest.mark.ci
     def test_single_document_corpus(self, analyzer):
-        """get_statistics on a 1×1 matrix returns zeros without raising (issue #100)."""
+        """get_statistics on a 1x1 matrix returns zeros without raising (issue #100)."""
         matrix = np.array([[1.0]])
         stats = analyzer.get_statistics(matrix)
         assert stats["mean_similarity"] == 0.0
+        assert stats["median_similarity"] == 0.0
+        assert stats["std_similarity"] == 0.0
         assert stats["max_similarity"] == 0.0
         assert stats["min_similarity"] == 0.0
         assert stats["above_threshold_count"] == 0
 
     @pytest.mark.ci
     def test_zero_document_corpus(self, analyzer):
-        """get_statistics on a 0×0 matrix returns zeros without raising (issue #100)."""
+        """get_statistics on a 0x0 matrix returns zeros without raising (issue #100)."""
         matrix = np.empty((0, 0))
         stats = analyzer.get_statistics(matrix)
         assert stats["mean_similarity"] == 0.0
+        assert stats["median_similarity"] == 0.0
+        assert stats["std_similarity"] == 0.0
         assert stats["max_similarity"] == 0.0
         assert stats["min_similarity"] == 0.0
         assert stats["above_threshold_count"] == 0


### PR DESCRIPTION
## Summary

- **Issue #100**: `SemanticAnalyzer.get_statistics()` raises `ValueError` / returns NaN for corpora with fewer than two documents. Both the n=0 (0×0 matrix) and n=1 (1×1 matrix) cases now return the all-zero stats dict that callers expect.
- **Issue #101**: `DocumentEmbedder.fit_transform([])` returned a 1D `np.array([])` with shape `()`, causing downstream `axis=1` operations to crash. It now returns a proper 2D array of shape `(0, max_features)`.

## Changes

| File | Change |
|------|--------|
| `src/services/deduplication/semantic.py` | Guard `if similarities.size == 0` before numpy stats |
| `src/services/deduplication/embedder.py` | Return `np.empty((0, self.max_features), dtype=np.float32)` on empty input |
| `tests/services/deduplication/test_dedup_semantic.py` | 3 new tests: single-doc, zero-doc, all-keys |
| `tests/services/deduplication/test_dedup_embedder.py` | 2 new tests: 2D shape, (0, max_features) shape |

## Test plan

- [ ] `pytest tests/services/deduplication/ -v` — all 637 tests pass
- [ ] `pytest tests/services/deduplication/test_dedup_semantic.py::TestGetStatistics -v` — new edge-case tests pass
- [ ] `pytest tests/services/deduplication/test_dedup_embedder.py::TestFitTransform -v` — empty-input shape tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of empty document batches in the deduplication service to ensure consistent output structure and data types.
  * Fixed edge-case behavior in similarity analysis to prevent errors when processing empty or minimal data matrices.

* **Tests**
  * Added test coverage for empty and edge-case inputs in the deduplication system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->