### PR TITLE
docs(epic): install-size reduction spec and implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-04-19-install-size-reduction.md
+++ b/docs/superpowers/plans/2026-04-19-install-size-reduction.md
@@ -1,0 +1,1338 @@
+# Install Size Reduction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce the default `fo-core` install from 206 MB to 181 MB by removing NLTK and numpy from default dependencies, adding lightweight format libraries (RTF, 7Z/RAR, audio metadata) to default, and restructuring optional extras.
+
+**Architecture:** Prerequisites first (guard numpy-dependent `__init__.py` imports, capture golden fixtures), then NLTK replacement and pyproject.toml changes in tandem, then test/CI/docs cleanup. Each task is self-contained and commits on completion.
+
+**Tech Stack:** `snowballstemmer` (replaces NLTK stemming), `striprtf` (RTF reader), stdlib `re` + `collections.Counter` (replaces NLTK tokenization + FreqDist), `pytest` subprocess fixture for numpy isolation smoke test.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-install-size-epic-design.md`
+
+---
+
+## Task 1: Capture golden fixtures for NLTK-affected functions
+
+Run this **before any code changes**. Records current NLTK output so the behavioral
+difference between NLTK and Snowball is explicit and reviewable.
+
+**Files:**
+- Create: `tests/utils/golden_nltk_output.py` (one-off capture script, deleted after use)
+- Modify: `tests/unit/utils/test_text_processing.py` (add golden fixture constants)
+
+- [ ] **Step 1: Run the capture script**
+
+```bash
+cd /path/to/fo-core
+python - <<'EOF'
+import sys
+sys.path.insert(0, "src")
+from utils.text_processing import get_unwanted_words, clean_text, extract_keywords
+
+# Must have NLTK data available; if not, run: python -c "import nltk; nltk.download('stopwords'); nltk.download('punkt'); nltk.download('wordnet')"
+print("=== get_unwanted_words() ===")
+print(repr(sorted(get_unwanted_words())))
+
+print("\n=== clean_text('Studies in running and analysis') ===")
+print(repr(clean_text("Studies in running and analysis")))
+
+print("\n=== extract_keywords('The quick brown fox jumps over the lazy dog') ===")
+print(repr(extract_keywords("The quick brown fox jumps over the lazy dog")))
+EOF
+```
+
+- [ ] **Step 2: Record outputs as OLD_* constants**
+
+Open `tests/unit/utils/test_text_processing.py` and add near the top:
+
+```python
+# Golden outputs captured under NLTK implementation — kept as acknowledgement
+# artifact showing the behavioral difference vs Snowball replacement.
+_OLD_CLEAN_TEXT = "<paste actual output from Step 1>"
+_OLD_EXTRACT_KEYWORDS = <paste actual output from Step 1>
+```
+
+- [ ] **Step 3: Write failing test stubs with placeholder values**
+
+In `tests/unit/utils/test_text_processing.py` add:
+
+```python
+# OLD_* captured under NLTK — acknowledgement artifact only.
+_OLD_CLEAN_TEXT = "<captured in Step 1>"
+_OLD_EXTRACT_KEYWORDS = "<captured in Step 1>"
+
+# NEW_* = expected Snowball output. Fill in after Task 4 is implemented:
+# run the two functions and paste the repr() output here.
+_NEW_CLEAN_TEXT = "FILL_AFTER_TASK_4"
+_NEW_EXTRACT_KEYWORDS: list[str] = []
+
+
+def test_clean_text_golden_snowball() -> None:
+    assert clean_text("Studies in running and analysis") == _NEW_CLEAN_TEXT
+
+
+def test_extract_keywords_golden_snowball() -> None:
+    assert extract_keywords("The quick brown fox jumps over the lazy dog") == _NEW_EXTRACT_KEYWORDS
+```
+
+- [ ] **Step 4: Run the new tests (should FAIL — NLTK still active)**
+
+```bash
+pytest tests/unit/utils/test_text_processing.py::test_clean_text_golden_snowball \
+       tests/unit/utils/test_text_processing.py::test_extract_keywords_golden_snowball -v
+```
+
+Expected: FAIL
+
+> **Note:** `_NEW_CLEAN_TEXT` and `_NEW_EXTRACT_KEYWORDS` are filled in during Task 4
+> Step 8 (after the Snowball implementation is in place). The test stubs are written
+> now so git tracks the intent; actual values are captured from the working implementation.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/utils/test_text_processing.py
+git commit -m "test(text): add Snowball golden fixture stubs (values filled in Task 4)"
+```
+
+---
+
+## Task 2: Guard numpy-dependent imports in services/deduplication/__init__.py
+
+**Prerequisite for removing numpy from pyproject.toml.** Without this guard, importing
+`cli.dedupe_hash` (which imports `services.deduplication.detector`, which triggers
+`__init__.py`) fails with `ModuleNotFoundError: numpy` on a default install.
+
+**Files:**
+- Modify: `src/services/deduplication/__init__.py`
+
+- [ ] **Step 1: Write the failing import-boundary test**
+
+```bash
+python - <<'EOF'
+import sys
+sys.modules["numpy"] = None  # simulate numpy absent
+try:
+    from services.deduplication.detector import DuplicateDetector
+    print("PASS - no numpy import triggered")
+except Exception as e:
+    print(f"FAIL: {e}")
+EOF
+```
+Run from repo root with `PYTHONPATH=src`. Expected: FAIL (numpy import triggered).
+
+- [ ] **Step 2: Apply the guard**
+
+Open `src/services/deduplication/__init__.py`. The three unconditional numpy-dependent
+imports are at lines 20–21 and 35:
+
+```python
+from .document_dedup import DocumentDeduplicator   # line 20
+from .embedder import DocumentEmbedder             # line 21
+from .semantic import SemanticAnalyzer             # line 35
+```
+
+Replace those three lines (keeping all other imports unchanged) with:
+
+```python
+# DocumentEmbedder, SemanticAnalyzer, DocumentDeduplicator require numpy
+# (via sklearn/sentence-transformers). Guard so a default install without
+# the dedup-text extra can still import the hash-based dedup path.
+try:
+    from .document_dedup import DocumentDeduplicator
+    from .embedder import DocumentEmbedder
+    from .semantic import SemanticAnalyzer
+except ImportError:
+    pass  # numpy not available; hash-based dedup still works
+```
+
+- [ ] **Step 3: Add a scope comment to document_dedup.py**
+
+Open `src/services/deduplication/document_dedup.py` and add after the class definition
+line of `DocumentDeduplicator`:
+
+```python
+# DocumentDeduplicator: requires dedup-text extra; CLI integration tracked separately
+```
+
+- [ ] **Step 4: Verify the guard works**
+
+```bash
+python - <<'EOF'
+import sys
+sys.modules["numpy"] = None
+sys.path.insert(0, "src")
+from services.deduplication.detector import DuplicateDetector
+print("PASS")
+EOF
+```
+
+Expected: `PASS`
+
+- [ ] **Step 5: Run existing dedup tests to confirm no regression**
+
+```bash
+pytest tests/ -k "dedup" -x -q
+```
+
+Expected: all passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/services/deduplication/__init__.py src/services/deduplication/document_dedup.py
+git commit -m "fix(dedup): guard numpy-dependent __init__ imports behind ImportError"
+```
+
+---
+
+## Task 3: Guard numpy-dependent imports in services/search/__init__.py
+
+The import chain `search/__init__.py` → `HybridRetriever` → `VectorIndex` →
+`from numpy.typing import NDArray` means `import services.search` fails without numpy.
+
+**Files:**
+- Modify: `src/services/search/__init__.py`
+
+- [ ] **Step 1: Confirm the failure**
+
+```bash
+python - <<'EOF'
+import sys
+sys.modules["numpy"] = None
+sys.path.insert(0, "src")
+import services.search
+print("PASS")
+EOF
+```
+
+Expected: FAIL (numpy.typing import triggered).
+
+- [ ] **Step 2: Apply the guard**
+
+`src/services/search/__init__.py` currently contains:
+
+```python
+from services.search.hybrid_retriever import HybridRetriever, read_text_safe
+```
+
+Replace with:
+
+```python
+# HybridRetriever requires numpy (via VectorIndex). Guard so a default
+# install without the search extra can still import this package.
+try:
+    from services.search.hybrid_retriever import HybridRetriever, read_text_safe
+except ImportError:
+    pass  # numpy not available; search subsystem disabled
+```
+
+- [ ] **Step 3: Verify the guard works**
+
+```bash
+python - <<'EOF'
+import sys
+sys.modules["numpy"] = None
+sys.path.insert(0, "src")
+import services.search
+print("PASS")
+EOF
+```
+
+Expected: `PASS`
+
+- [ ] **Step 4: Run existing search tests**
+
+```bash
+pytest tests/ -k "search" -x -q
+```
+
+Expected: all passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/search/__init__.py
+git commit -m "fix(search): guard numpy-dependent HybridRetriever import behind ImportError"
+```
+
+---
+
+## Task 4: Replace NLTK with snowballstemmer in utils/text_processing.py
+
+**Files:**
+- Modify: `src/utils/text_processing.py`
+
+- [ ] **Step 1: Replace the import block and module-level flags**
+
+Open `src/utils/text_processing.py`. Lines 1–20 currently contain:
+
+```python
+import re
+...
+try:
+    import nltk
+    from nltk.corpus import stopwords
+    from nltk.stem import WordNetLemmatizer
+    from nltk.tokenize import word_tokenize
+    NLTK_AVAILABLE = True
+except ImportError:
+    NLTK_AVAILABLE = False
+
+_nltk_ready: bool = False
+```
+
+Replace the NLTK try/except block and the `_nltk_ready` / `NLTK_AVAILABLE` declarations
+with:
+
+```python
+from collections import Counter
+from snowballstemmer import stemmer as Stemmer
+```
+
+Keep `import re` and any other existing stdlib imports. Remove `NLTK_AVAILABLE = True/False`
+and `_nltk_ready` entirely.
+
+- [ ] **Step 2: Delete the ensure_nltk_data() function**
+
+Delete lines 23–95 (the entire `ensure_nltk_data()` function, including its docstring).
+Confirm nothing else in this file calls `ensure_nltk_data`.
+
+- [ ] **Step 3: Add the _ENGLISH_STOPWORDS module-level constant**
+
+Add this constant immediately after the import block (before `get_unwanted_words`):
+
+```python
+_ENGLISH_STOPWORDS: frozenset[str] = frozenset({
+    "a", "an", "and", "are", "as", "at", "be", "but", "by", "for",
+    "from", "has", "he", "in", "is", "it", "its", "of", "on", "or",
+    "that", "the", "to", "was", "will", "with", "i", "you", "we",
+    "they", "she", "him", "her", "me", "us", "can", "could", "would",
+    "should", "do", "does", "did", "have", "having", "not", "no",
+    "nor", "so", "than", "too", "very", "just", "own", "same",
+})
+```
+
+- [ ] **Step 4: Update get_unwanted_words()**
+
+Find the NLTK block near the end of `get_unwanted_words()` (around line 237–244):
+
+```python
+# Add NLTK stopwords if available
+if NLTK_AVAILABLE:
+    try:
+        unwanted.update(stopwords.words("english"))
+    except LookupError:
+        logger.warning("NLTK stopwords not available")
+```
+
+Replace with:
+
+```python
+unwanted.update(_ENGLISH_STOPWORDS)
+```
+
+- [ ] **Step 5: Update clean_text() — tokenization**
+
+Find the tokenization block (around lines 275–286):
+
+```python
+# Tokenize
+if NLTK_AVAILABLE:
+    try:
+        words = word_tokenize(text.lower())
+    except LookupError:
+        # Fallback if NLTK data not available
+        words = text.lower().split()
+else:
+    words = text.lower().split()
+
+# Filter alpha-only words
+words = [word for word in words if word.isalpha()]
+```
+
+Replace with:
+
+```python
+# Tokenize — ASCII words only; unicode letters are excluded (accepted trade-off
+# vs NLTK's unicode-aware word_tokenize; fo-core filenames are ASCII-dominated)
+words = re.findall(r'\b[a-z]+\b', text.lower())
+```
+
+(The `re.findall` already yields only alpha tokens, so the `word.isalpha()` filter
+line that followed is also deleted.)
+
+- [ ] **Step 6: Update clean_text() — lemmatization**
+
+Find the lemmatization block (around lines 288–294):
+
+```python
+# Lemmatize if available
+if lemmatize and NLTK_AVAILABLE:
+    try:
+        lemmatizer = WordNetLemmatizer()
+        words = [lemmatizer.lemmatize(word) for word in words]
+    except (LookupError, ValueError, OSError) as e:
+        logger.debug(f"Lemmatization failed: {e}")
+```
+
+Replace with:
+
+```python
+if lemmatize:
+    _stemmer = Stemmer("english")
+    words = [_stemmer.stemWord(word) for word in words]
+```
+
+Update the docstring parameter description for `lemmatize` from
+`"Whether to lemmatize words"` to `"Whether to stem words (Snowball stemmer)"`.
+
+- [ ] **Step 7: Rewrite extract_keywords()**
+
+The current function has an early NLTK_AVAILABLE branch and uses `FreqDist`. Replace
+the entire function body with:
+
+```python
+def extract_keywords(text: str, top_n: int = 5) -> list[str]:
+    """Extract the most frequent meaningful words from input text.
+
+    Parameters:
+        text (str): Text to analyze for keyword extraction.
+        top_n (int): Number of top keywords to return.
+
+    Returns:
+        list[str]: Top `top_n` keywords ordered by frequency; returns an empty
+        list if extraction fails or no keywords are found.
+    """
+    try:
+        words = re.findall(r'\b[a-z]+\b', text.lower())
+        words = [w for w in words if len(w) > 3]
+        unwanted = get_unwanted_words()
+        words = [w for w in words if w not in unwanted]
+        return [word for word, _ in Counter(words).most_common(top_n)]
+    except Exception as e:
+        logger.debug(f"Keyword extraction failed: {e}")
+        return []
+```
+
+- [ ] **Step 8: Run the golden fixture tests (should now PASS)**
+
+```bash
+pytest tests/unit/utils/test_text_processing.py::test_clean_text_golden_snowball \
+       tests/unit/utils/test_text_processing.py::test_extract_keywords_golden_snowball -v
+```
+
+Expected: PASS
+
+- [ ] **Step 9: Run the full text_processing test suite**
+
+```bash
+pytest tests/unit/utils/test_text_processing.py tests/utils/test_text_processing.py -x -v
+```
+
+Some existing mock-based tests will fail — that's expected. They are fixed in Task 9.
+The golden fixture tests must pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/utils/text_processing.py
+git commit -m "feat(text): replace NLTK with snowballstemmer + re + Counter"
+```
+
+---
+
+## Task 5: Remove ensure_nltk_data from services/text_processor.py
+
+**Files:**
+- Modify: `src/services/text_processor.py`
+
+- [ ] **Step 1: Remove the import**
+
+Find line 18:
+```python
+    ensure_nltk_data,
+```
+Delete it. Verify `ensure_nltk_data` does not appear anywhere else in the import block.
+
+- [ ] **Step 2: Remove the call**
+
+Find line 110:
+```python
+        # Ensure NLTK data is available
+        ensure_nltk_data()
+```
+Delete both lines.
+
+- [ ] **Step 3: Run text_processor tests**
+
+```bash
+pytest tests/services/test_text_processor.py tests/services/test_text_processor_logging.py -x -q
+```
+
+These tests patch `ensure_nltk_data` — they will fail until Task 9 removes those patches.
+If they fail only on `ensure_nltk_data` patches, that is expected. Fix is in Task 9.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/services/text_processor.py
+git commit -m "fix(text_processor): remove ensure_nltk_data call — NLTK no longer required"
+```
+
+---
+
+## Task 6: Update pyproject.toml — remove nltk/numpy, add default libs, restructure extras
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Remove from [project.dependencies]**
+
+Find and delete these two lines from the `[project.dependencies]` list:
+```toml
+"nltk~=3.8",
+"numpy~=1.24",
+```
+
+- [ ] **Step 2: Add new default dependencies**
+
+Add to `[project.dependencies]` (alphabetical order within the list):
+```toml
+"mutagen~=1.47",
+"py7zr>=0.20.0",
+"pypdf~=6.10",
+"rarfile~=4.1",
+"snowballstemmer>=2.2.0",
+"striprtf>=0.0.26",
+"tinytag~=2.2",
+```
+
+- [ ] **Step 3: Restructure optional-dependencies**
+
+In `[project.optional-dependencies]`:
+
+**Remove** the `audio`, `video`, `archive`, and `dedup` extras entirely.
+
+**Add** the following new/restructured extras:
+
+```toml
+media = [
+    "faster-whisper~=1.0",
+    "torch~=2.1",
+    "pydub>=0.25.0",
+    "opencv-python~=4.8",
+    "scenedetect[opencv]>=0.6.0",
+]
+dedup-text = [
+    "scikit-learn>=1.4,<1.9",
+]
+dedup-image = [
+    "fo-core[dedup-text]",
+    "imagededup>=0.3.0",
+    "torch~=2.1",
+]
+```
+
+**Update** the `all` meta-extra to reference new names:
+```toml
+all = [
+    "fo-core[dev,cloud,llama,mlx,claude,media,dedup-text,dedup-image,scientific,cad,build,search]",
+]
+```
+
+- [ ] **Step 4: Verify pyproject.toml parses cleanly**
+
+```bash
+python -c "import tomllib; tomllib.load(open('pyproject.toml', 'rb'))"
+```
+
+Expected: no output (no parse errors).
+
+- [ ] **Step 5: Verify default install resolves**
+
+```bash
+pip install --dry-run . 2>&1 | head -20
+```
+
+Expected: no errors about missing packages.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "feat(deps): remove nltk+numpy from default; add snowballstemmer, striprtf, pypdf, py7zr, rarfile, mutagen, tinytag; restructure extras"
+```
+
+---
+
+## Task 7: Add RTF reader to utils/readers/
+
+**Files:**
+- Modify: `src/utils/readers/documents.py`
+- Modify: `src/utils/readers/__init__.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# In tests/utils/test_readers.py (or appropriate existing test file)
+def test_read_rtf_file_returns_text(tmp_path: Path) -> None:
+    rtf_file = tmp_path / "sample.rtf"
+    rtf_file.write_bytes(
+        rb"{\rtf1\ansi{\fonttbl\f0\fswiss Helvetica;}\f0\pard Hello RTF\par}"
+    )
+    from utils.readers import read_file
+    result = read_file(rtf_file)
+    assert "Hello RTF" in result
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+```bash
+pytest tests/utils/test_readers.py::test_read_rtf_file_returns_text -v
+```
+
+Expected: FAIL (`.rtf` not in dispatch table)
+
+- [ ] **Step 3: Add read_rtf_file() to documents.py**
+
+Open `src/utils/readers/documents.py`. The existing reader functions follow this pattern:
+
+```python
+def read_<format>_file(file_path: str | Path, **kwargs: Any) -> str:
+    file_path = Path(file_path)
+    _check_file_size(file_path)
+    try:
+        # read and return str
+    except Exception as exc:
+        raise FileReadError(f"Failed to read {file_path.name}: {exc}") from exc
+```
+
+Add this function after the existing document readers (before any spreadsheet readers):
+
+```python
+def read_rtf_file(file_path: str | Path, max_chars: int = 50_000, **kwargs: Any) -> str:
+    """Extract plain text from an RTF file using striprtf."""
+    from striprtf.striprtf import rtf_to_text
+
+    file_path = Path(file_path)
+    _check_file_size(file_path)
+    try:
+        raw = file_path.read_text(encoding="utf-8", errors="replace")
+        text = rtf_to_text(raw)
+        return text[:max_chars] if len(text) > max_chars else text
+    except Exception as exc:
+        raise FileReadError(f"Failed to read RTF {file_path.name}: {exc}") from exc
+```
+
+- [ ] **Step 4: Add .rtf to the dispatch table in __init__.py**
+
+Open `src/utils/readers/__init__.py`. Find the `readers` dict (around line 127). Add:
+
+```python
+    (".rtf",): read_rtf_file,
+```
+
+Also add `read_rtf_file` to the import from `documents.py` at the top of `__init__.py`.
+
+- [ ] **Step 5: Run the test**
+
+```bash
+pytest tests/utils/test_readers.py::test_read_rtf_file_returns_text -v
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/readers/documents.py src/utils/readers/__init__.py tests/utils/test_readers.py
+git commit -m "feat(readers): add RTF reader using striprtf; wire .rtf into dispatch table"
+```
+
+---
+
+## Task 8: Remove NLTK download steps from CI workflow files
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Modify: `.github/workflows/ci-full.yml`
+- Modify: `.github/workflows/pr-integration.yml`
+
+- [ ] **Step 1: Audit all NLTK references**
+
+```bash
+rg 'nltk' .github/workflows/
+```
+
+Expected: lines in ci.yml (4 blocks), ci-full.yml (3 blocks), pr-integration.yml (1 block).
+
+- [ ] **Step 2: Remove from ci.yml**
+
+For each of the following blocks (appears 4 times in ci.yml), delete both the cache
+step and the download step:
+
+```yaml
+      - name: Cache NLTK data
+        uses: actions/cache@v4
+        with:
+          path: ~/nltk_data
+          key: nltk-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: nltk-${{ runner.os }}-
+      - name: Download NLTK data
+        run: python -c "import nltk; nltk.download('stopwords', quiet=True); nltk.download('punkt', quiet=True); nltk.download('punkt_tab', quiet=True); nltk.download('wordnet', quiet=True)"
+```
+
+Delete all four pairs.
+
+- [ ] **Step 3: Remove from ci-full.yml**
+
+Same pattern — delete all three cache + download pairs.
+
+- [ ] **Step 4: Remove from pr-integration.yml**
+
+Same pattern — delete the one cache + download pair.
+
+- [ ] **Step 5: Verify no NLTK references remain in workflows**
+
+```bash
+rg 'nltk' .github/workflows/
+```
+
+Expected: zero hits.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/ci.yml .github/workflows/ci-full.yml .github/workflows/pr-integration.yml
+git commit -m "ci: remove NLTK data cache and download steps from all workflow files"
+```
+
+---
+
+## Task 9: Remove NLTK fixtures from tests/conftest.py
+
+**Files:**
+- Modify: `tests/conftest.py`
+
+- [ ] **Step 1: Delete the six NLTK fixture functions**
+
+Open `tests/conftest.py`. The NLTK fixtures start after line 166
+(`# NLTK test fixtures for hermeticity`). Delete:
+- The comment block header
+- `mock_nltk_tokenizer()` fixture
+- `mock_nltk_stopwords()` fixture
+- `mock_nltk_lemmatizer()` fixture
+- `mock_nltk_freqdist()` fixture
+- `mock_nltk_ensure_data_no_op()` fixture
+- `isolated_nltk_environment()` fixture
+
+Also delete the `from unittest.mock import MagicMock, patch` import if `MagicMock` and
+`patch` are no longer used elsewhere in the file (check before deleting).
+
+- [ ] **Step 2: Verify conftest imports still resolve**
+
+```bash
+python -c "import tests.conftest" 2>&1 || python -m pytest tests/conftest.py --collect-only -q 2>&1 | head -5
+```
+
+Expected: no import errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/conftest.py
+git commit -m "test: remove NLTK mock fixtures from root conftest"
+```
+
+---
+
+## Task 10: Remove NLTK fixtures from tests/integration/conftest.py
+
+**Files:**
+- Modify: `tests/integration/conftest.py`
+
+- [ ] **Step 1: Delete stub_nltk and ensure_nltk_available**
+
+Open `tests/integration/conftest.py`. Delete:
+- `stub_nltk` fixture (line 157–161)
+- `ensure_nltk_available` fixture (line 164–200, including the skip logic and download calls)
+
+- [ ] **Step 2: Remove imports no longer needed**
+
+If `nltk` is imported at the top of this file, delete that import.
+
+- [ ] **Step 3: Verify collection succeeds**
+
+```bash
+pytest tests/integration/ --collect-only -q 2>&1 | tail -5
+```
+
+Expected: no `fixture 'stub_nltk' not found` or similar errors. (Tests that requested
+`stub_nltk` as a parameter are fixed in Task 11.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/conftest.py
+git commit -m "test: remove stub_nltk and ensure_nltk_available from integration conftest"
+```
+
+---
+
+## Task 11: Remove all remaining NLTK fixture consumers and patches
+
+**Files:** (discovered by rg — do not skip this audit)
+
+- [ ] **Step 1: Find all remaining NLTK test consumers**
+
+```bash
+rg 'stub_nltk|ensure_nltk_available|ensure_nltk_data|NLTK_AVAILABLE|mock_nltk' tests/
+```
+
+For each file in the results:
+
+- [ ] **Step 2: For each test file — remove fixture parameters**
+
+Files that request `stub_nltk: None` as a parameter: remove the parameter from the
+function signature. Example:
+
+```python
+# Before
+def test_organize_creates_folders(
+    tmp_path: Path,
+    stub_nltk: None,
+    stub_models: None,
+) -> None:
+
+# After
+def test_organize_creates_folders(
+    tmp_path: Path,
+    stub_models: None,
+) -> None:
+```
+
+- [ ] **Step 3: For each test file — remove ensure_nltk_data patches**
+
+Lines like `with patch("services.text_processor.ensure_nltk_data"):` — delete the
+`with` block and de-indent the body. Lines like
+`mocker.patch("utils.text_processing.ensure_nltk_data")` — delete the statement.
+
+- [ ] **Step 4: For tests/utils/test_text_processing_hermeticity.py**
+
+This file tests NLTK-specific hermetic behavior. Delete it entirely — its purpose no
+longer exists.
+
+- [ ] **Step 5: For tests/utils/test_text_processing.py and tests/unit/utils/test_text_processing.py**
+
+Remove mock-based tests that patch NLTK internals. Rewrite any that test
+`clean_text` or `extract_keywords` to call the functions directly and assert the
+Snowball output (use `_NEW_CLEAN_TEXT` / `_NEW_EXTRACT_KEYWORDS` from Task 1).
+
+- [ ] **Step 6: For tests/integration/test_coverage_gap_supplements.py**
+
+Remove the NLTK-specific coverage gap tests (any test that imports or patches
+`ensure_nltk_data` or `NLTK_AVAILABLE`).
+
+- [ ] **Step 7: Run the full test suite**
+
+```bash
+pytest tests/ -x -q --ignore=tests/extras --ignore=tests/smoke
+```
+
+Expected: all passing. Fix any remaining `fixture not found` errors by repeating
+Steps 2–6 for any files the rg in Step 1 may have missed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -u tests/
+git commit -m "test: remove all NLTK fixture consumers and patches from test suite"
+```
+
+---
+
+## Task 12: Remove importorskip guards for newly-default libraries
+
+`py7zr`, `rarfile`, `mutagen`, `tinytag`, `striprtf`, `pypdf` are now default deps.
+Tests that guard against their absence with `pytest.importorskip` should be cleaned up.
+
+**Files:** (discovered by rg)
+
+- [ ] **Step 1: Find all importorskip guards for default-dep libs**
+
+```bash
+rg 'importorskip.*py7zr|importorskip.*rarfile|importorskip.*mutagen|importorskip.*tinytag|importorskip.*striprtf|importorskip.*pypdf' tests/
+```
+
+- [ ] **Step 2: For each hit — remove the guard**
+
+Delete the `pytest.importorskip(...)` call. The import will now succeed unconditionally.
+If the guard was in a `@pytest.fixture(autouse=True)` that exists solely for the skip,
+delete the fixture too.
+
+- [ ] **Step 3: Run affected tests**
+
+```bash
+pytest tests/ -x -q --ignore=tests/extras --ignore=tests/smoke
+```
+
+Expected: all passing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -u tests/
+git commit -m "test: remove importorskip guards for libs now in default install"
+```
+
+---
+
+## Task 13: Add import-boundary smoke test
+
+Verifies no numpy-dependent code is reachable from the default install at import time.
+Uses subprocess isolation so the `sys.modules["numpy"] = None` block does not affect
+other tests in the same worker.
+
+**Files:**
+- Create: `tests/smoke/test_default_import_boundary.py`
+
+- [ ] **Step 1: Create the test file**
+
+```python
+"""Verify that default-install imports do not require numpy."""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = [pytest.mark.ci, pytest.mark.smoke]
+
+
+def test_default_imports_without_numpy() -> None:
+    """No module reachable from the default install should import numpy."""
+    code = """
+import sys
+sys.modules["numpy"] = None  # block numpy
+
+import core.organizer        # must not raise
+import cli.dedupe_hash       # must not raise (hash-based dedup path)
+from services.deduplication.detector import DuplicateDetector  # must not raise
+import services.search        # must not raise (HybridRetriever guard required)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env={"PYTHONPATH": "src"},  # adjust if project uses a different path
+    )
+    assert result.returncode == 0, (
+        f"Default import triggered numpy dependency:\n{result.stderr}"
+    )
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+```bash
+pytest tests/smoke/test_default_import_boundary.py -v
+```
+
+Expected: PASS (Tasks 2 and 3 already guard the numpy imports).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/smoke/test_default_import_boundary.py
+git commit -m "test(smoke): add subprocess-isolated import-boundary test for numpy-free default install"
+```
+
+---
+
+## Task 14: Update ci-extras.yml — rename matrix entries and canary files
+
+**Files:**
+- Modify: `.github/workflows/ci-extras.yml`
+- Create: `tests/extras/test_extras_media.py`
+- Create: `tests/extras/test_extras_dedup_text.py`
+- Create: `tests/extras/test_extras_dedup_image.py`
+- Delete: `tests/extras/test_extras_audio.py`
+- Delete: `tests/extras/test_extras_video.py`
+- Delete: `tests/extras/test_extras_dedup.py`
+- Delete: `tests/extras/test_extras_archive.py`
+
+- [ ] **Step 1: Create test_extras_media.py (merges audio + video canaries)**
+
+```python
+"""Smoke canary for the media extra (faster-whisper, torch, pydub, opencv, scenedetect)."""
+from __future__ import annotations
+
+import struct
+import wave
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.fixture(autouse=True)
+def _require_media(tmp_path: Path) -> None:
+    pytest.importorskip("faster_whisper")
+    pytest.importorskip("cv2")
+    pytest.importorskip("pydub")
+    pytest.importorskip("scenedetect")
+
+
+def _make_wav(path: Path) -> None:
+    with wave.open(str(path), "w") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(44100)
+        wf.writeframes(struct.pack("<" + "h" * 4410, *([0] * 4410)))
+
+
+def test_pydub_reads_wav(tmp_path: Path) -> None:
+    from pydub import AudioSegment
+
+    wav_path = tmp_path / "clip.wav"
+    _make_wav(wav_path)
+    seg = AudioSegment.from_wav(str(wav_path))
+    assert seg.frame_rate == 44100
+
+
+def test_opencv_read_write_cycle(tmp_path: Path) -> None:
+    import cv2
+    import numpy as np
+
+    video_path = str(tmp_path / "clip.mp4")
+    out = cv2.VideoWriter(video_path, cv2.VideoWriter_fourcc(*"mp4v"), 10, (64, 64))
+    for _ in range(5):
+        out.write(np.zeros((64, 64, 3), dtype=np.uint8))
+    out.release()
+
+    cap = cv2.VideoCapture(video_path)
+    frames = []
+    while cap.isOpened():
+        ret, frame = cap.read()
+        if not ret:
+            break
+        frames.append(frame)
+    cap.release()
+    assert len(frames) == 5
+
+
+def test_faster_whisper_importable() -> None:
+    from faster_whisper import WhisperModel  # noqa: F401
+```
+
+- [ ] **Step 2: Create test_extras_dedup_text.py**
+
+```python
+"""Smoke canary for the dedup-text extra (scikit-learn)."""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.fixture(autouse=True)
+def _require_dedup_text() -> None:
+    pytest.importorskip("sklearn")
+
+
+def test_sklearn_importable() -> None:
+    from sklearn.feature_extraction.text import TfidfVectorizer  # noqa: F401
+
+
+def test_document_embedder_importable() -> None:
+    from services.deduplication.embedder import DocumentEmbedder  # noqa: F401
+
+
+def test_semantic_analyzer_importable() -> None:
+    from services.deduplication.semantic import SemanticAnalyzer  # noqa: F401
+```
+
+- [ ] **Step 3: Create test_extras_dedup_image.py**
+
+```python
+"""Smoke canary for the dedup-image extra (torch + imagededup)."""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.smoke
+
+
+@pytest.fixture(autouse=True)
+def _require_dedup_image() -> None:
+    pytest.importorskip("imagededup")
+    pytest.importorskip("torch")
+
+
+def test_imagededup_importable() -> None:
+    from imagededup.methods import PHash  # noqa: F401
+
+
+def test_image_deduplicator_importable() -> None:
+    from services.deduplication.image_dedup import ImageDeduplicator  # noqa: F401
+```
+
+- [ ] **Step 4: Delete old canary files**
+
+```bash
+git rm tests/extras/test_extras_audio.py \
+       tests/extras/test_extras_video.py \
+       tests/extras/test_extras_dedup.py \
+       tests/extras/test_extras_archive.py
+```
+
+- [ ] **Step 5: Update ci-extras.yml matrix**
+
+In `.github/workflows/ci-extras.yml`, find the matrix `include` list. Remove entries for
+`audio`, `video`, `archive`, and `dedup`. Add entries for the three new extras using the
+same schema as existing entries. The `extra` field drives both the pip install and the
+test file path — note that hyphenated names need a `test_file` override since Python
+filenames cannot contain hyphens:
+
+```yaml
+        - extra: media
+          key_import: "import faster_whisper; import cv2"
+          smoke: "true"
+          os: ubuntu-latest
+          timeout_minutes: 30
+        - extra: dedup-text
+          key_import: "import sklearn"
+          smoke: "true"
+          test_file: tests/extras/test_extras_dedup_text.py
+          os: ubuntu-latest
+          timeout_minutes: 20
+        - extra: dedup-image
+          key_import: "import imagededup; import torch"
+          smoke: "true"
+          test_file: tests/extras/test_extras_dedup_image.py
+          os: ubuntu-latest
+          timeout_minutes: 40
+```
+
+If the workflow uses `tests/extras/test_extras_${{ matrix.extra }}.py` directly, add a
+`test_file` field with a default expression so existing entries keep working:
+
+```yaml
+      - name: Run smoke canary
+        if: matrix.smoke == 'true'
+        run: |
+          TEST_FILE="${{ matrix.test_file || format('tests/extras/test_extras_{0}.py', matrix.extra) }}"
+          pytest "$TEST_FILE" -m "smoke" -x -v --override-ini="addopts="
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/ci-extras.yml \
+        tests/extras/test_extras_media.py \
+        tests/extras/test_extras_dedup_text.py \
+        tests/extras/test_extras_dedup_image.py
+git commit -m "ci: rename extras matrix entries and canary files for media/dedup-text/dedup-image"
+```
+
+---
+
+## Task 15: Add install-size CI gate to ci.yml
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add the size-check job**
+
+In `.github/workflows/ci.yml`, add a new job after the existing `test` job. The job
+must run on both `pull_request` and `push` to main:
+
+```yaml
+  install-size-check:
+    name: Default install size (≤185 MB)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Measure default install size (hermetic venv)
+        run: |
+          python -m venv /tmp/fo_size_venv
+          /tmp/fo_size_venv/bin/pip install --target /tmp/fo_size_check . -q
+          SIZE_MB=$(du -sm /tmp/fo_size_check | cut -f1)
+          echo "Default install: ${SIZE_MB} MB"
+          [ "$SIZE_MB" -le 185 ] || (echo "Install size ${SIZE_MB} MB exceeds 185 MB cap" && exit 1)
+```
+
+Confirm the `on:` trigger at the top of `ci.yml` includes both `pull_request` and
+`push` (it almost certainly does — verify before adding).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add hermetic install-size gate (≤185 MB) on pull_request and push"
+```
+
+---
+
+## Task 16: Update user-facing documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CONTRIBUTING.md`
+- Modify: `docs/getting-started.md`
+- Modify: `docs/USER_GUIDE.md`
+- Modify: `docs/troubleshooting.md`
+- Modify: `docs/developer/testing.md`
+- Modify: `docs/CONFIGURATION.md` (if it mentions NLTK)
+- Modify: `docs/setup/` files (if they mention nltk.download)
+
+- [ ] **Step 1: Audit stale extra names in user-facing docs**
+
+```bash
+rg '\[audio\]|\[video\]|\[archive\]|\[dedup\]' \
+  --glob '!docs/superpowers/specs/**' \
+  docs/ README.md CONTRIBUTING.md
+```
+
+For each hit: replace with the new extra name (`[media]`, `[dedup-text]`, `[dedup-image]`).
+Delete any `[archive]` install instructions (py7zr/rarfile are now default).
+
+- [ ] **Step 2: Remove NLTK first-run download callout from README.md**
+
+Find any mention of "NLTK downloads on first run", "nltk_data", or "corpus" and delete.
+Update the extras table to show `media`, `dedup-text`, `dedup-image` instead of `audio`,
+`video`, `dedup`.
+
+- [ ] **Step 3: Update CONTRIBUTING.md dev setup**
+
+Find the NLTK download step (around line 341). Delete:
+```
+python -c "import nltk; nltk.download('stopwords')..." 
+```
+or similar. Update any extras names in the dev setup instructions.
+
+- [ ] **Step 4: Remove stub_nltk reference from docs/developer/testing.md**
+
+Find any mention of `stub_nltk`, `ensure_nltk_available`, or NLTK fixture setup (line
+166+). Delete or replace with a note that NLTK is no longer used.
+
+- [ ] **Step 5: Run pymarkdown on all modified docs**
+
+```bash
+pymarkdown scan README.md CONTRIBUTING.md docs/getting-started.md \
+  docs/USER_GUIDE.md docs/troubleshooting.md docs/developer/testing.md
+```
+
+Expected: zero violations. Fix any heading-level or blank-line violations before
+committing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md CONTRIBUTING.md docs/
+git commit -m "docs: update extras names, remove NLTK references, update install instructions"
+```
+
+---
+
+## Task 17: Run all exit gates
+
+Confirm every exit condition from the spec is met.
+
+- [ ] **Step 1: Full test suite**
+
+```bash
+pytest tests/ -m "ci or smoke" -x -q
+```
+
+Expected: all passing on Linux, macOS, Windows (CI will validate cross-platform).
+
+- [ ] **Step 2: Import boundary smoke test**
+
+```bash
+pytest tests/smoke/test_default_import_boundary.py -v
+```
+
+Expected: PASS
+
+- [ ] **Step 3: NLTK repo-wide audit**
+
+```bash
+rg -i 'nltk|ensure_nltk_data|stub_nltk|mock_nltk' \
+  --glob '!docs/superpowers/specs/**' \
+  src/ .github/ tests/ docs/ README.md CONTRIBUTING.md pyproject.toml
+```
+
+Expected: zero hits.
+
+- [ ] **Step 4: Old extra name audit**
+
+```bash
+# Docs
+rg '\[audio\]|\[video\]|\[archive\]|\[dedup\]' \
+  --glob '!docs/superpowers/specs/**' \
+  docs/ README.md CONTRIBUTING.md
+
+# pyproject.toml extra definitions
+rg '^\s*(audio|video|archive|dedup)\s*=' pyproject.toml
+
+# CI matrix
+rg '"audio"|"video"|"archive"|"dedup"' .github/workflows/ci-extras.yml
+
+# Old canary files
+ls tests/extras/test_extras_audio.py tests/extras/test_extras_video.py \
+   tests/extras/test_extras_archive.py tests/extras/test_extras_dedup.py 2>&1
+```
+
+Expected: all four commands return zero hits / "No such file or directory".
+
+- [ ] **Step 5: RTF dispatch check**
+
+```bash
+python -c "
+import sys; sys.path.insert(0, 'src')
+from utils.readers import read_file
+from pathlib import Path
+import tempfile, os
+with tempfile.NamedTemporaryFile(suffix='.rtf', delete=False) as f:
+    f.write(rb'{\rtf1\ansi Hello RTF\par}')
+    name = f.name
+result = read_file(Path(name))
+os.unlink(name)
+assert 'Hello RTF' in result, repr(result)
+print('RTF dispatch: PASS')
+"
+```
+
+- [ ] **Step 6: Unconditional numpy import check**
+
+```bash
+rg 'import numpy|from numpy' src/ --glob '!*.pyc' | rg -v 'try:|except ImportError'
+```
+
+Expected: any remaining hits should be inside `try:` blocks (optional extras code).
+Inspect any hits outside try blocks.
+
+- [ ] **Step 7: pymarkdown**
+
+```bash
+pymarkdown scan docs/
+```
+
+Expected: zero violations.
+
+- [ ] **Step 8: Final commit if any cleanup needed**
+
+```bash
+git add -u
+git commit -m "chore: final exit gate cleanup"
+```

--- a/docs/superpowers/plans/2026-04-19-install-size-reduction.md
+++ b/docs/superpowers/plans/2026-04-19-install-size-reduction.md
@@ -425,30 +425,49 @@ def extract_keywords(text: str, top_n: int = 5) -> list[str]:
         return []
 ```
 
-- [ ] **Step 8: Run the golden fixture tests (should now PASS)**
+- [ ] **Step 8: Capture real Snowball output and finalize golden fixtures**
+
+Run the three functions and record their output:
+
+```bash
+python - <<'EOF'
+import sys; sys.path.insert(0, 'src')
+from utils.text_processing import clean_text, extract_keywords, get_unwanted_words
+print("NEW_CLEAN_TEXT   =", repr(clean_text("Studies in running and analysis")))
+print("NEW_EXTRACT_KEYWORDS =", repr(extract_keywords("The quick brown fox jumps over the lazy dog")))
+print("NEW_STOPWORDS    =", repr(get_unwanted_words()))
+EOF
+```
+
+Copy the three printed values into `tests/unit/utils/test_text_processing.py`:
+- Replace `"FILL_AFTER_TASK_4"` with the actual `clean_text` output
+- Replace `[]` on `_NEW_EXTRACT_KEYWORDS` with the actual list
+- Replace `set()` on `_NEW_STOPWORDS` with the actual set
+
+Remove all three `@pytest.mark.xfail(...)` decorators from `test_clean_text_golden_snowball`,
+`test_extract_keywords_golden_snowball`, and `test_get_unwanted_words_golden_snowball`.
+
+- [ ] **Step 9: Run all three golden tests (should now PASS)**
 
 ```bash
 pytest tests/unit/utils/test_text_processing.py::test_clean_text_golden_snowball \
-       tests/unit/utils/test_text_processing.py::test_extract_keywords_golden_snowball -v
+       tests/unit/utils/test_text_processing.py::test_extract_keywords_golden_snowball \
+       tests/unit/utils/test_text_processing.py::test_get_unwanted_words_golden_snowball -v
 ```
 
-Expected: PASS
+Expected: all three PASS (no xfail).
 
-- [ ] **Step 9: Run the full text_processing test suite**
-
-```bash
-pytest tests/unit/utils/test_text_processing.py tests/utils/test_text_processing.py -x -v
-```
-
-Some existing mock-based tests will fail — that's expected. They are fixed in Task 9.
-The golden fixture tests must pass.
-
-- [ ] **Step 10: Commit**
+- [ ] **Step 10: Stage both src and test changes — commit deferred to Task 11**
 
 ```bash
 git add src/utils/text_processing.py
-git commit -m "feat(text): replace NLTK with snowballstemmer + re + Counter"
+git add tests/unit/utils/test_text_processing.py
 ```
+
+> **Note:** Do NOT commit yet. Tasks 5, 9, 10, and 11 also modify source and test files
+> for NLTK removal. All these changes are committed together in Task 11 so the commit
+> tree stays green (no intermediate state where src is changed but tests still mock the
+> deleted function).
 
 ---
 
@@ -474,21 +493,15 @@ Find line 110:
 ```
 Delete both lines.
 
-- [ ] **Step 3: Run text_processor tests**
-
-```bash
-pytest tests/services/test_text_processor.py tests/services/test_text_processor_logging.py -x -q
-```
-
-These tests patch `ensure_nltk_data` — they will fail until Task 9 removes those patches.
-If they fail only on `ensure_nltk_data` patches, that is expected. Fix is in Task 9.
-
-- [ ] **Step 4: Commit**
+- [ ] **Step 3: Stage the change — commit deferred to Task 11**
 
 ```bash
 git add src/services/text_processor.py
-git commit -m "fix(text_processor): remove ensure_nltk_data call — NLTK no longer required"
 ```
+
+> **Note:** Do NOT run the text_processor tests yet and do NOT commit. Tests that patch
+> `ensure_nltk_data` will fail until Task 11 removes those patches. All staged src changes
+> (Tasks 4+5) plus test cleanup (Tasks 9–11) are committed together in Task 11.
 
 ---
 
@@ -748,12 +761,15 @@ python -c "import tests.conftest" 2>&1 || python -m pytest tests/conftest.py --c
 
 Expected: no import errors.
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 3: Stage the change — commit deferred to Task 11**
 
 ```bash
 git add tests/conftest.py
-git commit -m "test: remove NLTK mock fixtures from root conftest"
 ```
+
+> **Note:** Do NOT commit. Consumers of `mock_nltk_*` still exist in the test suite;
+> committing here leaves the tree broken. All accumulated changes are committed once at
+> the end of Task 11.
 
 ---
 
@@ -772,16 +788,15 @@ Open `tests/integration/conftest.py`. Delete:
 
 If `nltk` is imported at the top of this file, delete that import.
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 3: Stage the change — commit deferred to Task 11**
 
 ```bash
 git add tests/integration/conftest.py
-git commit -m "test: remove stub_nltk and ensure_nltk_available from integration conftest"
 ```
 
-> **Note:** Do NOT run `pytest --collect-only` here. Consumers of `stub_nltk` still exist
-> in the test suite and will error at collection until Task 11 removes them. The collection
-> check is done at the end of Task 11.
+> **Note:** Do NOT commit. Consumers of `stub_nltk` still exist and will error at
+> collection until Task 11 removes them. The collection check and the single atomic
+> commit happen at the end of Task 11.
 
 ---
 
@@ -856,11 +871,23 @@ pytest tests/ -x -q --ignore=tests/extras --ignore=tests/smoke
 Expected: all passing. Fix any remaining `fixture not found` errors by repeating
 Steps 2–6 for any files the rg in Step 1 may have missed.
 
-- [ ] **Step 10: Commit**
+- [ ] **Step 9: Atomic commit — all NLTK removal changes (Tasks 4, 5, 9, 10, 11)**
+
+This is the first green commit since the NLTK removal started. It captures all changes
+staged in Tasks 4, 5, 9, 10, and the work just completed in this task:
 
 ```bash
-git add -u tests/
-git commit -m "test: remove all NLTK fixture consumers and patches from test suite"
+git add -u
+git commit -m "feat: replace NLTK with snowballstemmer and remove NLTK from defaults
+
+- utils/text_processing.py: replace word_tokenize/WordNetLemmatizer/FreqDist
+  with re.findall + snowballstemmer.Stemmer + collections.Counter
+- services/text_processor.py: remove ensure_nltk_data call
+- tests/conftest.py: remove 6 mock_nltk_* fixtures
+- tests/integration/conftest.py: remove stub_nltk and ensure_nltk_available
+- tests/unit/utils/test_text_processing.py: finalize Snowball golden fixtures
+- Remove all stub_nltk / ensure_nltk_data / NLTK_AVAILABLE consumers
+"
 ```
 
 ---
@@ -936,11 +963,15 @@ import cli.dedupe_hash       # must not raise (hash-based dedup path)
 from services.deduplication.detector import DuplicateDetector  # must not raise
 import services.search        # must not raise (HybridRetriever guard required)
 """
+    env = os.environ.copy()
+    # Prepend src/ so imports work from a clean checkout before `pip install -e .`
+    # On CI the editable install covers this, but local runs may not have it.
+    env["PYTHONPATH"] = "src" + ((":" + env["PYTHONPATH"]) if env.get("PYTHONPATH") else "")
     result = subprocess.run(
         [sys.executable, "-c", code],
         capture_output=True,
         text=True,
-        env=os.environ.copy(),  # preserve full environment; editable install provides path
+        env=env,
     )
     assert result.returncode == 0, (
         f"Default import triggered numpy dependency:\n{result.stderr}"
@@ -992,11 +1023,13 @@ pytestmark = pytest.mark.smoke
 
 
 @pytest.fixture(autouse=True)
-def _require_media(tmp_path: Path) -> None:
-    pytest.importorskip("faster_whisper")
-    pytest.importorskip("cv2")
-    pytest.importorskip("pydub")
-    pytest.importorskip("scenedetect")
+def _require_media() -> None:
+    # Hard imports — any missing package means the extra is broken, not just skippable.
+    # These are all declared in [media]; if any are absent the canary must FAIL, not skip.
+    import cv2  # noqa: F401
+    import faster_whisper  # noqa: F401
+    import pydub  # noqa: F401
+    import scenedetect  # noqa: F401
 
 
 def _make_wav(path: Path) -> None:

--- a/docs/superpowers/plans/2026-04-19-install-size-reduction.md
+++ b/docs/superpowers/plans/2026-04-19-install-size-reduction.md
@@ -633,7 +633,7 @@ and call `ensure_nltk_data`. To keep every commit green, split the pyproject.tom
 **Commit now** (additions only — removes nothing):
 
 ```bash
-git commit -- pyproject.toml -m "feat(deps): add snowballstemmer, striprtf, pypdf, py7zr, rarfile, mutagen, tinytag; restructure extras to media/dedup-text/dedup-image"
+git commit -m "feat(deps): add snowballstemmer, striprtf, pypdf, py7zr, rarfile, mutagen, tinytag; restructure extras to media/dedup-text/dedup-image" -- pyproject.toml
 ```
 
 > **Note:** Leave the `"nltk~=3.8"` and `"numpy~=1.24"` deletion lines **unstaged** for

--- a/docs/superpowers/plans/2026-04-19-install-size-reduction.md
+++ b/docs/superpowers/plans/2026-04-19-install-size-reduction.md
@@ -129,6 +129,7 @@ except Exception as e:
     print(f"FAIL: {e}")
 EOF
 ```
+
 Run from repo root with `PYTHONPATH=src`. Expected: FAIL (numpy import triggered).
 
 - [ ] **Step 2: Apply the guard**
@@ -491,18 +492,22 @@ git add tests/unit/utils/test_text_processing.py
 - [ ] **Step 1: Remove the import**
 
 Find line 18:
+
 ```python
     ensure_nltk_data,
 ```
+
 Delete it. Verify `ensure_nltk_data` does not appear anywhere else in the import block.
 
 - [ ] **Step 2: Remove the call**
 
 Find line 110:
+
 ```python
         # Ensure NLTK data is available
         ensure_nltk_data()
 ```
+
 Delete both lines.
 
 - [ ] **Step 3: Stage the change — commit deferred to Task 11**
@@ -525,6 +530,7 @@ git add src/services/text_processor.py
 - [ ] **Step 1: Remove from [project.dependencies]**
 
 Find and delete these two lines from the `[project.dependencies]` list:
+
 ```toml
 "nltk~=3.8",
 "numpy~=1.24",
@@ -533,6 +539,7 @@ Find and delete these two lines from the `[project.dependencies]` list:
 - [ ] **Step 2: Add new default dependencies**
 
 Add to `[project.dependencies]` (alphabetical order within the list):
+
 ```toml
 "mutagen~=1.47",
 "py7zr>=0.20.0",
@@ -570,6 +577,7 @@ dedup-image = [
 ```
 
 **Update** the `all` meta-extra to reference new names:
+
 ```toml
 all = [
     "fo-core[dev,cloud,llama,mlx,claude,media,dedup-text,dedup-image,scientific,cad,build,search]",
@@ -1280,9 +1288,11 @@ Update the extras table to show `media`, `dedup-text`, `dedup-image` instead of 
 - [ ] **Step 3: Update CONTRIBUTING.md dev setup**
 
 Find the NLTK download step (around line 341). Delete:
+
 ```
 python -c "import nltk; nltk.download('stopwords')..." 
 ```
+
 or similar. Update any extras names in the dev setup instructions.
 
 - [ ] **Step 4: Remove stub_nltk reference from docs/developer/testing.md**

--- a/docs/superpowers/plans/2026-04-19-install-size-reduction.md
+++ b/docs/superpowers/plans/2026-04-19-install-size-reduction.md
@@ -273,6 +273,18 @@ git commit -m "fix(search): guard numpy-dependent HybridRetriever import behind 
 **Files:**
 - Modify: `src/utils/text_processing.py`
 
+- [ ] **Step 0: Install snowballstemmer into the working environment**
+
+`snowballstemmer` is added to `pyproject.toml` in Task 6, but Task 4 uses it now.
+Install it directly so the implementation and tests can run before the full dependency
+restructure is committed:
+
+```bash
+pip install "snowballstemmer>=2.2.0"
+```
+
+Expected: `Successfully installed snowballstemmer-...` (or "already satisfied").
+
 - [ ] **Step 1: Replace the import block and module-level flags**
 
 Open `src/utils/text_processing.py`. Lines 1–20 currently contain:
@@ -580,11 +592,13 @@ pip install --dry-run . 2>&1 | head -20
 
 Expected: no errors about missing packages.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 6: Commit pyproject.toml only**
+
+Tasks 4, 5, 9, and 10 have staged changes that are intentionally held until Task 11.
+Use a path-limited commit so those staged files are not swept up here:
 
 ```bash
-git add pyproject.toml
-git commit -m "feat(deps): remove nltk+numpy from default; add snowballstemmer, striprtf, pypdf, py7zr, rarfile, mutagen, tinytag; restructure extras"
+git commit -- pyproject.toml -m "feat(deps): remove nltk+numpy from default; add snowballstemmer, striprtf, pypdf, py7zr, rarfile, mutagen, tinytag; restructure extras"
 ```
 
 ---
@@ -946,6 +960,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -966,7 +981,10 @@ import services.search        # must not raise (HybridRetriever guard required)
     env = os.environ.copy()
     # Prepend src/ so imports work from a clean checkout before `pip install -e .`
     # On CI the editable install covers this, but local runs may not have it.
-    env["PYTHONPATH"] = "src" + ((":" + env["PYTHONPATH"]) if env.get("PYTHONPATH") else "")
+    # Use os.pathsep (';' on Windows, ':' on POSIX) for cross-platform portability.
+    src_path = str(Path(__file__).resolve().parents[2] / "src")
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = src_path + (os.pathsep + existing if existing else "")
     result = subprocess.run(
         [sys.executable, "-c", code],
         capture_output=True,

--- a/docs/superpowers/plans/2026-04-19-install-size-reduction.md
+++ b/docs/superpowers/plans/2026-04-19-install-size-reduction.md
@@ -53,47 +53,56 @@ _OLD_CLEAN_TEXT = "<paste actual output from Step 1>"
 _OLD_EXTRACT_KEYWORDS = <paste actual output from Step 1>
 ```
 
-- [ ] **Step 3: Write failing test stubs with placeholder values**
+- [ ] **Step 3: Write xfail test stubs with placeholder values**
 
 In `tests/unit/utils/test_text_processing.py` add:
 
 ```python
+import pytest
+
 # OLD_* captured under NLTK — acknowledgement artifact only.
 _OLD_CLEAN_TEXT = "<captured in Step 1>"
 _OLD_EXTRACT_KEYWORDS = "<captured in Step 1>"
+_OLD_STOPWORDS: set[str] = set()  # captured in Step 1
 
-# NEW_* = expected Snowball output. Fill in after Task 4 is implemented:
-# run the two functions and paste the repr() output here.
+# NEW_* = expected Snowball output. Filled in Task 4 Step 8 by running the
+# functions after the Snowball implementation is in place.
 _NEW_CLEAN_TEXT = "FILL_AFTER_TASK_4"
 _NEW_EXTRACT_KEYWORDS: list[str] = []
+_NEW_STOPWORDS: set[str] = set()  # filled in Task 4 Step 8
 
 
+@pytest.mark.xfail(strict=False, reason="Snowball values filled in Task 4")
 def test_clean_text_golden_snowball() -> None:
     assert clean_text("Studies in running and analysis") == _NEW_CLEAN_TEXT
 
 
+@pytest.mark.xfail(strict=False, reason="Snowball values filled in Task 4")
 def test_extract_keywords_golden_snowball() -> None:
     assert extract_keywords("The quick brown fox jumps over the lazy dog") == _NEW_EXTRACT_KEYWORDS
+
+
+@pytest.mark.xfail(strict=False, reason="Snowball values filled in Task 4")
+def test_get_unwanted_words_golden_snowball() -> None:
+    assert get_unwanted_words() == _NEW_STOPWORDS
 ```
 
-- [ ] **Step 4: Run the new tests (should FAIL — NLTK still active)**
+- [ ] **Step 4: Run the new tests (should XFAIL — NLTK still active)**
 
 ```bash
 pytest tests/unit/utils/test_text_processing.py::test_clean_text_golden_snowball \
-       tests/unit/utils/test_text_processing.py::test_extract_keywords_golden_snowball -v
+       tests/unit/utils/test_text_processing.py::test_extract_keywords_golden_snowball \
+       tests/unit/utils/test_text_processing.py::test_get_unwanted_words_golden_snowball -v
 ```
 
-Expected: FAIL
-
-> **Note:** `_NEW_CLEAN_TEXT` and `_NEW_EXTRACT_KEYWORDS` are filled in during Task 4
-> Step 8 (after the Snowball implementation is in place). The test stubs are written
-> now so git tracks the intent; actual values are captured from the working implementation.
+Expected: XFAIL (all three show `xfail` — CI stays green). The `xfail` markers are
+removed and `_NEW_*` values filled in during Task 4 Step 8.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add tests/unit/utils/test_text_processing.py
-git commit -m "test(text): add Snowball golden fixture stubs (values filled in Task 4)"
+git commit -m "test(text): add Snowball golden fixture stubs as xfail (values filled in Task 4)"
 ```
 
 ---
@@ -763,21 +772,16 @@ Open `tests/integration/conftest.py`. Delete:
 
 If `nltk` is imported at the top of this file, delete that import.
 
-- [ ] **Step 3: Verify collection succeeds**
-
-```bash
-pytest tests/integration/ --collect-only -q 2>&1 | tail -5
-```
-
-Expected: no `fixture 'stub_nltk' not found` or similar errors. (Tests that requested
-`stub_nltk` as a parameter are fixed in Task 11.)
-
-- [ ] **Step 4: Commit**
+- [ ] **Step 3: Commit**
 
 ```bash
 git add tests/integration/conftest.py
 git commit -m "test: remove stub_nltk and ensure_nltk_available from integration conftest"
 ```
+
+> **Note:** Do NOT run `pytest --collect-only` here. Consumers of `stub_nltk` still exist
+> in the test suite and will error at collection until Task 11 removes them. The collection
+> check is done at the end of Task 11.
 
 ---
 
@@ -835,7 +839,15 @@ Snowball output (use `_NEW_CLEAN_TEXT` / `_NEW_EXTRACT_KEYWORDS` from Task 1).
 Remove the NLTK-specific coverage gap tests (any test that imports or patches
 `ensure_nltk_data` or `NLTK_AVAILABLE`).
 
-- [ ] **Step 7: Run the full test suite**
+- [ ] **Step 7: Verify collection succeeds**
+
+```bash
+pytest tests/integration/ --collect-only -q 2>&1 | tail -5
+```
+
+Expected: no `fixture 'stub_nltk' not found` errors.
+
+- [ ] **Step 8: Run the full test suite**
 
 ```bash
 pytest tests/ -x -q --ignore=tests/extras --ignore=tests/smoke
@@ -844,7 +856,7 @@ pytest tests/ -x -q --ignore=tests/extras --ignore=tests/smoke
 Expected: all passing. Fix any remaining `fixture not found` errors by repeating
 Steps 2–6 for any files the rg in Step 1 may have missed.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 10: Commit**
 
 ```bash
 git add -u tests/
@@ -904,6 +916,7 @@ other tests in the same worker.
 """Verify that default-install imports do not require numpy."""
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 
@@ -927,7 +940,7 @@ import services.search        # must not raise (HybridRetriever guard required)
         [sys.executable, "-c", code],
         capture_output=True,
         text=True,
-        env={"PYTHONPATH": "src"},  # adjust if project uses a different path
+        env=os.environ.copy(),  # preserve full environment; editable install provides path
     )
     assert result.returncode == 0, (
         f"Default import triggered numpy dependency:\n{result.stderr}"
@@ -1156,9 +1169,9 @@ must run on both `pull_request` and `push` to main:
     name: Default install size (≤185 MB)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
 
@@ -1200,6 +1213,7 @@ git commit -m "ci: add hermetic install-size gate (≤185 MB) on pull_request an
 ```bash
 rg '\[audio\]|\[video\]|\[archive\]|\[dedup\]' \
   --glob '!docs/superpowers/specs/**' \
+  --glob '!docs/superpowers/plans/**' \
   docs/ README.md CONTRIBUTING.md
 ```
 
@@ -1269,6 +1283,7 @@ Expected: PASS
 ```bash
 rg -i 'nltk|ensure_nltk_data|stub_nltk|mock_nltk' \
   --glob '!docs/superpowers/specs/**' \
+  --glob '!docs/superpowers/plans/**' \
   src/ .github/ tests/ docs/ README.md CONTRIBUTING.md pyproject.toml
 ```
 
@@ -1277,23 +1292,27 @@ Expected: zero hits.
 - [ ] **Step 4: Old extra name audit**
 
 ```bash
-# Docs
+# Docs (exclude plan/spec files which intentionally list old names in migration tables)
 rg '\[audio\]|\[video\]|\[archive\]|\[dedup\]' \
   --glob '!docs/superpowers/specs/**' \
+  --glob '!docs/superpowers/plans/**' \
   docs/ README.md CONTRIBUTING.md
 
 # pyproject.toml extra definitions
 rg '^\s*(audio|video|archive|dedup)\s*=' pyproject.toml
 
-# CI matrix
-rg '"audio"|"video"|"archive"|"dedup"' .github/workflows/ci-extras.yml
+# CI matrix — YAML uses `extra: audio`, not quoted strings
+rg 'extra:\s*(audio|video|archive|dedup)\b' .github/workflows/ci-extras.yml
 
-# Old canary files
-ls tests/extras/test_extras_audio.py tests/extras/test_extras_video.py \
-   tests/extras/test_extras_archive.py tests/extras/test_extras_dedup.py 2>&1
+# Old canary files — test ! -e exits 0 when files are correctly absent
+test ! -e tests/extras/test_extras_audio.py   && echo "audio canary: absent (OK)"
+test ! -e tests/extras/test_extras_video.py   && echo "video canary: absent (OK)"
+test ! -e tests/extras/test_extras_archive.py && echo "archive canary: absent (OK)"
+test ! -e tests/extras/test_extras_dedup.py   && echo "dedup canary: absent (OK)"
 ```
 
-Expected: all four commands return zero hits / "No such file or directory".
+Expected: zero hits in docs and pyproject.toml; zero hits in ci-extras.yml; all four
+"absent (OK)" lines printed.
 
 - [ ] **Step 5: RTF dispatch check**
 
@@ -1313,14 +1332,16 @@ print('RTF dispatch: PASS')
 "
 ```
 
-- [ ] **Step 6: Unconditional numpy import check**
+- [ ] **Step 6: Numpy import survey (manual review aid)**
 
 ```bash
-rg 'import numpy|from numpy' src/ --glob '!*.pyc' | rg -v 'try:|except ImportError'
+rg 'import numpy|from numpy' src/ --glob '!*.pyc'
 ```
 
-Expected: any remaining hits should be inside `try:` blocks (optional extras code).
-Inspect any hits outside try blocks.
+Inspect the output. Lines inside `try:` / `except ImportError:` blocks are fine.
+Any import outside such a block needs a guard added. This is a manual review aid only —
+it cannot determine whether a line is reachable from the default install. The
+subprocess smoke test from Task 13 is the authoritative reachability gate.
 
 - [ ] **Step 7: pymarkdown**
 

--- a/docs/superpowers/plans/2026-04-19-install-size-reduction.md
+++ b/docs/superpowers/plans/2026-04-19-install-size-reduction.md
@@ -23,6 +23,18 @@ difference between NLTK and Snowball is explicit and reviewable.
 
 - [ ] **Step 1: Run the capture script**
 
+NLTK data must be present for this step. By default, `nltk.download()` saves to
+`~/nltk_data`. Run the download from the repo root so the script finds the data:
+
+```bash
+python -c "import nltk; nltk.download('stopwords'); nltk.download('punkt'); nltk.download('wordnet')"
+```
+
+If the default location is not suitable, set `NLTK_DATA` before running (e.g.
+`NLTK_DATA=/tmp/nltk_data python -c "import nltk; nltk.download(..., download_dir='/tmp/nltk_data')"`).
+
+Then run the capture script from the repo root:
+
 ```bash
 cd /path/to/fo-core
 python - <<'EOF'
@@ -30,7 +42,6 @@ import sys
 sys.path.insert(0, "src")
 from utils.text_processing import get_unwanted_words, clean_text, extract_keywords
 
-# Must have NLTK data available; if not, run: python -c "import nltk; nltk.download('stopwords'); nltk.download('punkt'); nltk.download('wordnet')"
 print("=== get_unwanted_words() ===")
 print(repr(sorted(get_unwanted_words())))
 
@@ -134,21 +145,30 @@ Run from repo root with `PYTHONPATH=src`. Expected: FAIL (numpy import triggered
 
 - [ ] **Step 2: Apply the guard**
 
-Open `src/services/deduplication/__init__.py`. The three unconditional numpy-dependent
-imports are at lines 20–21 and 35:
+Open `src/services/deduplication/__init__.py`. The three numpy-dependent imports
+appear at two separate locations:
+
+- **Lines 20–21** (top-level import area):
+
+  ```python
+  from .document_dedup import DocumentDeduplicator
+  from .embedder import DocumentEmbedder
+  ```
+
+- **Line 35** (further down, after the `ImageDeduplicator` guard):
+
+  ```python
+  from .semantic import SemanticAnalyzer
+  ```
+
+Delete all three individual import lines. At the position of the original lines 20–21
+(top-level import area), insert the single consolidated guard so the hash-based dedup
+path remains importable on a default install:
 
 ```python
-from .document_dedup import DocumentDeduplicator   # line 20
-from .embedder import DocumentEmbedder             # line 21
-from .semantic import SemanticAnalyzer             # line 35
-```
-
-Replace those three lines (keeping all other imports unchanged) with:
-
-```python
-# DocumentEmbedder, SemanticAnalyzer, DocumentDeduplicator require numpy
-# (via sklearn/sentence-transformers). Guard so a default install without
-# the dedup-text extra can still import the hash-based dedup path.
+# DocumentDeduplicator, DocumentEmbedder, SemanticAnalyzer require numpy.
+# Guard so a default install (no dedup-text extra) can still reach the
+# hash-based dedup path without a ModuleNotFoundError.
 try:
     from .document_dedup import DocumentDeduplicator
     from .embedder import DocumentEmbedder
@@ -156,6 +176,9 @@ try:
 except ImportError:
     pass  # numpy not available; hash-based dedup still works
 ```
+
+Do not leave the standalone `from .semantic import SemanticAnalyzer` at line 35 — it
+must be deleted; only the try/except block remains.
 
 - [ ] **Step 3: Add a scope comment to document_dedup.py**
 

--- a/docs/superpowers/plans/2026-04-19-install-size-reduction.md
+++ b/docs/superpowers/plans/2026-04-19-install-size-reduction.md
@@ -623,14 +623,24 @@ pip install --dry-run . 2>&1 | head -20
 
 Expected: no errors about missing packages.
 
-- [ ] **Step 6: Commit pyproject.toml only**
+- [ ] **Step 6: Commit only the new additions — defer nltk/numpy removal to Task 11**
 
-Tasks 4, 5, 9, and 10 have staged changes that are intentionally held until Task 11.
-Use a path-limited commit so those staged files are not swept up here:
+Removing `nltk` and `numpy` from `[project.dependencies]` before the source and test
+cleanup is committed (Task 11) leaves the tree in a state where the installed package
+no longer provides `nltk`, but committed tests still patch `utils.text_processing.nltk`
+and call `ensure_nltk_data`. To keep every commit green, split the pyproject.toml work:
+
+**Commit now** (additions only — removes nothing):
 
 ```bash
-git commit -- pyproject.toml -m "feat(deps): remove nltk+numpy from default; add snowballstemmer, striprtf, pypdf, py7zr, rarfile, mutagen, tinytag; restructure extras"
+git commit -- pyproject.toml -m "feat(deps): add snowballstemmer, striprtf, pypdf, py7zr, rarfile, mutagen, tinytag; restructure extras to media/dedup-text/dedup-image"
 ```
+
+> **Note:** Leave the `"nltk~=3.8"` and `"numpy~=1.24"` deletion lines **unstaged** for
+> now. They will be included in the Task 11 atomic commit together with the source and
+> test cleanup, so no committed state has nltk removed while tests still import it.
+> In your editor, commit only the additions (new deps + extras restructure) and revert
+> the two deletion lines until Task 11.
 
 ---
 
@@ -643,7 +653,7 @@ git commit -- pyproject.toml -m "feat(deps): remove nltk+numpy from default; add
 - [ ] **Step 1: Write the failing test**
 
 ```python
-# In tests/utils/test_readers.py (or appropriate existing test file)
+# Add to tests/utils/test_file_readers.py (the existing reader test file)
 def test_read_rtf_file_returns_text(tmp_path: Path) -> None:
     rtf_file = tmp_path / "sample.rtf"
     rtf_file.write_bytes(
@@ -657,7 +667,7 @@ def test_read_rtf_file_returns_text(tmp_path: Path) -> None:
 - [ ] **Step 2: Run to confirm it fails**
 
 ```bash
-pytest tests/utils/test_readers.py::test_read_rtf_file_returns_text -v
+pytest tests/utils/test_file_readers.py::test_read_rtf_file_returns_text -v
 ```
 
 Expected: FAIL (`.rtf` not in dispatch table)
@@ -714,7 +724,7 @@ Expected: PASS
 - [ ] **Step 6: Commit**
 
 ```bash
-git add src/utils/readers/documents.py src/utils/readers/__init__.py tests/utils/test_readers.py
+git add src/utils/readers/documents.py src/utils/readers/__init__.py tests/utils/test_file_readers.py
 git commit -m "feat(readers): add RTF reader using striprtf; wire .rtf into dispatch table"
 ```
 
@@ -923,8 +933,9 @@ staged in Tasks 4, 5, 9, 10, and the work just completed in this task:
 
 ```bash
 git add -u
-git commit -m "feat: replace NLTK with snowballstemmer and remove NLTK from defaults
+git commit -m "feat: replace NLTK with snowballstemmer and remove nltk/numpy from default deps
 
+- pyproject.toml: remove nltk~=3.8 and numpy~=1.24 from [project.dependencies]
 - utils/text_processing.py: replace word_tokenize/WordNetLemmatizer/FreqDist
   with re.findall + snowballstemmer.Stemmer + collections.Counter
 - services/text_processor.py: remove ensure_nltk_data call
@@ -1164,8 +1175,10 @@ pytestmark = pytest.mark.smoke
 
 @pytest.fixture(autouse=True)
 def _require_dedup_image() -> None:
-    pytest.importorskip("imagededup")
-    pytest.importorskip("torch")
+    # Hard imports — missing package means the extra is broken, not skippable.
+    import imagededup  # noqa: F401
+    import sklearn     # noqa: F401  verifies fo-core[dedup-text] self-dep resolved
+    import torch       # noqa: F401
 
 
 def test_imagededup_importable() -> None:
@@ -1174,6 +1187,11 @@ def test_imagededup_importable() -> None:
 
 def test_image_deduplicator_importable() -> None:
     from services.deduplication.image_dedup import ImageDeduplicator  # noqa: F401
+
+
+def test_dedup_text_stack_available() -> None:
+    """dedup-image declares fo-core[dedup-text]; verify sklearn came in."""
+    from services.deduplication.embedder import DocumentEmbedder  # noqa: F401
 ```
 
 - [ ] **Step 4: Delete old canary files**

--- a/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
+++ b/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
@@ -1,7 +1,7 @@
 # Install Size Reduction Epic — Design Spec
 
 **Date**: 2026-04-19
-**Status**: Approved (rev 2 — reviewer corrections applied 2026-04-19)
+**Status**: Approved (rev 3 — reviewer corrections applied 2026-04-19)
 **Target**: Reduce default install from 206 MB → 181 MB while maximising out-of-the-box
 format coverage.
 
@@ -160,9 +160,22 @@ except ImportError:
     pass  # numpy not available; hash-based dedup still works
 ```
 
-The same pattern applies to `services/search/` and `services/video/` if their
-`__init__.py` files have unconditional numpy imports — audit and guard all of them
-before dropping numpy from `pyproject.toml`.
+The same guard is **required** for `services/search/` before dropping numpy from
+`pyproject.toml`. The current import chain is unconditional:
+`services/search/__init__.py` → `HybridRetriever` → `VectorIndex` →
+`from numpy.typing import NDArray`. Apply the same `try/except ImportError` pattern
+to `services/search/__init__.py`:
+
+```python
+# Heavy optional exports — only available when search extra is installed
+try:
+    from .hybrid_retriever import HybridRetriever, read_text_safe
+except ImportError:
+    pass  # numpy/sklearn not available; search subsystem disabled
+```
+
+Apply the same audit to `services/video/` if its `__init__.py` has unconditional
+numpy imports — guard before dropping numpy from `pyproject.toml`.
 
 ### 2d. RTF reader wiring in `utils/readers`
 
@@ -242,16 +255,25 @@ Every hit must be updated in this PR.
 
 ### Behavioral regression fixtures (prerequisite)
 
-Before removing NLTK, capture golden output for the three affected public functions in
-`utils/text_processing.py` under the **current** NLTK implementation:
+Before removing NLTK, run the three affected public functions under the **current**
+NLTK implementation and record both the old (NLTK) output and the expected new
+(Snowball) output:
 
-- `get_unwanted_words()` → frozen expected set (stopwords list)
-- `clean_text("Studies in running and analysis")` → frozen expected string
-- `extract_keywords("The quick brown fox jumps over the lazy dog")` → frozen expected list
+- `get_unwanted_words()` — record the NLTK stopwords set as `OLD_STOPWORDS`; the
+  new output is the inline `frozenset` defined in Section 2a (deterministic, no
+  NLTK needed).
+- `clean_text("Studies in running and analysis")` — record both the NLTK output
+  (`OLD_CLEAN`) and the expected Snowball output (`NEW_CLEAN`).
+- `extract_keywords("The quick brown fox jumps over the lazy dog")` — record both
+  `OLD_KEYWORDS` and `NEW_KEYWORDS`.
 
-These fixtures define the accepted behavioral difference between NLTK and the
-snowballstemmer replacement. Tests pass if the new output matches the new fixture,
-not the old NLTK output.
+The test suite then contains **two** fixtures per function:
+1. A snapshot test asserting the post-replacement output equals `NEW_*` (regression
+   guard for the Snowball path).
+2. A comment or removed test showing `OLD_*` as an acknowledgement artifact, so the
+   behavioral difference is explicit and reviewable.
+
+Tests pass when the new implementation matches `NEW_*`, not `OLD_*`.
 
 ### Import-boundary smoke test (new exit gate)
 
@@ -276,6 +298,7 @@ sys.modules["numpy"] = None  # block numpy
 import core.organizer        # must not raise
 import cli.dedupe_hash       # must not raise (hash-based dedup path)
 from services.deduplication.detector import DuplicateDetector  # must not raise
+import services.search        # must not raise (HybridRetriever guard required)
 """
     result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
     assert result.returncode == 0, result.stderr
@@ -334,7 +357,7 @@ floor after measuring on CI.
 ## Exit Gates
 
 - [ ] `pytest tests/ -m "ci or smoke"` passes on Linux, macOS, Windows
-- [ ] `pip install fo-core` installs in ≤185 MB (enforced by CI size gate)
+- [ ] `pip install . --target /tmp/check` (local checkout) installs in ≤185 MB (enforced by CI size gate)
 - [ ] `tests/smoke/test_default_import_boundary.py` passes with numpy blocked
 - [ ] `pip install "fo-core[media]"` installs and canary imports pass
 - [ ] `pip install "fo-core[dedup-text]"` installs and canary imports pass

--- a/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
+++ b/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
@@ -9,7 +9,7 @@ format coverage.
 
 ## Problem
 
-The default install is 206 MB for a privacy-first CLI file organiser. The two largest
+The default install is 206 MB for a privacy-first CLI file organizer. The two largest
 avoidable costs are:
 
 1. **NLTK** (18 MB package + ~50 MB runtime corpus download on first run) — used only
@@ -192,7 +192,7 @@ numpy imports — guard before dropping numpy from `pyproject.toml`.
 2. A `.rtf` entry in the dispatch table in `utils/readers/__init__.py`
 
 This is the specific surface where "RTF in the default install" becomes real for
-the organise pass.
+the organize pass.
 
 ### 2e. `DocumentDeduplicator` — scope boundary
 
@@ -408,4 +408,4 @@ floor after measuring on CI.
   - Docs: `rg '\[audio\]|\[video\]|\[archive\]|\[dedup\]' --glob '!docs/superpowers/specs/**' docs/ README.md CONTRIBUTING.md`
   - pyproject.toml: `rg '^\s*(audio|video|archive|dedup)\s*=' pyproject.toml` (no old extra definitions)
   - CI matrix: `rg '"audio"|"video"|"archive"|"dedup"' .github/workflows/ci-extras.yml` (no old matrix entries)
-  - Test canaries: `ls tests/extras/test_extras_audio.py tests/extras/test_extras_video.py tests/extras/test_extras_archive.py tests/extras/test_extras_dedup.py 2>&1 | grep -v 'No such'` returns nothing
+  - Test canaries: all four old files absent (`test ! -e tests/extras/test_extras_audio.py && echo "audio: absent (OK)"`, same for video, archive, dedup)

--- a/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
+++ b/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
@@ -1,7 +1,7 @@
 # Install Size Reduction Epic — Design Spec
 
 **Date**: 2026-04-19
-**Status**: Approved (rev 6 — reviewer corrections applied 2026-04-19)
+**Status**: Approved
 **Target**: Reduce default install from 206 MB → 181 MB while maximising out-of-the-box
 format coverage.
 

--- a/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
+++ b/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
@@ -30,8 +30,8 @@ Moving them to the default extends format coverage at minimal cost.
 **Scope clarification**: RTF (`striprtf`) and `pypdf` are also moved to the default dep
 list, but this does **not** automatically extend the `utils.readers` dispatch table —
 those libs are currently only consumed by `services/deduplication/extractor.py`. Wiring
-RTF and pypdf into the reader dispatcher is an explicit sub-task of this epic (see
-Section 2c).
+RTF into the reader dispatcher is an explicit sub-task of this epic (see Section 2d).
+pypdf reader dispatch remains out of scope (see Section 5).
 
 ---
 
@@ -218,6 +218,8 @@ This list is exhaustive (verified by `grep -r nltk tests/ docs/ CONTRIBUTING.md`
 |------|----------------|
 | `README.md` | Update extras table: add `media`, rename `dedup`→`dedup-text`/`dedup-image`, remove `archive`, remove NLTK first-run download callout |
 | `docs/getting-started.md` | Update quick install commands and extras reference |
+| `docs/USER_GUIDE.md` | Update `[audio]`, `[video]`, `[dedup]`, `[archive]` references to new extra names |
+| `docs/troubleshooting.md` | Update stale install commands that reference removed/renamed extras |
 | `docs/developer/testing.md` | Remove `stub_nltk` fixture reference (line 166+) |
 | `docs/CONFIGURATION.md` | Remove any NLTK corpus path or `ensure_nltk_data` references |
 | `docs/setup/` | Remove `nltk.download(...)` setup step if present |
@@ -226,17 +228,26 @@ This list is exhaustive (verified by `grep -r nltk tests/ docs/ CONTRIBUTING.md`
 | `pyproject.toml` | Update inline comments on moved/removed deps; update `deptry` package map if needed |
 | `.github/workflows/ci-extras.yml` | Remove `audio`, `video`, `archive`, `dedup` matrix entries; add `media`, `dedup-text`, `dedup-image` entries |
 
+Before updating docs, run an audit to find all remaining references to removed/renamed extras:
+
+```bash
+rg '\[audio\]|\[video\]|\[archive\]|\[dedup\]' docs/ README.md CONTRIBUTING.md
+```
+
+Every hit must be updated in this PR.
+
 ---
 
 ## Section 4: Testing Strategy
 
 ### Behavioral regression fixtures (prerequisite)
 
-Before removing NLTK, capture golden output for the three affected functions in
+Before removing NLTK, capture golden output for the three affected public functions in
 `utils/text_processing.py` under the **current** NLTK implementation:
 
-- `clean_text_for_name("Studies in running and analysis")` → frozen expected string
-- `extract_keywords("The quick brown fox jumps...")` → frozen expected list
+- `get_unwanted_words()` → frozen expected set (stopwords list)
+- `clean_text("Studies in running and analysis")` → frozen expected string
+- `extract_keywords("The quick brown fox jumps over the lazy dog")` → frozen expected list
 
 These fixtures define the accepted behavioral difference between NLTK and the
 snowballstemmer replacement. Tests pass if the new output matches the new fixture,
@@ -244,20 +255,33 @@ not the old NLTK output.
 
 ### Import-boundary smoke test (new exit gate)
 
-Add a test (or CI step) that verifies the default install does not accidentally pull
-in numpy-dependent code at import time:
+Add a test that verifies the default install does not accidentally pull in
+numpy-dependent code at import time. The numpy block must run in a **subprocess**
+so it does not poison `sys.modules` for other tests in the same pytest worker:
 
 ```python
 # tests/smoke/test_default_import_boundary.py
+import subprocess
+import sys
+import pytest
+
+pytestmark = [pytest.mark.ci, pytest.mark.smoke]
+
+
+def test_default_imports_without_numpy() -> None:
+    code = """
 import sys
 sys.modules["numpy"] = None  # block numpy
 
 import core.organizer        # must not raise
 import cli.dedupe_hash       # must not raise (hash-based dedup path)
 from services.deduplication.detector import DuplicateDetector  # must not raise
+"""
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
 ```
 
-This test must run in the `ci` marker set.
+Running in a child process isolates the `sys.modules` mutation completely.
 
 ### Format libs now guaranteed present
 
@@ -275,14 +299,19 @@ not exist):
 
 ### Install-size CI gate
 
-Add a step to `ci.yml` on main-push that measures and enforces the install size floor:
+Add a step to `ci.yml` on main-push that measures and enforces the install size floor.
+The gate must install from the **local checkout** (not from PyPI) so the measured
+artifact matches the branch under test:
 
 ```bash
-pip install --target /tmp/fo_size_check "fo-core" -q
+pip install --target /tmp/fo_size_check . -q
 SIZE_MB=$(du -sm /tmp/fo_size_check | cut -f1)
 echo "Default install: ${SIZE_MB} MB"
 [ "$SIZE_MB" -le 185 ] || (echo "Install size ${SIZE_MB} MB exceeds 185 MB cap" && exit 1)
 ```
+
+The workflow step must run after `actions/checkout` so `.` resolves to the checked-out
+branch, not a published release.
 
 ### Coverage
 
@@ -315,3 +344,4 @@ floor after measuring on CI.
 - [ ] No remaining unconditional `import numpy` reachable from a default install
 - [ ] `.rtf` files routed through `utils/readers` dispatch table
 - [ ] All updated doc files verified against source (D1 rule)
+- [ ] `rg '\[audio\]|\[video\]|\[archive\]|\[dedup\]' docs/ README.md CONTRIBUTING.md` returns zero hits

--- a/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
+++ b/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
@@ -1,7 +1,7 @@
 # Install Size Reduction Epic — Design Spec
 
 **Date**: 2026-04-19
-**Status**: Approved (rev 5 — reviewer corrections applied 2026-04-19)
+**Status**: Approved (rev 6 — reviewer corrections applied 2026-04-19)
 **Target**: Reduce default install from 206 MB → 181 MB while maximising out-of-the-box
 format coverage.
 
@@ -38,7 +38,10 @@ pypdf reader dispatch remains out of scope (see Section 5).
 ## Decision: Option B
 
 All **lightweight** non-scientific, non-CAD formats included in the default: document
-formats (RTF, PDF fallback), archives (7Z, RAR), and audio metadata (mutagen, tinytag).
+formats (RTF via striprtf), archives (7Z, RAR), and audio metadata (mutagen, tinytag).
+`pypdf` is also moved to default but only improves the dedup extractor path — the
+organize reader still routes PDFs through PyMuPDF and full pypdf reader dispatch is
+out of scope (see Section 5).
 CAD stays optional because `ezdxf` hard-requires numpy (+74 MB total), which would negate
 the numpy removal gain. Scientific stays optional (h5py + netCDF4 + scipy = 201 MB, niche
 use case). Audio/video **transcription and processing** (faster-whisper, torch, pydub,
@@ -389,13 +392,14 @@ floor after measuring on CI.
 ## Exit Gates
 
 - [ ] `pytest tests/ -m "ci or smoke"` passes on Linux, macOS, Windows
-- [ ] `pip install . --target /tmp/check` (local checkout) installs in ≤185 MB (enforced by CI size gate)
+- [ ] CI install-size gate passes (hermetic venv install from local checkout ≤185 MB; see Section 4)
 - [ ] `tests/smoke/test_default_import_boundary.py` passes with numpy blocked
 - [ ] `pip install "fo-core[media]"` installs and canary imports pass
 - [ ] `pip install "fo-core[dedup-text]"` installs and canary imports pass
 - [ ] `pip install "fo-core[dedup-image]"` installs and canary imports pass
 - [ ] `pymarkdown scan docs/` passes (zero violations)
 - [ ] No remaining `nltk` or `ensure_nltk_data` references in `src/`
+- [ ] `rg 'nltk|ensure_nltk_data|stub_nltk|mock_nltk|NLTK_AVAILABLE' --glob '!docs/superpowers/specs/**' .github/ tests/ docs/ README.md CONTRIBUTING.md` returns zero hits
 - [ ] No remaining unconditional `import numpy` reachable from a default install
 - [ ] `.rtf` files routed through `utils/readers` dispatch table
 - [ ] All updated doc files verified against source (D1 rule)

--- a/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
+++ b/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
@@ -396,12 +396,16 @@ floor after measuring on CI.
 - [ ] `pytest tests/ -m "ci or smoke"` passes on Linux, macOS, Windows
 - [ ] CI install-size gate passes (hermetic venv install from local checkout ≤185 MB; see Section 4)
 - [ ] `tests/smoke/test_default_import_boundary.py` passes with numpy blocked
-- [ ] `pip install "fo-core[media]"` installs and canary imports pass
-- [ ] `pip install "fo-core[dedup-text]"` installs and canary imports pass
-- [ ] `pip install "fo-core[dedup-image]"` installs and canary imports pass
+- [ ] `pip install '.[media]'` (local checkout) installs and canary imports pass
+- [ ] `pip install '.[dedup-text]'` (local checkout) installs and canary imports pass
+- [ ] `pip install '.[dedup-image]'` (local checkout) installs and canary imports pass
 - [ ] `pymarkdown scan docs/` passes (zero violations)
 - [ ] `rg -i 'nltk|ensure_nltk_data|stub_nltk|mock_nltk' --glob '!docs/superpowers/specs/**' src/ .github/ tests/ docs/ README.md CONTRIBUTING.md pyproject.toml` returns zero hits
 - [ ] No remaining unconditional `import numpy` reachable from a default install
 - [ ] `.rtf` files routed through `utils/readers` dispatch table
 - [ ] All updated doc files verified against source (D1 rule)
-- [ ] `rg '\[audio\]|\[video\]|\[archive\]|\[dedup\]' --glob '!docs/superpowers/specs/**' docs/ README.md CONTRIBUTING.md` returns zero hits
+- [ ] Old extras removed from all surfaces — all of the following return zero hits:
+  - Docs: `rg '\[audio\]|\[video\]|\[archive\]|\[dedup\]' --glob '!docs/superpowers/specs/**' docs/ README.md CONTRIBUTING.md`
+  - pyproject.toml: `rg '^\s*(audio|video|archive|dedup)\s*=' pyproject.toml` (no old extra definitions)
+  - CI matrix: `rg '"audio"|"video"|"archive"|"dedup"' .github/workflows/ci-extras.yml` (no old matrix entries)
+  - Test canaries: `ls tests/extras/test_extras_audio.py tests/extras/test_extras_video.py tests/extras/test_extras_archive.py tests/extras/test_extras_dedup.py 2>&1 | grep -v 'No such'` returns nothing

--- a/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
+++ b/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
@@ -1,7 +1,7 @@
 # Install Size Reduction Epic — Design Spec
 
 **Date**: 2026-04-19
-**Status**: Approved
+**Status**: Approved (rev 2 — reviewer corrections applied 2026-04-19)
 **Target**: Reduce default install from 206 MB → 181 MB while maximising out-of-the-box
 format coverage.
 
@@ -23,21 +23,32 @@ avoidable costs are:
    subsystems. Removing it from the default dep list costs nothing for the organize pass.
    It re-enters only when an optional extra that needs it is installed.
 
-Additionally, several lightweight format libraries (RTF, 7Z/RAR, audio metadata) are
-gated behind optional extras despite having negligible size and no heavy transitive deps.
-Moving them to the default gives users complete non-scientific format coverage immediately.
+Additionally, several lightweight format libraries (7Z/RAR, audio metadata) are gated
+behind optional extras despite having negligible size and no heavy transitive deps.
+Moving them to the default extends format coverage at minimal cost.
+
+**Scope clarification**: RTF (`striprtf`) and `pypdf` are also moved to the default dep
+list, but this does **not** automatically extend the `utils.readers` dispatch table —
+those libs are currently only consumed by `services/deduplication/extractor.py`. Wiring
+RTF and pypdf into the reader dispatcher is an explicit sub-task of this epic (see
+Section 2c).
 
 ---
 
 ## Decision: Option B
 
-All non-scientific, non-CAD formats included in the default. CAD stays optional because
-`ezdxf` hard-requires numpy (+74 MB total), which would negate the numpy removal gain.
-Scientific stays optional (h5py + netCDF4 + scipy = 201 MB, niche use case).
+All non-scientific, non-CAD formats included in the default (with reader-dispatch wiring
+tasks included). CAD stays optional because `ezdxf` hard-requires numpy (+74 MB total),
+which would negate the numpy removal gain. Scientific stays optional (h5py + netCDF4 +
+scipy = 201 MB, niche use case).
 
 ---
 
 ## Measured Install Sizes
+
+**Methodology**: `pip install --target <tmpdir> <packages> -q`, then `du -sh <tmpdir>`.
+Platform: macOS Darwin 25.4.0, Python 3.12.13, pip 24.x, no pre-cached wheels.
+All sizes are post-install on-disk (not download size). Transitive deps included.
 
 | Configuration | Installed size | Packages |
 |---------------|---------------|----------|
@@ -49,6 +60,9 @@ Scientific stays optional (h5py + netCDF4 + scipy = 201 MB, niche use case).
 | `media` addon | +409 MB | faster-whisper + torch + pydub + opencv + scenedetect |
 | `scientific` addon | +201 MB | h5py + netCDF4 + scipy |
 | `cloud` / `claude` / `llama` / `mlx` | +13 / +8 / +33 / +4.5 MB | (unchanged) |
+
+CI enforces the ≤185 MB floor via an install-size check step added to `ci.yml`
+(see Section 4).
 
 ---
 
@@ -65,8 +79,8 @@ Scientific stays optional (h5py + netCDF4 + scipy = 201 MB, niche use case).
 
 ```toml
 "snowballstemmer>=2.2.0"  # replaces NLTK lemmatiser; no corpus download
-"striprtf>=0.0.26"        # RTF format support (was in dedup extra)
-"pypdf~=6.10"             # PDF text extraction fallback (was in dedup extra)
+"striprtf>=0.0.26"        # RTF text extraction; used by dedup extractor + new reader
+"pypdf~=6.10"             # PDF text extraction fallback; used by dedup extractor
 "py7zr>=0.20.0"           # 7Z archive support (was in archive extra)
 "rarfile~=4.1"            # RAR archive support (was in archive extra)
 "mutagen~=1.47"           # audio metadata — MP3/FLAC/MP4 tags (was in audio extra)
@@ -99,13 +113,22 @@ all = [
 
 ### 2a. `src/utils/text_processing.py` — NLTK replacement
 
-Replace every NLTK call with stdlib or snowballstemmer equivalents:
+This is a **behavior-changing substitution**, not a drop-in equivalence swap:
+
+- `word_tokenize` (unicode-aware, handles punctuation) → `re.findall(r'\b[a-z]+\b', text.lower())` — ASCII-only, drops unicode letters
+- `WordNetLemmatizer` (true lemmatisation: `studies` → `study`) → `Stemmer("english").stemWord()` (Snowball stemming: `studies` → `studi`)
+
+Accepted trade-offs: stemming is sufficient for filename/folder name generation; the
+ASCII regex is acceptable because fo-core operates on filenames which are typically
+ASCII-dominated. **Golden-output fixtures must be written before the replacement**
+(see Section 4 — behavioral regression tests) to define and freeze the accepted output
+difference.
 
 | NLTK call | Replacement |
 |-----------|-------------|
-| `import nltk` + corpus imports | `import re`, `from collections import Counter`, `from snowballstemmer import stemmer` |
+| `import nltk` + corpus imports | `import re`, `from collections import Counter`, `from snowballstemmer import stemmer as Stemmer` |
 | `word_tokenize(text)` | `re.findall(r'\b[a-z]+\b', text.lower())` |
-| `stopwords.words("english")` | Inline frozen set (~55 words, ported from `tests/conftest.py` `mock_nltk_stopwords`) |
+| `stopwords.words("english")` | Inline `frozenset` (~55 words, ported from `tests/conftest.py` `mock_nltk_stopwords`) |
 | `WordNetLemmatizer().lemmatize(word)` | `Stemmer("english").stemWord(word)` |
 | `FreqDist(words)` | `Counter(words)` |
 | `ensure_nltk_data()` | Delete entirely |
@@ -116,23 +139,53 @@ Replace every NLTK call with stdlib or snowballstemmer equivalents:
 
 Remove any NLTK import or `ensure_nltk_data()` call. Verify no remaining NLTK references.
 
-### 2c. numpy — no code change required
+### 2c. numpy — `services/deduplication/__init__.py` must be guarded first
 
-All numpy imports in `dedup/`, `search/`, and `video/` are already scoped to those
-optional modules. Removing numpy from `pyproject.toml` default deps is the only change.
-No import guards need to be added.
+**This is a prerequisite for dropping numpy from defaults.** The current `__init__.py`
+unconditionally imports `DocumentEmbedder`, `SemanticAnalyzer`, and `DocumentDeduplicator`
+at module load time. All three import numpy. Because `cli/dedupe_hash.py` imports
+`services.deduplication.detector`, which triggers `__init__.py`, a default install
+without numpy fails on import before any optional dedup-text feature is reached.
 
-### 2d. `DocumentDeduplicator` — scope boundary
+Required change: make the heavy numpy-dependent exports lazy or guarded in
+`services/deduplication/__init__.py`:
+
+```python
+# Heavy optional exports — only available when dedup-text extra is installed
+try:
+    from .document_dedup import DocumentDeduplicator
+    from .embedder import DocumentEmbedder
+    from .semantic import SemanticAnalyzer
+except ImportError:
+    pass  # numpy not available; hash-based dedup still works
+```
+
+The same pattern applies to `services/search/` and `services/video/` if their
+`__init__.py` files have unconditional numpy imports — audit and guard all of them
+before dropping numpy from `pyproject.toml`.
+
+### 2d. RTF reader wiring in `utils/readers`
+
+`striprtf` is moved to the default dep list, but the reader dispatch table in
+`utils/readers/__init__.py` does not currently route `.rtf` files. Add:
+
+1. A `read_rtf_file()` function in `utils/readers/documents.py` using `striprtf`
+2. A `.rtf` entry in the dispatch table in `utils/readers/__init__.py`
+
+This is the specific surface where "RTF in the default install" becomes real for
+the organise pass.
+
+### 2e. `DocumentDeduplicator` — scope boundary
 
 `services/deduplication/document_dedup.py` exports `DocumentDeduplicator` but it is
 never called from any CLI command or the organizer. This epic does **not** wire it up.
-Add a comment at the `__init__.py` export:
+After the `__init__.py` guard is added (Section 2c), add a comment:
 
 ```python
-# DocumentDeduplicator: wired in dedup-text extra; CLI integration tracked separately
+# DocumentDeduplicator: requires dedup-text extra; CLI integration tracked separately
 ```
 
-### 2e. `tqdm` — no change
+### 2f. `tqdm` — no change
 
 Used only in `cli/dedupe_hash.py`. At 200 KB it is not worth conditionalising.
 
@@ -142,74 +195,123 @@ Used only in `cli/dedupe_hash.py`. At 200 KB it is not worth conditionalising.
 
 All documentation changes ship in the same PR as the code changes. No deferred doc PRs.
 
+### NLTK reference audit
+
+The following files contain NLTK references outside `src/` and must all be updated.
+This list is exhaustive (verified by `grep -r nltk tests/ docs/ CONTRIBUTING.md`):
+
+**Test files** (remove fixtures, update or delete NLTK-specific tests):
+
+- `tests/conftest.py` — remove `mock_nltk_tokenizer`, `mock_nltk_stopwords`, `mock_nltk_lemmatizer`, `mock_nltk_freqdist`, `mock_nltk_ensure_data_no_op`, `isolated_nltk_environment`
+- `tests/integration/conftest.py` — remove `stub_nltk`, `ensure_nltk_available` fixtures
+- `tests/utils/test_text_processing.py` — migrate from mock-based to real snowballstemmer
+- `tests/utils/test_text_processing_hermeticity.py` — remove or rewrite
+- `tests/unit/utils/test_text_processing.py` — migrate from mock-based to real snowballstemmer
+- `tests/services/test_text_processor.py` — remove `ensure_nltk_data` patches
+- `tests/services/test_text_processor_logging.py` — remove `ensure_nltk_data` patches
+- `tests/integration/test_coverage_gap_supplements.py` — remove NLTK-specific coverage gaps
+- All other integration tests patching `services.text_processor.ensure_nltk_data` — remove patches
+
+**Documentation files**:
+
 | File | Required change |
 |------|----------------|
-| `README.md` | Update extras table: add `media`, rename `dedup`→`dedup-text`/`dedup-image`, remove `archive`, add CAD note; remove NLTK first-run download callout |
+| `README.md` | Update extras table: add `media`, rename `dedup`→`dedup-text`/`dedup-image`, remove `archive`, remove NLTK first-run download callout |
 | `docs/getting-started.md` | Update quick install commands and extras reference |
+| `docs/developer/testing.md` | Remove `stub_nltk` fixture reference (line 166+) |
 | `docs/CONFIGURATION.md` | Remove any NLTK corpus path or `ensure_nltk_data` references |
 | `docs/setup/` | Remove `nltk.download(...)` setup step if present |
 | `docs/reference/` | Update dependencies/extras reference page if present |
-| `CONTRIBUTING.md` | Remove NLTK download step from dev setup; update extras names |
-| `pyproject.toml` | Update inline comments on moved/removed deps |
-| `.claude/rules/ci-generation-patterns.md` | Remove NLTK-specific CI patterns if any |
-| `tests/conftest.py` | Remove `mock_nltk_tokenizer`, `mock_nltk_stopwords`, `mock_nltk_lemmatizer`, `mock_nltk_freqdist`, `mock_nltk_ensure_data_no_op`, `isolated_nltk_environment` fixtures |
+| `CONTRIBUTING.md` | Remove NLTK download step from dev setup (line 341+); update extras names |
+| `pyproject.toml` | Update inline comments on moved/removed deps; update `deptry` package map if needed |
+| `.github/workflows/ci-extras.yml` | Remove `audio`, `video`, `archive`, `dedup` matrix entries; add `media`, `dedup-text`, `dedup-image` entries |
 
 ---
 
 ## Section 4: Testing Strategy
 
-### NLTK replacement tests
+### Behavioral regression fixtures (prerequisite)
 
-Existing `tests/utils/test_text_processing.py` tests that currently use `mock_nltk_*`
-fixtures are migrated to run against real snowballstemmer. No mocks needed — the
-dependency is now always present and deterministic.
+Before removing NLTK, capture golden output for the three affected functions in
+`utils/text_processing.py` under the **current** NLTK implementation:
+
+- `clean_text_for_name("Studies in running and analysis")` → frozen expected string
+- `extract_keywords("The quick brown fox jumps...")` → frozen expected list
+
+These fixtures define the accepted behavioral difference between NLTK and the
+snowballstemmer replacement. Tests pass if the new output matches the new fixture,
+not the old NLTK output.
+
+### Import-boundary smoke test (new exit gate)
+
+Add a test (or CI step) that verifies the default install does not accidentally pull
+in numpy-dependent code at import time:
+
+```python
+# tests/smoke/test_default_import_boundary.py
+import sys
+sys.modules["numpy"] = None  # block numpy
+
+import core.organizer        # must not raise
+import cli.dedupe_hash       # must not raise (hash-based dedup path)
+from services.deduplication.detector import DuplicateDetector  # must not raise
+```
+
+This test must run in the `ci` marker set.
 
 ### Format libs now guaranteed present
 
-Remove `pytest.importorskip` guards on striprtf, pypdf, py7zr, rarfile, mutagen, and
-tinytag in any test files that currently guard them. They are now default deps.
+Remove `pytest.importorskip` guards on py7zr, rarfile, mutagen, and tinytag in any
+test files that currently guard them. They are now default deps. `striprtf` and `pypdf`
+guards similarly removed.
 
 ### Extras validation workflow
 
-Update `.github/workflows/extras-validation.yml`:
+Update `.github/workflows/ci-extras.yml` (not `extras-validation.yml` — that file does
+not exist):
 
-- Remove `audio` and `video` matrix entries
-- Add `media` matrix entry with smoke canary
-- Rename `dedup` entry to `dedup-text`
-- Add `dedup-image` entry
+- Remove `audio`, `video`, `archive`, `dedup` matrix entries
+- Add `media`, `dedup-text`, `dedup-image` entries with smoke canaries
 
-### CI matrix
+### Install-size CI gate
 
-No changes to the OS/Python matrix. Windows and macOS both benefit from numpy removal
-(fewer native lib build complications on those platforms).
+Add a step to `ci.yml` on main-push that measures and enforces the install size floor:
+
+```bash
+pip install --target /tmp/fo_size_check "fo-core" -q
+SIZE_MB=$(du -sm /tmp/fo_size_check | cut -f1)
+echo "Default install: ${SIZE_MB} MB"
+[ "$SIZE_MB" -le 185 ] || (echo "Install size ${SIZE_MB} MB exceeds 185 MB cap" && exit 1)
+```
 
 ### Coverage
 
-No coverage floor changes expected — the NLTK replacement is a functional equivalence
-swap, not a feature removal. If coverage shifts, adjust the floor after measuring.
+No coverage floor changes expected. If the NLTK removal causes a shift in line coverage
+(the `ensure_nltk_data` download branches are deleted, not just unreachable), adjust the
+floor after measuring on CI.
 
 ---
 
 ## Section 5: What This Does Not Include
 
 - **Wiring `DocumentDeduplicator` into the organize pass** — separate epic
-- **CAD in default** — ezdxf's numpy dep makes this a net regression; revisit if ezdxf
-  drops the numpy requirement in a future release
-- **Further splitting of PyMuPDF or python-pptx into optional extras** — these are
-  core to the organize-pass file reading; deferring until a tiered-format epic is scoped
-- **ML near-duplicate detection on every organize pass** — separate epic; requires
-  design work on threshold config, performance budget, and user-facing output
+- **CAD in default** — ezdxf's numpy dep makes this a net regression; revisit if ezdxf drops the numpy requirement
+- **pypdf in the reader dispatch** — pypdf is moved to default for the dedup extractor path only; full PDF reader fallback via pypdf is out of scope
+- **Further splitting of PyMuPDF or python-pptx into optional extras** — deferred
+- **ML near-duplicate detection on every organize pass** — separate epic
 
 ---
 
 ## Exit Gates
 
 - [ ] `pytest tests/ -m "ci or smoke"` passes on Linux, macOS, Windows
-- [ ] `pip install fo-core` installs in ≤185 MB (measured in CI)
+- [ ] `pip install fo-core` installs in ≤185 MB (enforced by CI size gate)
+- [ ] `tests/smoke/test_default_import_boundary.py` passes with numpy blocked
 - [ ] `pip install "fo-core[media]"` installs and canary imports pass
 - [ ] `pip install "fo-core[dedup-text]"` installs and canary imports pass
 - [ ] `pip install "fo-core[dedup-image]"` installs and canary imports pass
 - [ ] `pymarkdown scan docs/` passes (zero violations)
 - [ ] No remaining `nltk` or `ensure_nltk_data` references in `src/`
-- [ ] No remaining `import numpy` in non-optional `src/` modules
+- [ ] No remaining unconditional `import numpy` reachable from a default install
+- [ ] `.rtf` files routed through `utils/readers` dispatch table
 - [ ] All updated doc files verified against source (D1 rule)

--- a/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
+++ b/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
@@ -1,7 +1,7 @@
 # Install Size Reduction Epic — Design Spec
 
 **Date**: 2026-04-19
-**Status**: Approved (rev 3 — reviewer corrections applied 2026-04-19)
+**Status**: Approved (rev 4 — reviewer corrections applied 2026-04-19)
 **Target**: Reduce default install from 206 MB → 181 MB while maximising out-of-the-box
 format coverage.
 
@@ -244,10 +244,13 @@ This list is exhaustive (verified by `grep -r nltk tests/ docs/ CONTRIBUTING.md`
 Before updating docs, run an audit to find all remaining references to removed/renamed extras:
 
 ```bash
-rg '\[audio\]|\[video\]|\[archive\]|\[dedup\]' docs/ README.md CONTRIBUTING.md
+rg '\[audio\]|\[video\]|\[archive\]|\[dedup\]' \
+  --glob '!docs/superpowers/specs/**' \
+  docs/ README.md CONTRIBUTING.md
 ```
 
-Every hit must be updated in this PR.
+Every hit must be updated in this PR. The spec file itself is excluded because it
+intentionally contains these names in the migration table.
 
 ---
 
@@ -327,14 +330,18 @@ The gate must install from the **local checkout** (not from PyPI) so the measure
 artifact matches the branch under test:
 
 ```bash
-pip install --target /tmp/fo_size_check . -q
+# Run in a clean environment so dev/search extras installed by earlier CI
+# steps do not undercount the real default install surface.
+python -m venv /tmp/fo_size_venv
+/tmp/fo_size_venv/bin/pip install --target /tmp/fo_size_check . -q
 SIZE_MB=$(du -sm /tmp/fo_size_check | cut -f1)
 echo "Default install: ${SIZE_MB} MB"
 [ "$SIZE_MB" -le 185 ] || (echo "Install size ${SIZE_MB} MB exceeds 185 MB cap" && exit 1)
 ```
 
 The workflow step must run after `actions/checkout` so `.` resolves to the checked-out
-branch, not a published release.
+branch, not a published release. The dedicated venv prevents earlier CI pip installs
+(dev extras, test deps) from satisfying transitive deps and masking the true size.
 
 ### Coverage
 
@@ -367,4 +374,4 @@ floor after measuring on CI.
 - [ ] No remaining unconditional `import numpy` reachable from a default install
 - [ ] `.rtf` files routed through `utils/readers` dispatch table
 - [ ] All updated doc files verified against source (D1 rule)
-- [ ] `rg '\[audio\]|\[video\]|\[archive\]|\[dedup\]' docs/ README.md CONTRIBUTING.md` returns zero hits
+- [ ] `rg '\[audio\]|\[video\]|\[archive\]|\[dedup\]' --glob '!docs/superpowers/specs/**' docs/ README.md CONTRIBUTING.md` returns zero hits

--- a/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
+++ b/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
@@ -1,0 +1,215 @@
+# Install Size Reduction Epic — Design Spec
+
+**Date**: 2026-04-19
+**Status**: Approved
+**Target**: Reduce default install from 206 MB → 181 MB while maximising out-of-the-box
+format coverage.
+
+---
+
+## Problem
+
+The default install is 206 MB for a privacy-first CLI file organiser. The two largest
+avoidable costs are:
+
+1. **NLTK** (18 MB package + ~50 MB runtime corpus download on first run) — used only
+   for tokenisation, stopwords, and lemmatisation in `utils/text_processing.py`. All
+   three use cases are replaceable with stdlib `re` + `snowballstemmer` (1.9 MB, no
+   downloads). NLTK's runtime download behaviour is the root cause of 23 CI fix commits
+   to date.
+
+2. **numpy** (33 MB) — declared as an explicit default dep but consumed exclusively by
+   `services/deduplication/`, `services/search/`, and `services/video/` — all optional
+   subsystems. Removing it from the default dep list costs nothing for the organize pass.
+   It re-enters only when an optional extra that needs it is installed.
+
+Additionally, several lightweight format libraries (RTF, 7Z/RAR, audio metadata) are
+gated behind optional extras despite having negligible size and no heavy transitive deps.
+Moving them to the default gives users complete non-scientific format coverage immediately.
+
+---
+
+## Decision: Option B
+
+All non-scientific, non-CAD formats included in the default. CAD stays optional because
+`ezdxf` hard-requires numpy (+74 MB total), which would negate the numpy removal gain.
+Scientific stays optional (h5py + netCDF4 + scipy = 201 MB, niche use case).
+
+---
+
+## Measured Install Sizes
+
+| Configuration | Installed size | Packages |
+|---------------|---------------|----------|
+| Current default | 206 MB | ~55 direct / ~409 files |
+| **New default (this epic)** | **181 MB** | ~59 direct / ~400 files |
+| `cad` addon | +74 MB | ezdxf + numpy |
+| `dedup-text` addon | +179 MB | scikit-learn |
+| `dedup-image` addon | +~600 MB on top of dedup-text | torch + imagededup |
+| `media` addon | +409 MB | faster-whisper + torch + pydub + opencv + scenedetect |
+| `scientific` addon | +201 MB | h5py + netCDF4 + scipy |
+| `cloud` / `claude` / `llama` / `mlx` | +13 / +8 / +33 / +4.5 MB | (unchanged) |
+
+---
+
+## Section 1: Dependency Changes (`pyproject.toml`)
+
+### Remove from `[project.dependencies]`
+
+```toml
+"nltk~=3.8"     # replaced by stdlib re + snowballstemmer
+"numpy~=1.24"   # only used by optional subsystems (dedup/search/video)
+```
+
+### Add to `[project.dependencies]`
+
+```toml
+"snowballstemmer>=2.2.0"  # replaces NLTK lemmatiser; no corpus download
+"striprtf>=0.0.26"        # RTF format support (was in dedup extra)
+"pypdf~=6.10"             # PDF text extraction fallback (was in dedup extra)
+"py7zr>=0.20.0"           # 7Z archive support (was in archive extra)
+"rarfile~=4.1"            # RAR archive support (was in archive extra)
+"mutagen~=1.47"           # audio metadata — MP3/FLAC/MP4 tags (was in audio extra)
+"tinytag~=2.2"            # lightweight audio metadata fallback (was in audio extra)
+```
+
+### Extra restructuring
+
+| Old extra | New extra | Change |
+|-----------|-----------|--------|
+| `audio` + `video` | `media` | Merged: faster-whisper, torch, pydub, opencv-python, scenedetect |
+| `dedup` | `dedup-text` | sklearn only (imagededup removed — it requires torch) |
+| *(new)* | `dedup-image` | torch + imagededup (~600 MB); declares `fo-core[dedup-text]` as a pip dep so sklearn comes in automatically |
+| `archive` | *(removed)* | py7zr + rarfile absorbed into default |
+| `cad` | `cad` | Unchanged: ezdxf + numpy (74 MB total) |
+| `scientific` | `scientific` | Unchanged: h5py + netCDF4 + scipy |
+| `all` | `all` | Updated to reference new extra names |
+
+### Updated `all` meta-extra
+
+```toml
+all = [
+    "fo-core[dev,cloud,llama,mlx,claude,media,dedup-text,dedup-image,scientific,cad,build,search]",
+]
+```
+
+---
+
+## Section 2: Code Changes
+
+### 2a. `src/utils/text_processing.py` — NLTK replacement
+
+Replace every NLTK call with stdlib or snowballstemmer equivalents:
+
+| NLTK call | Replacement |
+|-----------|-------------|
+| `import nltk` + corpus imports | `import re`, `from collections import Counter`, `from snowballstemmer import stemmer` |
+| `word_tokenize(text)` | `re.findall(r'\b[a-z]+\b', text.lower())` |
+| `stopwords.words("english")` | Inline frozen set (~55 words, ported from `tests/conftest.py` `mock_nltk_stopwords`) |
+| `WordNetLemmatizer().lemmatize(word)` | `Stemmer("english").stemWord(word)` |
+| `FreqDist(words)` | `Counter(words)` |
+| `ensure_nltk_data()` | Delete entirely |
+| `NLTK_AVAILABLE` flag | Delete entirely |
+| `_nltk_ready` guard | Delete entirely |
+
+### 2b. `src/services/text_processor.py`
+
+Remove any NLTK import or `ensure_nltk_data()` call. Verify no remaining NLTK references.
+
+### 2c. numpy — no code change required
+
+All numpy imports in `dedup/`, `search/`, and `video/` are already scoped to those
+optional modules. Removing numpy from `pyproject.toml` default deps is the only change.
+No import guards need to be added.
+
+### 2d. `DocumentDeduplicator` — scope boundary
+
+`services/deduplication/document_dedup.py` exports `DocumentDeduplicator` but it is
+never called from any CLI command or the organizer. This epic does **not** wire it up.
+Add a comment at the `__init__.py` export:
+
+```python
+# DocumentDeduplicator: wired in dedup-text extra; CLI integration tracked separately
+```
+
+### 2e. `tqdm` — no change
+
+Used only in `cli/dedupe_hash.py`. At 200 KB it is not worth conditionalising.
+
+---
+
+## Section 3: Documentation Updates
+
+All documentation changes ship in the same PR as the code changes. No deferred doc PRs.
+
+| File | Required change |
+|------|----------------|
+| `README.md` | Update extras table: add `media`, rename `dedup`→`dedup-text`/`dedup-image`, remove `archive`, add CAD note; remove NLTK first-run download callout |
+| `docs/getting-started.md` | Update quick install commands and extras reference |
+| `docs/CONFIGURATION.md` | Remove any NLTK corpus path or `ensure_nltk_data` references |
+| `docs/setup/` | Remove `nltk.download(...)` setup step if present |
+| `docs/reference/` | Update dependencies/extras reference page if present |
+| `CONTRIBUTING.md` | Remove NLTK download step from dev setup; update extras names |
+| `pyproject.toml` | Update inline comments on moved/removed deps |
+| `.claude/rules/ci-generation-patterns.md` | Remove NLTK-specific CI patterns if any |
+| `tests/conftest.py` | Remove `mock_nltk_tokenizer`, `mock_nltk_stopwords`, `mock_nltk_lemmatizer`, `mock_nltk_freqdist`, `mock_nltk_ensure_data_no_op`, `isolated_nltk_environment` fixtures |
+
+---
+
+## Section 4: Testing Strategy
+
+### NLTK replacement tests
+
+Existing `tests/utils/test_text_processing.py` tests that currently use `mock_nltk_*`
+fixtures are migrated to run against real snowballstemmer. No mocks needed — the
+dependency is now always present and deterministic.
+
+### Format libs now guaranteed present
+
+Remove `pytest.importorskip` guards on striprtf, pypdf, py7zr, rarfile, mutagen, and
+tinytag in any test files that currently guard them. They are now default deps.
+
+### Extras validation workflow
+
+Update `.github/workflows/extras-validation.yml`:
+
+- Remove `audio` and `video` matrix entries
+- Add `media` matrix entry with smoke canary
+- Rename `dedup` entry to `dedup-text`
+- Add `dedup-image` entry
+
+### CI matrix
+
+No changes to the OS/Python matrix. Windows and macOS both benefit from numpy removal
+(fewer native lib build complications on those platforms).
+
+### Coverage
+
+No coverage floor changes expected — the NLTK replacement is a functional equivalence
+swap, not a feature removal. If coverage shifts, adjust the floor after measuring.
+
+---
+
+## Section 5: What This Does Not Include
+
+- **Wiring `DocumentDeduplicator` into the organize pass** — separate epic
+- **CAD in default** — ezdxf's numpy dep makes this a net regression; revisit if ezdxf
+  drops the numpy requirement in a future release
+- **Further splitting of PyMuPDF or python-pptx into optional extras** — these are
+  core to the organize-pass file reading; deferring until a tiered-format epic is scoped
+- **ML near-duplicate detection on every organize pass** — separate epic; requires
+  design work on threshold config, performance budget, and user-facing output
+
+---
+
+## Exit Gates
+
+- [ ] `pytest tests/ -m "ci or smoke"` passes on Linux, macOS, Windows
+- [ ] `pip install fo-core` installs in ≤185 MB (measured in CI)
+- [ ] `pip install "fo-core[media]"` installs and canary imports pass
+- [ ] `pip install "fo-core[dedup-text]"` installs and canary imports pass
+- [ ] `pip install "fo-core[dedup-image]"` installs and canary imports pass
+- [ ] `pymarkdown scan docs/` passes (zero violations)
+- [ ] No remaining `nltk` or `ensure_nltk_data` references in `src/`
+- [ ] No remaining `import numpy` in non-optional `src/` modules
+- [ ] All updated doc files verified against source (D1 rule)

--- a/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
+++ b/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
@@ -1,7 +1,7 @@
 # Install Size Reduction Epic — Design Spec
 
 **Date**: 2026-04-19
-**Status**: Approved (rev 4 — reviewer corrections applied 2026-04-19)
+**Status**: Approved (rev 5 — reviewer corrections applied 2026-04-19)
 **Target**: Reduce default install from 206 MB → 181 MB while maximising out-of-the-box
 format coverage.
 
@@ -37,10 +37,13 @@ pypdf reader dispatch remains out of scope (see Section 5).
 
 ## Decision: Option B
 
-All non-scientific, non-CAD formats included in the default (with reader-dispatch wiring
-tasks included). CAD stays optional because `ezdxf` hard-requires numpy (+74 MB total),
-which would negate the numpy removal gain. Scientific stays optional (h5py + netCDF4 +
-scipy = 201 MB, niche use case).
+All **lightweight** non-scientific, non-CAD formats included in the default: document
+formats (RTF, PDF fallback), archives (7Z, RAR), and audio metadata (mutagen, tinytag).
+CAD stays optional because `ezdxf` hard-requires numpy (+74 MB total), which would negate
+the numpy removal gain. Scientific stays optional (h5py + netCDF4 + scipy = 201 MB, niche
+use case). Audio/video **transcription and processing** (faster-whisper, torch, pydub,
+opencv, scenedetect) remain under the `media` extra — these are explicitly not in the
+default despite "audio" metadata being default.
 
 ---
 
@@ -210,22 +213,31 @@ All documentation changes ship in the same PR as the code changes. No deferred d
 
 ### NLTK reference audit
 
-The following files contain NLTK references outside `src/` and must all be updated.
-This list is exhaustive (verified by `grep -r nltk tests/ docs/ CONTRIBUTING.md`):
+Use `rg` to find every NLTK reference outside `src/` — do not rely on a static list,
+as new fixture consumers are regularly added:
 
-**Test files** (remove fixtures, update or delete NLTK-specific tests):
+**Step 1 — find all NLTK test consumers (must all be updated):**
 
-- `tests/conftest.py` — remove `mock_nltk_tokenizer`, `mock_nltk_stopwords`, `mock_nltk_lemmatizer`, `mock_nltk_freqdist`, `mock_nltk_ensure_data_no_op`, `isolated_nltk_environment`
-- `tests/integration/conftest.py` — remove `stub_nltk`, `ensure_nltk_available` fixtures
-- `tests/utils/test_text_processing.py` — migrate from mock-based to real snowballstemmer
-- `tests/utils/test_text_processing_hermeticity.py` — remove or rewrite
-- `tests/unit/utils/test_text_processing.py` — migrate from mock-based to real snowballstemmer
-- `tests/services/test_text_processor.py` — remove `ensure_nltk_data` patches
-- `tests/services/test_text_processor_logging.py` — remove `ensure_nltk_data` patches
-- `tests/integration/test_coverage_gap_supplements.py` — remove NLTK-specific coverage gaps
-- All other integration tests patching `services.text_processor.ensure_nltk_data` — remove patches
+```bash
+rg 'stub_nltk|ensure_nltk_available|ensure_nltk_data|NLTK_AVAILABLE|mock_nltk' tests/
+```
 
-**Documentation files**:
+For each hit:
+- Fixture definitions (`conftest.py`) → remove the fixture
+- Fixture parameters (`stub_nltk: None`, `mock_nltk_tokenizer`) → remove the parameter and any mock-dependent assertions
+- Direct patches (`patch("...ensure_nltk_data")`) → remove the patch and rewrite the test against real snowballstemmer output
+
+**Step 2 — find all NLTK CI workflow steps (must all be removed):**
+
+```bash
+rg 'nltk' .github/workflows/
+```
+
+Remove every `cache: nltk_data` step and every `python -c "import nltk; nltk.download(...)"` step from
+`ci.yml`, `ci-full.yml`, and `pr-integration.yml`. These steps fail once `nltk` is no
+longer in the default dependencies.
+
+**Step 3 — documentation files:**
 
 | File | Required change |
 |------|----------------|
@@ -239,9 +251,9 @@ This list is exhaustive (verified by `grep -r nltk tests/ docs/ CONTRIBUTING.md`
 | `docs/reference/` | Update dependencies/extras reference page if present |
 | `CONTRIBUTING.md` | Remove NLTK download step from dev setup (line 341+); update extras names |
 | `pyproject.toml` | Update inline comments on moved/removed deps; update `deptry` package map if needed |
-| `.github/workflows/ci-extras.yml` | Remove `audio`, `video`, `archive`, `dedup` matrix entries; add `media`, `dedup-text`, `dedup-image` entries |
+| `.github/workflows/ci-extras.yml` | Remove `audio`, `video`, `archive`, `dedup` matrix entries; add `media`, `dedup-text`, `dedup-image` entries (see canary file note below) |
 
-Before updating docs, run an audit to find all remaining references to removed/renamed extras:
+**Step 4 — stale extra-name audit across user-facing docs:**
 
 ```bash
 rg '\[audio\]|\[video\]|\[archive\]|\[dedup\]' \
@@ -322,6 +334,19 @@ not exist):
 
 - Remove `audio`, `video`, `archive`, `dedup` matrix entries
 - Add `media`, `dedup-text`, `dedup-image` entries with smoke canaries
+
+**Canary file renaming is required.** The workflow resolves test files via
+`tests/extras/test_extras_${{ matrix.extra }}.py`. Hyphenated extra names
+(`dedup-text`, `dedup-image`) do not map to valid Python filenames. Rename as follows
+and update the workflow's `test_file` field (or add an explicit mapping) accordingly:
+
+| Old canary file | Old extra | New canary file | New extra |
+|----------------|-----------|----------------|-----------|
+| `tests/extras/test_extras_audio.py` | `audio` | `tests/extras/test_extras_media.py` | `media` |
+| `tests/extras/test_extras_video.py` | `video` | *(merged into test_extras_media.py)* | `media` |
+| `tests/extras/test_extras_dedup.py` | `dedup` | `tests/extras/test_extras_dedup_text.py` | `dedup-text` |
+| *(new)* | — | `tests/extras/test_extras_dedup_image.py` | `dedup-image` |
+| `tests/extras/test_extras_archive.py` | `archive` | *(delete — py7zr/rarfile now default)* | — |
 
 ### Install-size CI gate
 

--- a/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
+++ b/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
@@ -204,7 +204,19 @@ After the `__init__.py` guard is added (Section 2c), add a comment:
 # DocumentDeduplicator: requires dedup-text extra; CLI integration tracked separately
 ```
 
-### 2f. `tqdm` — no change
+### 2f. `src/cli/doctor.py` — extra recommendation registry
+
+`doctor.py` contains a file-extension → extra name mapping (e.g. `.mp3` → `"audio"`,
+`.7z` → `"archive"`, `.zip`/`.rar` → `"archive"`). This registry drives the
+`fo doctor` command's install suggestions. It must be updated alongside the extras:
+
+- `.mp3`, `.wav`, `.flac`, `.ogg`, `.m4a`, `.wma`, `.aac`, `.opus` → `"media"` (was `"audio"`)
+- `.mp4`, `.avi`, `.mkv`, `.mov`, `.wmv`, `.webm` → `"media"` (was `"video"`)
+- `.7z`, `.rar`, `.tar.gz` → remove entry (py7zr + rarfile now in default, no extra needed)
+
+Update `tests/unit/test_doctor_registry.py` to assert the new mapping.
+
+### 2g. `tqdm` — no change
 
 Used only in `cli/dedupe_hash.py`. At 200 KB it is not worth conditionalising.
 
@@ -400,12 +412,14 @@ floor after measuring on CI.
 - [ ] `pip install '.[dedup-text]'` (local checkout) installs and canary imports pass
 - [ ] `pip install '.[dedup-image]'` (local checkout) installs and canary imports pass
 - [ ] `pymarkdown scan docs/` passes (zero violations)
-- [ ] `rg -i 'nltk|ensure_nltk_data|stub_nltk|mock_nltk' --glob '!docs/superpowers/specs/**' src/ .github/ tests/ docs/ README.md CONTRIBUTING.md pyproject.toml` returns zero hits
+- [ ] `rg -i 'nltk|ensure_nltk_data|stub_nltk|mock_nltk' --glob '!docs/superpowers/specs/**' --glob '!docs/superpowers/plans/**' src/ .github/ tests/ docs/ README.md CONTRIBUTING.md pyproject.toml` returns zero hits
 - [ ] No remaining unconditional `import numpy` reachable from a default install
 - [ ] `.rtf` files routed through `utils/readers` dispatch table
+- [ ] `src/cli/doctor.py` extra recommendations updated: `audio`/`video` → `media`, `archive` removed, `dedup` → `dedup-text`/`dedup-image`
 - [ ] All updated doc files verified against source (D1 rule)
 - [ ] Old extras removed from all surfaces — all of the following return zero hits:
-  - Docs: `rg '\[audio\]|\[video\]|\[archive\]|\[dedup\]' --glob '!docs/superpowers/specs/**' docs/ README.md CONTRIBUTING.md`
+  - Docs: `rg '\[audio\]|\[video\]|\[archive\]|\[dedup\]' --glob '!docs/superpowers/specs/**' --glob '!docs/superpowers/plans/**' docs/ README.md CONTRIBUTING.md`
   - pyproject.toml: `rg '^\s*(audio|video|archive|dedup)\s*=' pyproject.toml` (no old extra definitions)
-  - CI matrix: `rg '"audio"|"video"|"archive"|"dedup"' .github/workflows/ci-extras.yml` (no old matrix entries)
+  - CI matrix: `rg 'extra:\s*(audio|video|archive|dedup)\b' .github/workflows/ci-extras.yml` (no old YAML matrix entries)
+  - Source + tests: `rg '"audio"|"video"|"archive"|"dedup"' src/cli/doctor.py tests/unit/test_doctor_registry.py` returns zero hits
   - Test canaries: all four old files absent (`test ! -e tests/extras/test_extras_audio.py && echo "audio: absent (OK)"`, same for video, archive, dedup)

--- a/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
+++ b/docs/superpowers/specs/2026-04-19-install-size-epic-design.md
@@ -353,9 +353,11 @@ and update the workflow's `test_file` field (or add an explicit mapping) accordi
 
 ### Install-size CI gate
 
-Add a step to `ci.yml` on main-push that measures and enforces the install size floor.
-The gate must install from the **local checkout** (not from PyPI) so the measured
-artifact matches the branch under test:
+Add a step to `ci.yml` on **both `pull_request` and `push` to main** that measures and
+enforces the install size floor. Running on PRs is required — a main-push-only gate
+would allow a size regression to merge and discover the failure after the fact. The gate
+must install from the **local checkout** (not from PyPI) so the measured artifact
+matches the branch under test:
 
 ```bash
 # Run in a clean environment so dev/search extras installed by earlier CI
@@ -398,8 +400,7 @@ floor after measuring on CI.
 - [ ] `pip install "fo-core[dedup-text]"` installs and canary imports pass
 - [ ] `pip install "fo-core[dedup-image]"` installs and canary imports pass
 - [ ] `pymarkdown scan docs/` passes (zero violations)
-- [ ] No remaining `nltk` or `ensure_nltk_data` references in `src/`
-- [ ] `rg 'nltk|ensure_nltk_data|stub_nltk|mock_nltk|NLTK_AVAILABLE' --glob '!docs/superpowers/specs/**' .github/ tests/ docs/ README.md CONTRIBUTING.md` returns zero hits
+- [ ] `rg -i 'nltk|ensure_nltk_data|stub_nltk|mock_nltk' --glob '!docs/superpowers/specs/**' src/ .github/ tests/ docs/ README.md CONTRIBUTING.md pyproject.toml` returns zero hits
 - [ ] No remaining unconditional `import numpy` reachable from a default install
 - [ ] `.rtf` files routed through `utils/readers` dispatch table
 - [ ] All updated doc files verified against source (D1 rule)


### PR DESCRIPTION
## Summary

- Adds the install-size reduction epic design spec (`docs/superpowers/specs/2026-04-19-install-size-epic-design.md`)
- Adds the corresponding 17-task implementation plan (`docs/superpowers/plans/2026-04-19-install-size-reduction.md`)

Both documents are merged ahead of any implementation work so that spec and plan reviews stay independent from code review (avoids the sync issues from the previous epic pattern).

**Spec covers:** Problem statement, Option B decision (181 MB target, lightweight-format libs in default), dependency restructuring, code changes (NLTK→snowballstemmer, numpy import guards, RTF reader wiring), exhaustive NLTK audit commands, golden fixture approach, and exit gates.

**Plan covers:** 17 TDD tasks with full code, exact file paths, and run commands — from golden fixture capture through NLTK removal, pyproject.toml restructuring, CI workflow cleanup, test cleanup, subprocess smoke test, ci-extras rename, hermetic install-size gate, and docs updates.

## Test plan

- [x] No code changes — CI should pass trivially (only `.md` files added)
- [x] Verify both files render correctly in GitHub markdown preview
- [x] Verify `pymarkdown scan docs/` passes (enforced in pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive implementation plan and design specification for install size reduction initiative
  * Outlines strategy to reduce default install size from ~206 MB to ~181 MB
  * Specifies dependency restructuring and expanded default format support
  * Details code changes, test strategy, and CI workflow updates roadmap

<!-- end of auto-generated comment: release notes by coderabbit.ai -->