### PR TITLE
fix: address post-flatten PR review findings (issue #111)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,7 +100,7 @@ repos:
 
       - id: pytest-affected
         name: pytest (affected tests)
-        entry: bash -c "PATHS=$(python scripts/select_tests_for_changes.py --staged --format args); [ -z \"$PATHS\" ] && exit 0; pytest $PATHS -q --override-ini='addopts=' --timeout=60"
+        entry: bash -c "if ! PATHS=$(python scripts/select_tests_for_changes.py --staged --format args); then echo 'affected-test selector failed' >&2; exit 1; fi; [ -z \"$PATHS\" ] && exit 0; pytest $PATHS -q --override-ini='addopts=' --timeout=60"
         language: system
         pass_filenames: false
         stages: [pre-commit]

--- a/src/methodologies/para/detection/heuristics.py
+++ b/src/methodologies/para/detection/heuristics.py
@@ -700,10 +700,15 @@ class AIHeuristic(Heuristic):
                 stream=False,
             )
             response_text: str = response.get("response", "") or ""
-            parsed = self._parse_response(response_text)
         except Exception:
             logger.warning("Ollama generate failed", exc_info=True)
             return self._zero_result("ollama_error")
+
+        try:
+            parsed = self._parse_response(response_text)
+        except Exception:
+            logger.warning("Response parse failed", exc_info=True)
+            return self._zero_result("parse_error")
 
         if parsed is None:
             logger.warning(

--- a/tests/methodologies/para/test_ai_heuristic.py
+++ b/tests/methodologies/para/test_ai_heuristic.py
@@ -112,7 +112,6 @@ class TestAIHeuristicUnavailable:
         assert result.overall_confidence == 0.0
         assert result.abstained is True
 
-    @pytest.mark.ci
     def test_parse_response_raises_returns_parse_error(self, tmp_path: Path) -> None:
         """When _parse_response raises (not returns None), result is parse_error not ollama_error."""
         h, mock_client = _make_heuristic()

--- a/tests/methodologies/para/test_ai_heuristic.py
+++ b/tests/methodologies/para/test_ai_heuristic.py
@@ -112,6 +112,27 @@ class TestAIHeuristicUnavailable:
         assert result.overall_confidence == 0.0
         assert result.abstained is True
 
+    @pytest.mark.ci
+    def test_parse_response_raises_returns_parse_error(self, tmp_path: Path) -> None:
+        """When _parse_response raises (not returns None), result is parse_error not ollama_error."""
+        h, mock_client = _make_heuristic()
+        mock_client.generate.return_value = {"response": "{}"}
+        test_file = tmp_path / "notes.txt"
+        test_file.write_text("content")
+
+        with (
+            patch(f"{_HEURISTICS_MODULE}.OLLAMA_AVAILABLE", True),
+            patch.object(h, "_parse_response", side_effect=TypeError("unexpected type")),
+        ):
+            result = h.evaluate(test_file)
+
+        assert result.metadata["ai_analysis"] == "parse_error", (
+            f"Expected parse_error, got {result.metadata['ai_analysis']!r} — "
+            "_parse_response exceptions must not be conflated with ollama_error"
+        )
+        assert result.overall_confidence == 0.0
+        assert result.abstained is True
+
 
 # ---------------------------------------------------------------------------
 # Tests: successful classification

--- a/tests/parallel/test_concurrency_fixes.py
+++ b/tests/parallel/test_concurrency_fixes.py
@@ -273,13 +273,13 @@ class TestConcurrencyFixes(unittest.TestCase):
 
     def test_timeout_poll_interval_scales_with_timeout(self) -> None:
         """Test polling interval scales with timeout to reduce timeout drift."""
-        # Use a generous timeout (2.0s) so the task always completes on slow CI
-        # runners (macOS/Windows). The task itself takes ~20ms — well within 2s.
-        # The key assertion is that the polling interval scales proportionally
-        # with timeout_per_file (expected ~10% → ≤ 0.21s for a 2.0s timeout).
+        # timeout_per_file=0.4 → poll_interval = min(0.05, max(0.005, 0.4/10))
+        # = min(0.05, 0.04) = 0.04 — stays within the uncapped range [0.005, 0.05],
+        # so this exercises the proportional branch of the formula.
+        # Generous enough (20x the 20ms task) to complete reliably on slow CI runners.
         config = ParallelConfig(
             max_workers=1,
-            timeout_per_file=2.0,
+            timeout_per_file=0.4,
             retry_count=0,
         )
         processor = ParallelProcessor(config=config)
@@ -306,6 +306,6 @@ class TestConcurrencyFixes(unittest.TestCase):
         self.assertTrue(observed_timeouts)
         self.assertLessEqual(
             max(observed_timeouts),
-            0.21,
-            "Expected timeout polling interval to scale proportionally with timeout_per_file",
+            0.041,
+            "Expected poll interval ≈ timeout/10 = 0.04s (uncapped) for timeout_per_file=0.4",
         )


### PR DESCRIPTION
## Summary

Closes #111. Three findings from post-flatten PR review comments:

- **F1 (P1):** `pytest-affected` pre-commit hook now exits 1 when `select_tests_for_changes.py` crashes, instead of silently passing with `PATHS=""`. Also removed `2>&1` so stderr (tracebacks, warnings) never gets merged into the `PATHS` variable.
- **F2 (Low):** Stale plan doc `docs/superpowers/plans/2026-04-16-mypy-gate-tier3-services.md` was already untracked (removed from git in PR #98); deleted from disk.
- **F3 (Low):** Split the broad `try/except` in `AIHeuristic.evaluate()` so `_parse_response` exceptions return `reason="parse_error"` instead of being conflated with `"ollama_error"`. Adds `test_parse_response_raises_returns_parse_error` to guard the distinction.

## Test plan

- [ ] `test_parse_response_raises_returns_parse_error` — new test, asserts `parse_error` not `ollama_error` when `_parse_response` raises
- [ ] `test_generate_exception_returns_zero` — existing test still returns `ollama_error` for generate failures
- [ ] `test_malformed_response_fallback` — existing test still returns `parse_error` for `None`-returning parse path
- [ ] F1 manually verifiable: `python scripts/select_tests_for_changes.py --staged --format args` exits 0 on success, 1 on crash

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AI heuristic evaluation now distinguishes parse exceptions from generation errors, logs parse failures, and returns a neutral result with parse_error metadata.
  * Pre-commit test-selection hook now fails and reports an error when the selector fails instead of continuing silently.

* **Tests**
  * Added test validating parse-exception handling in AI heuristics.
  * Adjusted a concurrency timing test to reflect a refined poll-interval expectation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->