### PR TITLE
fix(tests): override event_loop_policy to use SelectorEventLoop on Windows (#125)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,7 @@ def event_loop_policy() -> asyncio.AbstractEventLoopPolicy:
     """
     if sys.platform == "win32":
         return asyncio.WindowsSelectorEventLoopPolicy()
-    return asyncio.DefaultEventLoopPolicy()
+    return asyncio.get_event_loop_policy()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,25 @@ skip_below_py312 = pytest.mark.skipif(
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(scope="session")
+def event_loop_policy() -> asyncio.AbstractEventLoopPolicy:
+    """Override pytest-asyncio's default policy to use SelectorEventLoop on Windows.
+
+    pytest-asyncio's ``event_loop_policy`` fixture (session-scoped, autouse) returns
+    ``WindowsProactorEventLoopPolicy`` by default on Windows.  Its session-level runner
+    creates a ProactorEventLoop; when ``Runner.__exit__`` fires at session teardown,
+    IOCP cleanup races with pytest finalization and delivers ``CTRL_C_EVENT`` →
+    ``KeyboardInterrupt`` at ``socket.py``, causing exit code 1 even when all tests
+    pass.
+
+    Returning ``WindowsSelectorEventLoopPolicy`` propagates to *all* pytest-asyncio
+    runners (function-, module-, and session-scoped), eliminating IOCP entirely.
+    """
+    if sys.platform == "win32":
+        return asyncio.WindowsSelectorEventLoopPolicy()
+    return asyncio.DefaultEventLoopPolicy()
+
+
 @pytest.fixture(autouse=True)
 def ensure_default_event_loop(request: pytest.FixtureRequest) -> None:
     """Ensure sync tests can instantiate asyncio-bound widgets across Python versions.


### PR DESCRIPTION
## Summary

- **Root cause**: pytest-asyncio 1.3.0's `event_loop_policy` fixture (session-scoped, autouse) returns `WindowsProactorEventLoopPolicy` on Windows. Its session-level `Runner.__exit__()` closes a ProactorEventLoop at pytest session teardown; IOCP cleanup races with pytest finalization and delivers `CTRL_C_EVENT` → `KeyboardInterrupt` at `socket.py:499`, causing exit code 1 even when all tests pass.
- **Why not caught before**: PR #124's `ensure_default_event_loop` fix only covered the per-test loop for sync tests. pytest-asyncio creates its own loops (including a session-scoped one) independently.
- **Evidence**: ci-full run 24575527237 — 2480 tests pass, crash at `socket.py:499` during session teardown immediately after the final test file.
- **Fix**: Override `event_loop_policy` in `tests/conftest.py` to return `WindowsSelectorEventLoopPolicy()` on Windows. This propagates to **all** pytest-asyncio runners (function-, module-, and session-scoped), eliminating IOCP entirely.

## Test plan

- [ ] ci-full Windows py3.12 passes (no `KeyboardInterrupt` at teardown)
- [ ] ci-full Linux py3.11 and py3.12 unaffected (policy override is `win32`-gated)
- [ ] ci-full macOS py3.12 unaffected
- [ ] Local `pytest tests/ -m "ci or smoke"` — 3260 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows for release and build processes.
  * Enhanced test environment configuration for improved Windows compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->