### PR TITLE
test(johnny-decimal): close final 2 uncovered branches to reach 100%

### DIFF
--- a/tests/methodologies/johnny_decimal/test_categories.py
+++ b/tests/methodologies/johnny_decimal/test_categories.py
@@ -566,3 +566,8 @@ class TestCategoriesCoverage:
             reasons=["test"],
         )
         assert isinstance(result.file_path, Path)
+
+    # Line 337: NumberingScheme.__post_init__ — empty name
+    def test_numbering_scheme_empty_name(self) -> None:
+        with pytest.raises(ValueError, match="Scheme name cannot be empty"):
+            NumberingScheme(name="", description="Test")

--- a/tests/methodologies/johnny_decimal/test_numbering.py
+++ b/tests/methodologies/johnny_decimal/test_numbering.py
@@ -414,3 +414,9 @@ class TestAdvancedScenarios:
         # Should get different category
         assert new_number.category != 5
         assert new_number.area == 10
+
+    def test_get_next_available_area_no_areas(self) -> None:
+        empty_scheme = NumberingScheme(name="Empty", description="No areas")
+        gen = JohnnyDecimalGenerator(empty_scheme)
+        with pytest.raises(InvalidNumberError, match="No areas defined in scheme"):
+            gen.get_next_available_area()


### PR DESCRIPTION
## Summary

- Adds test for `NumberingScheme.__post_init__` raising `ValueError` when `name` is empty (`categories.py:337`)
- Adds test for `JohnnyDecimalGenerator.get_next_available_area` raising `InvalidNumberError` when the scheme has no areas defined (`numbering.py:108`)

Both were the last two uncovered branches in the Johnny Decimal module. All 11 files now report 100% line and branch coverage.

## Test plan

- [x] `pytest tests/methodologies/johnny_decimal/ --cov=src/methodologies/johnny_decimal --cov-branch` — all 11 files at 100%, 426 tests pass
- [x] `ruff check` and `ruff format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for NumberingScheme validation when the name is empty.
  * Added test coverage for error handling when no areas are defined in a numbering scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->