### PR TITLE
fix(tests): use SelectorEventLoop on Windows to prevent IOCP teardown crash

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -144,5 +144,7 @@ jobs:
         # CTRL_C_EVENT as KeyboardInterrupt, causing exit code 1 when all tests pass.
         # --timeout omitted: pytest-timeout thread-mode fires during teardown on Windows,
         # producing a spurious KeyboardInterrupt after all tests pass (exit code 1).
+        # ProactorEventLoop IOCP teardown race: fixed in tests/conftest.py via
+        # SelectorEventLoop on win32 (see ensure_default_event_loop fixture).
         # The 20-minute job timeout provides a sufficient hard cap.
         run: pytest tests/ --strict-markers --override-ini="addopts=" -m "ci or smoke"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,15 @@ def ensure_default_event_loop(request: pytest.FixtureRequest) -> None:
         yield
         return
 
-    created_loop = asyncio.new_event_loop()
+    # On Windows, asyncio.new_event_loop() returns a ProactorEventLoop backed by
+    # IOCP.  Its cleanup thread races with pytest's session teardown and generates
+    # CTRL_C_EVENT → KeyboardInterrupt at _pytest/stash.py during finalization,
+    # causing exit code 1 even when all tests pass.  SelectorEventLoop avoids
+    # IOCP entirely and is safe for the only thing sync tests need: asyncio.Lock.
+    if sys.platform == "win32":
+        created_loop: asyncio.AbstractEventLoop = asyncio.SelectorEventLoop()
+    else:
+        created_loop = asyncio.new_event_loop()
     asyncio.set_event_loop(created_loop)
 
     yield


### PR DESCRIPTION
## Root cause

The `ensure_default_event_loop` fixture in `tests/conftest.py` creates a new event loop for every sync test. On Windows, `asyncio.new_event_loop()` returns a `ProactorEventLoop` backed by IOCP (I/O Completion Ports).

When the IOCP worker thread races with pytest's session cleanup during finalization, it generates `CTRL_C_EVENT` → `KeyboardInterrupt` at `_pytest/stash.py:79` **after all tests pass** — causing exit code 1. This explains why the CI Full Matrix Windows job consistently showed `333 passed, 1 skipped` then failed.

This is a third distinct Windows teardown cause, separate from:
- xdist CTRL_C_EVENT propagation (why `-n=auto` is omitted)  
- pytest-timeout thread-mode teardown (why `--timeout` is omitted)

## Fix

Switch `ensure_default_event_loop` to use `asyncio.SelectorEventLoop()` on `win32`. `SelectorEventLoop` is selector-based (no IOCP), avoids the race entirely, and is sufficient for what sync tests need: `asyncio.Lock` instantiation from Textual widgets.

Updated the `ci-full.yml` Windows job comment to document all three causes.

## Test plan
- [ ] CI Full Matrix Windows job passes with 333 tests (0 failures)
- [ ] Linux and macOS jobs unaffected (the `else` branch still uses `asyncio.new_event_loop()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved event loop teardown race condition on Windows that was causing intermittent test failures.

* **Chores**
  * Updated CI workflow documentation to clarify event loop configuration on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->