### PR TITLE
ci: remove --timeout=30 from Windows matrix job to fix teardown crash

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -142,5 +142,7 @@ jobs:
         # CI Full's cross-platform contract: validate the portable ci/smoke subset on Windows.
         # -n=auto intentionally omitted: xdist worker shutdown on Windows propagates
         # CTRL_C_EVENT as KeyboardInterrupt, causing exit code 1 when all tests pass.
-        # The ci/smoke subset (~61 tests) is small enough that parallelism adds no benefit.
-        run: pytest tests/ --strict-markers --timeout=30 --override-ini="addopts=" -m "ci or smoke"
+        # --timeout omitted: pytest-timeout thread-mode fires during teardown on Windows,
+        # producing a spurious KeyboardInterrupt after all tests pass (exit code 1).
+        # The 20-minute job timeout provides a sufficient hard cap.
+        run: pytest tests/ --strict-markers --override-ini="addopts=" -m "ci or smoke"


### PR DESCRIPTION
## Summary

- pytest-timeout in thread mode fires a spurious `KeyboardInterrupt` during session teardown on Windows after all tests pass, causing exit code 1
- Observed with both 2.4.0 (`AssertionError` in `capture.py:802`) and 2.3.1 (`KeyboardInterrupt` at `functools.py:982`)
- The timer thread outlives test execution and fires during pytest's shutdown sequence
- The 20-minute job-level `timeout-minutes` is a sufficient hard cap — no per-test timeout needed in this job
- Also updates the stale comment ("~61 tests" — actual count is ~3261 with `-m "ci or smoke"`)

## Root cause chain

1. CI Full Matrix has always been failing on Windows
2. Earlier failures were test assertion issues (path separators, `is_absolute()`) — now fixed
3. After those were fixed, the teardown crash became the new blocker
4. pytest-timeout 2.4.0 and 2.3.1 both have this Windows teardown bug in thread mode

## Test plan

- [ ] CI passes on this PR
- [ ] CI Full Matrix Windows job passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)