### PR TITLE
chore(patterns): tighten generation-pattern rules and CI guardrails from PR-review audit

### DIFF
--- a/.claude/rules/feature-generation-patterns.md
+++ b/.claude/rules/feature-generation-patterns.md
@@ -119,7 +119,11 @@ with self._lock:
 **Pre-generation checklist for shared state**:
 - [ ] Multiple threads access this variable? → Lock required
 - [ ] Read-modify-write sequence? → Must be atomic (lock or atomic op)
-- [ ] File write? → Use temp file + `os.replace()` pattern
+- [ ] File write? → Use temp file + `os.replace()` pattern. **This applies to
+      every persistent file you write: cache files, embedding indexes, coverage
+      baselines, module-floor snapshots, history databases, and one-off scripts
+      that produce a file another tool consumes.** A mid-write crash or a
+      concurrent CI job truncates the file; downstream tooling then reads garbage.
 - [ ] `@lru_cache` on a function reading env vars? → Remove cache
 
 ---
@@ -263,12 +267,15 @@ class FileOrganizer:
 
 ---
 
-## Pattern F9: DYNAMIC_IMPORT_ANTIPATTERN — 11 findings
+## Pattern F9: DYNAMIC_IMPORT_ANTIPATTERN — 14 findings
 
-**What it is**: `__import__()` used inline (e.g., in `default_factory` lambdas)
-instead of top-level `import` statements. Breaks static analysis and mypy.
+**What it is**: Imports placed somewhere other than the top of the module — either
+`__import__()` used inline in factory lambdas, or `from X import Y` / `import X`
+statements deferred inside a function/method body. Breaks static analysis (mypy can't
+see the binding), hides dependency graphs from tools like `deptry`, and forces the
+import to re-execute on every call.
 
-**Bad**:
+**Bad — `__import__()` inline**:
 
 ```python
 @dataclass
@@ -276,18 +283,57 @@ class Config:
     dirs: Any = field(default_factory=lambda: __import__("platformdirs").user_data_dir("app"))
 ```
 
+**Bad — function-scoped import** (from PR #48 transcriber/embedder/bm25):
+
+```python
+class Transcriber:
+    def _load_model(self) -> None:
+        from faster_whisper import WhisperModel   # deferred — mypy loses the type,
+        self._model = WhisperModel(...)           # deptry can't see the dep
+
+class BM25Index:
+    def build(self, files: list[Path]) -> None:
+        from rank_bm25 import BM25Okapi           # re-imports on every build call
+        self._index = BM25Okapi(...)
+```
+
 **Good**:
 
 ```python
-import platformdirs
+# Top-level import with an explicit optional-dependency guard
+try:
+    import platformdirs
+    HAS_PLATFORMDIRS = True
+except ImportError:
+    platformdirs = None  # type: ignore[assignment]
+    HAS_PLATFORMDIRS = False
 
 @dataclass
 class Config:
     dirs: str = field(default_factory=lambda: platformdirs.user_data_dir("app"))
+
+# For optional deps that genuinely require lazy loading (large models, CLI startup
+# time), wrap the import in a module-level helper so it executes at most once and the
+# rationale is documented:
+_WhisperModel = None  # type: ignore[assignment]
+
+def _get_whisper_model_class():
+    """Lazy import: faster_whisper pulls in torch (~1 GB) and delays CLI startup."""
+    global _WhisperModel
+    if _WhisperModel is None:
+        from faster_whisper import WhisperModel  # documented lazy loader
+        _WhisperModel = WhisperModel
+    return _WhisperModel
 ```
 
-**Pre-generation check**: Never use `__import__()` inline. Use `try/except ImportError`
-for optional deps instead.
+**Pre-generation check**:
+- Never use `__import__()` inline.
+- Never write `from X import Y` or `import X` inside a function body unless you are
+  implementing a _documented_ lazy loader (expensive import, CLI startup cost, or
+  unavoidable circular dependency). If you do, wrap it in a module-level helper with
+  a one-line comment explaining why the top-level import was rejected.
+- For optional deps, the correct pattern is a top-level `try/except ImportError` with
+  an `HAS_X` flag — not a deferred in-function import.
 
 ---
 
@@ -328,12 +374,12 @@ flow, re-read the docstring and update it to match.
 For every new feature:
 
 1. **F4**: Path from user input? Config bypassed? API key near a logger? → Security checklist
-2. **F3**: Shared state? → Lock required; file write? → temp + `os.replace()`
-3. **F1**: Every external call → what exception, is it handled?
+2. **F3**: Shared state? → Lock required; file write (cache/index/baseline/script output)? → temp + `os.replace()`
+3. **F1**: Every external call → what exception, is it handled? Does the `except` leave any symbol undefined for downstream use?
 4. **F2**: Every function signature → concrete `->` return type
 5. **F5**: `ConfigManager` / `AppConfig` already own this value?
-6. **F9**: `__import__()` inline? → Move to top-level import
+6. **F9**: `__import__()` inline OR `from X import Y` inside a function body? → Top-level import (or documented lazy-loader helper)
 7. **F10**: Changed `except` / return type / control flow? → Update docstring
 8. **F4+**: Writing search/index code? → Apply `search-generation-patterns.md`
 
-**Last audited PR**: #23
+**Last audited PR**: #140 (PR review cycle 2026-03-21 to 2026-04-21)

--- a/.claude/rules/test-generation-patterns.md
+++ b/.claude/rules/test-generation-patterns.md
@@ -405,6 +405,215 @@ def test_is_resolve_path_call_does_not_match_arbitrary_receiver():
 
 ---
 
+## Pattern T11: PRAGMA_ON_TESTED_BRANCH
+
+**What it is**: `# pragma: no cover` added to a branch that is already exercised by a
+dedicated test. The branch still executes (and counts toward runtime coverage), but the
+pragma hides it from the coverage report — which means a future refactor can drop the
+test without the coverage metric noticing.
+
+**Bad** (from PR #140 `src/methodologies/johnny_decimal/categories.py`):
+
+```python
+def __eq__(self, other: object) -> bool:
+    if not isinstance(other, JohnnyDecimalNumber):  # pragma: no cover
+        return NotImplemented
+    return self.area == other.area and ...
+```
+
+But `test_categories.py::test_jd_number_eq_not_implemented` explicitly calls
+`num.__eq__("not a jd number")` and asserts `NotImplemented`. The pragma is wrong:
+the branch is tested.
+
+**Good**:
+
+```python
+def __eq__(self, other: object) -> bool:
+    if not isinstance(other, JohnnyDecimalNumber):
+        return NotImplemented   # no pragma — this branch is exercised by tests
+    return self.area == other.area and ...
+```
+
+**Pre-generation check**: Before adding `# pragma: no cover`, search test files for the
+enclosing function/method name. If any test references it, the pragma is wrong — either
+the branch is tested, or the test is broken (fix the test, don't hide the branch).
+
+```bash
+# Quick check for the enclosing function
+rg "def <function_name>\(" tests/
+```
+
+Legitimate uses of `# pragma: no cover`: truly unreachable defensive branches
+(e.g. `if TYPE_CHECKING:`), platform-specific code blocks not exercised in CI, and
+`@overload` stubs. When in doubt, write the test instead of adding the pragma.
+
+---
+
+## Pattern T12: FIXTURE_STATE_LEAK
+
+**What it is**: A test snapshots shared singleton/module state with the intent to
+restore it, but either (a) never uses the snapshot in teardown, (b) restores only the
+top-level key leaving sub-modules patched, or (c) silently swallows setup failures
+and still yields. Leaks cross-test state under xdist and produces order-dependent
+failures.
+
+This is distinct from xdist-safe-patterns Pattern 2 (which covers _missing_ restoration
+of `sys.modules` sub-modules) — T12 adds the "snapshot-but-never-used" and "restoration
+that partially succeeds" variants.
+
+**Bad — snapshot never used** (from PR #61):
+
+```python
+@pytest.fixture
+def clean_registry():
+    original_providers = _registry.registered_providers  # snapshotted
+    yield
+    _registry._reset_for_testing()
+    _registry._register_builtins()
+    # original_providers never restored — any custom registrations at import time
+    # are silently lost for the rest of the session
+```
+
+**Bad — partial restoration** (from PR #76):
+
+```python
+saved_sklearn = sys.modules.get("sklearn")
+# ... mutate sys.modules["sklearn"] and sklearn.feature_extraction ...
+if saved_sklearn is not None:
+    sys.modules["sklearn"] = saved_sklearn
+    # sys.modules["sklearn.feature_extraction"] still points at the mock —
+    # later tests in this worker will load the stale mock
+```
+
+**Bad — swallow-and-yield** (from PR #76):
+
+```python
+@pytest.fixture
+def ensure_nltk():
+    try:
+        nltk.download("punkt_tab", quiet=True)
+    except Exception:
+        pass  # silent failure — test still yields, assertion later fails opaquely
+    yield
+```
+
+**Good**:
+
+```python
+# Use patch.dict for sys.modules — atomic restore on exit, including sub-modules
+with patch.dict(sys.modules, {
+    "sklearn": mock_sklearn,
+    "sklearn.feature_extraction": mock_sklearn.feature_extraction,
+    "sklearn.feature_extraction.text": mock_sklearn.feature_extraction.text,
+}):
+    yield mock_sklearn
+
+# For singletons: restore the actual snapshot, not just reset
+@pytest.fixture
+def clean_registry():
+    original = dict(_registry.registered_providers)
+    try:
+        yield
+    finally:
+        _registry._reset_for_testing()
+        for name, provider in original.items():
+            _registry.register(name, provider)
+```
+
+**Pre-generation check**: For every `<var> = sys.modules.get(...)` or
+`<var> = <singleton>.<field>` in a test, ensure `<var>` is actually referenced in the
+teardown. If it isn't, the snapshot is a no-op.
+
+**Cross-reference**: `xdist-safe-patterns.md` Pattern 2 (sys.modules restoration) and
+Pattern 3 (shared singletons).
+
+---
+
+## Pattern T13: HARDCODED_TEST_DATA_PATHS
+
+**What it is**: Hardcoded `/tmp/`, `/dev/null`, or other absolute path literals inside
+test _data_ (dataclass fields, fixture dicts, parametrize values). Ruff `S108` catches
+`tempfile.mktemp` and direct `open()` on hardcoded temp paths, but misses string
+literals passed to constructors. The G1 pre-commit hook greps diff for
+`/tmp/|/Users/|/home/` but only scans _added_ lines — older pre-existing literals in a
+file being edited are not re-checked.
+
+Impact: Windows-unportable tests, xdist file collisions, and tests that pass locally
+then fail in clean CI containers.
+
+**Bad** (from PR #61):
+
+```python
+def test_update_patterns(self, tmp_path: Path) -> None:
+    entry = FeedbackEntry(file_path="/tmp/f.txt")   # S108 misses this
+    tracker.add(entry)
+
+def test_null_output(self):
+    with open("/dev/null", "w") as f:               # not portable to Windows CI
+        process_file(f)
+```
+
+**Good**:
+
+```python
+def test_update_patterns(self, tmp_path: Path) -> None:
+    entry = FeedbackEntry(file_path=str(tmp_path / "f.txt"))
+    tracker.add(entry)
+
+def test_null_output(self, tmp_path: Path):
+    sink = tmp_path / "sink.txt"
+    with sink.open("w") as f:
+        process_file(f)
+```
+
+**Pre-generation check**: Any time you write a path string in a test, ask: *"Could
+this be `tmp_path / 'X'` instead?"* If yes — use `tmp_path`. The only acceptable
+hardcoded paths in tests are:
+- `/` root-based fixtures that are explicitly path-traversal test inputs
+  (e.g. `"/etc/passwd"` as an _input_ to a validator, never as an output target)
+- Path-validation test constants clearly marked as adversarial inputs
+
+---
+
+## Pattern T14: GENERATOR_THROW_FALSE_RAISE
+
+**What it is**: `(_ for _ in ()).throw(SomeError(...))` used as a mock side-effect.
+The expression _returns a generator object_; it does not raise. When the production
+code invokes it — e.g. `netCDF4.Dataset(path)` — it receives the generator (truthy,
+and `__enter__`-capable in some codepaths) and the error branch is never exercised.
+The test still passes green, but the exception-handling path is untested.
+
+**Bad** (from PR #82, scientific reader tests):
+
+```python
+sci_module.netCDF4.Dataset = lambda *a, **k: (_ for _ in ()).throw(OSError("boom"))
+
+# Production code:
+with netCDF4.Dataset(path) as ds:   # receives a generator, not an OSError
+    ...
+# Test passes, but the OSError-handling branch never ran.
+```
+
+**Good**:
+
+```python
+def _raise_oserror(*a, **k):
+    raise OSError("boom")
+sci_module.netCDF4.Dataset = _raise_oserror
+
+# Or with Mock:
+from unittest.mock import MagicMock
+sci_module.netCDF4.Dataset = MagicMock(side_effect=OSError("boom"))
+```
+
+**Pre-generation check**: The literal pattern `(_ for _ in ()).throw` is always wrong
+in a test mock. If you want a callable that raises, write a named function or use
+`MagicMock(side_effect=...)`.
+
+Automatable: a grep guardrail bans this pattern outright (see `tests/ci/test_test_quality_guardrails.py`).
+
+---
+
 ## Rule of Thumb
 
 For every assertion, ask:
@@ -417,5 +626,9 @@ For every assertion, ask:
 7. **T8**: "Does this test file import an optional dep at module level without a guard?"
 8. **T9**: "Is `assert X >= 0` where X is a length/count/duration? Replace with a meaningful bound."
 9. **T10**: "Is this a predicate in detector code? Add a negative case with the same surface shape but wrong context."
+10. **T11**: "About to add `# pragma: no cover`? Grep tests for the enclosing function — if any hits, the pragma is wrong."
+11. **T12**: "Snapshotted shared state? Make sure teardown actually restores the snapshot (including sub-module keys)."
+12. **T13**: "Hardcoded path string in test data? Use `tmp_path` instead."
+13. **T14**: "`(_ for _ in ()).throw(...)` — never. Use a named function or `MagicMock(side_effect=...)`."
 
-**Last audited PR**: #929
+**Last audited PR**: #140 (PR review cycle 2026-03-21 to 2026-04-21)

--- a/.claude/rules/test-generation-patterns.md
+++ b/.claude/rules/test-generation-patterns.md
@@ -16,10 +16,16 @@ Before writing any test:
 - [ ] Does each assertion verify a *specific value*, not just a type or non-None? (T1 — use Fix-by-type table)
 - [ ] After calling a mutating method, does the test verify the mutation persisted? (T2)
 - [ ] Are mocks asserted with exact call args, not just `call_count >= 1`? (T3)
+- [ ] Is any assertion an `X or isinstance(X, T)` or `X is not None or X is None` tautology? (T4 / T9)
 - [ ] Is `pytest.importorskip` scoped to only the classes that use the optional dep? (T5)
+- [ ] Does any `try/except` guard an exception the production code never raises? (T7)
 - [ ] Does this file import an optional dep at module level without `pytest.importorskip`? (T8)
 - [ ] Does any assertion use `>= 0` on a length, count, or duration? Replace with a meaningful bound. (T9)
 - [ ] For every `_is_X()` / `_has_X()` predicate in detector/guardrail code — is there a negative test case that passes the same surface shape with the wrong context and asserts `False`? (T10)
+- [ ] About to add `# pragma: no cover`? Grep `tests/` for the enclosing function first. (T11)
+- [ ] Snapshotting singleton or `sys.modules` state? Confirm teardown actually restores it (including sub-module keys). (T12)
+- [ ] Any hardcoded `/tmp/` or `/dev/null` path literals in test data? Use `tmp_path`. (T13)
+- [ ] Any `(_ for _ in ()).throw(...)` mock side-effect? Use a named function or `MagicMock(side_effect=...)`. (T14)
 
 ---
 

--- a/.claude/rules/test-generation-patterns.md
+++ b/.claude/rules/test-generation-patterns.md
@@ -584,20 +584,26 @@ hardcoded paths in tests are:
 ## Pattern T14: GENERATOR_THROW_FALSE_RAISE
 
 **What it is**: `(_ for _ in ()).throw(SomeError(...))` used as a mock side-effect.
-The expression _returns a generator object_; it does not raise. When the production
-code invokes it — e.g. `netCDF4.Dataset(path)` — it receives the generator (truthy,
-and `__enter__`-capable in some codepaths) and the error branch is never exercised.
-The test still passes green, but the exception-handling path is untested.
+
+Technically the expression _does_ raise — `generator.throw(exc)` on a fresh
+generator-expression starts it and propagates the exception back to the caller.
+The pattern is banned anyway because:
+
+1. **It reads as a no-op.** The five-token idiom is easily misread as "create a
+   generator and configure it to throw later" — which is exactly why reviewers
+   repeatedly flag it as a bug (and why the original PR-review comment for this
+   pattern was itself wrong about the runtime behavior).
+2. **Clearer alternatives exist.** `MagicMock(side_effect=exc)` or a named
+   `def _raise(): raise exc` helper conveys intent in one read.
+3. **It silently couples test correctness to a Python-implementation detail** —
+   `generator.throw` on an unstarted generator is "raises into the first yield
+   point, which is the start of the body"; if that ever changes, every use of
+   this idiom breaks at once.
 
 **Bad** (from PR #82, scientific reader tests):
 
 ```python
 sci_module.netCDF4.Dataset = lambda *a, **k: (_ for _ in ()).throw(OSError("boom"))
-
-# Production code:
-with netCDF4.Dataset(path) as ds:   # receives a generator, not an OSError
-    ...
-# Test passes, but the OSError-handling branch never ran.
 ```
 
 **Good**:

--- a/.claude/rules/xdist-safe-patterns.md
+++ b/.claude/rules/xdist-safe-patterns.md
@@ -64,6 +64,11 @@ def mock_sklearn() -> Generator[MagicMock, None, None]:
 **Rule**: When mocking a package with sub-modules, list ALL sub-module keys that the
 code under test imports, not just the top-level key.
 
+**Watch for**: _partial_ restoration — code that saves the top-level key and restores
+it in teardown, but mutated sub-module keys during the test body. The top-level
+restore looks correct at a glance; the sub-module stays patched for the rest of the
+xdist worker. See also `test-generation-patterns.md` T12 FIXTURE_STATE_LEAK.
+
 ---
 
 ## Pattern 3: Shared Singletons
@@ -90,6 +95,32 @@ Run with: `pytest ... --dist=loadgroup -n auto`
 def reset_registry() -> Generator[None, None, None]:
     yield
     _registry._reset_for_testing()
+```
+
+**Watch for**: _snapshot-but-never-used_ teardown — capturing the singleton's initial
+state into a local variable and then never restoring from it. Pattern looks like
+cleanup but is a no-op. See `test-generation-patterns.md` T12 FIXTURE_STATE_LEAK.
+
+```python
+# BAD — snapshot ignored
+@pytest.fixture
+def clean_registry():
+    original = _registry.registered_providers  # captured, never used
+    yield
+    _registry._reset_for_testing()
+    _registry._register_builtins()             # re-registers defaults only;
+                                                # any pre-existing custom provider is lost
+
+# GOOD — snapshot actually restored
+@pytest.fixture
+def clean_registry():
+    original = dict(_registry.registered_providers)
+    try:
+        yield
+    finally:
+        _registry._reset_for_testing()
+        for name, provider in original.items():
+            _registry.register(name, provider)
 ```
 
 ---

--- a/.claude/scripts/check-stale-doc-refs.sh
+++ b/.claude/scripts/check-stale-doc-refs.sh
@@ -111,9 +111,15 @@ done
 
 # --- Check 4: Removed features / terminology drift ---
 # Each entry: "grep-E-pattern:reason". Patterns use POSIX-extended regex
-# (as accepted by `grep -E`).  Lines inside fenced code blocks and lines
-# containing explicit "removed", "deprecated", "was ", "formerly",
-# "no longer", or "previously" are exempt so we can still document history.
+# (as accepted by `grep -E`).
+#
+# NOTE: `reason` must not contain a literal ':' — the split is
+# ${entry%%:*} / ${entry#*:}, so a colon in the reason truncates it.
+#
+# Exempt lines: fenced code blocks, and lines explicitly documenting the
+# change in history (e.g. "was removed", "renamed to X", "deprecated").
+# The exemption regex below is deliberately narrow — using bare "was\b"
+# would exempt almost any prose paragraph.
 REMOVED_TERMS=(
   '\[parsers\]:the "parsers" extra was removed; valid extras are dev cloud llama mlx claude audio video dedup archive scientific cad build search all'
   '\[gui\]:fo-core is CLI-only; no [gui] extra exists'
@@ -124,10 +130,8 @@ REMOVED_TERMS=(
   '\bmarketplace\b:the marketplace CLI command was removed'
 )
 
-# Strip fenced-code-block content from a file so we only search prose.
-_strip_fences() {
-  awk '/^```/ { in_fence = !in_fence; next } !in_fence' "$1"
-}
+# Matches history-context phrases only — not every sentence that uses "was".
+HISTORY_EXEMPT_REGEX='\b(was|were|is|are) (removed|deprecated|renamed|replaced|deleted|dropped|retired)\b|\bno longer\b|\bformerly\b|\bpreviously\b'
 
 for entry in "${REMOVED_TERMS[@]}"; do
   pattern="${entry%%:*}"
@@ -144,7 +148,7 @@ for entry in "${REMOVED_TERMS[@]}"; do
       hits=$(git diff --cached --unified=0 -- "$md_file" 2>/dev/null \
         | grep -E '^\+' \
         | grep -v '^+++' \
-        | grep -v -E 'removed|deprecated|formerly|previously|no longer|was\b' \
+        | grep -v -E "$HISTORY_EXEMPT_REGEX" \
         | grep -E "$pattern" || true)
       if [[ -n "$hits" ]]; then
         echo "  ⚠️  $md_file → newly added line matches stale pattern '$pattern' ($reason)"
@@ -154,7 +158,7 @@ for entry in "${REMOVED_TERMS[@]}"; do
       # Full-scan mode: line-numbered output across the whole file.
       hits=$(cat -n "$full_path" 2>/dev/null \
         | awk '/^[[:space:]]*[0-9]+\t```/ { in_fence = !in_fence; next } !in_fence' \
-        | grep -v -E 'removed|deprecated|formerly|previously|no longer|was\b' \
+        | grep -v -E "$HISTORY_EXEMPT_REGEX" \
         | grep -E "$pattern" || true)
       if [[ -n "$hits" ]]; then
         while IFS= read -r hit; do

--- a/.claude/scripts/check-stale-doc-refs.sh
+++ b/.claude/scripts/check-stale-doc-refs.sh
@@ -145,11 +145,25 @@ for entry in "${REMOVED_TERMS[@]}"; do
     if $STAGED_ONLY; then
       # Only flag newly ADDED lines.  Pre-existing violations in files being
       # edited for unrelated reasons must not block the commit.
-      hits=$(git diff --cached --unified=0 -- "$md_file" 2>/dev/null \
-        | grep -E '^\+' \
-        | grep -v '^+++' \
-        | grep -v -E "$HISTORY_EXEMPT_REGEX" \
-        | grep -E "$pattern" || true)
+      #
+      # Fenced code blocks are exempt (docs often show the old term as a
+      # historical example, e.g. `ollama ls` inside a ```bash fence).  We
+      # compute the intersection of (a) lines added by the staged diff and
+      # (b) the post-staged file's non-fenced content.  Only lines in both
+      # sets — i.e. added to prose, not inside a fence — proceed to the
+      # pattern match.
+      non_fenced=$(git show ":$md_file" 2>/dev/null \
+        | awk '/^```/ { in_fence = !in_fence; next } !in_fence' || true)
+      added=$(git diff --cached --unified=0 -- "$md_file" 2>/dev/null \
+        | grep -E '^\+[^+]' | sed 's/^+//' || true)
+      if [[ -z "$added" || -z "$non_fenced" ]]; then
+        hits=""
+      else
+        prose_added=$(echo "$added" | grep -Fxf <(echo "$non_fenced") 2>/dev/null || true)
+        hits=$(echo "$prose_added" \
+          | grep -v -E "$HISTORY_EXEMPT_REGEX" \
+          | grep -E "$pattern" || true)
+      fi
       if [[ -n "$hits" ]]; then
         echo "  ⚠️  $md_file → newly added line matches stale pattern '$pattern' ($reason)"
         ERRORS=$((ERRORS + 1))

--- a/.claude/scripts/check-stale-doc-refs.sh
+++ b/.claude/scripts/check-stale-doc-refs.sh
@@ -109,10 +109,68 @@ for method in "${FALSE_METHODS[@]}"; do
   done <<< "$MD_FILES"
 done
 
+# --- Check 4: Removed features / terminology drift ---
+# Each entry: "grep-E-pattern:reason". Patterns use POSIX-extended regex
+# (as accepted by `grep -E`).  Lines inside fenced code blocks and lines
+# containing explicit "removed", "deprecated", "was ", "formerly",
+# "no longer", or "previously" are exempt so we can still document history.
+REMOVED_TERMS=(
+  '\[parsers\]:the "parsers" extra was removed; valid extras are dev cloud llama mlx claude audio video dedup archive scientific cad build search all'
+  '\[gui\]:fo-core is CLI-only; no [gui] extra exists'
+  '/plugins/:the plugin system was removed; fo-core has no plugin layer'
+  '\bFastAPI\b:fo-core is CLI-only; no FastAPI/uvicorn web server exists'
+  '\buvicorn\b:fo-core is CLI-only; no FastAPI/uvicorn web server exists'
+  '\bollama ls\b:correct command is "ollama list" (not "ollama ls")'
+  '\bmarketplace\b:the marketplace CLI command was removed'
+)
+
+# Strip fenced-code-block content from a file so we only search prose.
+_strip_fences() {
+  awk '/^```/ { in_fence = !in_fence; next } !in_fence' "$1"
+}
+
+for entry in "${REMOVED_TERMS[@]}"; do
+  pattern="${entry%%:*}"
+  reason="${entry#*:}"
+
+  while IFS= read -r md_file; do
+    [[ -z "$md_file" ]] && continue
+    full_path="$REPO_ROOT/$md_file"
+    [[ -f "$full_path" ]] || continue
+
+    if $STAGED_ONLY; then
+      # Only flag newly ADDED lines.  Pre-existing violations in files being
+      # edited for unrelated reasons must not block the commit.
+      hits=$(git diff --cached --unified=0 -- "$md_file" 2>/dev/null \
+        | grep -E '^\+' \
+        | grep -v '^+++' \
+        | grep -v -E 'removed|deprecated|formerly|previously|no longer|was\b' \
+        | grep -E "$pattern" || true)
+      if [[ -n "$hits" ]]; then
+        echo "  ⚠️  $md_file → newly added line matches stale pattern '$pattern' ($reason)"
+        ERRORS=$((ERRORS + 1))
+      fi
+    else
+      # Full-scan mode: line-numbered output across the whole file.
+      hits=$(cat -n "$full_path" 2>/dev/null \
+        | awk '/^[[:space:]]*[0-9]+\t```/ { in_fence = !in_fence; next } !in_fence' \
+        | grep -v -E 'removed|deprecated|formerly|previously|no longer|was\b' \
+        | grep -E "$pattern" || true)
+      if [[ -n "$hits" ]]; then
+        while IFS= read -r hit; do
+          line_num=$(echo "$hit" | awk '{print $1}')
+          echo "  ⚠️  $md_file:$line_num → stale reference matching '$pattern' ($reason)"
+          ERRORS=$((ERRORS + 1))
+        done <<< "$hits"
+      fi
+    fi
+  done <<< "$MD_FILES"
+done
+
 echo ""
 if [[ $ERRORS -gt 0 ]]; then
   echo "❌ Found $ERRORS stale reference(s) in documentation"
-  echo "   Fix these before committing, or add to DELETED_SYMBOLS/FALSE_METHODS if intentional."
+  echo "   Fix these before committing, or add to DELETED_SYMBOLS/FALSE_METHODS/REMOVED_TERMS if intentional."
   exit 1
 else
   echo "✓ No stale documentation references found"

--- a/.claude/scripts/check-stale-doc-refs.sh
+++ b/.claude/scripts/check-stale-doc-refs.sh
@@ -157,8 +157,15 @@ for entry in "${REMOVED_TERMS[@]}"; do
       # (common inside lists and blockquotes) as prose and flag their content.
       non_fenced=$(git show ":$md_file" 2>/dev/null \
         | awk '/^ ? ? ?```/ { in_fence = !in_fence; next } !in_fence' || true)
+      # Match every added line (prefix `+`) and strip the `+++ b/path` file
+      # header separately.  A previous `^\+[^+]` filter dropped any added line
+      # whose content itself started with `+` (appears as `++content` in the
+      # diff), producing a false negative when an author added e.g. bullet
+      # lines like `+ marketplace`.
       added=$(git diff --cached --unified=0 -- "$md_file" 2>/dev/null \
-        | grep -E '^\+[^+]' | sed 's/^+//' || true)
+        | grep -E '^\+' \
+        | grep -v -E '^\+\+\+ ' \
+        | sed 's/^+//' || true)
       if [[ -z "$added" || -z "$non_fenced" ]]; then
         hits=""
       else

--- a/.claude/scripts/check-stale-doc-refs.sh
+++ b/.claude/scripts/check-stale-doc-refs.sh
@@ -152,8 +152,11 @@ for entry in "${REMOVED_TERMS[@]}"; do
       # (b) the post-staged file's non-fenced content.  Only lines in both
       # sets — i.e. added to prose, not inside a fence — proceed to the
       # pattern match.
+      # CommonMark allows 0–3 spaces of indentation before a fence marker.
+      # Matching only column-0 fences would treat indented fenced blocks
+      # (common inside lists and blockquotes) as prose and flag their content.
       non_fenced=$(git show ":$md_file" 2>/dev/null \
-        | awk '/^```/ { in_fence = !in_fence; next } !in_fence' || true)
+        | awk '/^ ? ? ?```/ { in_fence = !in_fence; next } !in_fence' || true)
       added=$(git diff --cached --unified=0 -- "$md_file" 2>/dev/null \
         | grep -E '^\+[^+]' | sed 's/^+//' || true)
       if [[ -z "$added" || -z "$non_fenced" ]]; then
@@ -170,8 +173,10 @@ for entry in "${REMOVED_TERMS[@]}"; do
       fi
     else
       # Full-scan mode: line-numbered output across the whole file.
+      # After `cat -n`, content starts after the tab; allow 0–3 spaces of
+      # indentation before the fence marker (CommonMark rule).
       hits=$(cat -n "$full_path" 2>/dev/null \
-        | awk '/^[[:space:]]*[0-9]+\t```/ { in_fence = !in_fence; next } !in_fence' \
+        | awk '/^[[:space:]]*[0-9]+\t ? ? ?```/ { in_fence = !in_fence; next } !in_fence' \
         | grep -v -E "$HISTORY_EXEMPT_REGEX" \
         | grep -E "$pattern" || true)
       if [[ -n "$hits" ]]; then

--- a/.claude/scripts/check-stale-doc-refs.sh
+++ b/.claude/scripts/check-stale-doc-refs.sh
@@ -143,36 +143,55 @@ for entry in "${REMOVED_TERMS[@]}"; do
     [[ -f "$full_path" ]] || continue
 
     if $STAGED_ONLY; then
-      # Only flag newly ADDED lines.  Pre-existing violations in files being
-      # edited for unrelated reasons must not block the commit.
+      # Fence- and line-identity-aware staged-only scan.
       #
-      # Fenced code blocks are exempt (docs often show the old term as a
-      # historical example, e.g. `ollama ls` inside a ```bash fence).  We
-      # compute the intersection of (a) lines added by the staged diff and
-      # (b) the post-staged file's non-fenced content.  Only lines in both
-      # sets — i.e. added to prose, not inside a fence — proceed to the
-      # pattern match.
-      # CommonMark allows 0–3 spaces of indentation before a fence marker.
-      # Matching only column-0 fences would treat indented fenced blocks
-      # (common inside lists and blockquotes) as prose and flag their content.
-      non_fenced=$(git show ":$md_file" 2>/dev/null \
-        | awk '/^ ? ? ?```/ { in_fence = !in_fence; next } !in_fence' || true)
-      # Match every added line (prefix `+`) and strip the `+++ b/path` file
-      # header separately.  A previous `^\+[^+]` filter dropped any added line
-      # whose content itself started with `+` (appears as `++content` in the
-      # diff), producing a false negative when an author added e.g. bullet
-      # lines like `+ marketplace`.
-      added=$(git diff --cached --unified=0 -- "$md_file" 2>/dev/null \
-        | grep -E '^\+' \
-        | grep -v -E '^\+\+\+ ' \
-        | sed 's/^+//' || true)
-      if [[ -z "$added" || -z "$non_fenced" ]]; then
+      # 1. Compute line numbers in the post-staged file that are NOT inside a
+      #    fenced block.  Fence openers per CommonMark: 0-3 spaces of indent,
+      #    then 3+ backticks or 3+ tildes.  Previous regex matched only
+      #    exactly three backticks at column 0, missing indented fences,
+      #    tilde fences (`~~~`), and longer-backtick fences (` ```` `).
+      # 2. Parse the `@@ -L,N +M,P @@` hunk headers to get the set of added
+      #    line numbers in the post-staged file.
+      # 3. Intersect the two sets to get "added prose lines".  Previous
+      #    approach intersected by raw text (`grep -Fxf`), which lost line
+      #    identity: an added fenced line whose content happened to match
+      #    unchanged prose was wrongly flagged.  (Codex PR #144 threads.)
+      non_fenced_linenos=$(git show ":$md_file" 2>/dev/null | awk '
+        /^[[:space:]]{0,3}(`{3,}|~{3,})/ { in_fence = !in_fence; next }
+        !in_fence { print NR }
+      ' || true)
+      added_linenos=$(git diff --cached --unified=0 -- "$md_file" 2>/dev/null | awk '
+        /^@@/ {
+          if (match($0, /\+[0-9]+(,[0-9]+)?/)) {
+            spec = substr($0, RSTART + 1, RLENGTH - 1)
+            split(spec, parts, ",")
+            start = parts[1] + 0
+            count = (length(parts) > 1) ? (parts[2] + 0) : 1
+            for (i = 0; i < count; i++) print start + i
+          }
+        }
+      ' || true)
+      if [[ -z "$non_fenced_linenos" || -z "$added_linenos" ]]; then
         hits=""
       else
-        prose_added=$(echo "$added" | grep -Fxf <(echo "$non_fenced") 2>/dev/null || true)
-        hits=$(echo "$prose_added" \
-          | grep -v -E "$HISTORY_EXEMPT_REGEX" \
-          | grep -E "$pattern" || true)
+        # Hashmap-based set intersection — order-independent, avoids the
+        # numeric-vs-lexical sort pitfall that `comm` would hit.
+        prose_added_linenos=$(awk 'NR==FNR { seen[$0]=1; next } $0 in seen' \
+          <(echo "$non_fenced_linenos") <(echo "$added_linenos"))
+        if [[ -z "$prose_added_linenos" ]]; then
+          hits=""
+        else
+          # Space-separate line numbers before passing via `-v`: BSD awk warns
+          # on embedded newlines in `-v` values.
+          prose_added_linenos_str=$(echo "$prose_added_linenos" | tr '\n' ' ')
+          prose_added=$(git show ":$md_file" 2>/dev/null | awk -v LINES="$prose_added_linenos_str" '
+            BEGIN { n = split(LINES, arr, " "); for (i = 1; i <= n; i++) if (arr[i] != "") want[arr[i]+0] = 1 }
+            want[NR] { print }
+          ' || true)
+          hits=$(echo "$prose_added" \
+            | grep -v -E "$HISTORY_EXEMPT_REGEX" \
+            | grep -E "$pattern" || true)
+        fi
       fi
       if [[ -n "$hits" ]]; then
         echo "  ⚠️  $md_file → newly added line matches stale pattern '$pattern' ($reason)"
@@ -180,10 +199,10 @@ for entry in "${REMOVED_TERMS[@]}"; do
       fi
     else
       # Full-scan mode: line-numbered output across the whole file.
-      # After `cat -n`, content starts after the tab; allow 0–3 spaces of
-      # indentation before the fence marker (CommonMark rule).
+      # After `cat -n`, content starts after the tab; accept 0-3 spaces of
+      # indent and 3+ backticks or 3+ tildes as a fence marker.
       hits=$(cat -n "$full_path" 2>/dev/null \
-        | awk '/^[[:space:]]*[0-9]+\t ? ? ?```/ { in_fence = !in_fence; next } !in_fence' \
+        | awk '/^[[:space:]]*[0-9]+\t[[:space:]]{0,3}(`{3,}|~{3,})/ { in_fence = !in_fence; next } !in_fence' \
         | grep -v -E "$HISTORY_EXEMPT_REGEX" \
         | grep -E "$pattern" || true)
       if [[ -n "$hits" ]]; then

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -17,9 +17,9 @@ Checks changed code against the project's documented anti-pattern rules. Catches
 
 /simplify uses generic software engineering judgment. The pre-commit script uses regex/lint rules. Neither reads the project's anti-pattern documentation:
 
-- `.claude/rules/feature-generation-patterns.md` (F1-F9)
-- `memory/test-generation-patterns.md`
-- `.claude/rules/ci-generation-patterns.md` (C1-C6)
+- `.claude/rules/feature-generation-patterns.md` (F1-F10)
+- `.claude/rules/test-generation-patterns.md` (T1-T14)
+- `.claude/rules/ci-generation-patterns.md` (C1-C8)
 
 This skill bridges that gap by checking new code against documented patterns that caused past PR review churn.
 
@@ -65,16 +65,29 @@ For each finding, cite the exact file, line number, and which pattern it violate
 
 #### Agent 2: Test Generation Audit
 
-Read `memory/test-generation-patterns.md` in full, then audit ALL test code changes against each anti-pattern:
+Read `.claude/rules/test-generation-patterns.md` in full, then audit ALL test code changes against each anti-pattern (T1-T14):
 
-- **Weak assertions**: `assert result is not None` instead of `assert result is mock_obj`. `assert X.call_count > 0` without verifying args/payload.
-- **Missing mock verification**: Mock declared in `@patch` decorator but never asserted (no `assert_called_once_with`, no `assert_not_called`).
-- **Missing negative assertions**: Test verifies the happy path but doesn't assert the unhappy path was NOT taken (e.g., verifies AI processing was called but doesn't check fallback was NOT called).
-- **Permissive filters**: Looping through results and checking `if X` instead of asserting exact count or using `mock.assert_not_called()`.
+- **T1 SOLE_ISINSTANCE**: `assert isinstance(x, T)` as the only assertion — verifies the type but not the value.
+- **T2 MISSING_STATE_VERIFICATION**: Mutating method called but only return value checked — state change not verified.
+- **T3 MOCK_CALL_COUNT_WITHOUT_PAYLOAD**: `mock.assert_called_once()` without `_with(...)`, or `call_count >= 1` without payload verification.
+- **T4 TAUTOLOGICAL_DISJUNCTION**: `assert X or isinstance(X, T)` always passes for None + type combinations.
+- **T5 IMPORTSKIP_SCOPE**: `pytest.importorskip` at module level in a file with classes that don't need the optional dep.
+- **T7 UNVERIFIED_EXCEPTION_GUARD**: `try/except SomeError: pass` guarding an exception production code never raises.
+- **T8 MISSING_IMPORT_GUARD**: Test file imports an optional dep at module level without `pytest.importorskip`.
+- **T9 VACUOUS_TAUTOLOGY**: `assert X >= 0` on lengths/counts/durations; `assert X is not None or X is None`.
+- **T10 PREDICATE_MISSING_NEGATIVE_CASE**: `_is_X()` predicate tested only with positive inputs; no test asserts False for same-shape-wrong-context.
+- **T11 PRAGMA_ON_TESTED_BRANCH**: `# pragma: no cover` added to a branch that already has a dedicated test.
+- **T12 FIXTURE_STATE_LEAK**: Singleton/sys.modules snapshot captured but never restored; partial sub-module restoration.
+- **T13 HARDCODED_TEST_DATA_PATHS**: `/tmp/`, `/dev/null` literals in test dataclass fields or fixture dicts (use `tmp_path`).
+- **T14 GENERATOR_THROW_FALSE_RAISE**: `(_ for _ in ()).throw(X(...))` as a mock side-effect — returns generator, never raises.
+
+Also check generic test-quality concerns beyond the numbered patterns:
+- **Missing mock verification**: Mock declared in `@patch` decorator but never asserted.
+- **Missing negative assertions**: Happy path verified but unhappy path not asserted as *not* taken.
 - **Private attribute access**: `assert obj._private_attr == val` instead of testing via public API.
-- **Resource leaks in tests**: File-backed SQLAlchemy engines without `engine.dispose()`, temp files without cleanup.
+- **Resource leaks**: File-backed engines without `.dispose()`, temp files without cleanup.
 - **Dead test helpers**: Unused helper methods left in test files.
-- **Missing direct unit tests**: New methods only exercised indirectly through integration tests, not tested directly.
+- **Missing direct unit tests**: New methods only exercised indirectly through integration tests.
 
 For each finding, cite the exact test file, test method, line number, and which anti-pattern it matches.
 
@@ -100,7 +113,7 @@ After fixes, re-run affected tests to confirm nothing broke.
 |------|----------------|---------------|
 | Pre-commit script | Syntax, formatting, lint, test pass/fail | Semantic correctness, assertion quality, exception scope |
 | /simplify | Generic reuse, copy-paste, efficiency | Project-specific anti-patterns, test assertion quality |
-| **/audit** | **F1-F9 feature patterns, test anti-patterns, CI patterns** | Generic code quality (that's /simplify's job) |
+| **/audit** | **F1-F10 feature patterns, T1-T14 test patterns, C1-C8 CI patterns** | Generic code quality (that's /simplify's job) |
 
 ## Integration with /pr-prep
 

--- a/.gitignore
+++ b/.gitignore
@@ -78,9 +78,6 @@ output/
 coverage.xml
 htmlcov/
 
-# MkDocs build output
-site/
-
 # Backup files and directories
 *.bak
 .fo_backups/
@@ -117,8 +114,6 @@ __snapshots__/
 # Node modules (if not already there)
 node_modules/
 
-# MkDocs build output
-site/
 .claude/worktrees/
 /.worktrees/
 
@@ -140,4 +135,3 @@ coverage.json
 # Superpowers scaffolding (implementation artifacts, not permanent docs)
 docs/superpowers/plans/
 docs/superpowers/specs/
-.worktrees/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,19 @@ repos:
         pass_filenames: false
 
       # ----------------------------------------------------------------
+      # G3: No duplicate entries in .gitignore
+      # Detected repeatedly in PR review (e.g. PR #99 and #102 both had
+      # a duplicated `.worktrees/` line).  Ignores blank lines and comments.
+      # ----------------------------------------------------------------
+      - id: no-duplicate-gitignore
+        name: no duplicate .gitignore entries (G3)
+        entry: >
+          bash -c "DUPES=$(awk 'NF && !/^#/' .gitignore | sort | uniq -d); if [ -n \"$DUPES\" ]; then printf 'ERROR: duplicate .gitignore entries:\n%s\n' \"$DUPES\"; exit 1; fi"
+        language: system
+        pass_filenames: false
+        files: ^\.gitignore$
+
+      # ----------------------------------------------------------------
       # No build artifacts committed
       # Covers: .coverage, *.bak, *.pyc, *.pyo, coverage.xml, htmlcov/,
       #         __pycache__/, build/, dist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,12 +68,15 @@ repos:
       # ----------------------------------------------------------------
       # G3: No duplicate entries in .gitignore
       # Detected repeatedly in PR review (e.g. PR #99 and #102 both had
-      # a duplicated `.worktrees/` line).  Ignores blank lines and comments.
+      # a duplicated `.worktrees/` line).  Normalizes each entry before
+      # comparison: strips inline comments (`pattern  # note`) and trims
+      # trailing whitespace so `foo` vs `foo ` are treated as identical.
+      # Blank lines and full-line comments are skipped.
       # ----------------------------------------------------------------
       - id: no-duplicate-gitignore
         name: no duplicate .gitignore entries (G3)
         entry: >
-          bash -c "DUPES=$(awk 'NF && !/^#/' .gitignore | sort | uniq -d); if [ -n \"$DUPES\" ]; then printf 'ERROR: duplicate .gitignore entries:\n%s\n' \"$DUPES\"; exit 1; fi"
+          bash -c "DUPES=$(sed -E 's/[[:space:]]+#.*$//; s/[[:space:]]+$//' .gitignore | awk 'NF && !/^[[:space:]]*#/' | sort | uniq -d); if [ -n \"$DUPES\" ]; then printf 'ERROR: duplicate .gitignore entries:\n%s\n' \"$DUPES\"; exit 1; fi"
         language: system
         pass_filenames: false
         files: ^\.gitignore$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,8 @@ dev = [
     "pytest-timeout~=2.4.0",  # 2.4.0 regression: timer thread not cancelled on Windows; crashes during teardown (AssertionError in read_global_capture)
     "pytest-xdist~=3.5",
     "pytest-randomly~=3.15",
-    "mypy~=1.8",
+    "mypy~=1.8,!=1.20.2",  # 1.20.2 regression: INTERNAL ERROR analyzing optional-dep models (llama_cpp_text_model, mlx_text_model) even with ignore_errors override; 1.20.1 works
+
     "types-PyYAML~=6.0",
     "ruff>=0.1.0",  # 0.x — unstable API, keep >=
     "black~=26.3",

--- a/tests/ci/test_test_quality_guardrails.py
+++ b/tests/ci/test_test_quality_guardrails.py
@@ -337,8 +337,13 @@ def _find_vacuous_len_gte_zero_assertions(source: str, path: str = "<string>") -
        ``len()`` always returns a non-negative integer, so ``>= 0`` is tautological.
 
     2. ``assert x.attr >= 0``  (forward) and ``assert 0 <= x.attr``  (reverse)
-       where ``attr`` is one of the known non-negative attribute names
-       (``count``, ``duration``, ``total_size``, ``size``, ``length``).
+       where ``attr`` is one of the known non-negative attribute names.  The
+       authoritative set is ``_GTE_ZERO_NON_NEGATIVE_ATTRS``; at the time of
+       writing it covers sizes/lengths (``count``, ``length``, ``size``,
+       ``total_size``), durations (``duration``, ``elapsed``, ``elapsed_ms``,
+       ``elapsed_seconds``), and counts/depths flagged in 2026-03..04 PR
+       reviews (``depth``, ``files_per_second``, ``keyword_count``,
+       ``topic_count``).
 
     These pass even when the code under test is completely broken.  Use a
     meaningful bound (``>= 1``, ``== N``, ``< max_val``) instead.

--- a/tests/ci/test_test_quality_guardrails.py
+++ b/tests/ci/test_test_quality_guardrails.py
@@ -1,6 +1,6 @@
 """CI guardrails for test quality anti-patterns.
 
-Covers four regression classes:
+Covers six regression classes:
 
 1. ``time.sleep()`` in tests — wall-clock sleeps make tests flaky under
    load and mask real timing bugs.  Use ``os.utime()`` for mtime bumps or
@@ -11,10 +11,13 @@ Covers four regression classes:
    the upper-bound assertion is vacuous: it passes even when the index
    returns zero matches.  Use ``assert len(results) == N`` instead.
 
-3. ``assert len(results) >= 0`` / ``assert 0 <= len(results)`` patterns —
-   ``len()`` is always non-negative by definition, so these assertions always
+3. ``assert len(results) >= 0`` / ``assert 0 <= len(results)`` patterns and
+   ``assert x.attr >= 0`` for non-negative attrs (count, size, duration,
+   elapsed, depth, files_per_second, topic_count, keyword_count, …) —
+   these are always non-negative by definition, so the assertions always
    pass even when the tested code is completely broken.  Use a meaningful
-   lower bound (``>= 1``) or exact count (``== N``) instead.
+   lower bound (``>= 1``) or exact count (``== N``) instead.  See T9 in
+   ``.claude/rules/test-generation-patterns.md``.
 
 4. Sole ``assert isinstance(x, T)`` in a test function — verifies the return
    type but not the value.  For ``bool`` this is especially weak (only two
@@ -23,10 +26,19 @@ Covers four regression classes:
    Applies to changed files only.  TODO: broaden to full suite after a
    clean-up sweep analogous to issue #900.
 
-Guardrails 1, 2, and 3 apply to ALL test files under ``tests/``.  Streams
-1-4 of issue #900 eliminated every pre-existing violation, so the scope can
-be expanded from diff-based (changed files only) to the full test suite.
-Guardrail 4 is diff-based until a full-suite clean-up is done.
+5. ``assert X is not None or X is None`` tautology — the disjunction is
+   always true for every value of X, so the assertion detects nothing.
+   Pick the specific branch the test is exercising and assert it directly.
+
+6. ``(_ for _ in ()).throw(SomeError(...))`` mock side-effects — the
+   expression returns a generator object instead of raising.  Use a named
+   function or ``MagicMock(side_effect=...)`` instead.  See T14 in
+   ``.claude/rules/test-generation-patterns.md``.
+
+Guardrails 1, 2, 3, and 5 apply to ALL test files under ``tests/``.  Streams
+1-4 of issue #900 eliminated every pre-existing violation in 3, and the 2026-04
+pattern-tightening cleanup eliminated the sole violation in 5.  Guardrails 4
+and 6 are diff-based pending full-suite cleanups.
 """
 
 from __future__ import annotations
@@ -278,7 +290,27 @@ def test_changed_tests_have_no_vacuous_len_lte_assertions() -> None:
 # Fix 5b: vacuous >= 0 assertions (always-true lower bounds)
 # -------------------------------------------------------------------------
 
-_GTE_ZERO_NON_NEGATIVE_ATTRS = frozenset({"count", "duration", "total_size", "size", "length"})
+_GTE_ZERO_NON_NEGATIVE_ATTRS = frozenset(
+    {
+        # Sizes and lengths
+        "count",
+        "length",
+        "size",
+        "total_size",
+        # Durations / elapsed times (>=0 by construction)
+        "duration",
+        "elapsed",
+        "elapsed_ms",
+        "elapsed_seconds",
+        # Counts flagged in 2026-03..04 PR reviews (files_per_second is a rate
+        # but always non-negative in our tests; topic_count / keyword_count
+        # are counts)
+        "depth",
+        "files_per_second",
+        "keyword_count",
+        "topic_count",
+    }
+)
 
 
 def _find_vacuous_len_gte_zero_assertions(source: str, path: str = "<string>") -> list[str]:
@@ -350,6 +382,12 @@ def _find_vacuous_len_gte_zero_assertions(source: str, path: str = "<string>") -
         ("assert x.total_size >= 0\n", 1),
         ("assert x.size >= 0\n", 1),
         ("assert x.length >= 0\n", 1),
+        ("assert x.elapsed >= 0\n", 1),
+        ("assert x.elapsed_ms >= 0\n", 1),
+        ("assert x.files_per_second >= 0\n", 1),
+        ("assert x.topic_count >= 0\n", 1),
+        ("assert x.keyword_count >= 0\n", 1),
+        ("assert x.depth >= 0\n", 1),
         ("assert 0 <= x.count\n", 1),
         # Meaningful bounds — should NOT flag
         ("assert len(results) >= 1\n", 0),
@@ -500,4 +538,165 @@ def test_changed_tests_have_no_sole_isinstance_assertions() -> None:
     assert not violations, (
         "Sole ``assert isinstance(x, T)`` found — add a specific value assertion:\n"
         + "\n".join(violations)
+    )
+
+
+# -------------------------------------------------------------------------
+# Fix 7: X is not None or X is None tautology (T9 extension)
+# -------------------------------------------------------------------------
+
+
+def _find_is_not_none_or_is_none_tautology(source: str, path: str = "<string>") -> list[str]:
+    """Return assertions of the form ``assert X is not None or X is None``.
+
+    The disjunction is always true for any value of X.  Seen in PR review #61
+    as a rationalized "covers both branches" — but it covers nothing: it
+    passes even when the function raises, returns a truthy-but-wrong value,
+    or leaks state.
+
+    Also flags the symmetric ``X is None or X is not None``.
+    """
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError:
+        return []
+
+    def _is_is_none(n: ast.AST, negated: bool) -> str | None:
+        if not isinstance(n, ast.Compare) or len(n.ops) != 1 or len(n.comparators) != 1:
+            return None
+        comp = n.comparators[0]
+        if not (isinstance(comp, ast.Constant) and comp.value is None):
+            return None
+        op = n.ops[0]
+        if negated and isinstance(op, ast.IsNot):
+            return ast.unparse(n.left)
+        if not negated and isinstance(op, ast.Is):
+            return ast.unparse(n.left)
+        return None
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assert):
+            continue
+        test = node.test
+        if not isinstance(test, ast.BoolOp) or not isinstance(test.op, ast.Or):
+            continue
+        if len(test.values) != 2:
+            continue
+        left_not_none = _is_is_none(test.values[0], negated=True)
+        right_is_none = _is_is_none(test.values[1], negated=False)
+        if left_not_none and right_is_none and left_not_none == right_is_none:
+            violations.append(f"{path}:{node.lineno}")
+            continue
+        left_is_none = _is_is_none(test.values[0], negated=False)
+        right_not_none = _is_is_none(test.values[1], negated=True)
+        if left_is_none and right_not_none and left_is_none == right_not_none:
+            violations.append(f"{path}:{node.lineno}")
+
+    return violations
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_count"),
+    [
+        # Tautologies — flag
+        ("assert result is not None or result is None\n", 1),
+        ("assert result is None or result is not None\n", 1),
+        # Different operands — NOT a tautology
+        ("assert a is not None or b is None\n", 0),
+        # Single comparisons — NOT a tautology
+        ("assert result is not None\n", 0),
+        ("assert result is None\n", 0),
+        # Meaningful disjunction — NOT a tautology
+        ("assert result is None or isinstance(result, str)\n", 0),
+    ],
+)
+def test_detector_flags_is_none_tautology(source: str, expected_count: int) -> None:
+    assert len(_find_is_not_none_or_is_none_tautology(source)) == expected_count
+
+
+def test_changed_tests_have_no_is_none_tautology() -> None:
+    """Changed test files must not use ``assert X is not None or X is None``.
+
+    The disjunction covers every possible value of X, so the assertion passes
+    even when the code is broken.  Pick the specific branch the test is
+    exercising and assert it directly.
+    """
+    violations: list[str] = []
+    for path in _changed_test_files():
+        source = path.read_text(encoding="utf-8")
+        violations.extend(_find_is_not_none_or_is_none_tautology(source, str(path)))
+
+    assert not violations, (
+        "Tautological ``X is not None or X is None`` found — pick one branch:\n"
+        + "\n".join(violations)
+    )
+
+
+# -------------------------------------------------------------------------
+# Fix 8: Generator-throw false-raise pattern (T14)
+# -------------------------------------------------------------------------
+
+
+def _find_generator_throw_false_raise(source: str, path: str = "<string>") -> list[str]:
+    """Return locations of ``(_ for _ in ()).throw(...)`` expressions.
+
+    This expression is often used as a mock side-effect intending to raise an
+    exception when the mocked callable is invoked.  It does NOT raise — it
+    returns a generator object.  The production code receives the generator
+    (which is truthy and can even be ``__enter__``-compatible in some paths)
+    and the error-handling branch is never exercised.  The test passes green
+    while the exception path is silently untested.
+
+    Detection is textual because the AST shape varies (lambda, direct call,
+    assignment to ``obj.method``) but the literal ``(_ for _ in ())`` is
+    the telltale marker.
+    """
+    violations: list[str] = []
+    for lineno, line in enumerate(source.splitlines(), start=1):
+        if "(_ for _ in ())" in line and ".throw" in line:
+            violations.append(f"{path}:{lineno}")
+    return violations
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_count"),
+    [
+        # Direct lambda form — flag
+        (
+            "mock.Dataset = lambda *a, **k: (_ for _ in ()).throw(OSError('boom'))\n",
+            1,
+        ),
+        # Standalone expression — flag
+        ("(_ for _ in ()).throw(ValueError('x'))\n", 1),
+        # Named function that raises — NOT flagged (correct pattern)
+        ("def raise_oserror(*a, **k):\n    raise OSError('boom')\n", 0),
+        # Plain generator — NOT flagged
+        ("gen = (x for x in [1, 2, 3])\n", 0),
+    ],
+)
+def test_detector_flags_generator_throw_false_raise(source: str, expected_count: int) -> None:
+    assert len(_find_generator_throw_false_raise(source)) == expected_count
+
+
+def test_changed_tests_have_no_generator_throw_false_raise() -> None:
+    """Changed test files must not use ``(_ for _ in ()).throw(...)`` mocks.
+
+    The expression returns a generator instead of raising.  Use a named
+    function (``def _raise_x(): raise X(...)``) or
+    ``MagicMock(side_effect=X(...))`` instead.  See test-generation-patterns.md
+    T14 for details.
+
+    Diff-scoped for now — 9 pre-existing violations exist across the suite
+    (daemon, events, integration, pipeline).  TODO: broaden to the full suite
+    after a cleanup sweep analogous to the T1 cleanup.
+    """
+    violations: list[str] = []
+    for path in _git_changed_test_files():
+        source = path.read_text(encoding="utf-8")
+        violations.extend(_find_generator_throw_false_raise(source, str(path)))
+
+    assert not violations, (
+        "Generator-throw false-raise found — use a named function or "
+        "MagicMock(side_effect=...) instead:\n" + "\n".join(violations)
     )

--- a/tests/ci/test_test_quality_guardrails.py
+++ b/tests/ci/test_test_quality_guardrails.py
@@ -80,24 +80,39 @@ def _git_changed_test_files() -> list[Path]:
     Used for guardrails that have known pre-existing violations in the full
     suite.  Only files touched in the current branch are checked, preventing
     failures on historical code while blocking new violations.
+
+    The set is the *union* of three diffs so a new violation is caught at
+    every stage of the local workflow:
+
+    - ``origin/main...HEAD`` — commits landed on the branch
+    - ``--cached`` — changes already ``git add``-staged for the next commit
+    - ``HEAD`` — unstaged worktree changes
+
+    Without the staged/worktree diffs, a pre-commit invocation sitting on
+    top of an existing branch with prior commits would see a non-empty
+    commit-range diff, take that branch as the answer, and silently skip
+    the file the author is about to commit.
     """
-    try:
-        result = subprocess.run(
-            ["git", "diff", "--name-only", "origin/main...HEAD"],
-            capture_output=True,
-            text=True,
-            cwd=FO_ROOT,
-        )
-        if not result.stdout.strip():
+    changed: set[str] = set()
+    for diff_args in (
+        ["origin/main...HEAD"],
+        ["--cached"],
+        ["HEAD"],
+    ):
+        try:
             result = subprocess.run(
-                ["git", "diff", "--name-only", "HEAD"],
+                ["git", "diff", "--name-only", *diff_args],
                 capture_output=True,
                 text=True,
                 cwd=FO_ROOT,
             )
-        changed = {line.strip() for line in result.stdout.splitlines() if line.strip()}
-    except Exception:
-        changed = set()
+            changed.update(line.strip() for line in result.stdout.splitlines() if line.strip())
+        except Exception:
+            # Best-effort: any git failure leaves `changed` unchanged; if all
+            # three diffs fail we yield an empty set, which each caller treats
+            # as "no changed files" (diff-scoped guardrails then no-op).
+            continue
+
     return sorted(
         p
         for p in TESTS_ROOT.rglob("*.py")
@@ -561,7 +576,7 @@ def _find_is_not_none_or_is_none_tautology(source: str, path: str = "<string>") 
     except SyntaxError:
         return []
 
-    def _is_is_none(n: ast.AST, negated: bool) -> str | None:
+    def _is_is_none(n: ast.AST, *, negated: bool) -> str | None:
         if not isinstance(n, ast.Compare) or len(n.ops) != 1 or len(n.comparators) != 1:
             return None
         comp = n.comparators[0]
@@ -641,21 +656,33 @@ def test_changed_tests_have_no_is_none_tautology() -> None:
 def _find_generator_throw_false_raise(source: str, path: str = "<string>") -> list[str]:
     """Return locations of ``(_ for _ in ()).throw(...)`` expressions.
 
-    This expression is often used as a mock side-effect intending to raise an
-    exception when the mocked callable is invoked.  It does NOT raise — it
-    returns a generator object.  The production code receives the generator
-    (which is truthy and can even be ``__enter__``-compatible in some paths)
-    and the error-handling branch is never exercised.  The test passes green
-    while the exception path is silently untested.
+    The idiom DOES raise — ``generator.throw(exc)`` on a fresh generator-expression
+    starts it and propagates ``exc`` back to the caller.  It is banned anyway, for
+    clarity and policy reasons: a five-token obfuscation of ``raise exc`` is
+    easy to misread (historically assumed to be a no-op that returns a generator),
+    and ``MagicMock(side_effect=exc)`` or a named ``def _raise(): raise exc``
+    helper is both clearer and more conventional.
 
-    Detection is textual because the AST shape varies (lambda, direct call,
-    assignment to ``obj.method``) but the literal ``(_ for _ in ())`` is
-    the telltale marker.
+    Detection is AST-based so that occurrences in comments, string literals, and
+    docstrings are not flagged.  Matches any ``<genexp>.throw(...)`` where
+    ``<genexp>`` is a generator expression — not just the literal
+    ``(_ for _ in ())`` shape — because variations like ``(_ for _ in [])`` or
+    ``(x for x in ())`` fall under the same anti-pattern.
     """
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError:
+        return []
+
     violations: list[str] = []
-    for lineno, line in enumerate(source.splitlines(), start=1):
-        if "(_ for _ in ())" in line and ".throw" in line:
-            violations.append(f"{path}:{lineno}")
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "throw"):
+            continue
+        if isinstance(func.value, ast.GeneratorExp):
+            violations.append(f"{path}:{node.lineno}")
     return violations
 
 
@@ -669,10 +696,22 @@ def _find_generator_throw_false_raise(source: str, path: str = "<string>") -> li
         ),
         # Standalone expression — flag
         ("(_ for _ in ()).throw(ValueError('x'))\n", 1),
+        # Variant generator shapes — also flag (same anti-pattern)
+        ("(_ for _ in []).throw(OSError('x'))\n", 1),
+        ("(x for x in ()).throw(RuntimeError('y'))\n", 1),
+        # Comment mentioning the pattern — NOT flagged (AST ignores comments)
+        ("# (_ for _ in ()).throw(ValueError('x'))\nx = 1\n", 0),
+        # String literal containing the pattern — NOT flagged
+        ("text = \"(_ for _ in ()).throw(ValueError('x'))\"\n", 0),
+        # Docstring mentioning the pattern — NOT flagged
+        ('def f():\n    """(_ for _ in ()).throw(X())"""\n    pass\n', 0),
         # Named function that raises — NOT flagged (correct pattern)
         ("def raise_oserror(*a, **k):\n    raise OSError('boom')\n", 0),
-        # Plain generator — NOT flagged
+        # Plain generator without .throw — NOT flagged
         ("gen = (x for x in [1, 2, 3])\n", 0),
+        # .throw on a named variable (not a generator expression) — NOT flagged
+        # (style is fine when the generator is the intended object under test)
+        ("gen = some_generator()\ngen.throw(ValueError('x'))\n", 0),
     ],
 )
 def test_detector_flags_generator_throw_false_raise(source: str, expected_count: int) -> None:
@@ -680,12 +719,12 @@ def test_detector_flags_generator_throw_false_raise(source: str, expected_count:
 
 
 def test_changed_tests_have_no_generator_throw_false_raise() -> None:
-    """Changed test files must not use ``(_ for _ in ()).throw(...)`` mocks.
+    """Changed test files must not use ``<genexp>.throw(...)`` mocks.
 
-    The expression returns a generator instead of raising.  Use a named
-    function (``def _raise_x(): raise X(...)``) or
-    ``MagicMock(side_effect=X(...))`` instead.  See test-generation-patterns.md
-    T14 for details.
+    The idiom raises the exception (contrary to intuition) but is banned for
+    clarity: use a named ``def _raise(): raise X(...)`` helper or
+    ``MagicMock(side_effect=X(...))`` instead.  See T14 in
+    ``.claude/rules/test-generation-patterns.md``.
 
     Diff-scoped for now — 9 pre-existing violations exist across the suite
     (daemon, events, integration, pipeline).  TODO: broaden to the full suite
@@ -697,6 +736,6 @@ def test_changed_tests_have_no_generator_throw_false_raise() -> None:
         violations.extend(_find_generator_throw_false_raise(source, str(path)))
 
     assert not violations, (
-        "Generator-throw false-raise found — use a named function or "
+        "`<genexp>.throw(...)` found — use a named function or "
         "MagicMock(side_effect=...) instead:\n" + "\n".join(violations)
     )

--- a/tests/ci/test_test_quality_guardrails.py
+++ b/tests/ci/test_test_quality_guardrails.py
@@ -105,13 +105,18 @@ def _git_changed_test_files() -> list[Path]:
                 capture_output=True,
                 text=True,
                 cwd=FO_ROOT,
+                check=False,
             )
-            changed.update(line.strip() for line in result.stdout.splitlines() if line.strip())
-        except Exception:
-            # Best-effort: any git failure leaves `changed` unchanged; if all
-            # three diffs fail we yield an empty set, which each caller treats
-            # as "no changed files" (diff-scoped guardrails then no-op).
+        except (OSError, subprocess.SubprocessError):
+            # Launching git failed (binary missing, permissions, etc.).  Try
+            # the next diff variant.  If all three fail we yield an empty
+            # set — diff-scoped guardrails then no-op.
             continue
+        if result.returncode != 0:
+            # git exited non-zero (e.g. origin/main unknown on a shallow clone);
+            # skip this variant without treating stdout as authoritative.
+            continue
+        changed.update(line.strip() for line in result.stdout.splitlines() if line.strip())
 
     return sorted(
         p
@@ -566,6 +571,21 @@ def test_changed_tests_have_no_sole_isinstance_assertions() -> None:
 # -------------------------------------------------------------------------
 
 
+def _is_pure_operand(node: ast.AST) -> bool:
+    """Return True if *node* is a simple name or attribute chain (no calls/subscripts).
+
+    Restricting the tautology detector to pure operands keeps assertions like
+    ``f() is not None or f() is None`` out of scope — ``f()`` is evaluated twice
+    and may legitimately return different values or have side effects, so the
+    disjunction is not actually tautological.
+    """
+    if isinstance(node, ast.Name):
+        return True
+    if isinstance(node, ast.Attribute):
+        return _is_pure_operand(node.value)
+    return False
+
+
 def _find_is_not_none_or_is_none_tautology(source: str, path: str = "<string>") -> list[str]:
     """Return assertions of the form ``assert X is not None or X is None``.
 
@@ -575,6 +595,11 @@ def _find_is_not_none_or_is_none_tautology(source: str, path: str = "<string>") 
     or leaks state.
 
     Also flags the symmetric ``X is None or X is not None``.
+
+    Only fires when ``X`` is a simple name or attribute chain; expressions
+    containing calls, subscripts, or other side-effect-capable nodes are
+    intentionally skipped (``f() is not None or f() is None`` evaluates
+    ``f`` twice and is not a tautology in general).
     """
     try:
         tree = ast.parse(source, filename=path)
@@ -586,6 +611,8 @@ def _find_is_not_none_or_is_none_tautology(source: str, path: str = "<string>") 
             return None
         comp = n.comparators[0]
         if not (isinstance(comp, ast.Constant) and comp.value is None):
+            return None
+        if not _is_pure_operand(n.left):
             return None
         op = n.ops[0]
         if negated and isinstance(op, ast.IsNot):
@@ -619,9 +646,10 @@ def _find_is_not_none_or_is_none_tautology(source: str, path: str = "<string>") 
 @pytest.mark.parametrize(
     ("source", "expected_count"),
     [
-        # Tautologies — flag
+        # Tautologies — flag (simple name or attribute operand)
         ("assert result is not None or result is None\n", 1),
         ("assert result is None or result is not None\n", 1),
+        ("assert obj.field is not None or obj.field is None\n", 1),
         # Different operands — NOT a tautology
         ("assert a is not None or b is None\n", 0),
         # Single comparisons — NOT a tautology
@@ -629,6 +657,12 @@ def _find_is_not_none_or_is_none_tautology(source: str, path: str = "<string>") 
         ("assert result is None\n", 0),
         # Meaningful disjunction — NOT a tautology
         ("assert result is None or isinstance(result, str)\n", 0),
+        # Call-expression operands — NOT flagged (f() may return different
+        # values on each call or have side effects; not a true tautology)
+        ("assert f() is not None or f() is None\n", 0),
+        ("assert obj.method() is not None or obj.method() is None\n", 0),
+        # Subscript operand — NOT flagged for the same reason
+        ("assert data[0] is not None or data[0] is None\n", 0),
     ],
 )
 def test_detector_flags_is_none_tautology(source: str, expected_count: int) -> None:

--- a/tests/integration/test_preference_tracker_branches.py
+++ b/tests/integration/test_preference_tracker_branches.py
@@ -429,10 +429,9 @@ class TestGetPreference:
             destination=Path("/a/new.txt"),
             correction_type=CorrectionType.FILE_RENAME,
         )
-        # Same parent + same extension → same pattern key
+        # Same parent + same extension → same pattern key, so lookup must hit.
         result = tracker.get_preference(Path("/a/another.txt"), PreferenceType.NAMING_PATTERN)
-        # The key includes parent name — so must match
-        assert result is not None or result is None  # just exercising the path
+        assert result is not None
 
     def test_get_category_override_no_match(self) -> None:
         """CATEGORY_OVERRIDE with nothing tracked → None."""

--- a/tests/integration/test_preference_tracker_branches.py
+++ b/tests/integration/test_preference_tracker_branches.py
@@ -429,9 +429,12 @@ class TestGetPreference:
             destination=Path("/a/new.txt"),
             correction_type=CorrectionType.FILE_RENAME,
         )
-        # Same parent + same extension → same pattern key, so lookup must hit.
+        # Same parent + same extension → same pattern key, so lookup must hit
+        # and must return the naming pattern recorded from the prior correction.
         result = tracker.get_preference(Path("/a/another.txt"), PreferenceType.NAMING_PATTERN)
         assert result is not None
+        assert result.preference_type == PreferenceType.NAMING_PATTERN
+        assert result.value == "new.txt"
 
     def test_get_category_override_no_match(self) -> None:
         """CATEGORY_OVERRIDE with nothing tracked → None."""

--- a/tests/services/audio/test_audio_integration.py
+++ b/tests/services/audio/test_audio_integration.py
@@ -194,10 +194,10 @@ class TestFullPipeline:
         classification = classifier.classify(metadata, transcription)
         assert classification.audio_type == AudioType.PODCAST
 
-        # Analyze
+        # Analyze — podcast content has non-empty topic and keyword extraction
         analysis = analyzer.analyze(metadata, transcription)
         assert analysis.language == "en"
-        assert analysis.topic_count >= 0  # May detect Technology
+        assert analysis.topic_count + analysis.keyword_count >= 1
 
         # Organize
         path = organizer.generate_path(classification.audio_type, metadata)
@@ -256,7 +256,8 @@ class TestFullPipeline:
         assert classification.audio_type == AudioType.RECORDING
 
         analysis = analyzer.analyze(metadata, transcription)
-        assert analysis.keyword_count >= 0
+        # Recording transcription is substantive — analyzer should extract at least one keyword
+        assert analysis.keyword_count >= 1
 
         path = organizer.generate_path(classification.audio_type, metadata)
         assert "Recordings" in path.parts

--- a/tests/services/audio/test_audio_integration.py
+++ b/tests/services/audio/test_audio_integration.py
@@ -194,10 +194,13 @@ class TestFullPipeline:
         classification = classifier.classify(metadata, transcription)
         assert classification.audio_type == AudioType.PODCAST
 
-        # Analyze — podcast content has non-empty topic and keyword extraction
+        # Analyze — podcast content has non-empty topic and keyword extraction.
+        # Both paths must populate (sum-based bound lets one path regress
+        # silently); assert each independently.
         analysis = analyzer.analyze(metadata, transcription)
         assert analysis.language == "en"
-        assert analysis.topic_count + analysis.keyword_count >= 1
+        assert analysis.topic_count >= 1
+        assert analysis.keyword_count >= 1
 
         # Organize
         path = organizer.generate_path(classification.audio_type, metadata)


### PR DESCRIPTION
## Summary

Rolls forward rules, guardrails, and pre-commit hooks based on a systematic audit of the 92 merged PRs over the last month (~220 substantive review findings). Goal: catch the recurring classes of review churn before the commit ever goes up.

- **Four new test-generation patterns** (T11-T14) documented in \`.claude/rules/test-generation-patterns.md\`, sourced from real PR #61/#76/#82/#140 findings:
  - T11 **PRAGMA_ON_TESTED_BRANCH** — \`# pragma: no cover\` on branches that already have a dedicated test
  - T12 **FIXTURE_STATE_LEAK** — snapshot-but-never-used teardown and partial sub-module restoration
  - T13 **HARDCODED_TEST_DATA_PATHS** — \`/tmp/\` / \`/dev/null\` in test data literals
  - T14 **GENERATOR_THROW_FALSE_RAISE** — \`(_ for _ in ()).throw(X(...))\` mock that returns a generator instead of raising
- **Broadened F9** to cover function-scoped \`from X import Y\` (not just \`__import__\`), matching PR #48 findings.
- **Clarified F3** language to explicitly cover cache/baseline/index/script-output writes (PR #50, #52).
- **xdist-safe-patterns** — added notes about the snapshot-but-never-used and partial-sub-module-restore variants covered by T12.

## New CI guardrails (\`tests/ci/test_test_quality_guardrails.py\`)

- Extended the T9 non-negative-attr allowlist with \`elapsed\`, \`elapsed_ms\`, \`elapsed_seconds\`, \`files_per_second\`, \`topic_count\`, \`keyword_count\`, \`depth\` (from PRs #61, #140).
- Added a full-suite guard for \`assert X is not None or X is None\` tautologies — caught 1 pre-existing violation, fixed inline in \`tests/integration/test_preference_tracker_branches.py\`.
- Added a diff-scoped guard for \`(_ for _ in ()).throw(...)\` false-raise patterns — 9 pre-existing violations flagged for a follow-up cleanup (matches the T1 rollout pattern: diff-scoped until cleanup, then broaden to full-suite).
- Fixed 2 pre-existing vacuous \`>= 0\` violations in \`tests/services/audio/test_audio_integration.py\` (\`topic_count\` and \`keyword_count\` are now meaningful bounds).

## New pre-commit hooks

- **G3 \`no-duplicate-gitignore\`** — trivial \`awk | sort | uniq -d\` guard; PR #99 and #102 both shipped a duplicated \`.worktrees/\`.
- **Extended \`check-stale-doc-refs.sh\`** with 7 removed-terminology patterns: \`[parsers]\` extra, \`[gui]\` extra, \`plugins/\`, \`FastAPI\`, \`uvicorn\`, \`ollama ls\`, \`marketplace\`. Staged-only mode now checks only newly-added diff lines, so pre-existing violations in unrelated-edit files don't block commits. History-context regex (\`was removed\`, \`were renamed\`, \`formerly\`, \`previously\`, \`no longer\`) narrowed from the overbroad \`was\b\` that would have exempted almost any prose.

## Doc alignment (drift uncovered during /pr-prep)

- \`.claude/skills/audit/SKILL.md\` — fix path \`memory/test-generation-patterns.md\` → \`.claude/rules/test-generation-patterns.md\` (2×), bump pattern ranges F1-F9 → F1-F10 and add T1-T14 / C1-C8 to the comparison table, rewrite the test-generation audit prompt to enumerate all 14 T-codes explicitly.
- \`.claude/rules/test-generation-patterns.md\` pre-generation checklist — extended with T4, T7, T11, T12, T13, T14 so it matches the Rule of Thumb at the bottom of the file.

## Context

Full audit report at \`/tmp/pr-review-analysis.md\` (493 lines, generated from 92 PRs × ~220 findings). Deliberately deferred from this PR (blast radius too large, documented as follow-up candidates):

- Ruff ruleset tightening (PT011 / SIM117 / FBT003) — 82 / 248 / 512 pre-existing violations, needs dedicated cleanup.
- Generator-throw full-suite enforcement — 9 pre-existing violations across \`tests/{daemon,events,integration,pipeline}\`.
- NEW-P1 pragma-on-tested-branch deterministic hook — non-trivial AST+test-scan correlation.

## Test plan

- [x] \`pytest tests/ci/test_test_quality_guardrails.py -q\` — 50/50 pass (13 new detector unit tests + enforcers)
- [x] Affected tests (audio integration, preference_tracker_branches, guardrails) pass together — 121 passed in 9.94s
- [x] \`bash .claude/scripts/pre-commit-validation.sh\` — all 14 hooks green (ruff, format, G1/G2/G3, stale-doc-refs, smoke, ci-guardrails, affected, diff-cover 80%, codespell, mypy, pypi-version, threshold-drift, search-corpus-safety, deptry, pymarkdown)
- [x] Smoke test on stale-doc-refs: \`[parsers]\`, \`[gui]\`, \`ollama ls\` patterns correctly fire on new content; \`marketplace command was removed\` correctly exempted
- [ ] CI green on this PR
- [ ] Verify new guardrails don't regress an unrelated PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a pre-commit check to prevent duplicate .gitignore entries and removed redundant ignore lines.
  * Excluded a problematic dev dependency release from development tooling requirements.

* **Tests**
  * Expanded test-quality guardrails with two new anti-pattern detectors and improved detection of changed tests.
  * Tightened audio integration assertions to require minimum topic/keyword counts.
  * Strengthened a preference-tracker test to assert a concrete naming-pattern result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->