### PR TITLE
revert: action-gh-release 3.0.0 — merged with failing CI (#128)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
           cat SHA256SUMS.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2.6.1
         with:
           files: |
             artifacts/**/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           name: dist
           path: dist/
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2.6.1
         with:
           files: dist/*
           generate_release_notes: true


### PR DESCRIPTION
Reverts #128 (softprops/action-gh-release 2.6.1 → 3.0.0).

PR #128 had a failing CI check (`Test PR suite (py3.11)` — SSL error during pip install) and was merged before the failure was noticed. This restores `action-gh-release` to 2.6.1 in `build.yml` and `release.yml`. A clean re-bump can be done once the major version change has been validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release process infrastructure for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->