### PR TITLE
refactor(para): tighten stat_provider return type from Any to _StatLike Protocol (#151)

### DIFF
--- a/src/methodologies/para/detection/heuristics.py
+++ b/src/methodologies/para/detection/heuristics.py
@@ -18,7 +18,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 try:
     import ollama
@@ -92,6 +92,20 @@ class Heuristic(ABC):
         pass
 
 
+class _StatLike(Protocol):
+    """Structural subtyping interface for the attributes TemporalHeuristic.evaluate() reads."""
+
+    st_mtime: float
+    st_atime: float
+    st_ctime: float
+    st_mode: int
+
+
+def _path_stat(path: Path) -> _StatLike:
+    # os.stat_result is a C namedtuple; mypy can't verify Protocol conformance without this bridge.
+    return path.stat()  # type: ignore[return-value]
+
+
 class TemporalHeuristic(Heuristic):
     """Temporal heuristic using file timestamps and patterns.
 
@@ -110,7 +124,7 @@ class TemporalHeuristic(Heuristic):
         clock: Callable[[], float] | None = None,
         current_year_provider: Callable[[], int] | None = None,
         os_name: str | None = None,
-        stat_provider: Callable[[Path], Any] | None = None,
+        stat_provider: Callable[[Path], _StatLike] | None = None,
     ) -> None:
         """Initialize the temporal heuristic.
 
@@ -129,8 +143,8 @@ class TemporalHeuristic(Heuristic):
             else lambda: datetime.now(UTC).year
         )
         self._os_name: str = os_name if os_name is not None else os.name
-        self._stat_provider: Callable[[Path], Any] = (
-            stat_provider if stat_provider is not None else Path.stat
+        self._stat_provider: Callable[[Path], _StatLike] = (
+            stat_provider if stat_provider is not None else _path_stat
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary

- Defines `_StatLike` Protocol in `heuristics.py` declaring `st_mtime`, `st_atime`, `st_ctime`, `st_mode` — the attributes `TemporalHeuristic.evaluate()` reads
- Updates `stat_provider` parameter and `_stat_provider` field from `Callable[[Path], Any]` to `Callable[[Path], _StatLike]`
- Adds `_path_stat()` typed bridge function so `Path.stat` (a C namedtuple) satisfies mypy's Protocol check

## Test plan

- [ ] All 125 existing `test_ai_heuristic.py` / `test_feature_extractor.py` tests pass unchanged — existing `MockStat` classes already declare the required attributes
- [ ] `mypy --strict` on `heuristics.py` passes with no errors
- [ ] Pre-commit validation passes (300 passed, 1 skipped)

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety and code organization in the temporal heuristics detection module through enhanced type annotations and internal code restructuring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->