### PR TITLE
refactor(tests): add provider_env fixture and migrate 4 test files (issue #141 Phase 1)

### DIFF
--- a/tests/config/test_provider_env.py
+++ b/tests/config/test_provider_env.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from unittest.mock import patch
 
 import pytest
@@ -20,39 +21,41 @@ pytestmark = [pytest.mark.unit, pytest.mark.ci]
 
 
 class TestGetCurrentProvider:
-    def test_defaults_to_ollama_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("FO_PROVIDER", raising=False)
+    def test_defaults_to_ollama_when_unset(self, provider_env: Callable[..., None]) -> None:
+        provider_env()
 
         assert get_current_provider() == "ollama"
 
-    def test_returns_openai_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "openai")
+    def test_returns_openai_when_set(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_PROVIDER="openai")
 
         assert get_current_provider() == "openai"
 
-    def test_returns_ollama_when_set_explicitly(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "ollama")
+    def test_returns_ollama_when_set_explicitly(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_PROVIDER="ollama")
 
         assert get_current_provider() == "ollama"
 
-    def test_returns_mlx_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "mlx")
+    def test_returns_mlx_when_set(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_PROVIDER="mlx")
 
         assert get_current_provider() == "mlx"
 
-    def test_falls_back_to_ollama_on_unknown_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "anthropic")
+    def test_falls_back_to_ollama_on_unknown_value(
+        self, provider_env: Callable[..., None]
+    ) -> None:
+        provider_env(FO_PROVIDER="anthropic")
 
         # Should not raise — returns safe default
         assert get_current_provider() == "ollama"
 
-    def test_strips_whitespace(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "  openai  ")
+    def test_strips_whitespace(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_PROVIDER="  openai  ")
 
         assert get_current_provider() == "openai"
 
-    def test_case_insensitive(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "OPENAI")
+    def test_case_insensitive(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_PROVIDER="OPENAI")
 
         assert get_current_provider() == "openai"
 
@@ -64,9 +67,9 @@ class TestGetCurrentProvider:
 
 class TestGetModelConfigsFromEnvOllama:
     def test_returns_ollama_defaults_when_provider_unset(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
-        monkeypatch.delenv("FO_PROVIDER", raising=False)
+        provider_env()
         expected_text = TextModel.get_default_config()
         expected_vision = VisionModel.get_default_config()
 
@@ -78,9 +81,9 @@ class TestGetModelConfigsFromEnvOllama:
         assert vision_cfg.provider == "ollama"
 
     def test_returned_configs_have_correct_model_types(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
-        monkeypatch.delenv("FO_PROVIDER", raising=False)
+        provider_env()
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
@@ -94,77 +97,68 @@ class TestGetModelConfigsFromEnvOllama:
 
 
 class TestGetModelConfigsFromEnvOpenAI:
-    def test_openai_provider_sets_provider_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.setenv("FO_OPENAI_API_KEY", "sk-abc")
-        monkeypatch.delenv("FO_OPENAI_BASE_URL", raising=False)
-        monkeypatch.delenv("FO_OPENAI_MODEL", raising=False)
-        monkeypatch.delenv("FO_OPENAI_VISION_MODEL", raising=False)
+    def test_openai_provider_sets_provider_field(
+        self, provider_env: Callable[..., None]
+    ) -> None:
+        provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-abc")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
         assert text_cfg.provider == "openai"
         assert vision_cfg.provider == "openai"
 
-    def test_api_key_propagated_to_both_configs(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.setenv("FO_OPENAI_API_KEY", "sk-secret")
-        monkeypatch.delenv("FO_OPENAI_BASE_URL", raising=False)
+    def test_api_key_propagated_to_both_configs(
+        self, provider_env: Callable[..., None]
+    ) -> None:
+        provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-secret")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
         assert text_cfg.api_key == "sk-secret"
         assert vision_cfg.api_key == "sk-secret"
 
-    def test_base_url_propagated_to_both_configs(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.setenv("FO_OPENAI_BASE_URL", "http://localhost:1234/v1")
-        monkeypatch.delenv("FO_OPENAI_API_KEY", raising=False)
+    def test_base_url_propagated_to_both_configs(
+        self, provider_env: Callable[..., None]
+    ) -> None:
+        provider_env(FO_PROVIDER="openai", FO_OPENAI_BASE_URL="http://localhost:1234/v1")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
         assert text_cfg.api_base_url == "http://localhost:1234/v1"
         assert vision_cfg.api_base_url == "http://localhost:1234/v1"
 
-    def test_custom_text_model_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.setenv("FO_OPENAI_MODEL", "gpt-4o")
-        monkeypatch.delenv("FO_OPENAI_VISION_MODEL", raising=False)
-        monkeypatch.delenv("FO_OPENAI_API_KEY", raising=False)
-        monkeypatch.delenv("FO_OPENAI_BASE_URL", raising=False)
+    def test_custom_text_model_name(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_PROVIDER="openai", FO_OPENAI_MODEL="gpt-4o")
 
         text_cfg, _ = get_model_configs_from_env()
 
         assert text_cfg.name == "gpt-4o"
 
     def test_vision_model_falls_back_to_text_model_name(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.setenv("FO_OPENAI_MODEL", "gpt-4o")
-        monkeypatch.delenv("FO_OPENAI_VISION_MODEL", raising=False)
-        monkeypatch.delenv("FO_OPENAI_API_KEY", raising=False)
-        monkeypatch.delenv("FO_OPENAI_BASE_URL", raising=False)
+        provider_env(FO_PROVIDER="openai", FO_OPENAI_MODEL="gpt-4o")
 
         _, vision_cfg = get_model_configs_from_env()
 
         assert vision_cfg.name == "gpt-4o"
 
-    def test_separate_vision_model_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.setenv("FO_OPENAI_MODEL", "gpt-4o-mini")
-        monkeypatch.setenv("FO_OPENAI_VISION_MODEL", "gpt-4o")
-        monkeypatch.delenv("FO_OPENAI_API_KEY", raising=False)
-        monkeypatch.delenv("FO_OPENAI_BASE_URL", raising=False)
+    def test_separate_vision_model_name(self, provider_env: Callable[..., None]) -> None:
+        provider_env(
+            FO_PROVIDER="openai",
+            FO_OPENAI_MODEL="gpt-4o-mini",
+            FO_OPENAI_VISION_MODEL="gpt-4o",
+        )
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
         assert text_cfg.name == "gpt-4o-mini"
         assert vision_cfg.name == "gpt-4o"
 
-    def test_model_types_correct_for_openai_configs(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.setenv("FO_OPENAI_API_KEY", "sk-test")
+    def test_model_types_correct_for_openai_configs(
+        self, provider_env: Callable[..., None]
+    ) -> None:
+        provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
@@ -178,9 +172,8 @@ class TestGetModelConfigsFromEnvOpenAI:
 
 
 class TestGetModelConfigsFromEnvMLX:
-    def test_mlx_provider_sets_provider_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "mlx")
-        monkeypatch.setenv("FO_MLX_MODEL_PATH", "mlx-community/Qwen2.5-3B-Instruct-4bit")
+    def test_mlx_provider_sets_provider_field(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_PROVIDER="mlx", FO_MLX_MODEL_PATH="mlx-community/Qwen2.5-3B-Instruct-4bit")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
@@ -188,19 +181,19 @@ class TestGetModelConfigsFromEnvMLX:
         assert vision_cfg.provider == "mlx"
 
     def test_mlx_model_path_propagates_to_text_and_vision(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "mlx")
-        monkeypatch.setenv("FO_MLX_MODEL_PATH", "/models/mlx")
+        provider_env(FO_PROVIDER="mlx", FO_MLX_MODEL_PATH="/models/mlx")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
         assert text_cfg.model_path == "/models/mlx"
         assert vision_cfg.model_path == "/models/mlx"
 
-    def test_missing_mlx_model_path_does_not_crash(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "mlx")
-        monkeypatch.delenv("FO_MLX_MODEL_PATH", raising=False)
+    def test_missing_mlx_model_path_does_not_crash(
+        self, provider_env: Callable[..., None]
+    ) -> None:
+        provider_env(FO_PROVIDER="mlx")
 
         with patch("config.provider_env.logger.warning") as mock_warning:
             text_cfg, vision_cfg = get_model_configs_from_env()
@@ -212,9 +205,10 @@ class TestGetModelConfigsFromEnvMLX:
         warning_messages = " ".join(str(call.args[0]) for call in mock_warning.call_args_list)
         assert "FO_MLX_MODEL_PATH" in warning_messages
 
-    def test_model_types_correct_for_mlx_configs(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "mlx")
-        monkeypatch.setenv("FO_MLX_MODEL_PATH", "mlx-community/Qwen2.5-3B-Instruct-4bit")
+    def test_model_types_correct_for_mlx_configs(
+        self, provider_env: Callable[..., None]
+    ) -> None:
+        provider_env(FO_PROVIDER="mlx", FO_MLX_MODEL_PATH="mlx-community/Qwen2.5-3B-Instruct-4bit")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 

--- a/tests/config/test_provider_env.py
+++ b/tests/config/test_provider_env.py
@@ -41,9 +41,7 @@ class TestGetCurrentProvider:
 
         assert get_current_provider() == "mlx"
 
-    def test_falls_back_to_ollama_on_unknown_value(
-        self, provider_env: Callable[..., None]
-    ) -> None:
+    def test_falls_back_to_ollama_on_unknown_value(self, provider_env: Callable[..., None]) -> None:
         provider_env(FO_PROVIDER="anthropic")
 
         # Should not raise — returns safe default
@@ -97,9 +95,7 @@ class TestGetModelConfigsFromEnvOllama:
 
 
 class TestGetModelConfigsFromEnvOpenAI:
-    def test_openai_provider_sets_provider_field(
-        self, provider_env: Callable[..., None]
-    ) -> None:
+    def test_openai_provider_sets_provider_field(self, provider_env: Callable[..., None]) -> None:
         provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-abc")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
@@ -107,9 +103,7 @@ class TestGetModelConfigsFromEnvOpenAI:
         assert text_cfg.provider == "openai"
         assert vision_cfg.provider == "openai"
 
-    def test_api_key_propagated_to_both_configs(
-        self, provider_env: Callable[..., None]
-    ) -> None:
+    def test_api_key_propagated_to_both_configs(self, provider_env: Callable[..., None]) -> None:
         provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-secret")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
@@ -117,9 +111,7 @@ class TestGetModelConfigsFromEnvOpenAI:
         assert text_cfg.api_key == "sk-secret"
         assert vision_cfg.api_key == "sk-secret"
 
-    def test_base_url_propagated_to_both_configs(
-        self, provider_env: Callable[..., None]
-    ) -> None:
+    def test_base_url_propagated_to_both_configs(self, provider_env: Callable[..., None]) -> None:
         provider_env(FO_PROVIDER="openai", FO_OPENAI_BASE_URL="http://localhost:1234/v1")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
@@ -190,9 +182,7 @@ class TestGetModelConfigsFromEnvMLX:
         assert text_cfg.model_path == "/models/mlx"
         assert vision_cfg.model_path == "/models/mlx"
 
-    def test_missing_mlx_model_path_does_not_crash(
-        self, provider_env: Callable[..., None]
-    ) -> None:
+    def test_missing_mlx_model_path_does_not_crash(self, provider_env: Callable[..., None]) -> None:
         provider_env(FO_PROVIDER="mlx")
 
         with patch("config.provider_env.logger.warning") as mock_warning:
@@ -205,9 +195,7 @@ class TestGetModelConfigsFromEnvMLX:
         warning_messages = " ".join(str(call.args[0]) for call in mock_warning.call_args_list)
         assert "FO_MLX_MODEL_PATH" in warning_messages
 
-    def test_model_types_correct_for_mlx_configs(
-        self, provider_env: Callable[..., None]
-    ) -> None:
+    def test_model_types_correct_for_mlx_configs(self, provider_env: Callable[..., None]) -> None:
         provider_env(FO_PROVIDER="mlx", FO_MLX_MODEL_PATH="mlx-community/Qwen2.5-3B-Instruct-4bit")
 
         text_cfg, vision_cfg = get_model_configs_from_env()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -161,3 +162,58 @@ def sample_files_dir(tmp_path: Path) -> Path:
     (d / "notes.md").write_text("# Notes\n\n- Item 1\n- Item 2\n")
     (d / "data.csv").write_text("col1,col2\nval1,val2\n")
     return d
+
+
+# ---------------------------------------------------------------------------
+# Provider environment fixture
+# ---------------------------------------------------------------------------
+
+_KNOWN_PROVIDER_VARS: frozenset[str] = frozenset(
+    {
+        "FO_PROVIDER",
+        "FO_PROFILE",
+        "FO_OPENAI_API_KEY",
+        "FO_OPENAI_BASE_URL",
+        "FO_OPENAI_MODEL",
+        "FO_OPENAI_VISION_MODEL",
+        "OPENAI_API_KEY",
+        "FO_LLAMA_CPP_MODEL_PATH",
+        "FO_LLAMA_CPP_N_GPU_LAYERS",
+        "FO_MLX_MODEL_PATH",
+        "FO_CLAUDE_API_KEY",
+        "FO_CLAUDE_MODEL",
+        "FO_CLAUDE_VISION_MODEL",
+        "ANTHROPIC_API_KEY",
+    }
+)
+
+
+@pytest.fixture
+def provider_env(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
+    """Return a callable that clears all known provider env vars then sets the given ones.
+
+    Usage::
+
+        def test_openai(provider_env):
+            provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test")
+            ...
+
+    Rules:
+
+    - Calling with no arguments clears all known vars.
+    - A value of ``None`` keeps the var unset (same as not providing it).
+    - An empty string ``""`` sets the var to an empty string.
+    - Passing an unknown var name raises ``KeyError``.
+    """
+
+    def _set(**values: str | None) -> None:
+        unknown = set(values) - _KNOWN_PROVIDER_VARS
+        if unknown:
+            raise KeyError(f"Unknown provider env var(s): {unknown!r}")
+        for var in _KNOWN_PROVIDER_VARS:
+            monkeypatch.delenv(var, raising=False)
+        for name, value in values.items():
+            if value is not None:
+                monkeypatch.setenv(name, value)
+
+    return _set

--- a/tests/integration/config/test_provider_env.py
+++ b/tests/integration/config/test_provider_env.py
@@ -33,9 +33,7 @@ pytestmark = [pytest.mark.integration]
 
 
 class TestGetCurrentProviderUnknownValue:
-    def test_unknown_provider_falls_back_to_ollama(
-        self, provider_env: Callable[..., None]
-    ) -> None:
+    def test_unknown_provider_falls_back_to_ollama(self, provider_env: Callable[..., None]) -> None:
         provider_env(FO_PROVIDER="unknown_provider_xyz")
 
         result = get_current_provider()
@@ -60,9 +58,7 @@ class TestGetCurrentProviderUnknownValue:
 
 
 class TestGetLlamaCppConfigs:
-    def test_model_path_propagated_to_both_configs(
-        self, provider_env: Callable[..., None]
-    ) -> None:
+    def test_model_path_propagated_to_both_configs(self, provider_env: Callable[..., None]) -> None:
         provider_env(FO_LLAMA_CPP_MODEL_PATH="/models/llama3.gguf")
 
         text_cfg, vision_cfg = _get_llama_cpp_configs()
@@ -130,9 +126,7 @@ class TestGetLlamaCppConfigs:
 
 
 class TestGetMlxConfigs:
-    def test_model_path_propagated_to_both_configs(
-        self, provider_env: Callable[..., None]
-    ) -> None:
+    def test_model_path_propagated_to_both_configs(self, provider_env: Callable[..., None]) -> None:
         provider_env(FO_MLX_MODEL_PATH="mlx-community/Qwen2.5-3B-Instruct-4bit")
 
         text_cfg, vision_cfg = _get_mlx_configs()
@@ -331,9 +325,7 @@ class TestGetModelConfigsFromEnvOpenAIWarningBranch:
 
 
 class TestGetModelConfigsPriorityCascade:
-    def test_fo_provider_set_uses_env_over_profile(
-        self, provider_env: Callable[..., None]
-    ) -> None:
+    def test_fo_provider_set_uses_env_over_profile(self, provider_env: Callable[..., None]) -> None:
         """When FO_PROVIDER is set, env config wins over profile config."""
         provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test")
 

--- a/tests/integration/config/test_provider_env.py
+++ b/tests/integration/config/test_provider_env.py
@@ -8,6 +8,7 @@ values.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from unittest.mock import patch
 
 import pytest
@@ -32,15 +33,17 @@ pytestmark = [pytest.mark.integration]
 
 
 class TestGetCurrentProviderUnknownValue:
-    def test_unknown_provider_falls_back_to_ollama(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "unknown_provider_xyz")
+    def test_unknown_provider_falls_back_to_ollama(
+        self, provider_env: Callable[..., None]
+    ) -> None:
+        provider_env(FO_PROVIDER="unknown_provider_xyz")
 
         result = get_current_provider()
 
         assert result == "ollama"
 
-    def test_unknown_provider_emits_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "bogus")
+    def test_unknown_provider_emits_warning(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_PROVIDER="bogus")
 
         with patch("config.provider_env.logger.warning") as mock_warn:
             get_current_provider()
@@ -57,45 +60,48 @@ class TestGetCurrentProviderUnknownValue:
 
 
 class TestGetLlamaCppConfigs:
-    def test_model_path_propagated_to_both_configs(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_LLAMA_CPP_MODEL_PATH", "/models/llama3.gguf")
-        monkeypatch.delenv("FO_LLAMA_CPP_N_GPU_LAYERS", raising=False)
+    def test_model_path_propagated_to_both_configs(
+        self, provider_env: Callable[..., None]
+    ) -> None:
+        provider_env(FO_LLAMA_CPP_MODEL_PATH="/models/llama3.gguf")
 
         text_cfg, vision_cfg = _get_llama_cpp_configs()
 
         assert text_cfg.model_path == "/models/llama3.gguf"
         assert vision_cfg.model_path == "/models/llama3.gguf"
 
-    def test_provider_field_is_llama_cpp(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_LLAMA_CPP_MODEL_PATH", "/models/llama3.gguf")
-        monkeypatch.delenv("FO_LLAMA_CPP_N_GPU_LAYERS", raising=False)
+    def test_provider_field_is_llama_cpp(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_LLAMA_CPP_MODEL_PATH="/models/llama3.gguf")
 
         text_cfg, vision_cfg = _get_llama_cpp_configs()
 
         assert text_cfg.provider == "llama_cpp"
         assert vision_cfg.provider == "llama_cpp"
 
-    def test_model_types_correct(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_LLAMA_CPP_MODEL_PATH", "/models/llama3.gguf")
-        monkeypatch.delenv("FO_LLAMA_CPP_N_GPU_LAYERS", raising=False)
+    def test_model_types_correct(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_LLAMA_CPP_MODEL_PATH="/models/llama3.gguf")
 
         text_cfg, vision_cfg = _get_llama_cpp_configs()
 
         assert text_cfg.model_type == ModelType.TEXT
         assert vision_cfg.model_type == ModelType.VISION
 
-    def test_n_gpu_layers_added_to_extra_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_LLAMA_CPP_MODEL_PATH", "/models/llama3.gguf")
-        monkeypatch.setenv("FO_LLAMA_CPP_N_GPU_LAYERS", "32")
+    def test_n_gpu_layers_added_to_extra_params(self, provider_env: Callable[..., None]) -> None:
+        provider_env(
+            FO_LLAMA_CPP_MODEL_PATH="/models/llama3.gguf",
+            FO_LLAMA_CPP_N_GPU_LAYERS="32",
+        )
 
         text_cfg, vision_cfg = _get_llama_cpp_configs()
 
         assert text_cfg.extra_params["n_gpu_layers"] == 32
         assert vision_cfg.extra_params["n_gpu_layers"] == 32
 
-    def test_invalid_n_gpu_layers_is_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_LLAMA_CPP_MODEL_PATH", "/models/llama3.gguf")
-        monkeypatch.setenv("FO_LLAMA_CPP_N_GPU_LAYERS", "not_a_number")
+    def test_invalid_n_gpu_layers_is_ignored(self, provider_env: Callable[..., None]) -> None:
+        provider_env(
+            FO_LLAMA_CPP_MODEL_PATH="/models/llama3.gguf",
+            FO_LLAMA_CPP_N_GPU_LAYERS="not_a_number",
+        )
 
         with patch("config.provider_env.logger.warning") as mock_warn:
             text_cfg, _vision_cfg = _get_llama_cpp_configs()
@@ -106,9 +112,8 @@ class TestGetLlamaCppConfigs:
         warning_text = " ".join(str(c) for c in mock_warn.call_args_list)
         assert "not_a_number" in warning_text or "FO_LLAMA_CPP_N_GPU_LAYERS" in warning_text
 
-    def test_missing_model_path_emits_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("FO_LLAMA_CPP_MODEL_PATH", raising=False)
-        monkeypatch.delenv("FO_LLAMA_CPP_N_GPU_LAYERS", raising=False)
+    def test_missing_model_path_emits_warning(self, provider_env: Callable[..., None]) -> None:
+        provider_env()
 
         with patch("config.provider_env.logger.warning") as mock_warn:
             text_cfg, vision_cfg = _get_llama_cpp_configs()
@@ -125,32 +130,34 @@ class TestGetLlamaCppConfigs:
 
 
 class TestGetMlxConfigs:
-    def test_model_path_propagated_to_both_configs(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_MLX_MODEL_PATH", "mlx-community/Qwen2.5-3B-Instruct-4bit")
+    def test_model_path_propagated_to_both_configs(
+        self, provider_env: Callable[..., None]
+    ) -> None:
+        provider_env(FO_MLX_MODEL_PATH="mlx-community/Qwen2.5-3B-Instruct-4bit")
 
         text_cfg, vision_cfg = _get_mlx_configs()
 
         assert text_cfg.model_path == "mlx-community/Qwen2.5-3B-Instruct-4bit"
         assert vision_cfg.model_path == "mlx-community/Qwen2.5-3B-Instruct-4bit"
 
-    def test_provider_field_is_mlx(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_MLX_MODEL_PATH", "/local/mlx-model")
+    def test_provider_field_is_mlx(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_MLX_MODEL_PATH="/local/mlx-model")
 
         text_cfg, vision_cfg = _get_mlx_configs()
 
         assert text_cfg.provider == "mlx"
         assert vision_cfg.provider == "mlx"
 
-    def test_model_types_correct(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_MLX_MODEL_PATH", "/local/mlx-model")
+    def test_model_types_correct(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_MLX_MODEL_PATH="/local/mlx-model")
 
         text_cfg, vision_cfg = _get_mlx_configs()
 
         assert text_cfg.model_type == ModelType.TEXT
         assert vision_cfg.model_type == ModelType.VISION
 
-    def test_missing_model_path_emits_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("FO_MLX_MODEL_PATH", raising=False)
+    def test_missing_model_path_emits_warning(self, provider_env: Callable[..., None]) -> None:
+        provider_env()
 
         with patch("config.provider_env.logger.warning") as mock_warn:
             text_cfg, vision_cfg = _get_mlx_configs()
@@ -167,77 +174,60 @@ class TestGetMlxConfigs:
 
 
 class TestGetClaudeConfigs:
-    def test_provider_field_is_claude(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_CLAUDE_API_KEY", "sk-ant-test")
-        monkeypatch.delenv("FO_CLAUDE_MODEL", raising=False)
-        monkeypatch.delenv("FO_CLAUDE_VISION_MODEL", raising=False)
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    def test_provider_field_is_claude(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_CLAUDE_API_KEY="sk-ant-test")
 
         text_cfg, vision_cfg = _get_claude_configs()
 
         assert text_cfg.provider == "claude"
         assert vision_cfg.provider == "claude"
 
-    def test_api_key_propagated_to_both_configs(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_CLAUDE_API_KEY", "sk-ant-secret")
-        monkeypatch.delenv("FO_CLAUDE_MODEL", raising=False)
-        monkeypatch.delenv("FO_CLAUDE_VISION_MODEL", raising=False)
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    def test_api_key_propagated_to_both_configs(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_CLAUDE_API_KEY="sk-ant-secret")
 
         text_cfg, vision_cfg = _get_claude_configs()
 
         assert text_cfg.api_key == "sk-ant-secret"
         assert vision_cfg.api_key == "sk-ant-secret"
 
-    def test_model_types_correct(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_CLAUDE_API_KEY", "sk-ant-test")
-        monkeypatch.delenv("FO_CLAUDE_MODEL", raising=False)
-        monkeypatch.delenv("FO_CLAUDE_VISION_MODEL", raising=False)
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    def test_model_types_correct(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_CLAUDE_API_KEY="sk-ant-test")
 
         text_cfg, vision_cfg = _get_claude_configs()
 
         assert text_cfg.model_type == ModelType.TEXT
         assert vision_cfg.model_type == ModelType.VISION
 
-    def test_custom_text_model_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_CLAUDE_API_KEY", "sk-ant-test")
-        monkeypatch.setenv("FO_CLAUDE_MODEL", "claude-3-opus-20240229")
-        monkeypatch.delenv("FO_CLAUDE_VISION_MODEL", raising=False)
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    def test_custom_text_model_name(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_CLAUDE_API_KEY="sk-ant-test", FO_CLAUDE_MODEL="claude-3-opus-20240229")
 
         text_cfg, _ = _get_claude_configs()
 
         assert text_cfg.name == "claude-3-opus-20240229"
 
     def test_vision_model_falls_back_to_text_model_name(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
-        monkeypatch.setenv("FO_CLAUDE_API_KEY", "sk-ant-test")
-        monkeypatch.setenv("FO_CLAUDE_MODEL", "claude-3-opus-20240229")
-        monkeypatch.delenv("FO_CLAUDE_VISION_MODEL", raising=False)
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        provider_env(FO_CLAUDE_API_KEY="sk-ant-test", FO_CLAUDE_MODEL="claude-3-opus-20240229")
 
         _, vision_cfg = _get_claude_configs()
 
         assert vision_cfg.name == "claude-3-opus-20240229"
 
-    def test_separate_vision_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_CLAUDE_API_KEY", "sk-ant-test")
-        monkeypatch.setenv("FO_CLAUDE_MODEL", "claude-3-5-haiku-20241022")
-        monkeypatch.setenv("FO_CLAUDE_VISION_MODEL", "claude-3-5-sonnet-20241022")
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    def test_separate_vision_model(self, provider_env: Callable[..., None]) -> None:
+        provider_env(
+            FO_CLAUDE_API_KEY="sk-ant-test",
+            FO_CLAUDE_MODEL="claude-3-5-haiku-20241022",
+            FO_CLAUDE_VISION_MODEL="claude-3-5-sonnet-20241022",
+        )
 
         text_cfg, vision_cfg = _get_claude_configs()
 
         assert text_cfg.name == "claude-3-5-haiku-20241022"
         assert vision_cfg.name == "claude-3-5-sonnet-20241022"
 
-    def test_warning_when_no_api_key_at_all(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("FO_CLAUDE_API_KEY", raising=False)
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-        monkeypatch.delenv("FO_CLAUDE_MODEL", raising=False)
-        monkeypatch.delenv("FO_CLAUDE_VISION_MODEL", raising=False)
+    def test_warning_when_no_api_key_at_all(self, provider_env: Callable[..., None]) -> None:
+        provider_env()
 
         with patch("config.provider_env.logger.warning") as mock_warn:
             text_cfg, vision_cfg = _get_claude_configs()
@@ -249,12 +239,9 @@ class TestGetClaudeConfigs:
         assert "FO_CLAUDE_API_KEY" in warning_text or "ANTHROPIC_API_KEY" in warning_text
 
     def test_no_warning_when_anthropic_sdk_key_present(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
-        monkeypatch.delenv("FO_CLAUDE_API_KEY", raising=False)
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-sdk")
-        monkeypatch.delenv("FO_CLAUDE_MODEL", raising=False)
-        monkeypatch.delenv("FO_CLAUDE_VISION_MODEL", raising=False)
+        provider_env(ANTHROPIC_API_KEY="sk-ant-sdk")
 
         with patch("config.provider_env.logger.warning") as mock_warn:
             _get_claude_configs()
@@ -271,12 +258,10 @@ class TestGetClaudeConfigs:
 
 class TestGetModelConfigsFromEnvProviderDispatch:
     def test_llama_cpp_dispatch_via_get_model_configs_from_env(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
         """FO_PROVIDER=llama_cpp routes through get_model_configs_from_env correctly."""
-        monkeypatch.setenv("FO_PROVIDER", "llama_cpp")
-        monkeypatch.setenv("FO_LLAMA_CPP_MODEL_PATH", "/models/test.gguf")
-        monkeypatch.delenv("FO_LLAMA_CPP_N_GPU_LAYERS", raising=False)
+        provider_env(FO_PROVIDER="llama_cpp", FO_LLAMA_CPP_MODEL_PATH="/models/test.gguf")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
@@ -285,11 +270,10 @@ class TestGetModelConfigsFromEnvProviderDispatch:
         assert text_cfg.model_path == "/models/test.gguf"
 
     def test_mlx_dispatch_via_get_model_configs_from_env(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
         """FO_PROVIDER=mlx routes through get_model_configs_from_env correctly."""
-        monkeypatch.setenv("FO_PROVIDER", "mlx")
-        monkeypatch.setenv("FO_MLX_MODEL_PATH", "mlx-community/test-model")
+        provider_env(FO_PROVIDER="mlx", FO_MLX_MODEL_PATH="mlx-community/test-model")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
@@ -298,14 +282,10 @@ class TestGetModelConfigsFromEnvProviderDispatch:
         assert text_cfg.model_path == "mlx-community/test-model"
 
     def test_claude_dispatch_via_get_model_configs_from_env(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
         """FO_PROVIDER=claude routes through get_model_configs_from_env correctly."""
-        monkeypatch.setenv("FO_PROVIDER", "claude")
-        monkeypatch.setenv("FO_CLAUDE_API_KEY", "sk-ant-dispatch-test")
-        monkeypatch.delenv("FO_CLAUDE_MODEL", raising=False)
-        monkeypatch.delenv("FO_CLAUDE_VISION_MODEL", raising=False)
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        provider_env(FO_PROVIDER="claude", FO_CLAUDE_API_KEY="sk-ant-dispatch-test")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
@@ -321,12 +301,9 @@ class TestGetModelConfigsFromEnvProviderDispatch:
 
 class TestGetModelConfigsFromEnvOpenAIWarningBranch:
     def test_warning_when_no_key_no_base_url_no_sdk_key(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.delenv("FO_OPENAI_API_KEY", raising=False)
-        monkeypatch.delenv("FO_OPENAI_BASE_URL", raising=False)
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        provider_env(FO_PROVIDER="openai")
 
         with patch("config.provider_env.logger.warning") as mock_warn:
             text_cfg, vision_cfg = get_model_configs_from_env()
@@ -336,11 +313,8 @@ class TestGetModelConfigsFromEnvOpenAIWarningBranch:
         warning_text = " ".join(str(c) for c in mock_warn.call_args_list)
         assert "FO_OPENAI_API_KEY" in warning_text or "FO_OPENAI_BASE_URL" in warning_text
 
-    def test_no_warning_when_sdk_key_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.delenv("FO_OPENAI_API_KEY", raising=False)
-        monkeypatch.delenv("FO_OPENAI_BASE_URL", raising=False)
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-sdk-key")
+    def test_no_warning_when_sdk_key_present(self, provider_env: Callable[..., None]) -> None:
+        provider_env(FO_PROVIDER="openai", OPENAI_API_KEY="sk-sdk-key")
 
         with patch("config.provider_env.logger.warning") as mock_warn:
             text_cfg, vision_cfg = get_model_configs_from_env()
@@ -357,13 +331,11 @@ class TestGetModelConfigsFromEnvOpenAIWarningBranch:
 
 
 class TestGetModelConfigsPriorityCascade:
-    def test_fo_provider_set_uses_env_over_profile(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_fo_provider_set_uses_env_over_profile(
+        self, provider_env: Callable[..., None]
+    ) -> None:
         """When FO_PROVIDER is set, env config wins over profile config."""
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.setenv("FO_OPENAI_API_KEY", "sk-test")
-        monkeypatch.delenv("FO_OPENAI_BASE_URL", raising=False)
-        monkeypatch.delenv("FO_OPENAI_MODEL", raising=False)
-        monkeypatch.delenv("FO_OPENAI_VISION_MODEL", raising=False)
+        provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test")
 
         text_cfg, vision_cfg = get_model_configs()
 
@@ -371,11 +343,10 @@ class TestGetModelConfigsPriorityCascade:
         assert vision_cfg.provider == "openai"
 
     def test_falls_back_to_ollama_when_no_provider_and_default_profile(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
         """No FO_PROVIDER + default profile → Ollama defaults."""
-        monkeypatch.delenv("FO_PROVIDER", raising=False)
-        monkeypatch.delenv("FO_PROFILE", raising=False)
+        provider_env()
 
         with patch("config.provider_env._get_model_configs_from_profile") as mock_profile:
             # Default profile returns None → fall through to Ollama defaults
@@ -386,13 +357,12 @@ class TestGetModelConfigsPriorityCascade:
         assert vision_cfg.provider == "ollama"
 
     def test_profile_config_used_when_non_default_profile(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
         """When profile returns configs, those are used."""
         from models.base import ModelConfig, ModelType
 
-        monkeypatch.delenv("FO_PROVIDER", raising=False)
-        monkeypatch.setenv("FO_PROFILE", "work")
+        provider_env(FO_PROFILE="work")
 
         profile_text = ModelConfig(name="llama3:8b", model_type=ModelType.TEXT)
         profile_vision = ModelConfig(name="llava:13b", model_type=ModelType.VISION)

--- a/tests/integration/config/test_provider_env_integration.py
+++ b/tests/integration/config/test_provider_env_integration.py
@@ -122,9 +122,7 @@ class TestGetModelConfigsFromEnvOllamaIntegration:
 
 
 class TestGetLlamaCppConfigsIntegration:
-    def test_model_path_propagates_to_both_configs(
-        self, provider_env: Callable[..., None]
-    ) -> None:
+    def test_model_path_propagates_to_both_configs(self, provider_env: Callable[..., None]) -> None:
         """FO_LLAMA_CPP_MODEL_PATH is reflected in both text and vision configs."""
         provider_env(FO_PROVIDER="llama_cpp", FO_LLAMA_CPP_MODEL_PATH="/models/llama.gguf")
 
@@ -193,9 +191,7 @@ class TestGetLlamaCppConfigsIntegration:
 
 
 class TestGetMlxConfigsIntegration:
-    def test_model_path_propagates_to_both_configs(
-        self, provider_env: Callable[..., None]
-    ) -> None:
+    def test_model_path_propagates_to_both_configs(self, provider_env: Callable[..., None]) -> None:
         """FO_MLX_MODEL_PATH appears in both text and vision configs."""
         provider_env(FO_MLX_MODEL_PATH="mlx-community/Qwen2.5-3B-4bit")
 
@@ -273,9 +269,7 @@ class TestGetClaudeConfigsIntegration:
 
         assert text_cfg.name == "claude-3-haiku-20240307"
 
-    def test_vision_model_falls_back_to_text_model(
-        self, provider_env: Callable[..., None]
-    ) -> None:
+    def test_vision_model_falls_back_to_text_model(self, provider_env: Callable[..., None]) -> None:
         """When FO_CLAUDE_VISION_MODEL is unset, vision model name matches text model."""
         provider_env(
             FO_CLAUDE_API_KEY="sk-ant-test",
@@ -309,9 +303,7 @@ class TestGetClaudeConfigsIntegration:
         assert text_cfg.provider == "claude"
         assert vision_cfg.provider == "claude"
 
-    def test_anthropic_sdk_key_suppresses_warning(
-        self, provider_env: Callable[..., None]
-    ) -> None:
+    def test_anthropic_sdk_key_suppresses_warning(self, provider_env: Callable[..., None]) -> None:
         """ANTHROPIC_API_KEY present means the SDK will pick it up — no warning needed."""
         provider_env(ANTHROPIC_API_KEY="sk-ant-sdk-key")
 

--- a/tests/integration/config/test_provider_env_integration.py
+++ b/tests/integration/config/test_provider_env_integration.py
@@ -22,6 +22,7 @@ Coverage targets (missing lines before this file was added):
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from unittest.mock import patch
 
 import pytest
@@ -49,24 +50,24 @@ pytestmark = [pytest.mark.integration, pytest.mark.ci]
 
 class TestGetCurrentProviderIntegration:
     def test_unknown_provider_emits_warning_and_returns_ollama(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
         """Unrecognised FO_PROVIDER logs a warning and returns 'ollama'."""
-        monkeypatch.setenv("FO_PROVIDER", "gemini")
+        provider_env(FO_PROVIDER="gemini")
 
         result = get_current_provider()
 
         assert result == "ollama"
 
-    def test_claude_provider_is_recognised(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_claude_provider_is_recognised(self, provider_env: Callable[..., None]) -> None:
         """'claude' is in the known-providers set and must not trigger the warning."""
-        monkeypatch.setenv("FO_PROVIDER", "claude")
+        provider_env(FO_PROVIDER="claude")
 
         assert get_current_provider() == "claude"
 
-    def test_llama_cpp_provider_is_recognised(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_llama_cpp_provider_is_recognised(self, provider_env: Callable[..., None]) -> None:
         """'llama_cpp' is a valid provider."""
-        monkeypatch.setenv("FO_PROVIDER", "llama_cpp")
+        provider_env(FO_PROVIDER="llama_cpp")
 
         assert get_current_provider() == "llama_cpp"
 
@@ -78,10 +79,10 @@ class TestGetCurrentProviderIntegration:
 
 class TestGetModelConfigsFromEnvOllamaIntegration:
     def test_unset_provider_returns_ollama_text_defaults(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
         """When FO_PROVIDER is absent the function returns Ollama TextModel defaults."""
-        monkeypatch.delenv("FO_PROVIDER", raising=False)
+        provider_env()
         expected = TextModel.get_default_config()
 
         text_cfg, _ = get_model_configs_from_env()
@@ -90,10 +91,10 @@ class TestGetModelConfigsFromEnvOllamaIntegration:
         assert text_cfg.provider == "ollama"
 
     def test_unset_provider_returns_ollama_vision_defaults(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
         """When FO_PROVIDER is absent the function returns Ollama VisionModel defaults."""
-        monkeypatch.delenv("FO_PROVIDER", raising=False)
+        provider_env()
         expected = VisionModel.get_default_config()
 
         _, vision_cfg = get_model_configs_from_env()
@@ -102,10 +103,10 @@ class TestGetModelConfigsFromEnvOllamaIntegration:
         assert vision_cfg.provider == "ollama"
 
     def test_explicit_ollama_provider_returns_defaults(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
         """Explicitly setting FO_PROVIDER=ollama also returns the default configs."""
-        monkeypatch.setenv("FO_PROVIDER", "ollama")
+        provider_env(FO_PROVIDER="ollama")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
@@ -121,11 +122,11 @@ class TestGetModelConfigsFromEnvOllamaIntegration:
 
 
 class TestGetLlamaCppConfigsIntegration:
-    def test_model_path_propagates_to_both_configs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_model_path_propagates_to_both_configs(
+        self, provider_env: Callable[..., None]
+    ) -> None:
         """FO_LLAMA_CPP_MODEL_PATH is reflected in both text and vision configs."""
-        monkeypatch.setenv("FO_PROVIDER", "llama_cpp")
-        monkeypatch.setenv("FO_LLAMA_CPP_MODEL_PATH", "/models/llama.gguf")
-        monkeypatch.delenv("FO_LLAMA_CPP_N_GPU_LAYERS", raising=False)
+        provider_env(FO_PROVIDER="llama_cpp", FO_LLAMA_CPP_MODEL_PATH="/models/llama.gguf")
 
         text_cfg, vision_cfg = _get_llama_cpp_configs()
 
@@ -134,38 +135,40 @@ class TestGetLlamaCppConfigsIntegration:
         assert text_cfg.model_path == "/models/llama.gguf"
         assert vision_cfg.model_path == "/models/llama.gguf"
 
-    def test_model_types_are_correct(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_model_types_are_correct(self, provider_env: Callable[..., None]) -> None:
         """Text config has ModelType.TEXT; vision config has ModelType.VISION."""
-        monkeypatch.setenv("FO_LLAMA_CPP_MODEL_PATH", "/models/llama.gguf")
-        monkeypatch.delenv("FO_LLAMA_CPP_N_GPU_LAYERS", raising=False)
+        provider_env(FO_LLAMA_CPP_MODEL_PATH="/models/llama.gguf")
 
         text_cfg, vision_cfg = _get_llama_cpp_configs()
 
         assert text_cfg.model_type == ModelType.TEXT
         assert vision_cfg.model_type == ModelType.VISION
 
-    def test_n_gpu_layers_added_to_extra_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_n_gpu_layers_added_to_extra_params(self, provider_env: Callable[..., None]) -> None:
         """Valid FO_LLAMA_CPP_N_GPU_LAYERS is parsed into extra_params."""
-        monkeypatch.setenv("FO_LLAMA_CPP_MODEL_PATH", "/models/llama.gguf")
-        monkeypatch.setenv("FO_LLAMA_CPP_N_GPU_LAYERS", "32")
+        provider_env(
+            FO_LLAMA_CPP_MODEL_PATH="/models/llama.gguf",
+            FO_LLAMA_CPP_N_GPU_LAYERS="32",
+        )
 
         text_cfg, _ = _get_llama_cpp_configs()
 
         assert text_cfg.extra_params.get("n_gpu_layers") == 32
 
-    def test_invalid_n_gpu_layers_is_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_invalid_n_gpu_layers_is_ignored(self, provider_env: Callable[..., None]) -> None:
         """Non-integer FO_LLAMA_CPP_N_GPU_LAYERS does not crash — it is silently ignored."""
-        monkeypatch.setenv("FO_LLAMA_CPP_MODEL_PATH", "/models/llama.gguf")
-        monkeypatch.setenv("FO_LLAMA_CPP_N_GPU_LAYERS", "not-a-number")
+        provider_env(
+            FO_LLAMA_CPP_MODEL_PATH="/models/llama.gguf",
+            FO_LLAMA_CPP_N_GPU_LAYERS="not-a-number",
+        )
 
         text_cfg, _ = _get_llama_cpp_configs()
 
         assert "n_gpu_layers" not in text_cfg.extra_params
 
-    def test_missing_model_path_does_not_crash(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_missing_model_path_does_not_crash(self, provider_env: Callable[..., None]) -> None:
         """Absent FO_LLAMA_CPP_MODEL_PATH emits a warning but does not raise."""
-        monkeypatch.delenv("FO_LLAMA_CPP_MODEL_PATH", raising=False)
-        monkeypatch.delenv("FO_LLAMA_CPP_N_GPU_LAYERS", raising=False)
+        provider_env()
 
         text_cfg, vision_cfg = _get_llama_cpp_configs()
 
@@ -173,12 +176,10 @@ class TestGetLlamaCppConfigsIntegration:
         assert vision_cfg.model_path == ""
 
     def test_get_model_configs_from_env_routes_to_llama_cpp(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
         """FO_PROVIDER=llama_cpp routes through get_model_configs_from_env correctly."""
-        monkeypatch.setenv("FO_PROVIDER", "llama_cpp")
-        monkeypatch.setenv("FO_LLAMA_CPP_MODEL_PATH", "/models/q4.gguf")
-        monkeypatch.delenv("FO_LLAMA_CPP_N_GPU_LAYERS", raising=False)
+        provider_env(FO_PROVIDER="llama_cpp", FO_LLAMA_CPP_MODEL_PATH="/models/q4.gguf")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
@@ -192,9 +193,11 @@ class TestGetLlamaCppConfigsIntegration:
 
 
 class TestGetMlxConfigsIntegration:
-    def test_model_path_propagates_to_both_configs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_model_path_propagates_to_both_configs(
+        self, provider_env: Callable[..., None]
+    ) -> None:
         """FO_MLX_MODEL_PATH appears in both text and vision configs."""
-        monkeypatch.setenv("FO_MLX_MODEL_PATH", "mlx-community/Qwen2.5-3B-4bit")
+        provider_env(FO_MLX_MODEL_PATH="mlx-community/Qwen2.5-3B-4bit")
 
         text_cfg, vision_cfg = _get_mlx_configs()
 
@@ -203,18 +206,18 @@ class TestGetMlxConfigsIntegration:
         assert text_cfg.model_path == "mlx-community/Qwen2.5-3B-4bit"
         assert vision_cfg.model_path == "mlx-community/Qwen2.5-3B-4bit"
 
-    def test_model_types_are_correct(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_model_types_are_correct(self, provider_env: Callable[..., None]) -> None:
         """MLX configs carry the correct ModelType values."""
-        monkeypatch.setenv("FO_MLX_MODEL_PATH", "mlx-community/Qwen2.5-3B-4bit")
+        provider_env(FO_MLX_MODEL_PATH="mlx-community/Qwen2.5-3B-4bit")
 
         text_cfg, vision_cfg = _get_mlx_configs()
 
         assert text_cfg.model_type == ModelType.TEXT
         assert vision_cfg.model_type == ModelType.VISION
 
-    def test_missing_model_path_does_not_crash(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_missing_model_path_does_not_crash(self, provider_env: Callable[..., None]) -> None:
         """Absent FO_MLX_MODEL_PATH emits a warning but does not raise."""
-        monkeypatch.delenv("FO_MLX_MODEL_PATH", raising=False)
+        provider_env()
 
         text_cfg, vision_cfg = _get_mlx_configs()
 
@@ -222,11 +225,10 @@ class TestGetMlxConfigsIntegration:
         assert vision_cfg.model_path == ""
 
     def test_get_model_configs_from_env_routes_to_mlx(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
         """FO_PROVIDER=mlx routes through get_model_configs_from_env correctly."""
-        monkeypatch.setenv("FO_PROVIDER", "mlx")
-        monkeypatch.setenv("FO_MLX_MODEL_PATH", "mlx-community/Qwen2.5-3B-4bit")
+        provider_env(FO_PROVIDER="mlx", FO_MLX_MODEL_PATH="mlx-community/Qwen2.5-3B-4bit")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
@@ -240,12 +242,9 @@ class TestGetMlxConfigsIntegration:
 
 
 class TestGetClaudeConfigsIntegration:
-    def test_api_key_propagates_to_both_configs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_api_key_propagates_to_both_configs(self, provider_env: Callable[..., None]) -> None:
         """FO_CLAUDE_API_KEY is set on both text and vision configs."""
-        monkeypatch.setenv("FO_CLAUDE_API_KEY", "sk-ant-test123")
-        monkeypatch.delenv("FO_CLAUDE_MODEL", raising=False)
-        monkeypatch.delenv("FO_CLAUDE_VISION_MODEL", raising=False)
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        provider_env(FO_CLAUDE_API_KEY="sk-ant-test123")
 
         text_cfg, vision_cfg = _get_claude_configs()
 
@@ -254,58 +253,55 @@ class TestGetClaudeConfigsIntegration:
         assert text_cfg.api_key == "sk-ant-test123"
         assert vision_cfg.api_key == "sk-ant-test123"
 
-    def test_model_types_are_correct(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_model_types_are_correct(self, provider_env: Callable[..., None]) -> None:
         """Claude configs carry correct ModelType values."""
-        monkeypatch.setenv("FO_CLAUDE_API_KEY", "sk-ant-test")
-        monkeypatch.delenv("FO_CLAUDE_MODEL", raising=False)
-        monkeypatch.delenv("FO_CLAUDE_VISION_MODEL", raising=False)
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        provider_env(FO_CLAUDE_API_KEY="sk-ant-test")
 
         text_cfg, vision_cfg = _get_claude_configs()
 
         assert text_cfg.model_type == ModelType.TEXT
         assert vision_cfg.model_type == ModelType.VISION
 
-    def test_custom_text_model_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_custom_text_model_name(self, provider_env: Callable[..., None]) -> None:
         """FO_CLAUDE_MODEL sets the text model name."""
-        monkeypatch.setenv("FO_CLAUDE_API_KEY", "sk-ant-test")
-        monkeypatch.setenv("FO_CLAUDE_MODEL", "claude-3-haiku-20240307")
-        monkeypatch.delenv("FO_CLAUDE_VISION_MODEL", raising=False)
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        provider_env(
+            FO_CLAUDE_API_KEY="sk-ant-test",
+            FO_CLAUDE_MODEL="claude-3-haiku-20240307",
+        )
 
         text_cfg, _ = _get_claude_configs()
 
         assert text_cfg.name == "claude-3-haiku-20240307"
 
-    def test_vision_model_falls_back_to_text_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_vision_model_falls_back_to_text_model(
+        self, provider_env: Callable[..., None]
+    ) -> None:
         """When FO_CLAUDE_VISION_MODEL is unset, vision model name matches text model."""
-        monkeypatch.setenv("FO_CLAUDE_API_KEY", "sk-ant-test")
-        monkeypatch.setenv("FO_CLAUDE_MODEL", "claude-3-haiku-20240307")
-        monkeypatch.delenv("FO_CLAUDE_VISION_MODEL", raising=False)
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        provider_env(
+            FO_CLAUDE_API_KEY="sk-ant-test",
+            FO_CLAUDE_MODEL="claude-3-haiku-20240307",
+        )
 
         text_cfg, vision_cfg = _get_claude_configs()
 
         assert vision_cfg.name == text_cfg.name
 
-    def test_separate_vision_model_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_separate_vision_model_name(self, provider_env: Callable[..., None]) -> None:
         """FO_CLAUDE_VISION_MODEL overrides the vision model name independently."""
-        monkeypatch.setenv("FO_CLAUDE_API_KEY", "sk-ant-test")
-        monkeypatch.setenv("FO_CLAUDE_MODEL", "claude-3-haiku-20240307")
-        monkeypatch.setenv("FO_CLAUDE_VISION_MODEL", "claude-3-5-sonnet-20241022")
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        provider_env(
+            FO_CLAUDE_API_KEY="sk-ant-test",
+            FO_CLAUDE_MODEL="claude-3-haiku-20240307",
+            FO_CLAUDE_VISION_MODEL="claude-3-5-sonnet-20241022",
+        )
 
         text_cfg, vision_cfg = _get_claude_configs()
 
         assert text_cfg.name == "claude-3-haiku-20240307"
         assert vision_cfg.name == "claude-3-5-sonnet-20241022"
 
-    def test_no_api_key_emits_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_no_api_key_emits_warning(self, provider_env: Callable[..., None]) -> None:
         """When neither FO_CLAUDE_API_KEY nor ANTHROPIC_API_KEY is set a warning is logged."""
-        monkeypatch.delenv("FO_CLAUDE_API_KEY", raising=False)
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-        monkeypatch.delenv("FO_CLAUDE_MODEL", raising=False)
-        monkeypatch.delenv("FO_CLAUDE_VISION_MODEL", raising=False)
+        provider_env()
 
         # Must not raise — function should complete and return configs.
         text_cfg, vision_cfg = _get_claude_configs()
@@ -313,26 +309,21 @@ class TestGetClaudeConfigsIntegration:
         assert text_cfg.provider == "claude"
         assert vision_cfg.provider == "claude"
 
-    def test_anthropic_sdk_key_suppresses_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_anthropic_sdk_key_suppresses_warning(
+        self, provider_env: Callable[..., None]
+    ) -> None:
         """ANTHROPIC_API_KEY present means the SDK will pick it up — no warning needed."""
-        monkeypatch.delenv("FO_CLAUDE_API_KEY", raising=False)
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-sdk-key")
-        monkeypatch.delenv("FO_CLAUDE_MODEL", raising=False)
-        monkeypatch.delenv("FO_CLAUDE_VISION_MODEL", raising=False)
+        provider_env(ANTHROPIC_API_KEY="sk-ant-sdk-key")
 
         text_cfg, _ = _get_claude_configs()
 
         assert text_cfg.provider == "claude"
 
     def test_get_model_configs_from_env_routes_to_claude(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
         """FO_PROVIDER=claude routes through get_model_configs_from_env correctly."""
-        monkeypatch.setenv("FO_PROVIDER", "claude")
-        monkeypatch.setenv("FO_CLAUDE_API_KEY", "sk-ant-test")
-        monkeypatch.delenv("FO_CLAUDE_MODEL", raising=False)
-        monkeypatch.delenv("FO_CLAUDE_VISION_MODEL", raising=False)
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        provider_env(FO_PROVIDER="claude", FO_CLAUDE_API_KEY="sk-ant-test")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
@@ -347,15 +338,10 @@ class TestGetClaudeConfigsIntegration:
 
 class TestOpenAINoKeyWarningIntegration:
     def test_openai_without_key_or_url_does_not_crash(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
         """FO_PROVIDER=openai with no credentials set logs a warning but returns configs."""
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.delenv("FO_OPENAI_API_KEY", raising=False)
-        monkeypatch.delenv("FO_OPENAI_BASE_URL", raising=False)
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        monkeypatch.delenv("FO_OPENAI_MODEL", raising=False)
-        monkeypatch.delenv("FO_OPENAI_VISION_MODEL", raising=False)
+        provider_env(FO_PROVIDER="openai")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
@@ -364,12 +350,9 @@ class TestOpenAINoKeyWarningIntegration:
         assert text_cfg.api_key is None
         assert text_cfg.api_base_url is None
 
-    def test_openai_sdk_key_suppresses_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_openai_sdk_key_suppresses_warning(self, provider_env: Callable[..., None]) -> None:
         """OPENAI_API_KEY suppresses the missing-credentials warning."""
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.delenv("FO_OPENAI_API_KEY", raising=False)
-        monkeypatch.delenv("FO_OPENAI_BASE_URL", raising=False)
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-sdk-key")
+        provider_env(FO_PROVIDER="openai", OPENAI_API_KEY="sk-sdk-key")
 
         text_cfg, _ = get_model_configs_from_env()
 
@@ -455,11 +438,10 @@ class TestGetModelConfigsFromProfileIntegration:
 
 class TestGetModelConfigsFallbackIntegration:
     def test_falls_back_to_ollama_when_no_env_or_profile(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
         """When FO_PROVIDER is unset and no profile exists, Ollama defaults are used."""
-        monkeypatch.delenv("FO_PROVIDER", raising=False)
-        monkeypatch.delenv("FO_PROFILE", raising=False)
+        provider_env()
 
         with patch(
             "config.provider_env._get_model_configs_from_profile",
@@ -471,11 +453,10 @@ class TestGetModelConfigsFallbackIntegration:
         assert vision_cfg.provider == "ollama"
 
     def test_env_provider_takes_priority_over_profile(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
         """FO_PROVIDER set means profile lookup is skipped entirely."""
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.setenv("FO_OPENAI_API_KEY", "sk-priority-test")
+        provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-priority-test")
 
         text_cfg, _ = get_model_configs()
 

--- a/tests/integration/test_models_utils_config_undo.py
+++ b/tests/integration/test_models_utils_config_undo.py
@@ -956,7 +956,9 @@ class TestGetModelConfigsFromEnvAdditional:
     def test_openai_custom_model_name(self, provider_env: Callable[..., None]) -> None:
         from config.provider_env import get_model_configs_from_env
 
-        provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test", FO_OPENAI_MODEL="gpt-4-turbo")
+        provider_env(
+            FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test", FO_OPENAI_MODEL="gpt-4-turbo"
+        )
 
         text_cfg, _ = get_model_configs_from_env()
 
@@ -967,7 +969,9 @@ class TestGetModelConfigsFromEnvAdditional:
     ) -> None:
         from config.provider_env import get_model_configs_from_env
 
-        provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test", FO_OPENAI_MODEL="gpt-4o-mini")
+        provider_env(
+            FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test", FO_OPENAI_MODEL="gpt-4o-mini"
+        )
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 

--- a/tests/integration/test_models_utils_config_undo.py
+++ b/tests/integration/test_models_utils_config_undo.py
@@ -13,6 +13,7 @@ Modules targeted:
 from __future__ import annotations
 
 import base64
+from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -908,106 +909,98 @@ class TestExtractKeywordsAdditional:
 
 
 class TestGetCurrentProviderAdditional:
-    def test_default_is_ollama(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_default_is_ollama(self, provider_env: Callable[..., None]) -> None:
         from config.provider_env import get_current_provider
 
-        monkeypatch.delenv("FO_PROVIDER", raising=False)
+        provider_env()
 
         assert get_current_provider() == "ollama"
 
-    def test_openai_recognised(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_openai_recognised(self, provider_env: Callable[..., None]) -> None:
         from config.provider_env import get_current_provider
 
-        monkeypatch.setenv("FO_PROVIDER", "openai")
+        provider_env(FO_PROVIDER="openai")
 
         assert get_current_provider() == "openai"
 
-    def test_mlx_recognised(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_mlx_recognised(self, provider_env: Callable[..., None]) -> None:
         from config.provider_env import get_current_provider
 
-        monkeypatch.setenv("FO_PROVIDER", "mlx")
+        provider_env(FO_PROVIDER="mlx")
 
         assert get_current_provider() == "mlx"
 
-    def test_whitespace_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_whitespace_stripped(self, provider_env: Callable[..., None]) -> None:
         from config.provider_env import get_current_provider
 
-        monkeypatch.setenv("FO_PROVIDER", "  openai  ")
+        provider_env(FO_PROVIDER="  openai  ")
 
         assert get_current_provider() == "openai"
 
-    def test_case_insensitive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_case_insensitive(self, provider_env: Callable[..., None]) -> None:
         from config.provider_env import get_current_provider
 
-        monkeypatch.setenv("FO_PROVIDER", "OLLAMA")
+        provider_env(FO_PROVIDER="OLLAMA")
 
         assert get_current_provider() == "ollama"
 
-    def test_invalid_value_falls_back_to_ollama(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_invalid_value_falls_back_to_ollama(self, provider_env: Callable[..., None]) -> None:
         from config.provider_env import get_current_provider
 
-        monkeypatch.setenv("FO_PROVIDER", "notreal")
+        provider_env(FO_PROVIDER="notreal")
 
         assert get_current_provider() == "ollama"
 
 
 class TestGetModelConfigsFromEnvAdditional:
-    def test_openai_custom_model_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_openai_custom_model_name(self, provider_env: Callable[..., None]) -> None:
         from config.provider_env import get_model_configs_from_env
 
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.setenv("FO_OPENAI_API_KEY", "sk-test")
-        monkeypatch.setenv("FO_OPENAI_MODEL", "gpt-4-turbo")
-        monkeypatch.delenv("FO_OPENAI_VISION_MODEL", raising=False)
+        provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test", FO_OPENAI_MODEL="gpt-4-turbo")
 
         text_cfg, _ = get_model_configs_from_env()
 
         assert text_cfg.name == "gpt-4-turbo"
 
     def test_openai_vision_model_falls_back_to_text_model(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, provider_env: Callable[..., None]
     ) -> None:
         from config.provider_env import get_model_configs_from_env
 
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.setenv("FO_OPENAI_API_KEY", "sk-test")
-        monkeypatch.setenv("FO_OPENAI_MODEL", "gpt-4o-mini")
-        monkeypatch.delenv("FO_OPENAI_VISION_MODEL", raising=False)
+        provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test", FO_OPENAI_MODEL="gpt-4o-mini")
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
         assert vision_cfg.name == text_cfg.name
 
-    def test_openai_separate_vision_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_openai_separate_vision_model(self, provider_env: Callable[..., None]) -> None:
         from config.provider_env import get_model_configs_from_env
 
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.setenv("FO_OPENAI_API_KEY", "sk-test")
-        monkeypatch.setenv("FO_OPENAI_MODEL", "gpt-4o-mini")
-        monkeypatch.setenv("FO_OPENAI_VISION_MODEL", "gpt-4o")
+        provider_env(
+            FO_PROVIDER="openai",
+            FO_OPENAI_API_KEY="sk-test",
+            FO_OPENAI_MODEL="gpt-4o-mini",
+            FO_OPENAI_VISION_MODEL="gpt-4o",
+        )
 
         text_cfg, vision_cfg = get_model_configs_from_env()
 
         assert text_cfg.name == "gpt-4o-mini"
         assert vision_cfg.name == "gpt-4o"
 
-    def test_openai_base_url_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_openai_base_url_set(self, provider_env: Callable[..., None]) -> None:
         from config.provider_env import get_model_configs_from_env
 
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.setenv("FO_OPENAI_BASE_URL", "http://localhost:1234/v1")
-        monkeypatch.delenv("FO_OPENAI_API_KEY", raising=False)
+        provider_env(FO_PROVIDER="openai", FO_OPENAI_BASE_URL="http://localhost:1234/v1")
 
         text_cfg, _ = get_model_configs_from_env()
 
         assert text_cfg.api_base_url == "http://localhost:1234/v1"
 
-    def test_openai_empty_api_key_becomes_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_openai_empty_api_key_becomes_none(self, provider_env: Callable[..., None]) -> None:
         from config.provider_env import get_model_configs_from_env
 
-        monkeypatch.setenv("FO_PROVIDER", "openai")
-        monkeypatch.setenv("FO_OPENAI_API_KEY", "   ")
-        monkeypatch.setenv("OPENAI_API_KEY", "sdk-key")  # suppress warning
+        provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="   ", OPENAI_API_KEY="sdk-key")
 
         text_cfg, _ = get_model_configs_from_env()
 

--- a/tests/methodologies/para/test_feature_extractor.py
+++ b/tests/methodologies/para/test_feature_extractor.py
@@ -547,16 +547,11 @@ class TestEdgeCasesAndErrorHandling:
             re.compile(r"\bTODO\b", re.I),
         ]
 
-        # Temporarily replace the module-level patterns
-        original_patterns = fe_module._ACTION_PATTERNS
         monkeypatch.setattr(fe_module, "_ACTION_PATTERNS", custom_patterns)
 
         # Test with text that triggers both edge cases
         text = "      \nLONGTEXT:" + ("x" * 250) + "\nTODO: normal task"
         features = extractor.extract_text_features(text)
-
-        # Restore original patterns
-        monkeypatch.setattr(fe_module, "_ACTION_PATTERNS", original_patterns)
 
         # Should only have the normal TODO task
         assert len(features.action_items) >= 1

--- a/tests/test_test_helpers.py
+++ b/tests/test_test_helpers.py
@@ -185,9 +185,13 @@ class TestProviderEnvFixture:
     ) -> None:
         monkeypatch.setenv("FO_PROVIDER", "openai")
         monkeypatch.setenv("FO_OPENAI_API_KEY", "sk-test")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant")
+        monkeypatch.setenv("FO_LLAMA_CPP_MODEL_PATH", "/models/llama.gguf")
         provider_env()
-        assert "FO_PROVIDER" not in os.environ
-        assert "FO_OPENAI_API_KEY" not in os.environ
+        from tests.conftest import _KNOWN_PROVIDER_VARS
+
+        for var in _KNOWN_PROVIDER_VARS:
+            assert var not in os.environ, f"{var} should have been cleared by provider_env()"
 
     def test_unknown_var_raises_key_error(self, provider_env) -> None:
         with pytest.raises(KeyError, match="UNKNOWN_VAR"):
@@ -204,3 +208,9 @@ class TestProviderEnvFixture:
         monkeypatch.setenv("FO_OPENAI_BASE_URL", "http://localhost:1234/v1")
         provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test")
         assert "FO_OPENAI_BASE_URL" not in os.environ
+
+    def test_second_call_clears_vars_from_first_call(self, provider_env) -> None:
+        provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test")
+        provider_env(FO_PROVIDER="claude")
+        assert os.environ["FO_PROVIDER"] == "claude"
+        assert "FO_OPENAI_API_KEY" not in os.environ

--- a/tests/test_test_helpers.py
+++ b/tests/test_test_helpers.py
@@ -7,8 +7,11 @@ assert_html_contains, assert_html_contains_any, assert_html_tag_present.
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 
 import pytest
+
+from tests.conftest import _KNOWN_PROVIDER_VARS
 
 from .test_helpers import (
     assert_file_order_in_html,
@@ -171,45 +174,47 @@ class TestAssertHtmlTagPresent:
 class TestProviderEnvFixture:
     """Contract tests for the provider_env fixture."""
 
-    def test_empty_string_stays_as_env_value(self, provider_env) -> None:
+    def test_empty_string_stays_as_env_value(self, provider_env: Callable[..., None]) -> None:
         provider_env(FO_PROVIDER="")
         assert os.environ["FO_PROVIDER"] == ""
 
-    def test_none_unsets_var(self, monkeypatch: pytest.MonkeyPatch, provider_env) -> None:
+    def test_none_unsets_var(
+        self, monkeypatch: pytest.MonkeyPatch, provider_env: Callable[..., None]
+    ) -> None:
         monkeypatch.setenv("FO_PROVIDER", "openai")
         provider_env(FO_PROVIDER=None)
         assert "FO_PROVIDER" not in os.environ
 
     def test_clears_all_known_vars_when_called_with_no_args(
-        self, monkeypatch: pytest.MonkeyPatch, provider_env
+        self, monkeypatch: pytest.MonkeyPatch, provider_env: Callable[..., None]
     ) -> None:
         monkeypatch.setenv("FO_PROVIDER", "openai")
         monkeypatch.setenv("FO_OPENAI_API_KEY", "sk-test")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant")
         monkeypatch.setenv("FO_LLAMA_CPP_MODEL_PATH", "/models/llama.gguf")
         provider_env()
-        from tests.conftest import _KNOWN_PROVIDER_VARS
-
         for var in _KNOWN_PROVIDER_VARS:
             assert var not in os.environ, f"{var} should have been cleared by provider_env()"
 
-    def test_unknown_var_raises_key_error(self, provider_env) -> None:
+    def test_unknown_var_raises_key_error(self, provider_env: Callable[..., None]) -> None:
         with pytest.raises(KeyError, match="UNKNOWN_VAR"):
             provider_env(UNKNOWN_VAR="value")
 
-    def test_sets_multiple_vars(self, provider_env) -> None:
+    def test_sets_multiple_vars(self, provider_env: Callable[..., None]) -> None:
         provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test")
         assert os.environ["FO_PROVIDER"] == "openai"
         assert os.environ["FO_OPENAI_API_KEY"] == "sk-test"
 
     def test_clears_unmentioned_known_vars(
-        self, monkeypatch: pytest.MonkeyPatch, provider_env
+        self, monkeypatch: pytest.MonkeyPatch, provider_env: Callable[..., None]
     ) -> None:
         monkeypatch.setenv("FO_OPENAI_BASE_URL", "http://localhost:1234/v1")
         provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test")
         assert "FO_OPENAI_BASE_URL" not in os.environ
 
-    def test_second_call_clears_vars_from_first_call(self, provider_env) -> None:
+    def test_second_call_clears_vars_from_first_call(
+        self, provider_env: Callable[..., None]
+    ) -> None:
         provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test")
         provider_env(FO_PROVIDER="claude")
         assert os.environ["FO_PROVIDER"] == "claude"

--- a/tests/test_test_helpers.py
+++ b/tests/test_test_helpers.py
@@ -6,6 +6,8 @@ assert_html_contains, assert_html_contains_any, assert_html_tag_present.
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from .test_helpers import (
@@ -159,3 +161,46 @@ class TestAssertHtmlTagPresent:
         """A tag absent from the HTML must raise AssertionError."""
         with pytest.raises(AssertionError, match="<table"):
             assert_html_tag_present("<html></html>", "<table")
+
+
+# ---------------------------------------------------------------------------
+# provider_env fixture contract tests
+# ---------------------------------------------------------------------------
+
+
+class TestProviderEnvFixture:
+    """Contract tests for the provider_env fixture."""
+
+    def test_empty_string_stays_as_env_value(self, provider_env) -> None:
+        provider_env(FO_PROVIDER="")
+        assert os.environ["FO_PROVIDER"] == ""
+
+    def test_none_unsets_var(self, monkeypatch: pytest.MonkeyPatch, provider_env) -> None:
+        monkeypatch.setenv("FO_PROVIDER", "openai")
+        provider_env(FO_PROVIDER=None)
+        assert "FO_PROVIDER" not in os.environ
+
+    def test_clears_all_known_vars_when_called_with_no_args(
+        self, monkeypatch: pytest.MonkeyPatch, provider_env
+    ) -> None:
+        monkeypatch.setenv("FO_PROVIDER", "openai")
+        monkeypatch.setenv("FO_OPENAI_API_KEY", "sk-test")
+        provider_env()
+        assert "FO_PROVIDER" not in os.environ
+        assert "FO_OPENAI_API_KEY" not in os.environ
+
+    def test_unknown_var_raises_key_error(self, provider_env) -> None:
+        with pytest.raises(KeyError, match="UNKNOWN_VAR"):
+            provider_env(UNKNOWN_VAR="value")
+
+    def test_sets_multiple_vars(self, provider_env) -> None:
+        provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test")
+        assert os.environ["FO_PROVIDER"] == "openai"
+        assert os.environ["FO_OPENAI_API_KEY"] == "sk-test"
+
+    def test_clears_unmentioned_known_vars(
+        self, monkeypatch: pytest.MonkeyPatch, provider_env
+    ) -> None:
+        monkeypatch.setenv("FO_OPENAI_BASE_URL", "http://localhost:1234/v1")
+        provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-test")
+        assert "FO_OPENAI_BASE_URL" not in os.environ


### PR DESCRIPTION
## Summary

- Adds a shared `provider_env` fixture to `tests/conftest.py` that consolidates provider env var setup across the test suite
- Migrates 4 test files (~97 tests) from scattered `monkeypatch.setenv/delenv` calls to the new fixture
- Removes a redundant manual `_ACTION_PATTERNS` restore in `test_feature_extractor.py`

## What the fixture does

`provider_env` wraps `pytest.MonkeyPatch` internally (xdist-safe). On every call it:
1. Clears **all 14** known provider env vars (`_KNOWN_PROVIDER_VARS` frozenset)
2. Sets only the explicitly supplied ones

```python
# Before — 4 separate calls, easy to forget a delenv
monkeypatch.setenv("FO_PROVIDER", "openai")
monkeypatch.setenv("FO_OPENAI_API_KEY", "sk-abc")
monkeypatch.delenv("FO_OPENAI_BASE_URL", raising=False)
monkeypatch.delenv("FO_OPENAI_MODEL", raising=False)

# After — single declarative call
provider_env(FO_PROVIDER="openai", FO_OPENAI_API_KEY="sk-abc")
```

Calling with no args clears all 14 vars (used for "missing env var" test scenarios).
`None` value = leave unset (already cleared by the clear-all pass).
Unknown var names raise `KeyError` immediately.

## Files changed

| File | Tests | Change |
|------|-------|--------|
| `tests/conftest.py` | — | New `_KNOWN_PROVIDER_VARS` + `provider_env` fixture |
| `tests/test_test_helpers.py` | 7 contract tests | New contract test class `TestProviderEnvFixture` |
| `tests/config/test_provider_env.py` | 20 | Migrated |
| `tests/integration/config/test_provider_env.py` | 33 | Migrated |
| `tests/integration/config/test_provider_env_integration.py` | 33 | Migrated |
| `tests/integration/test_models_utils_config_undo.py` | 11 | Migrated (provider-env sections only) |
| `tests/methodologies/para/test_feature_extractor.py` | — | Removed redundant manual restore |

## Test plan

- [x] `tests/test_test_helpers.py::TestProviderEnvFixture` — 7 contract tests pass (clear-all checks all 14 vars, consecutive-call invariant, unknown var raises KeyError, etc.)
- [x] `tests/config/test_provider_env.py` — 20 tests pass
- [x] `tests/integration/config/test_provider_env.py` — 33 tests pass
- [x] `tests/integration/config/test_provider_env_integration.py` — 33 tests pass
- [x] `tests/integration/test_models_utils_config_undo.py` (affected classes) — 11 tests pass
- [x] `tests/methodologies/para/test_feature_extractor.py` — 48 tests pass
- [x] `pre-commit run --all-files` — all hooks pass
- [x] Raw provider-env monkeypatch calls remaining: 4 (all in the contract test file itself — intentional)

Closes #141 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test setup patterns for provider environment configuration validation to improve consistency across test modules.
  * Enhanced test coverage with additional contract tests validating environment variable handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->