### PR TITLE
feat(para): add test seams to FeatureExtractor, TemporalHeuristic, PARAFileMover

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
+            set -euo pipefail
             python -m pip install --upgrade pip
             pip install -e ".[dev]"
             pip install pyinstaller

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,10 +51,17 @@ jobs:
           sudo apt-get install -y fuse libfuse2
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
-          pip install pyinstaller
+        # Retry wrapper guards against transient TLS/CDN flakes during wheel
+        # downloads; see issue #145.
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: |
+            python -m pip install --upgrade pip
+            pip install -e ".[dev]"
+            pip install pyinstaller
 
       - name: Run tests
         run: |

--- a/.github/workflows/ci-extras.yml
+++ b/.github/workflows/ci-extras.yml
@@ -95,8 +95,14 @@ jobs:
           cache: pip
 
       - name: Install extra with dev dependencies
-        # .[dev,extra] ensures pytest and repo test toolchain are present for canary runs
-        run: pip install -e ".[dev,${{ matrix.extra }}]"
+        # .[dev,extra] ensures pytest and repo test toolchain are present for canary runs.
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev,${{ matrix.extra }}]"
 
       - name: Verify key imports
         run: python -c "${{ matrix.key_import }}"

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -38,6 +38,7 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
+            set -euo pipefail
             pip install -e ".[dev,search]"
             pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
       - name: Run full test suite

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -31,9 +31,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - name: Install dependencies
-        run: |
-          pip install -e ".[dev,search]"
-          pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: |
+            pip install -e ".[dev,search]"
+            pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
       - name: Run full test suite
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -65,7 +71,14 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
-      - run: pip install -e ".[dev]"
+      - name: Install dev extras
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev]"
       - name: Download coverage data (py3.11)
         uses: actions/download-artifact@v8
         with:
@@ -93,7 +106,13 @@ jobs:
       - name: Install dependencies
         # search extra (rank-bm25, scikit-learn) is required by @pytest.mark.ci tests
         # in TestBM25Index, TestVectorIndexRecall, TestHybridRetriever, and TestSemanticSearch.
-        run: pip install -e ".[dev,search]"
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev,search]"
       - name: Run tests
         # CI Full's cross-platform contract: validate the portable ci/smoke subset on macOS.
         run: pytest tests/ --strict-markers --timeout=30 -n=auto --override-ini="addopts=" -m "ci or smoke"
@@ -113,7 +132,13 @@ jobs:
       - name: Install dependencies
         # search extra (rank-bm25, scikit-learn) is required by @pytest.mark.ci tests
         # in TestBM25Index, TestVectorIndexRecall, TestHybridRetriever, and TestSemanticSearch.
-        run: pip install -e ".[dev,search]"
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev,search]"
       - name: Run tests
         # CI Full's cross-platform contract: validate the portable ci/smoke subset on Windows.
         # -n=auto intentionally omitted: xdist worker shutdown on Windows propagates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
+            set -euo pipefail
             pip install pre-commit
             pip install -e ".[dev]"
       - run: pre-commit run --all-files
@@ -90,6 +91,7 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
+            set -euo pipefail
             pip install "deptry>=0.16.0"
             pip install -e .
       - run: deptry src/
@@ -192,6 +194,7 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
+            set -euo pipefail
             pip install -e ".[dev,search]"
             # Explicitly install pytest-asyncio and faker to ensure they're available.
             # This fixes installation order issues on Python 3.11 where pytest might load before pytest-asyncio.
@@ -254,6 +257,7 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
+            set -euo pipefail
             pip install -e ".[dev,search]"
             pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
       - name: Run full test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,16 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - run: pip install pre-commit
-      - run: pip install -e ".[dev]"
+      - name: Install lint deps (pre-commit + dev extras)
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: |
+            pip install pre-commit
+            pip install -e ".[dev]"
       - run: pre-commit run --all-files
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,8 +82,16 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - run: pip install "deptry>=0.16.0"
-      - run: pip install -e .
+      - name: Install deptry + package
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: |
+            pip install "deptry>=0.16.0"
+            pip install -e .
       - run: deptry src/
 
   type-check:
@@ -86,7 +102,14 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-      - run: pip install -e ".[dev]"
+      - name: Install dev extras
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev]"
       - name: Run mypy on all source modules
         run: python -m mypy --config-file pyproject.toml src/
 
@@ -159,15 +182,20 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - name: Install dependencies
-        run: |
-          # Install core package with dev dependencies + search (rank-bm25, scikit-learn)
-          # search is required for TestBM25Index, TestVectorIndexRecall, TestHybridRetriever,
-          # and related CLI/API/copilot tests — not in dev because it is an optional runtime extra.
-          pip install -e ".[dev,search]"
-
-          # Explicitly install pytest-asyncio and faker to ensure they're available
-          # This fixes installation order issues on Python 3.11 where pytest might load before pytest-asyncio
-          pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
+        # Install core package with dev dependencies + search (rank-bm25, scikit-learn).
+        # search is required for TestBM25Index, TestVectorIndexRecall, TestHybridRetriever,
+        # and related CLI/API/copilot tests — not in dev because it is an optional runtime extra.
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: |
+            pip install -e ".[dev,search]"
+            # Explicitly install pytest-asyncio and faker to ensure they're available.
+            # This fixes installation order issues on Python 3.11 where pytest might load before pytest-asyncio.
+            pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
       - name: Verify test dependencies
         run: |
           # Fast plugin registration check — replaces the former pytest --collect-only
@@ -183,6 +211,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pytest tests/ --strict-markers -m "ci and not benchmark" --cov=src --cov-report=xml --timeout=30 -n=auto --override-ini="addopts="
+      - name: Install diff-cover
+        if: ${{ github.event.pull_request.changed_files <= 75 }}
+        # Split out of the diff-coverage-gate step so the retry wrapper only re-runs
+        # pip install, not the gate itself.  Retry wrapper guards against transient
+        # TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 3
+          max_attempts: 3
+          retry_on: error
+          command: pip install diff-cover --quiet
       - name: Diff coverage gate
         if: ${{ github.event.pull_request.changed_files <= 75 }}
         # Checks that lines added/changed in this PR are ≥80% covered.
@@ -190,9 +229,7 @@ jobs:
         # Ratchet: bump --fail-under as coverage improves. Target: 90% per issue #855.
         # Broad refactors and type-cleanup sweeps exceed the signal-to-noise ratio
         # where diff coverage is useful, so we skip the gate for very large PRs.
-        run: |
-          pip install diff-cover --quiet
-          diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
+        run: diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
 
   test-full:
     name: "Test full suite (py${{ matrix.python-version }})"
@@ -210,9 +247,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - name: Install dependencies
-        run: |
-          pip install -e ".[dev,search]"
-          pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: |
+            pip install -e ".[dev,search]"
+            pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
       - name: Run full test suite
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -246,7 +289,14 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
-      - run: pip install -e ".[dev]"
+      - name: Install dev extras
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev]"
       - name: Download coverage data (py3.11)
         uses: actions/download-artifact@v8
         with:
@@ -282,7 +332,13 @@ jobs:
           python-version: "3.11"
           cache: pip
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev]"
       - name: Download benchmark baseline (PR only)
         # Finds the latest successful main CI run that stored a benchmark-baseline
         # artifact and downloads it for comparison.  Skipped silently if none exists.
@@ -394,7 +450,15 @@ jobs:
           python-version: "3.11"
           cache: pip
       - name: Install dependencies
-        run: pip install -e ".[dev,search]"
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145) —
+        # the 2026-04-21 integration coverage-gate failure was exactly this
+        # case (mid-stream DECRYPTION_FAILED_OR_BAD_RECORD_MAC on a numpy wheel).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev,search]"
       - name: Run integration tests and capture coverage report
         id: integration_tests
         continue-on-error: true
@@ -450,9 +514,18 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
+      - name: Install package into size-check target
+        # Split out of the size-check step so the retry wrapper only re-runs
+        # pip install, not the size measurement.  Retry wrapper guards against
+        # transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: python -m pip install --target /tmp/fo_size_check . -q
       - name: Measure default install size
         run: |
-          python -m pip install --target /tmp/fo_size_check . -q
           SIZE_MB=$(du -sm /tmp/fo_size_check | awk '{print $1}')
           echo "Install size: ${SIZE_MB} MB"
           if [ "$SIZE_MB" -gt 215 ]; then

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -19,7 +19,13 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install pymarkdown
-        run: pip install 'pymarkdownlnt==0.9.25'
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_on: error
+          command: pip install 'pymarkdownlnt==0.9.25'
       - name: Run markdown linting
         run: |
           # Scan all tracked markdown files in repository (including nested)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,14 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-      - run: pip install -e ".[docs]"
+      - name: Install docs extras
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[docs]"
       - run: mkdocs build --strict
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
@@ -73,5 +80,12 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-      - run: pip install -e ".[docs]"
+      - name: Install docs extras
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[docs]"
       - run: mkdocs build --strict

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -54,6 +54,7 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
+            set -euo pipefail
             pip install -e ".[dev,search]"
             pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
       - name: Run integration tests

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -47,9 +47,15 @@ jobs:
           python-version: "3.11"
           cache: pip
       - name: Install dependencies
-        run: |
-          pip install -e ".[dev,search]"
-          pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: |
+            pip install -e ".[dev,search]"
+            pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
       - name: Run integration tests
         # --cov adds ~15-20% overhead to the 3-5 min run; bounded by cancel-in-progress.
         # Output teed to RUNNER_TEMP so the per-module floor script can parse it.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,13 @@ jobs:
           python-version: "3.12"
           cache: pip
       - name: Install build tools
-        run: pip install build twine
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_on: error
+          command: pip install build twine
       - name: Build package
         run: python -m build
       - name: Upload artifacts

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,9 +26,23 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install pip-audit
-        run: pip install pip-audit
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_on: error
+          command: pip install pip-audit
       - name: Audit dependencies
-        run: pip-audit -r <(pip install -e . && pip freeze)
+        # The inner `pip install -e . && pip freeze` also downloads wheels; wrap
+        # the whole step in retry so a transient flake on any of the pip calls
+        # is recoverable (issue #145).  continue-on-error stays on the step.
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip-audit -r <(pip install -e . && pip freeze)
         continue-on-error: true
 
   bandit-scan:
@@ -39,7 +53,13 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install bandit
-        run: pip install bandit[toml]
+        # Retry wrapper guards against transient TLS/CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_on: error
+          command: pip install bandit[toml]
       - name: Run bandit
         run: bandit -r src/ -c pyproject.toml || true
 

--- a/src/methodologies/para/ai/feature_extractor.py
+++ b/src/methodologies/para/ai/feature_extractor.py
@@ -11,9 +11,11 @@ import logging
 import os
 import re
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -220,13 +222,28 @@ class FeatureExtractor:
         structural_features = extractor.extract_structural_features(Path("/path/to/file.md"))
     """
 
-    def __init__(self, max_content_length: int = 50_000) -> None:
+    def __init__(
+        self,
+        max_content_length: int = 50_000,
+        *,
+        clock: Callable[[], float] | None = None,
+        os_name: str | None = None,
+        stat_provider: Callable[[Path], Any] | None = None,
+    ) -> None:
         """Initialize the feature extractor.
 
         Args:
             max_content_length: Maximum content length to analyze (truncates beyond).
+            clock: Override for time.time — used in tests to freeze time.
+            os_name: Override for os.name — used in tests to simulate platform.
+            stat_provider: Override for Path.stat — used in tests to inject stat results.
         """
         self._max_content_length = max_content_length
+        self._clock: Callable[[], float] = clock if clock is not None else time.time
+        self._os_name: str = os_name if os_name is not None else os.name
+        self._stat_provider: Callable[[Path], Any] = (
+            stat_provider if stat_provider is not None else Path.stat
+        )
 
     def extract_text_features(self, content: str) -> TextFeatures:
         """Extract features from text content.
@@ -307,12 +324,12 @@ class FeatureExtractor:
             return MetadataFeatures(file_type=file_path.suffix.lower())
 
         try:
-            stat = file_path.stat()
+            stat = self._stat_provider(file_path)
         except OSError as e:
             logger.error("Cannot stat file %s: %s", file_path, e, exc_info=True)
             return MetadataFeatures(file_type=file_path.suffix.lower())
 
-        now = time.time()
+        now = self._clock()
 
         # Cross-platform file creation time:
         #   macOS  → st_birthtime (true birth time)
@@ -320,7 +337,7 @@ class FeatureExtractor:
         #   Linux  → st_mtime     (st_ctime is inode-change time, not creation)
         # macOS: st_birthtime (true birth time); Linux: not present (use mtime); Windows: st_ctime
         creation_ref = getattr(stat, "st_birthtime", stat.st_mtime)
-        if os.name == "nt" and not hasattr(stat, "st_birthtime"):  # Windows fallback
+        if self._os_name == "nt" and not hasattr(stat, "st_birthtime"):  # Windows fallback
             creation_ref = getattr(stat, "st_ctime", stat.st_mtime)
 
         # Convert timestamps to datetime

--- a/src/methodologies/para/ai/file_mover.py
+++ b/src/methodologies/para/ai/file_mover.py
@@ -112,6 +112,8 @@ class PARAFileMover:
         config: PARAConfig | None = None,
         suggestion_engine: PARASuggestionEngine | None = None,
         root_dir: Path | None = None,
+        *,
+        max_collision_attempts: int = 1000,
     ) -> None:
         """Initialize the PARA file mover.
 
@@ -121,10 +123,12 @@ class PARAFileMover:
                 from config if not provided.
             root_dir: Root directory for PARA organization. Defaults to
                 config.default_root or current working directory.
+            max_collision_attempts: Maximum rename attempts before raising OSError.
         """
         self._config = config or PARAConfig()
         self._engine = suggestion_engine or PARASuggestionEngine(config=self._config)
         self._root_dir = root_dir or self._config.default_root or Path.cwd()
+        self._max_collision_attempts = max_collision_attempts
 
     @property
     def root_dir(self) -> Path:
@@ -448,7 +452,7 @@ class PARAFileMover:
             if not candidate.exists():
                 return candidate
             counter += 1
-            if counter > 1000:
+            if counter > self._max_collision_attempts:
                 raise OSError(
                     f"Cannot resolve collision for {destination}: "
                     f"too many existing files with same name"

--- a/src/methodologies/para/detection/heuristics.py
+++ b/src/methodologies/para/detection/heuristics.py
@@ -11,9 +11,12 @@ import logging
 import os
 import re
 import threading
+import time
 from abc import ABC, abstractmethod
 from collections import OrderedDict
+from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -100,6 +103,36 @@ class TemporalHeuristic(Heuristic):
     - Old year patterns in path (e.g., "2020") → ARCHIVE
     """
 
+    def __init__(
+        self,
+        weight: float = 1.0,
+        *,
+        clock: Callable[[], float] | None = None,
+        current_year_provider: Callable[[], int] | None = None,
+        os_name: str | None = None,
+        stat_provider: Callable[[Path], Any] | None = None,
+    ) -> None:
+        """Initialize the temporal heuristic.
+
+        Args:
+            weight: Scoring weight for this heuristic.
+            clock: Override for time.time — used in tests to freeze time.
+            current_year_provider: Override for current year — used in tests.
+            os_name: Override for os.name — used in tests to simulate platform.
+            stat_provider: Override for Path.stat — used in tests to inject stat results.
+        """
+        super().__init__(weight)
+        self._clock: Callable[[], float] = clock if clock is not None else time.time
+        self._current_year_provider: Callable[[], int] = (
+            current_year_provider
+            if current_year_provider is not None
+            else lambda: datetime.now(UTC).year
+        )
+        self._os_name: str = os_name if os_name is not None else os.name
+        self._stat_provider: Callable[[Path], Any] = (
+            stat_provider if stat_provider is not None else Path.stat
+        )
+
     @staticmethod
     def _contains_old_year(path_str: str, current_year: int, threshold_years: int = 3) -> bool:
         """Check if path contains old year patterns (folders named like "2020").
@@ -112,8 +145,6 @@ class TemporalHeuristic(Heuristic):
         Returns:
             True if path contains year older than threshold
         """
-        import re
-
         # Match standalone 4-digit years (word boundaries)
         year_pattern = r"\b(19\d{2}|20\d{2})\b"
         matches = re.findall(year_pattern, path_str)
@@ -127,17 +158,14 @@ class TemporalHeuristic(Heuristic):
 
     def evaluate(self, file_path: Path, metadata: dict[str, Any] | None = None) -> HeuristicResult:
         """Evaluate based on temporal patterns."""
-        import time
-        from datetime import UTC, datetime
-
         scores = {cat: CategoryScore(cat, 0.0, 0.0) for cat in PARACategory}
 
         if not file_path.exists():
             return HeuristicResult(scores, 0.0, None, True)
 
-        stat = file_path.stat()
-        now = time.time()
-        current_year = datetime.now(UTC).year
+        stat = self._stat_provider(file_path)
+        now = self._clock()
+        current_year = self._current_year_provider()
 
         # Calculate time differences
         days_since_modified = (now - stat.st_mtime) / 86400
@@ -146,7 +174,7 @@ class TemporalHeuristic(Heuristic):
         # fall back to modification time on Linux (st_ctime is inode change time, not creation).
         # macOS: st_birthtime (true birth time); Linux: not present (use mtime); Windows: st_ctime
         ref_time = getattr(stat, "st_birthtime", stat.st_mtime)
-        if os.name == "nt" and not hasattr(stat, "st_birthtime"):  # Windows fallback
+        if self._os_name == "nt" and not hasattr(stat, "st_birthtime"):  # Windows fallback
             ref_time = getattr(stat, "st_ctime", stat.st_mtime)
         days_since_created = (now - ref_time) / 86400
 

--- a/src/methodologies/para/detection/heuristics.py
+++ b/src/methodologies/para/detection/heuristics.py
@@ -161,9 +161,13 @@ class TemporalHeuristic(Heuristic):
         scores = {cat: CategoryScore(cat, 0.0, 0.0) for cat in PARACategory}
 
         if not file_path.exists():
-            return HeuristicResult(scores, 0.0, None, True)
+            return HeuristicResult(scores, 0.0, needs_manual_review=True)
 
-        stat = self._stat_provider(file_path)
+        try:
+            stat = self._stat_provider(file_path)
+        except OSError as e:
+            logger.warning("Cannot stat file %s: %s", file_path, e, exc_info=True)
+            return HeuristicResult(scores, 0.0, needs_manual_review=True)
         now = self._clock()
         current_year = self._current_year_provider()
 

--- a/tests/methodologies/para/test_ai_file_mover_branches.py
+++ b/tests/methodologies/para/test_ai_file_mover_branches.py
@@ -230,6 +230,11 @@ class TestMoveFile:
         )
         result = mover.move_file(suggestion, dry_run=False)
         assert result.success is False
+        assert result.error is not None
+        assert "too many existing files" in result.error
+        assert src.exists()
+        assert (dst_dir / "src.txt").read_text() == "existing"
+        assert (dst_dir / "src_1.txt").read_text() == "also existing"
 
 
 class TestBulkOrganize:

--- a/tests/methodologies/para/test_ai_file_mover_branches.py
+++ b/tests/methodologies/para/test_ai_file_mover_branches.py
@@ -204,6 +204,33 @@ class TestMoveFile:
         assert src.exists()
         assert not (dst_dir / "src.txt").exists()
 
+    def test_max_collision_attempts_seam_raises_at_limit(self, tmp_path: Path) -> None:
+        """max_collision_attempts=1 raises OSError after the first collision."""
+        src = tmp_path / "src.txt"
+        src.write_text("source")
+        dst_dir = tmp_path / "Projects"
+        dst_dir.mkdir()
+        # Both destination and the first fallback name exist, so counter hits limit
+        (dst_dir / "src.txt").write_text("existing")
+        (dst_dir / "src_1.txt").write_text("also existing")
+
+        config = PARAConfig()
+        engine = MagicMock()
+        mover = PARAFileMover(
+            config,
+            suggestion_engine=engine,
+            root_dir=tmp_path,
+            max_collision_attempts=1,
+        )
+        suggestion = MoveSuggestion(
+            file_path=src,
+            target_category=PARACategory.PROJECT,
+            target_path=dst_dir / "src.txt",
+            confidence=0.8,
+        )
+        result = mover.move_file(suggestion, dry_run=False)
+        assert result.success is False
+
 
 class TestBulkOrganize:
     """Cover bulk_organize branches — lines 258, 276-277, 289-293."""

--- a/tests/methodologies/para/test_ai_heuristic.py
+++ b/tests/methodologies/para/test_ai_heuristic.py
@@ -1298,7 +1298,7 @@ class TestPlatformSpecificPaths:
             st_mtime = now - (120 * 86400)
             st_atime = now - (120 * 86400)
             st_ctime = now - 86400
-            st_mode = 0o100644  # regular file — required by Path.is_dir()
+            st_mode = 0o100644
 
         f = tmp_path / "test.txt"
         f.write_text("test")
@@ -1317,7 +1317,7 @@ class TestPlatformSpecificPaths:
             st_mtime = now - (120 * 86400)
             st_atime = now - (120 * 86400)
             st_ctime = now - 86400
-            st_mode = 0o100644  # regular file — required by Path.is_dir()
+            st_mode = 0o100644
 
         f = tmp_path / "test.txt"
         f.write_text("test")
@@ -1407,7 +1407,7 @@ class TestPlatformSpecificBranches:
             st_mtime = real_stat.st_mtime
             st_atime = real_stat.st_atime
             st_ctime = real_stat.st_ctime
-            st_mode = real_stat.st_mode  # required by Path.is_dir() via pathlib internals
+            st_mode = real_stat.st_mode
             # Explicitly no st_birthtime attribute
 
         h = TemporalHeuristic(weight=0.25, os_name="nt", stat_provider=lambda _: MockStat())
@@ -1428,7 +1428,7 @@ class TestPlatformSpecificBranches:
             st_mtime = real_stat.st_mtime
             st_atime = real_stat.st_atime
             st_ctime = real_stat.st_ctime
-            st_mode = real_stat.st_mode  # required by Path.is_dir() via pathlib internals
+            st_mode = real_stat.st_mode
             # Explicitly no st_birthtime attribute
 
         h = TemporalHeuristic(weight=0.25, os_name="posix", stat_provider=lambda _: MockStat())
@@ -1456,7 +1456,7 @@ class TestPlatformSpecificBranches:
             st_atime = atime_100_days_ago
             st_ctime = birthtime_120_days_ago
             st_birthtime = birthtime_120_days_ago
-            st_mode = 0o100644  # required by Path.is_dir() via pathlib internals
+            st_mode = 0o100644
 
         h = TemporalHeuristic(weight=0.25, stat_provider=lambda _: MockStat())
         result = h.evaluate(f)
@@ -1481,3 +1481,4 @@ class TestPlatformSpecificBranches:
         assert result.needs_manual_review is True
         assert result.overall_confidence == 0.0
         assert result.recommended_category is None
+        assert all(s.score == 0.0 for s in result.scores.values())

--- a/tests/methodologies/para/test_ai_heuristic.py
+++ b/tests/methodologies/para/test_ai_heuristic.py
@@ -1288,55 +1288,40 @@ class TestRemainingCoverage:
 class TestPlatformSpecificPaths:
     """Tests for platform-specific code paths in TemporalHeuristic."""
 
-    def test_windows_platform_uses_ctime_for_creation(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_windows_platform_uses_ctime_for_creation(self, tmp_path: Path) -> None:
         """On Windows, st_ctime is used for file creation time."""
         from methodologies.para.detection.heuristics import TemporalHeuristic
 
-        class MockStat:
-            def __init__(self, *, now: float) -> None:
-                self.st_mtime = now - (120 * 86400)
-                self.st_atime = now - (120 * 86400)
-                self.st_ctime = now - 86400
-                self.st_mode = 0o100644  # regular file — required by Path.is_dir()
-
-        # Simulate Windows platform
-        monkeypatch.setattr(os, "name", "nt")
         now = time.time()
-        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat(now=now))
 
-        h = TemporalHeuristic(weight=0.25)
+        class MockStat:
+            st_mtime = now - (120 * 86400)
+            st_atime = now - (120 * 86400)
+            st_ctime = now - 86400
+            st_mode = 0o100644  # regular file — required by Path.is_dir()
+
         f = tmp_path / "test.txt"
         f.write_text("test")
-
+        h = TemporalHeuristic(weight=0.25, os_name="nt", stat_provider=lambda _: MockStat())
         result = h.evaluate(f)
 
         assert "stable_reference" in result.scores[PARACategory.RESOURCE].signals
 
-    def test_linux_platform_uses_mtime_for_creation(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_linux_platform_uses_mtime_for_creation(self, tmp_path: Path) -> None:
         """On Linux (without birthtime), st_mtime is used as creation proxy."""
-
         from methodologies.para.detection.heuristics import TemporalHeuristic
 
-        class MockStat:
-            def __init__(self, *, now: float) -> None:
-                self.st_mtime = now - (120 * 86400)
-                self.st_atime = now - (120 * 86400)
-                self.st_ctime = now - 86400
-                self.st_mode = 0o100644  # regular file — required by Path.is_dir()
-
-        # Simulate Linux platform
-        monkeypatch.setattr(os, "name", "posix")
         now = time.time()
-        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat(now=now))
 
-        h = TemporalHeuristic(weight=0.25)
+        class MockStat:
+            st_mtime = now - (120 * 86400)
+            st_atime = now - (120 * 86400)
+            st_ctime = now - 86400
+            st_mode = 0o100644  # regular file — required by Path.is_dir()
+
         f = tmp_path / "test.txt"
         f.write_text("test")
-
+        h = TemporalHeuristic(weight=0.25, os_name="posix", stat_provider=lambda _: MockStat())
         result = h.evaluate(f)
 
         assert "stable_reference" not in result.scores[PARACategory.RESOURCE].signals
@@ -1389,17 +1374,9 @@ class TestAIHeuristicEnsureClientEdgeCases:
 class TestPlatformSpecificBranches:
     """Tests to cover platform-specific code branches."""
 
-    def test_macos_platform_stat_birthtime(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_macos_platform_stat_birthtime(self, tmp_path: Path) -> None:
         """macOS branch uses st_birthtime (try succeeds — no AttributeError)."""
-        import time
-
         from methodologies.para.detection.heuristics import TemporalHeuristic
-
-        f = tmp_path / "test.txt"
-        f.write_text("test")
-        real_mode = f.stat().st_mode
 
         now = time.time()
 
@@ -1408,30 +1385,24 @@ class TestPlatformSpecificBranches:
             st_atime = now - (2 * 86400)
             st_ctime = now - (5 * 86400)
             st_birthtime = now - (5 * 86400)  # macOS — true birth time present
-            st_mode = real_mode
+            st_mode = 0o100644
 
-        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat())
-
-        h = TemporalHeuristic(weight=0.25)
+        f = tmp_path / "test.txt"
+        f.write_text("test")
+        h = TemporalHeuristic(weight=0.25, stat_provider=lambda _: MockStat())
         result = h.evaluate(f)
 
         # File was modified 5 days ago — recently_modified signal expected
         assert "recently_modified" in result.scores[PARACategory.PROJECT].signals
 
-    def test_windows_platform_stat_ctime(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_windows_platform_stat_ctime(self, tmp_path: Path) -> None:
         """Windows branch uses st_ctime when no st_birthtime (AttributeError → Windows branch)."""
-
         from methodologies.para.detection.heuristics import TemporalHeuristic
 
         f = tmp_path / "test.txt"
         f.write_text("test")
-
-        # Get real stat
         real_stat = f.stat()
 
-        # Create a mock stat object without st_birthtime
         class MockStat:
             st_mtime = real_stat.st_mtime
             st_atime = real_stat.st_atime
@@ -1439,30 +1410,20 @@ class TestPlatformSpecificBranches:
             st_mode = real_stat.st_mode  # required by Path.is_dir() via pathlib internals
             # Explicitly no st_birthtime attribute
 
-        # Monkeypatch both os.name and Path.stat
-        monkeypatch.setattr(os, "name", "nt")
-        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat())
-
-        h = TemporalHeuristic(weight=0.25)
+        h = TemporalHeuristic(weight=0.25, os_name="nt", stat_provider=lambda _: MockStat())
         result = h.evaluate(f)
 
         # Windows branch used st_ctime as creation proxy; file just created → recently_modified
         assert "recently_modified" in result.scores[PARACategory.PROJECT].signals
 
-    def test_linux_platform_stat_mtime_fallback(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_linux_platform_stat_mtime_fallback(self, tmp_path: Path) -> None:
         """Linux branch uses st_mtime as creation time proxy (no st_birthtime → AttributeError)."""
-
         from methodologies.para.detection.heuristics import TemporalHeuristic
 
         f = tmp_path / "test.txt"
         f.write_text("test")
-
-        # Get real stat
         real_stat = f.stat()
 
-        # Create a mock stat object without st_birthtime
         class MockStat:
             st_mtime = real_stat.st_mtime
             st_atime = real_stat.st_atime
@@ -1470,33 +1431,21 @@ class TestPlatformSpecificBranches:
             st_mode = real_stat.st_mode  # required by Path.is_dir() via pathlib internals
             # Explicitly no st_birthtime attribute
 
-        # Monkeypatch both os.name and Path.stat
-        monkeypatch.setattr(os, "name", "posix")
-        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat())
-
-        h = TemporalHeuristic(weight=0.25)
+        h = TemporalHeuristic(weight=0.25, os_name="posix", stat_provider=lambda _: MockStat())
         result = h.evaluate(f)
 
         # Linux branch used st_mtime as creation proxy; file just created → recently_modified
         assert "recently_modified" in result.scores[PARACategory.PROJECT].signals
 
-    def test_resource_stable_reference_signal(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_resource_stable_reference_signal(self, tmp_path: Path) -> None:
         """RESOURCE stable_reference signal when create/modify gap > 30 days."""
-        import time
-
         from methodologies.para.detection.heuristics import TemporalHeuristic
 
         f = tmp_path / "reference.pdf"
         f.write_text("reference")
-        real_mode = f.stat().st_mode  # capture before monkeypatching
 
-        # Create a mock stat where:
-        # - File was created 120 days ago (birthtime)
-        # - File was last modified 70 days ago (mtime)
-        # - Gap = 50 days > 30 days threshold
-        # - mtime age = 70 days > 60 days threshold
+        # File was created 120 days ago (birthtime), modified 70 days ago (mtime)
+        # Gap = 50 days > 30 days threshold; mtime age = 70 days > 60 days threshold
         now = time.time()
         mtime_70_days_ago = now - (70 * 86400)
         birthtime_120_days_ago = now - (120 * 86400)
@@ -1507,11 +1456,9 @@ class TestPlatformSpecificBranches:
             st_atime = atime_100_days_ago
             st_ctime = birthtime_120_days_ago
             st_birthtime = birthtime_120_days_ago
-            st_mode = real_mode  # required by Path.is_dir() via pathlib internals
+            st_mode = 0o100644  # required by Path.is_dir() via pathlib internals
 
-        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat())
-
-        h = TemporalHeuristic(weight=0.25)
+        h = TemporalHeuristic(weight=0.25, stat_provider=lambda _: MockStat())
         result = h.evaluate(f)
 
         # stable_reference signal should be present

--- a/tests/methodologies/para/test_ai_heuristic.py
+++ b/tests/methodologies/para/test_ai_heuristic.py
@@ -1465,3 +1465,19 @@ class TestPlatformSpecificBranches:
         resource_signals = result.scores[PARACategory.RESOURCE].signals
         assert "stable_reference" in resource_signals
         assert result.scores[PARACategory.RESOURCE].score > 0
+
+    def test_stat_provider_oserror_returns_neutral_result(self, tmp_path: Path) -> None:
+        """stat_provider raising OSError must return needs_manual_review, not propagate."""
+        from methodologies.para.detection.heuristics import TemporalHeuristic
+
+        def _raising_stat(path: object) -> object:
+            raise OSError("permission denied")
+
+        f = tmp_path / "locked.txt"
+        f.write_text("x")
+        h = TemporalHeuristic(weight=0.25, stat_provider=_raising_stat)
+        result = h.evaluate(f)
+
+        assert result.needs_manual_review is True
+        assert result.overall_confidence == 0.0
+        assert result.recommended_category is None

--- a/tests/methodologies/para/test_feature_extractor.py
+++ b/tests/methodologies/para/test_feature_extractor.py
@@ -243,35 +243,56 @@ class TestExtractMetadataFeatures:
 
         extractor = FeatureExtractor(stat_provider=fake_stat)
         extractor.extract_metadata_features(f)
-        assert len(calls) == 1
+        assert calls == [f]
 
     def test_custom_clock_is_called(self, tmp_path: Path) -> None:
         """Injected clock must be used instead of time.time."""
-        import time as _time
-
         f = tmp_path / "seam.txt"
         f.write_text("hello")
-        future_time = _time.time() + 86400.0  # 1 day in the future
+        future_time = f.stat().st_mtime + 86400.0  # exactly 1 day after mtime
         extractor = FeatureExtractor(clock=lambda: future_time)
         features = extractor.extract_metadata_features(f)
-        assert features.days_since_modified is not None
-        assert features.days_since_modified >= 0
+        assert features.days_since_modified == pytest.approx(1.0)
 
     def test_custom_os_name_windows(self, tmp_path: Path) -> None:
-        """Injected os_name='nt' must trigger Windows path logic."""
+        """Injected os_name='nt' must use st_ctime as creation reference."""
         f = tmp_path / "seam.txt"
         f.write_text("hello")
-        extractor = FeatureExtractor(os_name="nt")
+        now = 2_000_000_000.0
+
+        class MockStat:
+            st_size = 5
+            st_atime = now - (2 * 86400)
+            st_ctime = now - 86400  # Windows creation time: 1 day ago
+            st_mtime = now - (10 * 86400)
+
+        extractor = FeatureExtractor(
+            clock=lambda: now,
+            os_name="nt",
+            stat_provider=lambda _: MockStat(),
+        )
         features = extractor.extract_metadata_features(f)
-        assert features is not None
+        assert features.days_since_created == pytest.approx(1.0)
 
     def test_custom_os_name_posix(self, tmp_path: Path) -> None:
-        """Injected os_name='posix' must trigger POSIX path logic."""
+        """Injected os_name='posix' must use st_mtime as creation reference."""
         f = tmp_path / "seam.txt"
         f.write_text("hello")
-        extractor = FeatureExtractor(os_name="posix")
+        now = 2_000_000_000.0
+
+        class MockStat:
+            st_size = 5
+            st_atime = now - (2 * 86400)
+            st_ctime = now - 86400
+            st_mtime = now - (10 * 86400)  # POSIX creation fallback: 10 days ago
+
+        extractor = FeatureExtractor(
+            clock=lambda: now,
+            os_name="posix",
+            stat_provider=lambda _: MockStat(),
+        )
         features = extractor.extract_metadata_features(f)
-        assert features is not None
+        assert features.days_since_created == pytest.approx(10.0)
 
 
 # =========================================================================

--- a/tests/methodologies/para/test_feature_extractor.py
+++ b/tests/methodologies/para/test_feature_extractor.py
@@ -221,6 +221,58 @@ class TestExtractMetadataFeatures:
         features = extractor.extract_metadata_features(md_file)
         assert features.file_type == ".md"
 
+    def test_default_stat_provider_delegates_to_path_stat(self, tmp_path: Path) -> None:
+        """Default stat_provider must delegate to Path.stat — seam shape test."""
+        f = tmp_path / "shape.txt"
+        f.write_text("x")
+        extractor = FeatureExtractor()
+        real_stat = f.stat()
+        injected_stat = extractor._stat_provider(f)
+        assert injected_stat.st_size == real_stat.st_size
+
+    def test_custom_stat_provider_is_called(self, tmp_path: Path) -> None:
+        """Injected stat_provider must be used instead of Path.stat."""
+        f = tmp_path / "seam.txt"
+        f.write_text("hello")
+
+        calls: list[object] = []
+
+        def fake_stat(path: object) -> object:
+            calls.append(path)
+            return f.stat()
+
+        extractor = FeatureExtractor(stat_provider=fake_stat)
+        extractor.extract_metadata_features(f)
+        assert len(calls) == 1
+
+    def test_custom_clock_is_called(self, tmp_path: Path) -> None:
+        """Injected clock must be used instead of time.time."""
+        import time as _time
+
+        f = tmp_path / "seam.txt"
+        f.write_text("hello")
+        future_time = _time.time() + 86400.0  # 1 day in the future
+        extractor = FeatureExtractor(clock=lambda: future_time)
+        features = extractor.extract_metadata_features(f)
+        assert features.days_since_modified is not None
+        assert features.days_since_modified >= 0
+
+    def test_custom_os_name_windows(self, tmp_path: Path) -> None:
+        """Injected os_name='nt' must trigger Windows path logic."""
+        f = tmp_path / "seam.txt"
+        f.write_text("hello")
+        extractor = FeatureExtractor(os_name="nt")
+        features = extractor.extract_metadata_features(f)
+        assert features is not None
+
+    def test_custom_os_name_posix(self, tmp_path: Path) -> None:
+        """Injected os_name='posix' must trigger POSIX path logic."""
+        f = tmp_path / "seam.txt"
+        f.write_text("hello")
+        extractor = FeatureExtractor(os_name="posix")
+        features = extractor.extract_metadata_features(f)
+        assert features is not None
+
 
 # =========================================================================
 # StructuralFeatures extraction tests
@@ -387,7 +439,6 @@ class TestEdgeCasesAndErrorHandling:
 
     def test_metadata_extraction_with_stat_error(
         self,
-        extractor: FeatureExtractor,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -398,11 +449,10 @@ class TestEdgeCasesAndErrorHandling:
         # Mock exists() to return True so we pass the initial check
         monkeypatch.setattr(Path, "exists", lambda self: True)
 
-        # Mock stat() to raise OSError for the explicit stat() call
-        def mock_stat(_self: Path) -> None:
+        def mock_stat(_path: Path) -> None:
             raise OSError("Permission denied")
 
-        monkeypatch.setattr(Path, "stat", mock_stat)
+        extractor = FeatureExtractor(stat_provider=mock_stat)
         features = extractor.extract_metadata_features(test_file)
         # Should return defaults with just the file type
         assert features.file_type == ".txt"
@@ -411,21 +461,15 @@ class TestEdgeCasesAndErrorHandling:
 
     def test_metadata_extraction_fresh_file_zero_days_modified(
         self,
-        extractor: FeatureExtractor,
         tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Should handle edge case when file was just created/modified."""
         test_file = tmp_path / "fresh.txt"
         test_file.write_text("new content")
 
-        # Mock time.time() to return exactly the file's mtime
+        # Inject clock returning exactly the file's mtime so days_since_modified → 0
         original_stat = test_file.stat()
-
-        def mock_time() -> float:
-            return original_stat.st_mtime
-
-        monkeypatch.setattr("time.time", mock_time)
+        extractor = FeatureExtractor(clock=lambda: original_stat.st_mtime)
         features = extractor.extract_metadata_features(test_file)
         # days_since_modified should be 0 or very close to 0
         assert features.days_since_modified < 0.001
@@ -565,12 +609,9 @@ class TestEdgeCasesAndErrorHandling:
     @pytest.mark.ci
     def test_metadata_macos_platform_creation_time(
         self,
-        extractor: FeatureExtractor,
         tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Should use st_birthtime on macOS platform (try/except AttributeError path)."""
-        import methodologies.para.ai.feature_extractor as fe_module
 
         class MockStat:
             def __init__(self, *, now: float) -> None:
@@ -585,9 +626,10 @@ class TestEdgeCasesAndErrorHandling:
         test_file.write_text("content")
         now = 2_000_000_000.0
 
-        monkeypatch.setattr(fe_module.time, "time", lambda: now)
-        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat(now=now))
-
+        extractor = FeatureExtractor(
+            clock=lambda: now,
+            stat_provider=lambda _: MockStat(now=now),
+        )
         features = extractor.extract_metadata_features(test_file)
         # st_birthtime is 5 days ago → days_since_created ≈ 5.0
         assert features.days_since_created == pytest.approx(5.0)
@@ -596,12 +638,9 @@ class TestEdgeCasesAndErrorHandling:
     @pytest.mark.ci
     def test_metadata_windows_platform_creation_time(
         self,
-        extractor: FeatureExtractor,
         tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Should use st_ctime on Windows platform (no st_birthtime → AttributeError)."""
-        import methodologies.para.ai.feature_extractor as fe_module
 
         class MockStat:
             def __init__(self, *, now: float) -> None:
@@ -616,10 +655,11 @@ class TestEdgeCasesAndErrorHandling:
         test_file.write_text("content")
         now = 2_000_000_000.0
 
-        monkeypatch.setattr(fe_module.os, "name", "nt")
-        monkeypatch.setattr(fe_module.time, "time", lambda: now)
-        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat(now=now))
-
+        extractor = FeatureExtractor(
+            clock=lambda: now,
+            os_name="nt",
+            stat_provider=lambda _: MockStat(now=now),
+        )
         features = extractor.extract_metadata_features(test_file)
         assert features.days_since_created == pytest.approx(1.0)
         assert features.file_size == 7
@@ -627,12 +667,9 @@ class TestEdgeCasesAndErrorHandling:
     @pytest.mark.ci
     def test_metadata_linux_platform_creation_time(
         self,
-        extractor: FeatureExtractor,
         tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Should use st_mtime on Linux platform (no st_birthtime → AttributeError)."""
-        import methodologies.para.ai.feature_extractor as fe_module
 
         class MockStat:
             def __init__(self, *, now: float) -> None:
@@ -647,10 +684,11 @@ class TestEdgeCasesAndErrorHandling:
         test_file.write_text("content")
         now = 2_000_000_000.0
 
-        monkeypatch.setattr(fe_module.os, "name", "posix")
-        monkeypatch.setattr(fe_module.time, "time", lambda: now)
-        monkeypatch.setattr(Path, "stat", lambda _self, *_args, **_kwargs: MockStat(now=now))
-
+        extractor = FeatureExtractor(
+            clock=lambda: now,
+            os_name="posix",
+            stat_provider=lambda _: MockStat(now=now),
+        )
         features = extractor.extract_metadata_features(test_file)
         assert features.days_since_created == pytest.approx(10.0)
         assert features.file_size == 7


### PR DESCRIPTION
## Summary

Closes #142 (Phase 2) — replaces broad `monkeypatch.setattr(Path, "stat", ...)` and `monkeypatch.setattr(os, "name", ...)` patches with narrow keyword-only constructor seams.

- **`FeatureExtractor`**: adds `clock`, `os_name`, `stat_provider` keyword-only params; defaults to `time.time`, `os.name`, `Path.stat`
- **`TemporalHeuristic`**: adds same 3 seams plus `current_year_provider`; moves inline `import time`, `import re`, `from datetime import ...` to module level (F9 fix)
- **`PARAFileMover`**: adds `max_collision_attempts` seam replacing hardcoded `> 1000` check

**Tests refactored** (no more broad patches):
- `test_feature_extractor.py`: 5 existing tests switched to seam injection; 5 new seam-shape tests added
- `test_ai_heuristic.py`: 6 existing tests switched to seam injection
- `test_ai_file_mover_branches.py`: 1 new seam test for collision limit

**Diff coverage**: 100% (24 changed lines, 0 missing)

## Test plan

- [x] `pytest tests/methodologies/para/test_feature_extractor.py` — 53 passed
- [x] `pytest tests/methodologies/para/test_ai_heuristic.py` — 71 passed
- [x] `pytest tests/methodologies/para/test_ai_file_mover_branches.py` — 62 passed
- [x] `bash .claude/scripts/pre-commit-validation.sh` — all gates pass including diff-cover 100%
- [x] `ruff check` / `ruff format` — clean
- [x] `mypy` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability by wrapping dependency installs with retryable steps (limited attempts and timeouts) across workflows to reduce transient failures.
  * Added safer install split/strict-shell handling to reduce flakiness in checks and gates.
  * Introduced configurability for platform/time-dependent and file-collision behaviors to make operations more robust.

* **Tests**
  * Expanded and refactored tests to improve isolation, remove global state mutations, and cover new failure/seam cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->