### PR TITLE
ci: wrap every pip install in nick-fields/retry (#145)

### DIFF
--- a/.claude/rules/feature-generation-patterns.md
+++ b/.claude/rules/feature-generation-patterns.md
@@ -119,7 +119,11 @@ with self._lock:
 **Pre-generation checklist for shared state**:
 - [ ] Multiple threads access this variable? → Lock required
 - [ ] Read-modify-write sequence? → Must be atomic (lock or atomic op)
-- [ ] File write? → Use temp file + `os.replace()` pattern
+- [ ] File write? → Use temp file + `os.replace()` pattern. **This applies to
+      every persistent file you write: cache files, embedding indexes, coverage
+      baselines, module-floor snapshots, history databases, and one-off scripts
+      that produce a file another tool consumes.** A mid-write crash or a
+      concurrent CI job truncates the file; downstream tooling then reads garbage.
 - [ ] `@lru_cache` on a function reading env vars? → Remove cache
 
 ---
@@ -263,12 +267,15 @@ class FileOrganizer:
 
 ---
 
-## Pattern F9: DYNAMIC_IMPORT_ANTIPATTERN — 11 findings
+## Pattern F9: DYNAMIC_IMPORT_ANTIPATTERN — 14 findings
 
-**What it is**: `__import__()` used inline (e.g., in `default_factory` lambdas)
-instead of top-level `import` statements. Breaks static analysis and mypy.
+**What it is**: Imports placed somewhere other than the top of the module — either
+`__import__()` used inline in factory lambdas, or `from X import Y` / `import X`
+statements deferred inside a function/method body. Breaks static analysis (mypy can't
+see the binding), hides dependency graphs from tools like `deptry`, and forces the
+import to re-execute on every call.
 
-**Bad**:
+**Bad — `__import__()` inline**:
 
 ```python
 @dataclass
@@ -276,18 +283,57 @@ class Config:
     dirs: Any = field(default_factory=lambda: __import__("platformdirs").user_data_dir("app"))
 ```
 
+**Bad — function-scoped import** (from PR #48 transcriber/embedder/bm25):
+
+```python
+class Transcriber:
+    def _load_model(self) -> None:
+        from faster_whisper import WhisperModel   # deferred — mypy loses the type,
+        self._model = WhisperModel(...)           # deptry can't see the dep
+
+class BM25Index:
+    def build(self, files: list[Path]) -> None:
+        from rank_bm25 import BM25Okapi           # re-imports on every build call
+        self._index = BM25Okapi(...)
+```
+
 **Good**:
 
 ```python
-import platformdirs
+# Top-level import with an explicit optional-dependency guard
+try:
+    import platformdirs
+    HAS_PLATFORMDIRS = True
+except ImportError:
+    platformdirs = None  # type: ignore[assignment]
+    HAS_PLATFORMDIRS = False
 
 @dataclass
 class Config:
     dirs: str = field(default_factory=lambda: platformdirs.user_data_dir("app"))
+
+# For optional deps that genuinely require lazy loading (large models, CLI startup
+# time), wrap the import in a module-level helper so it executes at most once and the
+# rationale is documented:
+_WhisperModel = None  # type: ignore[assignment]
+
+def _get_whisper_model_class():
+    """Lazy import: faster_whisper pulls in torch (~1 GB) and delays CLI startup."""
+    global _WhisperModel
+    if _WhisperModel is None:
+        from faster_whisper import WhisperModel  # documented lazy loader
+        _WhisperModel = WhisperModel
+    return _WhisperModel
 ```
 
-**Pre-generation check**: Never use `__import__()` inline. Use `try/except ImportError`
-for optional deps instead.
+**Pre-generation check**:
+- Never use `__import__()` inline.
+- Never write `from X import Y` or `import X` inside a function body unless you are
+  implementing a _documented_ lazy loader (expensive import, CLI startup cost, or
+  unavoidable circular dependency). If you do, wrap it in a module-level helper with
+  a one-line comment explaining why the top-level import was rejected.
+- For optional deps, the correct pattern is a top-level `try/except ImportError` with
+  an `HAS_X` flag — not a deferred in-function import.
 
 ---
 
@@ -328,12 +374,12 @@ flow, re-read the docstring and update it to match.
 For every new feature:
 
 1. **F4**: Path from user input? Config bypassed? API key near a logger? → Security checklist
-2. **F3**: Shared state? → Lock required; file write? → temp + `os.replace()`
-3. **F1**: Every external call → what exception, is it handled?
+2. **F3**: Shared state? → Lock required; file write (cache/index/baseline/script output)? → temp + `os.replace()`
+3. **F1**: Every external call → what exception, is it handled? Does the `except` leave any symbol undefined for downstream use?
 4. **F2**: Every function signature → concrete `->` return type
 5. **F5**: `ConfigManager` / `AppConfig` already own this value?
-6. **F9**: `__import__()` inline? → Move to top-level import
+6. **F9**: `__import__()` inline OR `from X import Y` inside a function body? → Top-level import (or documented lazy-loader helper)
 7. **F10**: Changed `except` / return type / control flow? → Update docstring
 8. **F4+**: Writing search/index code? → Apply `search-generation-patterns.md`
 
-**Last audited PR**: #23
+**Last audited PR**: #140 (PR review cycle 2026-03-21 to 2026-04-21)

--- a/.claude/rules/test-generation-patterns.md
+++ b/.claude/rules/test-generation-patterns.md
@@ -405,6 +405,215 @@ def test_is_resolve_path_call_does_not_match_arbitrary_receiver():
 
 ---
 
+## Pattern T11: PRAGMA_ON_TESTED_BRANCH
+
+**What it is**: `# pragma: no cover` added to a branch that is already exercised by a
+dedicated test. The branch still executes (and counts toward runtime coverage), but the
+pragma hides it from the coverage report — which means a future refactor can drop the
+test without the coverage metric noticing.
+
+**Bad** (from PR #140 `src/methodologies/johnny_decimal/categories.py`):
+
+```python
+def __eq__(self, other: object) -> bool:
+    if not isinstance(other, JohnnyDecimalNumber):  # pragma: no cover
+        return NotImplemented
+    return self.area == other.area and ...
+```
+
+But `test_categories.py::test_jd_number_eq_not_implemented` explicitly calls
+`num.__eq__("not a jd number")` and asserts `NotImplemented`. The pragma is wrong:
+the branch is tested.
+
+**Good**:
+
+```python
+def __eq__(self, other: object) -> bool:
+    if not isinstance(other, JohnnyDecimalNumber):
+        return NotImplemented   # no pragma — this branch is exercised by tests
+    return self.area == other.area and ...
+```
+
+**Pre-generation check**: Before adding `# pragma: no cover`, search test files for the
+enclosing function/method name. If any test references it, the pragma is wrong — either
+the branch is tested, or the test is broken (fix the test, don't hide the branch).
+
+```bash
+# Quick check for the enclosing function
+rg "def <function_name>\(" tests/
+```
+
+Legitimate uses of `# pragma: no cover`: truly unreachable defensive branches
+(e.g. `if TYPE_CHECKING:`), platform-specific code blocks not exercised in CI, and
+`@overload` stubs. When in doubt, write the test instead of adding the pragma.
+
+---
+
+## Pattern T12: FIXTURE_STATE_LEAK
+
+**What it is**: A test snapshots shared singleton/module state with the intent to
+restore it, but either (a) never uses the snapshot in teardown, (b) restores only the
+top-level key leaving sub-modules patched, or (c) silently swallows setup failures
+and still yields. Leaks cross-test state under xdist and produces order-dependent
+failures.
+
+This is distinct from xdist-safe-patterns Pattern 2 (which covers _missing_ restoration
+of `sys.modules` sub-modules) — T12 adds the "snapshot-but-never-used" and "restoration
+that partially succeeds" variants.
+
+**Bad — snapshot never used** (from PR #61):
+
+```python
+@pytest.fixture
+def clean_registry():
+    original_providers = _registry.registered_providers  # snapshotted
+    yield
+    _registry._reset_for_testing()
+    _registry._register_builtins()
+    # original_providers never restored — any custom registrations at import time
+    # are silently lost for the rest of the session
+```
+
+**Bad — partial restoration** (from PR #76):
+
+```python
+saved_sklearn = sys.modules.get("sklearn")
+# ... mutate sys.modules["sklearn"] and sklearn.feature_extraction ...
+if saved_sklearn is not None:
+    sys.modules["sklearn"] = saved_sklearn
+    # sys.modules["sklearn.feature_extraction"] still points at the mock —
+    # later tests in this worker will load the stale mock
+```
+
+**Bad — swallow-and-yield** (from PR #76):
+
+```python
+@pytest.fixture
+def ensure_nltk():
+    try:
+        nltk.download("punkt_tab", quiet=True)
+    except Exception:
+        pass  # silent failure — test still yields, assertion later fails opaquely
+    yield
+```
+
+**Good**:
+
+```python
+# Use patch.dict for sys.modules — atomic restore on exit, including sub-modules
+with patch.dict(sys.modules, {
+    "sklearn": mock_sklearn,
+    "sklearn.feature_extraction": mock_sklearn.feature_extraction,
+    "sklearn.feature_extraction.text": mock_sklearn.feature_extraction.text,
+}):
+    yield mock_sklearn
+
+# For singletons: restore the actual snapshot, not just reset
+@pytest.fixture
+def clean_registry():
+    original = dict(_registry.registered_providers)
+    try:
+        yield
+    finally:
+        _registry._reset_for_testing()
+        for name, provider in original.items():
+            _registry.register(name, provider)
+```
+
+**Pre-generation check**: For every `<var> = sys.modules.get(...)` or
+`<var> = <singleton>.<field>` in a test, ensure `<var>` is actually referenced in the
+teardown. If it isn't, the snapshot is a no-op.
+
+**Cross-reference**: `xdist-safe-patterns.md` Pattern 2 (sys.modules restoration) and
+Pattern 3 (shared singletons).
+
+---
+
+## Pattern T13: HARDCODED_TEST_DATA_PATHS
+
+**What it is**: Hardcoded `/tmp/`, `/dev/null`, or other absolute path literals inside
+test _data_ (dataclass fields, fixture dicts, parametrize values). Ruff `S108` catches
+`tempfile.mktemp` and direct `open()` on hardcoded temp paths, but misses string
+literals passed to constructors. The G1 pre-commit hook greps diff for
+`/tmp/|/Users/|/home/` but only scans _added_ lines — older pre-existing literals in a
+file being edited are not re-checked.
+
+Impact: Windows-unportable tests, xdist file collisions, and tests that pass locally
+then fail in clean CI containers.
+
+**Bad** (from PR #61):
+
+```python
+def test_update_patterns(self, tmp_path: Path) -> None:
+    entry = FeedbackEntry(file_path="/tmp/f.txt")   # S108 misses this
+    tracker.add(entry)
+
+def test_null_output(self):
+    with open("/dev/null", "w") as f:               # not portable to Windows CI
+        process_file(f)
+```
+
+**Good**:
+
+```python
+def test_update_patterns(self, tmp_path: Path) -> None:
+    entry = FeedbackEntry(file_path=str(tmp_path / "f.txt"))
+    tracker.add(entry)
+
+def test_null_output(self, tmp_path: Path):
+    sink = tmp_path / "sink.txt"
+    with sink.open("w") as f:
+        process_file(f)
+```
+
+**Pre-generation check**: Any time you write a path string in a test, ask: *"Could
+this be `tmp_path / 'X'` instead?"* If yes — use `tmp_path`. The only acceptable
+hardcoded paths in tests are:
+- `/` root-based fixtures that are explicitly path-traversal test inputs
+  (e.g. `"/etc/passwd"` as an _input_ to a validator, never as an output target)
+- Path-validation test constants clearly marked as adversarial inputs
+
+---
+
+## Pattern T14: GENERATOR_THROW_FALSE_RAISE
+
+**What it is**: `(_ for _ in ()).throw(SomeError(...))` used as a mock side-effect.
+The expression _returns a generator object_; it does not raise. When the production
+code invokes it — e.g. `netCDF4.Dataset(path)` — it receives the generator (truthy,
+and `__enter__`-capable in some codepaths) and the error branch is never exercised.
+The test still passes green, but the exception-handling path is untested.
+
+**Bad** (from PR #82, scientific reader tests):
+
+```python
+sci_module.netCDF4.Dataset = lambda *a, **k: (_ for _ in ()).throw(OSError("boom"))
+
+# Production code:
+with netCDF4.Dataset(path) as ds:   # receives a generator, not an OSError
+    ...
+# Test passes, but the OSError-handling branch never ran.
+```
+
+**Good**:
+
+```python
+def _raise_oserror(*a, **k):
+    raise OSError("boom")
+sci_module.netCDF4.Dataset = _raise_oserror
+
+# Or with Mock:
+from unittest.mock import MagicMock
+sci_module.netCDF4.Dataset = MagicMock(side_effect=OSError("boom"))
+```
+
+**Pre-generation check**: The literal pattern `(_ for _ in ()).throw` is always wrong
+in a test mock. If you want a callable that raises, write a named function or use
+`MagicMock(side_effect=...)`.
+
+Automatable: a grep guardrail bans this pattern outright (see `tests/ci/test_test_quality_guardrails.py`).
+
+---
+
 ## Rule of Thumb
 
 For every assertion, ask:
@@ -417,5 +626,9 @@ For every assertion, ask:
 7. **T8**: "Does this test file import an optional dep at module level without a guard?"
 8. **T9**: "Is `assert X >= 0` where X is a length/count/duration? Replace with a meaningful bound."
 9. **T10**: "Is this a predicate in detector code? Add a negative case with the same surface shape but wrong context."
+10. **T11**: "About to add `# pragma: no cover`? Grep tests for the enclosing function — if any hits, the pragma is wrong."
+11. **T12**: "Snapshotted shared state? Make sure teardown actually restores the snapshot (including sub-module keys)."
+12. **T13**: "Hardcoded path string in test data? Use `tmp_path` instead."
+13. **T14**: "`(_ for _ in ()).throw(...)` — never. Use a named function or `MagicMock(side_effect=...)`."
 
-**Last audited PR**: #929
+**Last audited PR**: #140 (PR review cycle 2026-03-21 to 2026-04-21)

--- a/.claude/rules/test-generation-patterns.md
+++ b/.claude/rules/test-generation-patterns.md
@@ -16,10 +16,16 @@ Before writing any test:
 - [ ] Does each assertion verify a *specific value*, not just a type or non-None? (T1 — use Fix-by-type table)
 - [ ] After calling a mutating method, does the test verify the mutation persisted? (T2)
 - [ ] Are mocks asserted with exact call args, not just `call_count >= 1`? (T3)
+- [ ] Is any assertion an `X or isinstance(X, T)` or `X is not None or X is None` tautology? (T4 / T9)
 - [ ] Is `pytest.importorskip` scoped to only the classes that use the optional dep? (T5)
+- [ ] Does any `try/except` guard an exception the production code never raises? (T7)
 - [ ] Does this file import an optional dep at module level without `pytest.importorskip`? (T8)
 - [ ] Does any assertion use `>= 0` on a length, count, or duration? Replace with a meaningful bound. (T9)
 - [ ] For every `_is_X()` / `_has_X()` predicate in detector/guardrail code — is there a negative test case that passes the same surface shape with the wrong context and asserts `False`? (T10)
+- [ ] About to add `# pragma: no cover`? Grep `tests/` for the enclosing function first. (T11)
+- [ ] Snapshotting singleton or `sys.modules` state? Confirm teardown actually restores it (including sub-module keys). (T12)
+- [ ] Any hardcoded `/tmp/` or `/dev/null` path literals in test data? Use `tmp_path`. (T13)
+- [ ] Any `(_ for _ in ()).throw(...)` mock side-effect? Use a named function or `MagicMock(side_effect=...)`. (T14)
 
 ---
 

--- a/.claude/rules/test-generation-patterns.md
+++ b/.claude/rules/test-generation-patterns.md
@@ -584,20 +584,26 @@ hardcoded paths in tests are:
 ## Pattern T14: GENERATOR_THROW_FALSE_RAISE
 
 **What it is**: `(_ for _ in ()).throw(SomeError(...))` used as a mock side-effect.
-The expression _returns a generator object_; it does not raise. When the production
-code invokes it — e.g. `netCDF4.Dataset(path)` — it receives the generator (truthy,
-and `__enter__`-capable in some codepaths) and the error branch is never exercised.
-The test still passes green, but the exception-handling path is untested.
+
+Technically the expression _does_ raise — `generator.throw(exc)` on a fresh
+generator-expression starts it and propagates the exception back to the caller.
+The pattern is banned anyway because:
+
+1. **It reads as a no-op.** The five-token idiom is easily misread as "create a
+   generator and configure it to throw later" — which is exactly why reviewers
+   repeatedly flag it as a bug (and why the original PR-review comment for this
+   pattern was itself wrong about the runtime behavior).
+2. **Clearer alternatives exist.** `MagicMock(side_effect=exc)` or a named
+   `def _raise(): raise exc` helper conveys intent in one read.
+3. **It silently couples test correctness to a Python-implementation detail** —
+   `generator.throw` on an unstarted generator is "raises into the first yield
+   point, which is the start of the body"; if that ever changes, every use of
+   this idiom breaks at once.
 
 **Bad** (from PR #82, scientific reader tests):
 
 ```python
 sci_module.netCDF4.Dataset = lambda *a, **k: (_ for _ in ()).throw(OSError("boom"))
-
-# Production code:
-with netCDF4.Dataset(path) as ds:   # receives a generator, not an OSError
-    ...
-# Test passes, but the OSError-handling branch never ran.
 ```
 
 **Good**:

--- a/.claude/rules/xdist-safe-patterns.md
+++ b/.claude/rules/xdist-safe-patterns.md
@@ -64,6 +64,11 @@ def mock_sklearn() -> Generator[MagicMock, None, None]:
 **Rule**: When mocking a package with sub-modules, list ALL sub-module keys that the
 code under test imports, not just the top-level key.
 
+**Watch for**: _partial_ restoration — code that saves the top-level key and restores
+it in teardown, but mutated sub-module keys during the test body. The top-level
+restore looks correct at a glance; the sub-module stays patched for the rest of the
+xdist worker. See also `test-generation-patterns.md` T12 FIXTURE_STATE_LEAK.
+
 ---
 
 ## Pattern 3: Shared Singletons
@@ -90,6 +95,32 @@ Run with: `pytest ... --dist=loadgroup -n auto`
 def reset_registry() -> Generator[None, None, None]:
     yield
     _registry._reset_for_testing()
+```
+
+**Watch for**: _snapshot-but-never-used_ teardown — capturing the singleton's initial
+state into a local variable and then never restoring from it. Pattern looks like
+cleanup but is a no-op. See `test-generation-patterns.md` T12 FIXTURE_STATE_LEAK.
+
+```python
+# BAD — snapshot ignored
+@pytest.fixture
+def clean_registry():
+    original = _registry.registered_providers  # captured, never used
+    yield
+    _registry._reset_for_testing()
+    _registry._register_builtins()             # re-registers defaults only;
+                                                # any pre-existing custom provider is lost
+
+# GOOD — snapshot actually restored
+@pytest.fixture
+def clean_registry():
+    original = dict(_registry.registered_providers)
+    try:
+        yield
+    finally:
+        _registry._reset_for_testing()
+        for name, provider in original.items():
+            _registry.register(name, provider)
 ```
 
 ---

--- a/.claude/scripts/check-stale-doc-refs.sh
+++ b/.claude/scripts/check-stale-doc-refs.sh
@@ -111,9 +111,15 @@ done
 
 # --- Check 4: Removed features / terminology drift ---
 # Each entry: "grep-E-pattern:reason". Patterns use POSIX-extended regex
-# (as accepted by `grep -E`).  Lines inside fenced code blocks and lines
-# containing explicit "removed", "deprecated", "was ", "formerly",
-# "no longer", or "previously" are exempt so we can still document history.
+# (as accepted by `grep -E`).
+#
+# NOTE: `reason` must not contain a literal ':' — the split is
+# ${entry%%:*} / ${entry#*:}, so a colon in the reason truncates it.
+#
+# Exempt lines: fenced code blocks, and lines explicitly documenting the
+# change in history (e.g. "was removed", "renamed to X", "deprecated").
+# The exemption regex below is deliberately narrow — using bare "was\b"
+# would exempt almost any prose paragraph.
 REMOVED_TERMS=(
   '\[parsers\]:the "parsers" extra was removed; valid extras are dev cloud llama mlx claude audio video dedup archive scientific cad build search all'
   '\[gui\]:fo-core is CLI-only; no [gui] extra exists'
@@ -124,10 +130,8 @@ REMOVED_TERMS=(
   '\bmarketplace\b:the marketplace CLI command was removed'
 )
 
-# Strip fenced-code-block content from a file so we only search prose.
-_strip_fences() {
-  awk '/^```/ { in_fence = !in_fence; next } !in_fence' "$1"
-}
+# Matches history-context phrases only — not every sentence that uses "was".
+HISTORY_EXEMPT_REGEX='\b(was|were|is|are) (removed|deprecated|renamed|replaced|deleted|dropped|retired)\b|\bno longer\b|\bformerly\b|\bpreviously\b'
 
 for entry in "${REMOVED_TERMS[@]}"; do
   pattern="${entry%%:*}"
@@ -144,7 +148,7 @@ for entry in "${REMOVED_TERMS[@]}"; do
       hits=$(git diff --cached --unified=0 -- "$md_file" 2>/dev/null \
         | grep -E '^\+' \
         | grep -v '^+++' \
-        | grep -v -E 'removed|deprecated|formerly|previously|no longer|was\b' \
+        | grep -v -E "$HISTORY_EXEMPT_REGEX" \
         | grep -E "$pattern" || true)
       if [[ -n "$hits" ]]; then
         echo "  ⚠️  $md_file → newly added line matches stale pattern '$pattern' ($reason)"
@@ -154,7 +158,7 @@ for entry in "${REMOVED_TERMS[@]}"; do
       # Full-scan mode: line-numbered output across the whole file.
       hits=$(cat -n "$full_path" 2>/dev/null \
         | awk '/^[[:space:]]*[0-9]+\t```/ { in_fence = !in_fence; next } !in_fence' \
-        | grep -v -E 'removed|deprecated|formerly|previously|no longer|was\b' \
+        | grep -v -E "$HISTORY_EXEMPT_REGEX" \
         | grep -E "$pattern" || true)
       if [[ -n "$hits" ]]; then
         while IFS= read -r hit; do

--- a/.claude/scripts/check-stale-doc-refs.sh
+++ b/.claude/scripts/check-stale-doc-refs.sh
@@ -145,11 +145,25 @@ for entry in "${REMOVED_TERMS[@]}"; do
     if $STAGED_ONLY; then
       # Only flag newly ADDED lines.  Pre-existing violations in files being
       # edited for unrelated reasons must not block the commit.
-      hits=$(git diff --cached --unified=0 -- "$md_file" 2>/dev/null \
-        | grep -E '^\+' \
-        | grep -v '^+++' \
-        | grep -v -E "$HISTORY_EXEMPT_REGEX" \
-        | grep -E "$pattern" || true)
+      #
+      # Fenced code blocks are exempt (docs often show the old term as a
+      # historical example, e.g. `ollama ls` inside a ```bash fence).  We
+      # compute the intersection of (a) lines added by the staged diff and
+      # (b) the post-staged file's non-fenced content.  Only lines in both
+      # sets — i.e. added to prose, not inside a fence — proceed to the
+      # pattern match.
+      non_fenced=$(git show ":$md_file" 2>/dev/null \
+        | awk '/^```/ { in_fence = !in_fence; next } !in_fence' || true)
+      added=$(git diff --cached --unified=0 -- "$md_file" 2>/dev/null \
+        | grep -E '^\+[^+]' | sed 's/^+//' || true)
+      if [[ -z "$added" || -z "$non_fenced" ]]; then
+        hits=""
+      else
+        prose_added=$(echo "$added" | grep -Fxf <(echo "$non_fenced") 2>/dev/null || true)
+        hits=$(echo "$prose_added" \
+          | grep -v -E "$HISTORY_EXEMPT_REGEX" \
+          | grep -E "$pattern" || true)
+      fi
       if [[ -n "$hits" ]]; then
         echo "  ⚠️  $md_file → newly added line matches stale pattern '$pattern' ($reason)"
         ERRORS=$((ERRORS + 1))

--- a/.claude/scripts/check-stale-doc-refs.sh
+++ b/.claude/scripts/check-stale-doc-refs.sh
@@ -109,10 +109,68 @@ for method in "${FALSE_METHODS[@]}"; do
   done <<< "$MD_FILES"
 done
 
+# --- Check 4: Removed features / terminology drift ---
+# Each entry: "grep-E-pattern:reason". Patterns use POSIX-extended regex
+# (as accepted by `grep -E`).  Lines inside fenced code blocks and lines
+# containing explicit "removed", "deprecated", "was ", "formerly",
+# "no longer", or "previously" are exempt so we can still document history.
+REMOVED_TERMS=(
+  '\[parsers\]:the "parsers" extra was removed; valid extras are dev cloud llama mlx claude audio video dedup archive scientific cad build search all'
+  '\[gui\]:fo-core is CLI-only; no [gui] extra exists'
+  '/plugins/:the plugin system was removed; fo-core has no plugin layer'
+  '\bFastAPI\b:fo-core is CLI-only; no FastAPI/uvicorn web server exists'
+  '\buvicorn\b:fo-core is CLI-only; no FastAPI/uvicorn web server exists'
+  '\bollama ls\b:correct command is "ollama list" (not "ollama ls")'
+  '\bmarketplace\b:the marketplace CLI command was removed'
+)
+
+# Strip fenced-code-block content from a file so we only search prose.
+_strip_fences() {
+  awk '/^```/ { in_fence = !in_fence; next } !in_fence' "$1"
+}
+
+for entry in "${REMOVED_TERMS[@]}"; do
+  pattern="${entry%%:*}"
+  reason="${entry#*:}"
+
+  while IFS= read -r md_file; do
+    [[ -z "$md_file" ]] && continue
+    full_path="$REPO_ROOT/$md_file"
+    [[ -f "$full_path" ]] || continue
+
+    if $STAGED_ONLY; then
+      # Only flag newly ADDED lines.  Pre-existing violations in files being
+      # edited for unrelated reasons must not block the commit.
+      hits=$(git diff --cached --unified=0 -- "$md_file" 2>/dev/null \
+        | grep -E '^\+' \
+        | grep -v '^+++' \
+        | grep -v -E 'removed|deprecated|formerly|previously|no longer|was\b' \
+        | grep -E "$pattern" || true)
+      if [[ -n "$hits" ]]; then
+        echo "  ⚠️  $md_file → newly added line matches stale pattern '$pattern' ($reason)"
+        ERRORS=$((ERRORS + 1))
+      fi
+    else
+      # Full-scan mode: line-numbered output across the whole file.
+      hits=$(cat -n "$full_path" 2>/dev/null \
+        | awk '/^[[:space:]]*[0-9]+\t```/ { in_fence = !in_fence; next } !in_fence' \
+        | grep -v -E 'removed|deprecated|formerly|previously|no longer|was\b' \
+        | grep -E "$pattern" || true)
+      if [[ -n "$hits" ]]; then
+        while IFS= read -r hit; do
+          line_num=$(echo "$hit" | awk '{print $1}')
+          echo "  ⚠️  $md_file:$line_num → stale reference matching '$pattern' ($reason)"
+          ERRORS=$((ERRORS + 1))
+        done <<< "$hits"
+      fi
+    fi
+  done <<< "$MD_FILES"
+done
+
 echo ""
 if [[ $ERRORS -gt 0 ]]; then
   echo "❌ Found $ERRORS stale reference(s) in documentation"
-  echo "   Fix these before committing, or add to DELETED_SYMBOLS/FALSE_METHODS if intentional."
+  echo "   Fix these before committing, or add to DELETED_SYMBOLS/FALSE_METHODS/REMOVED_TERMS if intentional."
   exit 1
 else
   echo "✓ No stale documentation references found"

--- a/.claude/scripts/check-stale-doc-refs.sh
+++ b/.claude/scripts/check-stale-doc-refs.sh
@@ -157,8 +157,15 @@ for entry in "${REMOVED_TERMS[@]}"; do
       # (common inside lists and blockquotes) as prose and flag their content.
       non_fenced=$(git show ":$md_file" 2>/dev/null \
         | awk '/^ ? ? ?```/ { in_fence = !in_fence; next } !in_fence' || true)
+      # Match every added line (prefix `+`) and strip the `+++ b/path` file
+      # header separately.  A previous `^\+[^+]` filter dropped any added line
+      # whose content itself started with `+` (appears as `++content` in the
+      # diff), producing a false negative when an author added e.g. bullet
+      # lines like `+ marketplace`.
       added=$(git diff --cached --unified=0 -- "$md_file" 2>/dev/null \
-        | grep -E '^\+[^+]' | sed 's/^+//' || true)
+        | grep -E '^\+' \
+        | grep -v -E '^\+\+\+ ' \
+        | sed 's/^+//' || true)
       if [[ -z "$added" || -z "$non_fenced" ]]; then
         hits=""
       else

--- a/.claude/scripts/check-stale-doc-refs.sh
+++ b/.claude/scripts/check-stale-doc-refs.sh
@@ -152,8 +152,11 @@ for entry in "${REMOVED_TERMS[@]}"; do
       # (b) the post-staged file's non-fenced content.  Only lines in both
       # sets — i.e. added to prose, not inside a fence — proceed to the
       # pattern match.
+      # CommonMark allows 0–3 spaces of indentation before a fence marker.
+      # Matching only column-0 fences would treat indented fenced blocks
+      # (common inside lists and blockquotes) as prose and flag their content.
       non_fenced=$(git show ":$md_file" 2>/dev/null \
-        | awk '/^```/ { in_fence = !in_fence; next } !in_fence' || true)
+        | awk '/^ ? ? ?```/ { in_fence = !in_fence; next } !in_fence' || true)
       added=$(git diff --cached --unified=0 -- "$md_file" 2>/dev/null \
         | grep -E '^\+[^+]' | sed 's/^+//' || true)
       if [[ -z "$added" || -z "$non_fenced" ]]; then
@@ -170,8 +173,10 @@ for entry in "${REMOVED_TERMS[@]}"; do
       fi
     else
       # Full-scan mode: line-numbered output across the whole file.
+      # After `cat -n`, content starts after the tab; allow 0–3 spaces of
+      # indentation before the fence marker (CommonMark rule).
       hits=$(cat -n "$full_path" 2>/dev/null \
-        | awk '/^[[:space:]]*[0-9]+\t```/ { in_fence = !in_fence; next } !in_fence' \
+        | awk '/^[[:space:]]*[0-9]+\t ? ? ?```/ { in_fence = !in_fence; next } !in_fence' \
         | grep -v -E "$HISTORY_EXEMPT_REGEX" \
         | grep -E "$pattern" || true)
       if [[ -n "$hits" ]]; then

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -17,9 +17,9 @@ Checks changed code against the project's documented anti-pattern rules. Catches
 
 /simplify uses generic software engineering judgment. The pre-commit script uses regex/lint rules. Neither reads the project's anti-pattern documentation:
 
-- `.claude/rules/feature-generation-patterns.md` (F1-F9)
-- `memory/test-generation-patterns.md`
-- `.claude/rules/ci-generation-patterns.md` (C1-C6)
+- `.claude/rules/feature-generation-patterns.md` (F1-F10)
+- `.claude/rules/test-generation-patterns.md` (T1-T14)
+- `.claude/rules/ci-generation-patterns.md` (C1-C8)
 
 This skill bridges that gap by checking new code against documented patterns that caused past PR review churn.
 
@@ -65,16 +65,29 @@ For each finding, cite the exact file, line number, and which pattern it violate
 
 #### Agent 2: Test Generation Audit
 
-Read `memory/test-generation-patterns.md` in full, then audit ALL test code changes against each anti-pattern:
+Read `.claude/rules/test-generation-patterns.md` in full, then audit ALL test code changes against each anti-pattern (T1-T14):
 
-- **Weak assertions**: `assert result is not None` instead of `assert result is mock_obj`. `assert X.call_count > 0` without verifying args/payload.
-- **Missing mock verification**: Mock declared in `@patch` decorator but never asserted (no `assert_called_once_with`, no `assert_not_called`).
-- **Missing negative assertions**: Test verifies the happy path but doesn't assert the unhappy path was NOT taken (e.g., verifies AI processing was called but doesn't check fallback was NOT called).
-- **Permissive filters**: Looping through results and checking `if X` instead of asserting exact count or using `mock.assert_not_called()`.
+- **T1 SOLE_ISINSTANCE**: `assert isinstance(x, T)` as the only assertion — verifies the type but not the value.
+- **T2 MISSING_STATE_VERIFICATION**: Mutating method called but only return value checked — state change not verified.
+- **T3 MOCK_CALL_COUNT_WITHOUT_PAYLOAD**: `mock.assert_called_once()` without `_with(...)`, or `call_count >= 1` without payload verification.
+- **T4 TAUTOLOGICAL_DISJUNCTION**: `assert X or isinstance(X, T)` always passes for None + type combinations.
+- **T5 IMPORTSKIP_SCOPE**: `pytest.importorskip` at module level in a file with classes that don't need the optional dep.
+- **T7 UNVERIFIED_EXCEPTION_GUARD**: `try/except SomeError: pass` guarding an exception production code never raises.
+- **T8 MISSING_IMPORT_GUARD**: Test file imports an optional dep at module level without `pytest.importorskip`.
+- **T9 VACUOUS_TAUTOLOGY**: `assert X >= 0` on lengths/counts/durations; `assert X is not None or X is None`.
+- **T10 PREDICATE_MISSING_NEGATIVE_CASE**: `_is_X()` predicate tested only with positive inputs; no test asserts False for same-shape-wrong-context.
+- **T11 PRAGMA_ON_TESTED_BRANCH**: `# pragma: no cover` added to a branch that already has a dedicated test.
+- **T12 FIXTURE_STATE_LEAK**: Singleton/sys.modules snapshot captured but never restored; partial sub-module restoration.
+- **T13 HARDCODED_TEST_DATA_PATHS**: `/tmp/`, `/dev/null` literals in test dataclass fields or fixture dicts (use `tmp_path`).
+- **T14 GENERATOR_THROW_FALSE_RAISE**: `(_ for _ in ()).throw(X(...))` as a mock side-effect — returns generator, never raises.
+
+Also check generic test-quality concerns beyond the numbered patterns:
+- **Missing mock verification**: Mock declared in `@patch` decorator but never asserted.
+- **Missing negative assertions**: Happy path verified but unhappy path not asserted as *not* taken.
 - **Private attribute access**: `assert obj._private_attr == val` instead of testing via public API.
-- **Resource leaks in tests**: File-backed SQLAlchemy engines without `engine.dispose()`, temp files without cleanup.
+- **Resource leaks**: File-backed engines without `.dispose()`, temp files without cleanup.
 - **Dead test helpers**: Unused helper methods left in test files.
-- **Missing direct unit tests**: New methods only exercised indirectly through integration tests, not tested directly.
+- **Missing direct unit tests**: New methods only exercised indirectly through integration tests.
 
 For each finding, cite the exact test file, test method, line number, and which anti-pattern it matches.
 
@@ -100,7 +113,7 @@ After fixes, re-run affected tests to confirm nothing broke.
 |------|----------------|---------------|
 | Pre-commit script | Syntax, formatting, lint, test pass/fail | Semantic correctness, assertion quality, exception scope |
 | /simplify | Generic reuse, copy-paste, efficiency | Project-specific anti-patterns, test assertion quality |
-| **/audit** | **F1-F9 feature patterns, test anti-patterns, CI patterns** | Generic code quality (that's /simplify's job) |
+| **/audit** | **F1-F10 feature patterns, T1-T14 test patterns, C1-C8 CI patterns** | Generic code quality (that's /simplify's job) |
 
 ## Integration with /pr-prep
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
+            set -euo pipefail
             python -m pip install --upgrade pip
             pip install -e ".[dev]"
             pip install pyinstaller

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,10 +51,17 @@ jobs:
           sudo apt-get install -y fuse libfuse2
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
-          pip install pyinstaller
+        # Retry wrapper guards against transient TLS/CDN flakes during wheel
+        # downloads; see issue #145.
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: |
+            python -m pip install --upgrade pip
+            pip install -e ".[dev]"
+            pip install pyinstaller
 
       - name: Run tests
         run: |

--- a/.github/workflows/ci-extras.yml
+++ b/.github/workflows/ci-extras.yml
@@ -95,8 +95,14 @@ jobs:
           cache: pip
 
       - name: Install extra with dev dependencies
-        # .[dev,extra] ensures pytest and repo test toolchain are present for canary runs
-        run: pip install -e ".[dev,${{ matrix.extra }}]"
+        # .[dev,extra] ensures pytest and repo test toolchain are present for canary runs.
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev,${{ matrix.extra }}]"
 
       - name: Verify key imports
         run: python -c "${{ matrix.key_import }}"

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -38,6 +38,7 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
+            set -euo pipefail
             pip install -e ".[dev,search]"
             pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
       - name: Run full test suite

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -31,9 +31,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - name: Install dependencies
-        run: |
-          pip install -e ".[dev,search]"
-          pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: |
+            pip install -e ".[dev,search]"
+            pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
       - name: Run full test suite
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -65,7 +71,14 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
-      - run: pip install -e ".[dev]"
+      - name: Install dev extras
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev]"
       - name: Download coverage data (py3.11)
         uses: actions/download-artifact@v8
         with:
@@ -93,7 +106,13 @@ jobs:
       - name: Install dependencies
         # search extra (rank-bm25, scikit-learn) is required by @pytest.mark.ci tests
         # in TestBM25Index, TestVectorIndexRecall, TestHybridRetriever, and TestSemanticSearch.
-        run: pip install -e ".[dev,search]"
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev,search]"
       - name: Run tests
         # CI Full's cross-platform contract: validate the portable ci/smoke subset on macOS.
         run: pytest tests/ --strict-markers --timeout=30 -n=auto --override-ini="addopts=" -m "ci or smoke"
@@ -113,7 +132,13 @@ jobs:
       - name: Install dependencies
         # search extra (rank-bm25, scikit-learn) is required by @pytest.mark.ci tests
         # in TestBM25Index, TestVectorIndexRecall, TestHybridRetriever, and TestSemanticSearch.
-        run: pip install -e ".[dev,search]"
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev,search]"
       - name: Run tests
         # CI Full's cross-platform contract: validate the portable ci/smoke subset on Windows.
         # -n=auto intentionally omitted: xdist worker shutdown on Windows propagates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
+            set -euo pipefail
             pip install pre-commit
             pip install -e ".[dev]"
       - run: pre-commit run --all-files
@@ -90,6 +91,7 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
+            set -euo pipefail
             pip install "deptry>=0.16.0"
             pip install -e .
       - run: deptry src/
@@ -192,6 +194,7 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
+            set -euo pipefail
             pip install -e ".[dev,search]"
             # Explicitly install pytest-asyncio and faker to ensure they're available.
             # This fixes installation order issues on Python 3.11 where pytest might load before pytest-asyncio.
@@ -254,6 +257,7 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
+            set -euo pipefail
             pip install -e ".[dev,search]"
             pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
       - name: Run full test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,16 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - run: pip install pre-commit
-      - run: pip install -e ".[dev]"
+      - name: Install lint deps (pre-commit + dev extras)
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: |
+            pip install pre-commit
+            pip install -e ".[dev]"
       - run: pre-commit run --all-files
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,8 +82,16 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - run: pip install "deptry>=0.16.0"
-      - run: pip install -e .
+      - name: Install deptry + package
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: |
+            pip install "deptry>=0.16.0"
+            pip install -e .
       - run: deptry src/
 
   type-check:
@@ -86,7 +102,14 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - run: pip install -e ".[dev]"
+      - name: Install dev extras
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev]"
       - name: Run mypy on all source modules
         run: python -m mypy --config-file pyproject.toml src/
 
@@ -159,15 +182,20 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - name: Install dependencies
-        run: |
-          # Install core package with dev dependencies + search (rank-bm25, scikit-learn)
-          # search is required for TestBM25Index, TestVectorIndexRecall, TestHybridRetriever,
-          # and related CLI/API/copilot tests — not in dev because it is an optional runtime extra.
-          pip install -e ".[dev,search]"
-
-          # Explicitly install pytest-asyncio and faker to ensure they're available
-          # This fixes installation order issues on Python 3.11 where pytest might load before pytest-asyncio
-          pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
+        # Install core package with dev dependencies + search (rank-bm25, scikit-learn).
+        # search is required for TestBM25Index, TestVectorIndexRecall, TestHybridRetriever,
+        # and related CLI/API/copilot tests — not in dev because it is an optional runtime extra.
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: |
+            pip install -e ".[dev,search]"
+            # Explicitly install pytest-asyncio and faker to ensure they're available.
+            # This fixes installation order issues on Python 3.11 where pytest might load before pytest-asyncio.
+            pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
       - name: Verify test dependencies
         run: |
           # Fast plugin registration check — replaces the former pytest --collect-only
@@ -183,6 +211,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pytest tests/ --strict-markers -m "ci and not benchmark" --cov=src --cov-report=xml --timeout=30 -n=auto --override-ini="addopts="
+      - name: Install diff-cover
+        if: ${{ github.event.pull_request.changed_files <= 75 }}
+        # Split out of the diff-coverage-gate step so the retry wrapper only re-runs
+        # pip install, not the gate itself.  Retry wrapper guards against transient
+        # TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 3
+          max_attempts: 3
+          retry_on: error
+          command: pip install diff-cover --quiet
       - name: Diff coverage gate
         if: ${{ github.event.pull_request.changed_files <= 75 }}
         # Checks that lines added/changed in this PR are ≥80% covered.
@@ -190,9 +229,7 @@ jobs:
         # Ratchet: bump --fail-under as coverage improves. Target: 90% per issue #855.
         # Broad refactors and type-cleanup sweeps exceed the signal-to-noise ratio
         # where diff coverage is useful, so we skip the gate for very large PRs.
-        run: |
-          pip install diff-cover --quiet
-          diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
+        run: diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
 
   test-full:
     name: "Test full suite (py${{ matrix.python-version }})"
@@ -210,9 +247,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - name: Install dependencies
-        run: |
-          pip install -e ".[dev,search]"
-          pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: |
+            pip install -e ".[dev,search]"
+            pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
       - name: Run full test suite
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -246,7 +289,14 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
-      - run: pip install -e ".[dev]"
+      - name: Install dev extras
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev]"
       - name: Download coverage data (py3.11)
         uses: actions/download-artifact@v8
         with:
@@ -282,7 +332,13 @@ jobs:
           python-version: "3.11"
           cache: pip
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev]"
       - name: Download benchmark baseline (PR only)
         # Finds the latest successful main CI run that stored a benchmark-baseline
         # artifact and downloads it for comparison.  Skipped silently if none exists.
@@ -394,7 +450,15 @@ jobs:
           python-version: "3.11"
           cache: pip
       - name: Install dependencies
-        run: pip install -e ".[dev,search]"
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145) —
+        # the 2026-04-21 integration coverage-gate failure was exactly this
+        # case (mid-stream DECRYPTION_FAILED_OR_BAD_RECORD_MAC on a numpy wheel).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev,search]"
       - name: Run integration tests and capture coverage report
         id: integration_tests
         continue-on-error: true
@@ -450,9 +514,18 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
+      - name: Install package into size-check target
+        # Split out of the size-check step so the retry wrapper only re-runs
+        # pip install, not the size measurement.  Retry wrapper guards against
+        # transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: python -m pip install --target /tmp/fo_size_check . -q
       - name: Measure default install size
         run: |
-          python -m pip install --target /tmp/fo_size_check . -q
           SIZE_MB=$(du -sm /tmp/fo_size_check | awk '{print $1}')
           echo "Install size: ${SIZE_MB} MB"
           if [ "$SIZE_MB" -gt 215 ]; then

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -19,7 +19,13 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install pymarkdown
-        run: pip install 'pymarkdownlnt==0.9.25'
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_on: error
+          command: pip install 'pymarkdownlnt==0.9.25'
       - name: Run markdown linting
         run: |
           # Scan all tracked markdown files in repository (including nested)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,14 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-      - run: pip install -e ".[docs]"
+      - name: Install docs extras
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[docs]"
       - run: mkdocs build --strict
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -73,5 +80,12 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-      - run: pip install -e ".[docs]"
+      - name: Install docs extras
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[docs]"
       - run: mkdocs build --strict

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -54,6 +54,7 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
+            set -euo pipefail
             pip install -e ".[dev,search]"
             pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
       - name: Run integration tests

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -47,9 +47,15 @@ jobs:
           python-version: "3.11"
           cache: pip
       - name: Install dependencies
-        run: |
-          pip install -e ".[dev,search]"
-          pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: |
+            pip install -e ".[dev,search]"
+            pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
       - name: Run integration tests
         # --cov adds ~15-20% overhead to the 3-5 min run; bounded by cancel-in-progress.
         # Output teed to RUNNER_TEMP so the per-module floor script can parse it.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,13 @@ jobs:
           python-version: "3.12"
           cache: pip
       - name: Install build tools
-        run: pip install build twine
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_on: error
+          command: pip install build twine
       - name: Build package
         run: python -m build
       - name: Upload artifacts

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,9 +26,23 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install pip-audit
-        run: pip install pip-audit
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_on: error
+          command: pip install pip-audit
       - name: Audit dependencies
-        run: pip-audit -r <(pip install -e . && pip freeze)
+        # The inner `pip install -e . && pip freeze` also downloads wheels; wrap
+        # the whole step in retry so a transient flake on any of the pip calls
+        # is recoverable (issue #145).  continue-on-error stays on the step.
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip-audit -r <(pip install -e . && pip freeze)
         continue-on-error: true
 
   bandit-scan:
@@ -39,7 +53,13 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install bandit
-        run: pip install bandit[toml]
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_on: error
+          command: pip install bandit[toml]
       - name: Run bandit
         run: bandit -r src/ -c pyproject.toml || true
 

--- a/.gitignore
+++ b/.gitignore
@@ -78,9 +78,6 @@ output/
 coverage.xml
 htmlcov/
 
-# MkDocs build output
-site/
-
 # Backup files and directories
 *.bak
 .fo_backups/
@@ -117,8 +114,6 @@ __snapshots__/
 # Node modules (if not already there)
 node_modules/
 
-# MkDocs build output
-site/
 .claude/worktrees/
 /.worktrees/
 
@@ -140,4 +135,3 @@ coverage.json
 # Superpowers scaffolding (implementation artifacts, not permanent docs)
 docs/superpowers/plans/
 docs/superpowers/specs/
-.worktrees/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,19 @@ repos:
         pass_filenames: false
 
       # ----------------------------------------------------------------
+      # G3: No duplicate entries in .gitignore
+      # Detected repeatedly in PR review (e.g. PR #99 and #102 both had
+      # a duplicated `.worktrees/` line).  Ignores blank lines and comments.
+      # ----------------------------------------------------------------
+      - id: no-duplicate-gitignore
+        name: no duplicate .gitignore entries (G3)
+        entry: >
+          bash -c "DUPES=$(awk 'NF && !/^#/' .gitignore | sort | uniq -d); if [ -n \"$DUPES\" ]; then printf 'ERROR: duplicate .gitignore entries:\n%s\n' \"$DUPES\"; exit 1; fi"
+        language: system
+        pass_filenames: false
+        files: ^\.gitignore$
+
+      # ----------------------------------------------------------------
       # No build artifacts committed
       # Covers: .coverage, *.bak, *.pyc, *.pyo, coverage.xml, htmlcov/,
       #         __pycache__/, build/, dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,8 @@ dev = [
     "pytest-timeout~=2.4.0",  # 2.4.0 regression: timer thread not cancelled on Windows; crashes during teardown (AssertionError in read_global_capture)
     "pytest-xdist~=3.5",
     "pytest-randomly~=3.15",
-    "mypy~=1.8",
+    "mypy~=1.8,!=1.20.2",  # 1.20.2 regression: INTERNAL ERROR analyzing optional-dep models (llama_cpp_text_model, mlx_text_model) even with ignore_errors override; 1.20.1 works
+
     "types-PyYAML~=6.0",
     "ruff>=0.1.0",  # 0.x — unstable API, keep >=
     "black~=26.3",

--- a/tests/ci/test_test_quality_guardrails.py
+++ b/tests/ci/test_test_quality_guardrails.py
@@ -337,8 +337,13 @@ def _find_vacuous_len_gte_zero_assertions(source: str, path: str = "<string>") -
        ``len()`` always returns a non-negative integer, so ``>= 0`` is tautological.
 
     2. ``assert x.attr >= 0``  (forward) and ``assert 0 <= x.attr``  (reverse)
-       where ``attr`` is one of the known non-negative attribute names
-       (``count``, ``duration``, ``total_size``, ``size``, ``length``).
+       where ``attr`` is one of the known non-negative attribute names.  The
+       authoritative set is ``_GTE_ZERO_NON_NEGATIVE_ATTRS``; at the time of
+       writing it covers sizes/lengths (``count``, ``length``, ``size``,
+       ``total_size``), durations (``duration``, ``elapsed``, ``elapsed_ms``,
+       ``elapsed_seconds``), and counts/depths flagged in 2026-03..04 PR
+       reviews (``depth``, ``files_per_second``, ``keyword_count``,
+       ``topic_count``).
 
     These pass even when the code under test is completely broken.  Use a
     meaningful bound (``>= 1``, ``== N``, ``< max_val``) instead.

--- a/tests/ci/test_test_quality_guardrails.py
+++ b/tests/ci/test_test_quality_guardrails.py
@@ -1,6 +1,6 @@
 """CI guardrails for test quality anti-patterns.
 
-Covers four regression classes:
+Covers six regression classes:
 
 1. ``time.sleep()`` in tests — wall-clock sleeps make tests flaky under
    load and mask real timing bugs.  Use ``os.utime()`` for mtime bumps or
@@ -11,10 +11,13 @@ Covers four regression classes:
    the upper-bound assertion is vacuous: it passes even when the index
    returns zero matches.  Use ``assert len(results) == N`` instead.
 
-3. ``assert len(results) >= 0`` / ``assert 0 <= len(results)`` patterns —
-   ``len()`` is always non-negative by definition, so these assertions always
+3. ``assert len(results) >= 0`` / ``assert 0 <= len(results)`` patterns and
+   ``assert x.attr >= 0`` for non-negative attrs (count, size, duration,
+   elapsed, depth, files_per_second, topic_count, keyword_count, …) —
+   these are always non-negative by definition, so the assertions always
    pass even when the tested code is completely broken.  Use a meaningful
-   lower bound (``>= 1``) or exact count (``== N``) instead.
+   lower bound (``>= 1``) or exact count (``== N``) instead.  See T9 in
+   ``.claude/rules/test-generation-patterns.md``.
 
 4. Sole ``assert isinstance(x, T)`` in a test function — verifies the return
    type but not the value.  For ``bool`` this is especially weak (only two
@@ -23,10 +26,19 @@ Covers four regression classes:
    Applies to changed files only.  TODO: broaden to full suite after a
    clean-up sweep analogous to issue #900.
 
-Guardrails 1, 2, and 3 apply to ALL test files under ``tests/``.  Streams
-1-4 of issue #900 eliminated every pre-existing violation, so the scope can
-be expanded from diff-based (changed files only) to the full test suite.
-Guardrail 4 is diff-based until a full-suite clean-up is done.
+5. ``assert X is not None or X is None`` tautology — the disjunction is
+   always true for every value of X, so the assertion detects nothing.
+   Pick the specific branch the test is exercising and assert it directly.
+
+6. ``(_ for _ in ()).throw(SomeError(...))`` mock side-effects — the
+   expression returns a generator object instead of raising.  Use a named
+   function or ``MagicMock(side_effect=...)`` instead.  See T14 in
+   ``.claude/rules/test-generation-patterns.md``.
+
+Guardrails 1, 2, 3, and 5 apply to ALL test files under ``tests/``.  Streams
+1-4 of issue #900 eliminated every pre-existing violation in 3, and the 2026-04
+pattern-tightening cleanup eliminated the sole violation in 5.  Guardrails 4
+and 6 are diff-based pending full-suite cleanups.
 """
 
 from __future__ import annotations
@@ -278,7 +290,27 @@ def test_changed_tests_have_no_vacuous_len_lte_assertions() -> None:
 # Fix 5b: vacuous >= 0 assertions (always-true lower bounds)
 # -------------------------------------------------------------------------
 
-_GTE_ZERO_NON_NEGATIVE_ATTRS = frozenset({"count", "duration", "total_size", "size", "length"})
+_GTE_ZERO_NON_NEGATIVE_ATTRS = frozenset(
+    {
+        # Sizes and lengths
+        "count",
+        "length",
+        "size",
+        "total_size",
+        # Durations / elapsed times (>=0 by construction)
+        "duration",
+        "elapsed",
+        "elapsed_ms",
+        "elapsed_seconds",
+        # Counts flagged in 2026-03..04 PR reviews (files_per_second is a rate
+        # but always non-negative in our tests; topic_count / keyword_count
+        # are counts)
+        "depth",
+        "files_per_second",
+        "keyword_count",
+        "topic_count",
+    }
+)
 
 
 def _find_vacuous_len_gte_zero_assertions(source: str, path: str = "<string>") -> list[str]:
@@ -350,6 +382,12 @@ def _find_vacuous_len_gte_zero_assertions(source: str, path: str = "<string>") -
         ("assert x.total_size >= 0\n", 1),
         ("assert x.size >= 0\n", 1),
         ("assert x.length >= 0\n", 1),
+        ("assert x.elapsed >= 0\n", 1),
+        ("assert x.elapsed_ms >= 0\n", 1),
+        ("assert x.files_per_second >= 0\n", 1),
+        ("assert x.topic_count >= 0\n", 1),
+        ("assert x.keyword_count >= 0\n", 1),
+        ("assert x.depth >= 0\n", 1),
         ("assert 0 <= x.count\n", 1),
         # Meaningful bounds — should NOT flag
         ("assert len(results) >= 1\n", 0),
@@ -500,4 +538,165 @@ def test_changed_tests_have_no_sole_isinstance_assertions() -> None:
     assert not violations, (
         "Sole ``assert isinstance(x, T)`` found — add a specific value assertion:\n"
         + "\n".join(violations)
+    )
+
+
+# -------------------------------------------------------------------------
+# Fix 7: X is not None or X is None tautology (T9 extension)
+# -------------------------------------------------------------------------
+
+
+def _find_is_not_none_or_is_none_tautology(source: str, path: str = "<string>") -> list[str]:
+    """Return assertions of the form ``assert X is not None or X is None``.
+
+    The disjunction is always true for any value of X.  Seen in PR review #61
+    as a rationalized "covers both branches" — but it covers nothing: it
+    passes even when the function raises, returns a truthy-but-wrong value,
+    or leaks state.
+
+    Also flags the symmetric ``X is None or X is not None``.
+    """
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError:
+        return []
+
+    def _is_is_none(n: ast.AST, negated: bool) -> str | None:
+        if not isinstance(n, ast.Compare) or len(n.ops) != 1 or len(n.comparators) != 1:
+            return None
+        comp = n.comparators[0]
+        if not (isinstance(comp, ast.Constant) and comp.value is None):
+            return None
+        op = n.ops[0]
+        if negated and isinstance(op, ast.IsNot):
+            return ast.unparse(n.left)
+        if not negated and isinstance(op, ast.Is):
+            return ast.unparse(n.left)
+        return None
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assert):
+            continue
+        test = node.test
+        if not isinstance(test, ast.BoolOp) or not isinstance(test.op, ast.Or):
+            continue
+        if len(test.values) != 2:
+            continue
+        left_not_none = _is_is_none(test.values[0], negated=True)
+        right_is_none = _is_is_none(test.values[1], negated=False)
+        if left_not_none and right_is_none and left_not_none == right_is_none:
+            violations.append(f"{path}:{node.lineno}")
+            continue
+        left_is_none = _is_is_none(test.values[0], negated=False)
+        right_not_none = _is_is_none(test.values[1], negated=True)
+        if left_is_none and right_not_none and left_is_none == right_not_none:
+            violations.append(f"{path}:{node.lineno}")
+
+    return violations
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_count"),
+    [
+        # Tautologies — flag
+        ("assert result is not None or result is None\n", 1),
+        ("assert result is None or result is not None\n", 1),
+        # Different operands — NOT a tautology
+        ("assert a is not None or b is None\n", 0),
+        # Single comparisons — NOT a tautology
+        ("assert result is not None\n", 0),
+        ("assert result is None\n", 0),
+        # Meaningful disjunction — NOT a tautology
+        ("assert result is None or isinstance(result, str)\n", 0),
+    ],
+)
+def test_detector_flags_is_none_tautology(source: str, expected_count: int) -> None:
+    assert len(_find_is_not_none_or_is_none_tautology(source)) == expected_count
+
+
+def test_changed_tests_have_no_is_none_tautology() -> None:
+    """Changed test files must not use ``assert X is not None or X is None``.
+
+    The disjunction covers every possible value of X, so the assertion passes
+    even when the code is broken.  Pick the specific branch the test is
+    exercising and assert it directly.
+    """
+    violations: list[str] = []
+    for path in _changed_test_files():
+        source = path.read_text(encoding="utf-8")
+        violations.extend(_find_is_not_none_or_is_none_tautology(source, str(path)))
+
+    assert not violations, (
+        "Tautological ``X is not None or X is None`` found — pick one branch:\n"
+        + "\n".join(violations)
+    )
+
+
+# -------------------------------------------------------------------------
+# Fix 8: Generator-throw false-raise pattern (T14)
+# -------------------------------------------------------------------------
+
+
+def _find_generator_throw_false_raise(source: str, path: str = "<string>") -> list[str]:
+    """Return locations of ``(_ for _ in ()).throw(...)`` expressions.
+
+    This expression is often used as a mock side-effect intending to raise an
+    exception when the mocked callable is invoked.  It does NOT raise — it
+    returns a generator object.  The production code receives the generator
+    (which is truthy and can even be ``__enter__``-compatible in some paths)
+    and the error-handling branch is never exercised.  The test passes green
+    while the exception path is silently untested.
+
+    Detection is textual because the AST shape varies (lambda, direct call,
+    assignment to ``obj.method``) but the literal ``(_ for _ in ())`` is
+    the telltale marker.
+    """
+    violations: list[str] = []
+    for lineno, line in enumerate(source.splitlines(), start=1):
+        if "(_ for _ in ())" in line and ".throw" in line:
+            violations.append(f"{path}:{lineno}")
+    return violations
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_count"),
+    [
+        # Direct lambda form — flag
+        (
+            "mock.Dataset = lambda *a, **k: (_ for _ in ()).throw(OSError('boom'))\n",
+            1,
+        ),
+        # Standalone expression — flag
+        ("(_ for _ in ()).throw(ValueError('x'))\n", 1),
+        # Named function that raises — NOT flagged (correct pattern)
+        ("def raise_oserror(*a, **k):\n    raise OSError('boom')\n", 0),
+        # Plain generator — NOT flagged
+        ("gen = (x for x in [1, 2, 3])\n", 0),
+    ],
+)
+def test_detector_flags_generator_throw_false_raise(source: str, expected_count: int) -> None:
+    assert len(_find_generator_throw_false_raise(source)) == expected_count
+
+
+def test_changed_tests_have_no_generator_throw_false_raise() -> None:
+    """Changed test files must not use ``(_ for _ in ()).throw(...)`` mocks.
+
+    The expression returns a generator instead of raising.  Use a named
+    function (``def _raise_x(): raise X(...)``) or
+    ``MagicMock(side_effect=X(...))`` instead.  See test-generation-patterns.md
+    T14 for details.
+
+    Diff-scoped for now — 9 pre-existing violations exist across the suite
+    (daemon, events, integration, pipeline).  TODO: broaden to the full suite
+    after a cleanup sweep analogous to the T1 cleanup.
+    """
+    violations: list[str] = []
+    for path in _git_changed_test_files():
+        source = path.read_text(encoding="utf-8")
+        violations.extend(_find_generator_throw_false_raise(source, str(path)))
+
+    assert not violations, (
+        "Generator-throw false-raise found — use a named function or "
+        "MagicMock(side_effect=...) instead:\n" + "\n".join(violations)
     )

--- a/tests/ci/test_test_quality_guardrails.py
+++ b/tests/ci/test_test_quality_guardrails.py
@@ -80,24 +80,39 @@ def _git_changed_test_files() -> list[Path]:
     Used for guardrails that have known pre-existing violations in the full
     suite.  Only files touched in the current branch are checked, preventing
     failures on historical code while blocking new violations.
+
+    The set is the *union* of three diffs so a new violation is caught at
+    every stage of the local workflow:
+
+    - ``origin/main...HEAD`` — commits landed on the branch
+    - ``--cached`` — changes already ``git add``-staged for the next commit
+    - ``HEAD`` — unstaged worktree changes
+
+    Without the staged/worktree diffs, a pre-commit invocation sitting on
+    top of an existing branch with prior commits would see a non-empty
+    commit-range diff, take that branch as the answer, and silently skip
+    the file the author is about to commit.
     """
-    try:
-        result = subprocess.run(
-            ["git", "diff", "--name-only", "origin/main...HEAD"],
-            capture_output=True,
-            text=True,
-            cwd=FO_ROOT,
-        )
-        if not result.stdout.strip():
+    changed: set[str] = set()
+    for diff_args in (
+        ["origin/main...HEAD"],
+        ["--cached"],
+        ["HEAD"],
+    ):
+        try:
             result = subprocess.run(
-                ["git", "diff", "--name-only", "HEAD"],
+                ["git", "diff", "--name-only", *diff_args],
                 capture_output=True,
                 text=True,
                 cwd=FO_ROOT,
             )
-        changed = {line.strip() for line in result.stdout.splitlines() if line.strip()}
-    except Exception:
-        changed = set()
+            changed.update(line.strip() for line in result.stdout.splitlines() if line.strip())
+        except Exception:
+            # Best-effort: any git failure leaves `changed` unchanged; if all
+            # three diffs fail we yield an empty set, which each caller treats
+            # as "no changed files" (diff-scoped guardrails then no-op).
+            continue
+
     return sorted(
         p
         for p in TESTS_ROOT.rglob("*.py")
@@ -561,7 +576,7 @@ def _find_is_not_none_or_is_none_tautology(source: str, path: str = "<string>") 
     except SyntaxError:
         return []
 
-    def _is_is_none(n: ast.AST, negated: bool) -> str | None:
+    def _is_is_none(n: ast.AST, *, negated: bool) -> str | None:
         if not isinstance(n, ast.Compare) or len(n.ops) != 1 or len(n.comparators) != 1:
             return None
         comp = n.comparators[0]
@@ -641,21 +656,33 @@ def test_changed_tests_have_no_is_none_tautology() -> None:
 def _find_generator_throw_false_raise(source: str, path: str = "<string>") -> list[str]:
     """Return locations of ``(_ for _ in ()).throw(...)`` expressions.
 
-    This expression is often used as a mock side-effect intending to raise an
-    exception when the mocked callable is invoked.  It does NOT raise — it
-    returns a generator object.  The production code receives the generator
-    (which is truthy and can even be ``__enter__``-compatible in some paths)
-    and the error-handling branch is never exercised.  The test passes green
-    while the exception path is silently untested.
+    The idiom DOES raise — ``generator.throw(exc)`` on a fresh generator-expression
+    starts it and propagates ``exc`` back to the caller.  It is banned anyway, for
+    clarity and policy reasons: a five-token obfuscation of ``raise exc`` is
+    easy to misread (historically assumed to be a no-op that returns a generator),
+    and ``MagicMock(side_effect=exc)`` or a named ``def _raise(): raise exc``
+    helper is both clearer and more conventional.
 
-    Detection is textual because the AST shape varies (lambda, direct call,
-    assignment to ``obj.method``) but the literal ``(_ for _ in ())`` is
-    the telltale marker.
+    Detection is AST-based so that occurrences in comments, string literals, and
+    docstrings are not flagged.  Matches any ``<genexp>.throw(...)`` where
+    ``<genexp>`` is a generator expression — not just the literal
+    ``(_ for _ in ())`` shape — because variations like ``(_ for _ in [])`` or
+    ``(x for x in ())`` fall under the same anti-pattern.
     """
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError:
+        return []
+
     violations: list[str] = []
-    for lineno, line in enumerate(source.splitlines(), start=1):
-        if "(_ for _ in ())" in line and ".throw" in line:
-            violations.append(f"{path}:{lineno}")
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "throw"):
+            continue
+        if isinstance(func.value, ast.GeneratorExp):
+            violations.append(f"{path}:{node.lineno}")
     return violations
 
 
@@ -669,10 +696,22 @@ def _find_generator_throw_false_raise(source: str, path: str = "<string>") -> li
         ),
         # Standalone expression — flag
         ("(_ for _ in ()).throw(ValueError('x'))\n", 1),
+        # Variant generator shapes — also flag (same anti-pattern)
+        ("(_ for _ in []).throw(OSError('x'))\n", 1),
+        ("(x for x in ()).throw(RuntimeError('y'))\n", 1),
+        # Comment mentioning the pattern — NOT flagged (AST ignores comments)
+        ("# (_ for _ in ()).throw(ValueError('x'))\nx = 1\n", 0),
+        # String literal containing the pattern — NOT flagged
+        ("text = \"(_ for _ in ()).throw(ValueError('x'))\"\n", 0),
+        # Docstring mentioning the pattern — NOT flagged
+        ('def f():\n    """(_ for _ in ()).throw(X())"""\n    pass\n', 0),
         # Named function that raises — NOT flagged (correct pattern)
         ("def raise_oserror(*a, **k):\n    raise OSError('boom')\n", 0),
-        # Plain generator — NOT flagged
+        # Plain generator without .throw — NOT flagged
         ("gen = (x for x in [1, 2, 3])\n", 0),
+        # .throw on a named variable (not a generator expression) — NOT flagged
+        # (style is fine when the generator is the intended object under test)
+        ("gen = some_generator()\ngen.throw(ValueError('x'))\n", 0),
     ],
 )
 def test_detector_flags_generator_throw_false_raise(source: str, expected_count: int) -> None:
@@ -680,12 +719,12 @@ def test_detector_flags_generator_throw_false_raise(source: str, expected_count:
 
 
 def test_changed_tests_have_no_generator_throw_false_raise() -> None:
-    """Changed test files must not use ``(_ for _ in ()).throw(...)`` mocks.
+    """Changed test files must not use ``<genexp>.throw(...)`` mocks.
 
-    The expression returns a generator instead of raising.  Use a named
-    function (``def _raise_x(): raise X(...)``) or
-    ``MagicMock(side_effect=X(...))`` instead.  See test-generation-patterns.md
-    T14 for details.
+    The idiom raises the exception (contrary to intuition) but is banned for
+    clarity: use a named ``def _raise(): raise X(...)`` helper or
+    ``MagicMock(side_effect=X(...))`` instead.  See T14 in
+    ``.claude/rules/test-generation-patterns.md``.
 
     Diff-scoped for now — 9 pre-existing violations exist across the suite
     (daemon, events, integration, pipeline).  TODO: broaden to the full suite
@@ -697,6 +736,6 @@ def test_changed_tests_have_no_generator_throw_false_raise() -> None:
         violations.extend(_find_generator_throw_false_raise(source, str(path)))
 
     assert not violations, (
-        "Generator-throw false-raise found — use a named function or "
+        "`<genexp>.throw(...)` found — use a named function or "
         "MagicMock(side_effect=...) instead:\n" + "\n".join(violations)
     )

--- a/tests/integration/test_preference_tracker_branches.py
+++ b/tests/integration/test_preference_tracker_branches.py
@@ -429,10 +429,9 @@ class TestGetPreference:
             destination=Path("/a/new.txt"),
             correction_type=CorrectionType.FILE_RENAME,
         )
-        # Same parent + same extension → same pattern key
+        # Same parent + same extension → same pattern key, so lookup must hit.
         result = tracker.get_preference(Path("/a/another.txt"), PreferenceType.NAMING_PATTERN)
-        # The key includes parent name — so must match
-        assert result is not None or result is None  # just exercising the path
+        assert result is not None
 
     def test_get_category_override_no_match(self) -> None:
         """CATEGORY_OVERRIDE with nothing tracked → None."""

--- a/tests/integration/test_preference_tracker_branches.py
+++ b/tests/integration/test_preference_tracker_branches.py
@@ -429,9 +429,12 @@ class TestGetPreference:
             destination=Path("/a/new.txt"),
             correction_type=CorrectionType.FILE_RENAME,
         )
-        # Same parent + same extension → same pattern key, so lookup must hit.
+        # Same parent + same extension → same pattern key, so lookup must hit
+        # and must return the naming pattern recorded from the prior correction.
         result = tracker.get_preference(Path("/a/another.txt"), PreferenceType.NAMING_PATTERN)
         assert result is not None
+        assert result.preference_type == PreferenceType.NAMING_PATTERN
+        assert result.value == "new.txt"
 
     def test_get_category_override_no_match(self) -> None:
         """CATEGORY_OVERRIDE with nothing tracked → None."""

--- a/tests/services/audio/test_audio_integration.py
+++ b/tests/services/audio/test_audio_integration.py
@@ -194,10 +194,10 @@ class TestFullPipeline:
         classification = classifier.classify(metadata, transcription)
         assert classification.audio_type == AudioType.PODCAST
 
-        # Analyze
+        # Analyze — podcast content has non-empty topic and keyword extraction
         analysis = analyzer.analyze(metadata, transcription)
         assert analysis.language == "en"
-        assert analysis.topic_count >= 0  # May detect Technology
+        assert analysis.topic_count + analysis.keyword_count >= 1
 
         # Organize
         path = organizer.generate_path(classification.audio_type, metadata)
@@ -256,7 +256,8 @@ class TestFullPipeline:
         assert classification.audio_type == AudioType.RECORDING
 
         analysis = analyzer.analyze(metadata, transcription)
-        assert analysis.keyword_count >= 0
+        # Recording transcription is substantive — analyzer should extract at least one keyword
+        assert analysis.keyword_count >= 1
 
         path = organizer.generate_path(classification.audio_type, metadata)
         assert "Recordings" in path.parts

--- a/tests/services/audio/test_audio_integration.py
+++ b/tests/services/audio/test_audio_integration.py
@@ -194,10 +194,13 @@ class TestFullPipeline:
         classification = classifier.classify(metadata, transcription)
         assert classification.audio_type == AudioType.PODCAST
 
-        # Analyze — podcast content has non-empty topic and keyword extraction
+        # Analyze — podcast content has non-empty topic and keyword extraction.
+        # Both paths must populate (sum-based bound lets one path regress
+        # silently); assert each independently.
         analysis = analyzer.analyze(metadata, transcription)
         assert analysis.language == "en"
-        assert analysis.topic_count + analysis.keyword_count >= 1
+        assert analysis.topic_count >= 1
+        assert analysis.keyword_count >= 1
 
         # Organize
         path = organizer.generate_path(classification.audio_type, metadata)


### PR DESCRIPTION
## Summary

- Every non-bootstrap `pip install` in `.github/workflows/*.yml` is now wrapped in `nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08` (v3.0.2, SHA-pinned per repo convention).
- 30 pip install invocations across 9 workflow files → 3 retry attempts each, 10-minute (heavy installs) or 5-minute (single-package) per-attempt timeout.
- Two mixed steps split so the retry only re-runs pip install, not downstream work: Diff coverage gate and Install size gate.
- `python -m pip install --upgrade pip` in `build.yml` intentionally left un-wrapped — a tiny, always-reliable bootstrap.

## Why Option B, not Option A

Issue [#145](https://github.com/curdriceaurora/fo-core/issues/145) offered two paths. Option A (pip-native `--retries 10 --timeout 60`) doesn't help with the exact failure mode that triggered the issue: the [2026-04-21 integration coverage-gate failure](https://github.com/curdriceaurora/fo-core/actions/runs/24724628394) was `SSLError: DECRYPTION_FAILED_OR_BAD_RECORD_MAC` raised from `urllib3.response.read()` mid-stream on a 16.9 MB numpy wheel. pip's default `--retries=5` did not catch it — the process exited 2 without visibly retrying.

Step-level retry re-runs the entire pip process on non-zero exit, which transparently recovers from mid-stream TLS corruption, incomplete downloads, and any other transient pip failure.

## Test plan

- [x] YAML validity: all 12 workflow files parse via `python3 -c "import yaml; yaml.safe_load(open(...))"`
- [x] Coverage check: scan script confirms every non-bootstrap `pip install` line sits inside a `nick-fields/retry` step (30/30)
- [x] Local pre-commit run (14 hooks) — all green
- [x] CI green on this PR

## Notes

- **SHA pinning**: follows the repo's existing pattern (`actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2`).
- **Supply chain**: `nick-fields/retry` is a well-maintained 2k+-star action pinned to the v3.0.2 SHA; any future upgrade is an explicit commit.
- **Retry parameters**: `timeout_minutes: 10` for heavy installs (`.[dev,search]`, `.[dev,media]`, etc.), `timeout_minutes: 5` for single-package installs (diff-cover, pip-audit, build, etc.). `max_attempts: 3` across the board.

Closes #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)