### PR TITLE
chore: upgrade pytest 7.4.4→9.0.3 and pytest-asyncio 0.23.8→1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest~=7.4",
-    "pytest-asyncio~=0.23",
+    "pytest~=9.0",
+    "pytest-asyncio>=1.0",
     "pytest-cov~=4.1",
     "pytest-mock~=3.12",
     "pytest-timeout>=2.2.0,<2.5.0",  # 2.4.0 regression: timer thread not cancelled on Windows; crashes during teardown (AssertionError in read_global_capture)

--- a/uv.lock
+++ b/uv.lock
@@ -1350,8 +1350,8 @@ requires-dist = [
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = "~=10.7" },
     { name = "pymupdf", specifier = "~=1.23" },
     { name = "pypdf", marker = "extra == 'dedup'", specifier = "~=6.10" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = "~=7.4" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "~=0.23" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "~=9.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = "~=4.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "~=4.1" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = "~=3.12" },
@@ -2570,13 +2570,13 @@ name = "mlx-lm"
 version = "0.31.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jinja2", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "jinja2", marker = "sys_platform == 'darwin'" },
     { name = "mlx", marker = "sys_platform == 'darwin'" },
-    { name = "numpy", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
-    { name = "protobuf", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
-    { name = "pyyaml", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
-    { name = "sentencepiece", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
-    { name = "transformers", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
+    { name = "protobuf", marker = "sys_platform == 'darwin'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin'" },
+    { name = "sentencepiece", marker = "sys_platform == 'darwin'" },
+    { name = "transformers", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/f9/3f5597c62bd5733ebb3c9f96c33f2065db16353d743b8548bb05a01b7dd3/mlx_lm-0.31.1.tar.gz", hash = "sha256:1b2362ea301427004e5dda43b9241d751d4cb80eba641f6b85b29fc493affac5", size = 285473, upload-time = "2026-03-11T02:02:57.466Z" }
 wheels = [
@@ -3712,29 +3712,31 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116, upload-time = "2023-12-31T12:00:18.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8", size = 325287, upload-time = "2023-12-31T12:00:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.23.8"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/b4/0b378b7bf26a8ae161c3890c0b48a91a04106c5713ce81b4b080ea2f4f18/pytest_asyncio-0.23.8.tar.gz", hash = "sha256:759b10b33a6dc61cce40a8bd5205e302978bbbcc00e279a8b61d9a6a3c82e4d3", size = 46920, upload-time = "2024-07-17T17:39:34.617Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/82/62e2d63639ecb0fbe8a7ee59ef0bc69a4669ec50f6d3459f74ad4e4189a2/pytest_asyncio-0.23.8-py3-none-any.whl", hash = "sha256:50265d892689a5faefb84df80819d1ecef566eb3549cf915dfb33569359d1ce2", size = 17663, upload-time = "2024-07-17T17:39:32.478Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -4782,15 +4784,15 @@ name = "transformers"
 version = "5.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
-    { name = "numpy", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
-    { name = "packaging", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
-    { name = "pyyaml", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
-    { name = "regex", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
-    { name = "safetensors", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
-    { name = "tokenizers", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
-    { name = "tqdm", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
-    { name = "typer", marker = "platform_machine != 'ARM64' or sys_platform != 'win32'" },
+    { name = "huggingface-hub", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
+    { name = "packaging", marker = "sys_platform == 'darwin'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin'" },
+    { name = "regex", marker = "sys_platform == 'darwin'" },
+    { name = "safetensors", marker = "sys_platform == 'darwin'" },
+    { name = "tokenizers", marker = "sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin'" },
+    { name = "typer", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/1a/70e830d53ecc96ce69cfa8de38f163712d2b43ac52fbd743f39f56025c31/transformers-5.3.0.tar.gz", hash = "sha256:009555b364029da9e2946d41f1c5de9f15e6b1df46b189b7293f33a161b9c557", size = 8830831, upload-time = "2026-03-04T17:41:46.119Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- Upgrades `pytest` from `~=7.4` (7.4.4) to `~=9.0` (9.0.3)
- Upgrades `pytest-asyncio` from `~=0.23` (0.23.8) to `>=1.0` (1.3.0)

Replaces the broken Dependabot PR #114 which resolved `pytest-asyncio` to 0.23.3 — incompatible with pytest 9 (`AttributeError: 'Package' object has no attribute 'obj'`). pytest-asyncio 0.24–0.26 also pins `pytest<9`; only 1.x supports pytest 9.

## Why `pytest-asyncio>=1.0` (no upper bound)

`asyncio_mode = "auto"` is already set in `pyproject.toml` so the 1.x default-strict change has no effect. No other breaking changes affect this project.

## Security

Includes **CVE-2025-71176** fix (insecure temporary directory, patched in pytest 9.0.3).

## Test plan

Full suite run locally against pytest 9.0.3 + pytest-asyncio 1.3.0:
- Without xdist: **9698 passed, 0 failed**, 16 skipped in 123s
- With `-n auto`: **9698 passed, 0 failed**, 16 skipped in 41s

🤖 Generated with [Claude Code](https://claude.com/claude-code)