### PR TITLE
hardening(e-followups): close #164/#165/#166 + fix daemon-watch CI flake

### DIFF
--- a/.claude/scripts/check_pypi_versions.py
+++ b/.claude/scripts/check_pypi_versions.py
@@ -42,15 +42,30 @@ from urllib import error, parse, request
 
 
 def _version_is_pre_1(version: str) -> bool:
-    """Return True when the major component is 0.
+    """Return True when the PEP 440 *release* major component is 0.
 
     Covers every pre-1.0 shape: ``0.7.2``, ``0.0.19``, bare ``0``, and
     pre-releases like ``0rc1`` / ``0a1`` / ``0b0``. Previously only
     ``"0."`` was recognised, which silently let uncapped ``foo>=0`` pins
     bypass the E3 cap-or-marker rule (#164).
+
+    Uses ``packaging.version.Version`` so PEP 440 epoch syntax is
+    handled correctly — ``0!1.2`` has epoch ``0`` and major release ``1``,
+    i.e. *post-1.0*. A naive leading-digit regex would read the epoch
+    and misclassify it (codex P2 review on PR #171).
     """
-    match = re.match(r"^(\d+)", version)
-    return match is not None and int(match.group(1)) == 0
+    try:
+        from packaging.version import InvalidVersion, Version
+    except ImportError:  # pragma: no cover — packaging is pinned in pyproject.toml
+        # Fallback to the regex path if packaging somehow isn't available.
+        match = re.match(r"^(\d+)", version)
+        return match is not None and int(match.group(1)) == 0
+    try:
+        return Version(version).major == 0
+    except InvalidVersion:
+        # Non-PEP-440 garbage — treat as post-1.0 so the pre-1.0 rule
+        # doesn't enforce a cap on something we can't classify.
+        return False
 
 
 def _version_tuple(version: str) -> tuple[int, ...]:

--- a/.claude/scripts/check_pypi_versions.py
+++ b/.claude/scripts/check_pypi_versions.py
@@ -8,7 +8,9 @@ Two independent checks are bundled into one script (both run by default):
    version of *package* is >= X.Y.Z.  This catches cases like
    ``rank-bm25>=0.7.2`` where the latest published version is 0.2.2 — no
    installation is possible, so the requirement is effectively broken.
-   Only pre-1.0 packages are checked (version < 1.0.0).
+   Runs on **every** ``>=`` pin (pre-1.0 and post-1.0) — the ``psutil>=6.2``
+   fabrication that originally motivated this script was post-1.0 and was
+   missed by the earlier pre-1.0-only gate (#165).
 
 2. **Pre-1.0 cap-or-marker** (E3 of the hardening roadmap, #158):
    Any pre-1.0 ``>=`` pin must have either an upper bound (e.g. ``<1``) or
@@ -40,8 +42,15 @@ from urllib import error, parse, request
 
 
 def _version_is_pre_1(version: str) -> bool:
-    """Return True for pre-1.0 versions like 0.7.2, 0.0.19."""
-    return version.startswith("0.")
+    """Return True when the major component is 0.
+
+    Covers every pre-1.0 shape: ``0.7.2``, ``0.0.19``, bare ``0``, and
+    pre-releases like ``0rc1`` / ``0a1`` / ``0b0``. Previously only
+    ``"0."`` was recognised, which silently let uncapped ``foo>=0`` pins
+    bypass the E3 cap-or-marker rule (#164).
+    """
+    match = re.match(r"^(\d+)", version)
+    return match is not None and int(match.group(1)) == 0
 
 
 def _version_tuple(version: str) -> tuple[int, ...]:
@@ -135,8 +144,11 @@ def _check_caps_or_marker(pyproject_path: Path) -> list[str]:
         # Only audit bare `>=0.X` pins. `~=0.X` is already bounded by PEP 440
         # semantics (`~=0.18` means `>=0.18,<0.19`), and `==0.X` is pinned exactly.
         # Those forms are safe; this rule targets unbounded `>=`.
+        #
+        # `_version_is_pre_1` catches every pre-1.0 shape — `0`, `0rc1`,
+        # `0.0.19`, `0.7.2` — not just `"0."`-prefixed strings (#164).
         has_pre_1_lower = any(
-            s.operator == ">=" and s.version.startswith("0.") for s in req.specifier
+            s.operator == ">=" and _version_is_pre_1(s.version) for s in req.specifier
         )
         if not has_pre_1_lower:
             continue
@@ -159,7 +171,7 @@ def _check_caps_or_marker(pyproject_path: Path) -> list[str]:
     return failures
 
 
-def main(argv: list[str] | None = None) -> int:  # noqa: C901
+def main(argv: list[str] | None = None) -> int:
     """Entry point. Dispatches the two checks based on CLI flags.
 
     Complexity noqa: this is a linear CLI dispatcher — splitting into helpers
@@ -222,8 +234,12 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
         package = match.group(1)
         version = match.group(2)
 
-        if not _version_is_pre_1(version):
-            continue  # Only validate pre-1.0 packages (higher risk of invented versions)
+        # PyPI satisfiability applies to every ``>=X.Y.Z`` pin — not just
+        # pre-1.0. The ``psutil>=6.2,<7`` fabrication that originally
+        # motivated this script (PR #846, rule C8) was post-1.0 and got
+        # through under the old pre-1.0-only gate. The cap-or-marker rule
+        # still scopes to pre-1.0 (that's the E3 policy); PyPI
+        # satisfiability runs on everything (#165).
 
         pkg_norm = package.lower().replace("_", "-")
 

--- a/.github/accepted-risks-extras.yml
+++ b/.github/accepted-risks-extras.yml
@@ -1,0 +1,29 @@
+# Accepted-risk allowlist for the `.[all]` audit (optional extras).
+#
+# This file is paired with the `audit-dependencies-extras` job in
+# .github/workflows/security.yml, which installs `pip install -e .[all]` so
+# optional-extra transitive risks (via `[llama]`, `[media]`, `[search]`, etc.)
+# are surfaced. The base-install audit uses .github/accepted-risks.yml
+# separately; each allowlist scopes to only the packages its audit job
+# actually installs (#166).
+#
+# Schema is the same as .github/accepted-risks.yml — enforced by
+# scripts/pip_audit_gate.py:
+#   - advisory_id : string, GHSA-/PYSEC-/CVE- prefix
+#   - package     : string, PyPI distribution name
+#   - version_spec: string, PEP 440 specifier
+#   - reason      : string, why the code path is unreachable for fo-core
+#   - expires_on  : YYYY-MM-DD (≤ 6 months from add date)
+
+allowlist:
+  - advisory_id: GHSA-w8v5-vhqr-4h9v
+    package: diskcache
+    version_spec: "<=5.6.3"
+    reason: >-
+      Transitive via llama-cpp-python (``[llama]`` extra). The vulnerable
+      cache-path code path is never invoked by fo-core — the ``[llama]``
+      surface only uses llama-cpp-python for local inference, and the disk
+      cache is pinned to a per-model temp dir we control. Upstream has no
+      patched release as of 2026-04-22; re-evaluate when diskcache ships
+      a 5.6.x+ that addresses the advisory.
+    expires_on: 2026-10-22

--- a/.github/accepted-risks-extras.yml
+++ b/.github/accepted-risks-extras.yml
@@ -16,7 +16,7 @@
 #   - expires_on  : YYYY-MM-DD (≤ 6 months from add date)
 
 allowlist:
-  - advisory_id: GHSA-w8v5-vhqr-4h9v
+  - advisory_id: CVE-2025-69872
     package: diskcache
     version_spec: "<=5.6.3"
     reason: >-
@@ -24,6 +24,18 @@ allowlist:
       cache-path code path is never invoked by fo-core — the ``[llama]``
       surface only uses llama-cpp-python for local inference, and the disk
       cache is pinned to a per-model temp dir we control. Upstream has no
-      patched release as of 2026-04-22; re-evaluate when diskcache ships
+      patched release as of 2026-04-23; re-evaluate when diskcache ships
       a 5.6.x+ that addresses the advisory.
-    expires_on: 2026-10-22
+    expires_on: 2026-10-23
+  - advisory_id: PYSEC-2022-42969
+    package: py
+    version_spec: "<=1.11.0"
+    reason: >-
+      Transitive via pytest (``[dev]`` / ``[all]`` test extras). The
+      advisory is a ReDoS in ``py.path.svnwc`` — SVN working-copy handling
+      that fo-core never invokes. Our pytest usage is limited to the core
+      test runner; no SVN-adjacent helpers are imported. The ``py``
+      package is effectively unmaintained (last release 2022-11) so no
+      upstream fix is expected. Re-evaluate when pytest drops the ``py``
+      dependency entirely (upstream tracking issue pytest-dev/pytest#10462).
+    expires_on: 2026-10-23

--- a/.github/accepted-risks.yml
+++ b/.github/accepted-risks.yml
@@ -20,14 +20,16 @@
 # allowlist must correspond to packages installed by the base project. If a
 # risk applies only to an optional extra (e.g. `[llama]`, `[media]`), it must
 # not be seeded here — the gate's "allowlist entry for uninstalled package"
-# rule will fail the base audit. A separate extras-audit job (future work)
-# will own those entries.
+# rule will fail the base audit. The sibling `audit-dependencies-extras` job
+# (installs `.[all]`) uses .github/accepted-risks-extras.yml for those
+# entries; see #166.
 #
 # Historically seeded entries (both removed in epic-e-deps because they fall
 # outside the base audit scope):
 #   - GHSA-wj6h-64fc-37mp (ecdsa): was transitive via `python-jose`, which
 #     is no longer a dependency of fo-core in any scope.
 #   - GHSA-w8v5-vhqr-4h9v (diskcache): transitive via `llama-cpp-python`,
-#     which lives in the `[llama]` optional extra — out of base audit scope.
+#     which lives in the `[llama]` optional extra — now tracked in
+#     .github/accepted-risks-extras.yml.
 
 allowlist: []

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -70,6 +70,51 @@ jobs:
               --audit audit.json \
               --allowlist .github/accepted-risks.yml
 
+  audit-dependencies-extras:
+    # Mirrors `audit-dependencies` but installs `.[all]` so transitive risks
+    # from optional extras (`[llama]`, `[media]`, `[search]`, `[dedup-*]`,
+    # `[scientific]`, `[cad]`, `[claude]`, `[mlx]`, `[cloud]`) are audited
+    # against .github/accepted-risks-extras.yml. Separate job + separate
+    # allowlist because the base audit would fail on
+    # "allowlist entry for uninstalled package" if extras entries leaked
+    # into .github/accepted-risks.yml (#166).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install pip-audit + gate deps
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_on: error
+          command: pip install pip-audit pyyaml packaging
+      - name: Audit dependencies (.[all])
+        # `.[all]` pulls torch / opencv / faster-whisper / etc. — expect this
+        # step to be slower than the base audit. The retry wrapper also guards
+        # the large wheel downloads against transient CDN flakes (issue #145).
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_on: error
+          command: |
+            set -euo pipefail
+            pip install -e .[all] >/dev/null
+            set +e
+            pip-audit . --format=json > audit-extras.json
+            audit_exit=$?
+            set -e
+            if [ ! -s audit-extras.json ]; then
+              echo "::error::pip-audit produced no output (exit $audit_exit) — likely a crash"
+              exit 1
+            fi
+            python3 scripts/pip_audit_gate.py \
+              --audit audit-extras.json \
+              --allowlist .github/accepted-risks-extras.yml
+
   bandit-scan:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -84,6 +84,12 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
+          # Cache pip wheels keyed on pyproject.toml so the `.[all]` install
+          # (torch / opencv / faster-whisper — ~1 GB) doesn't re-download on
+          # every schedule/PR run. Keeps the retry wrapper for genuine CDN
+          # flakes but dramatically narrows its blast radius.
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - name: Install pip-audit + gate deps
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
         with:
@@ -95,6 +101,14 @@ jobs:
         # `.[all]` pulls torch / opencv / faster-whisper / etc. — expect this
         # step to be slower than the base audit. The retry wrapper also guards
         # the large wheel downloads against transient CDN flakes (issue #145).
+        #
+        # `pip-audit` (no path argument) audits the **installed environment**
+        # — which is exactly what we need here: `.[all]` has put every extra's
+        # transitive graph on disk, and that's what we want scanned.
+        # `pip-audit .` is project-path mode and ONLY inspects the
+        # `[project.dependencies]` block in pyproject.toml, silently ignoring
+        # `[project.optional-dependencies]`. Running the path form against a
+        # `.[all]`-installed env would defeat the whole reason this job exists.
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08  # v3.0.2
         with:
           timeout_minutes: 20
@@ -102,9 +116,13 @@ jobs:
           retry_on: error
           command: |
             set -euo pipefail
-            pip install -e .[all] >/dev/null
+            # Quote `.[all]` so bracket-glob-enabled shells (zsh / bash with
+            # failglob) can't accidentally expand or null-match it.
+            pip install -e '.[all]' >/dev/null
             set +e
-            pip-audit . --format=json > audit-extras.json
+            # Environment mode (no `.` argument) — audits the installed
+            # graph, not pyproject.toml. See the long comment on the step.
+            pip-audit --format=json > audit-extras.json
             audit_exit=$?
             set -e
             if [ ! -s audit-extras.json ]; then

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -78,7 +78,17 @@ jobs:
     # allowlist because the base audit would fail on
     # "allowlist entry for uninstalled package" if extras entries leaked
     # into .github/accepted-risks.yml (#166).
-    runs-on: ubuntu-latest
+    #
+    # Matrix across Linux + macOS so platform-gated extras (currently
+    # `mlx-lm`, pinned to `platform_system == 'Darwin'`) actually get
+    # audited. Running only on ubuntu-latest would silently leave
+    # macOS-only dependencies out of the coverage footprint — a real gap
+    # codex caught on PR #171.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/tests/cli/test_cli_daemon.py
+++ b/tests/cli/test_cli_daemon.py
@@ -264,8 +264,12 @@ class TestDaemonWatch:
 
         result = runner.invoke(app, ["daemon", "watch", str(watch_dir)])
         assert result.exit_code == 0
+        # Rich wraps long paths at the CliRunner terminal width — normalize
+        # line breaks before asserting file-name substrings so the test
+        # passes regardless of the platform's reported width.
+        normalized_output = result.output.replace("\n", "")
         assert "Watching" in result.output
-        assert "new.txt" in result.output
+        assert "new.txt" in normalized_output
         assert "Stopped watching" in result.output
         mock_monitor.start.assert_called_once()
         mock_monitor.stop.assert_called_once()
@@ -289,4 +293,9 @@ class TestDaemonWatch:
 
         result = runner.invoke(app, ["daemon", "watch", str(watch_dir)])
         assert result.exit_code == 0
-        assert "fallback.txt" in result.output
+        # Rich wraps long paths at the terminal width that CliRunner exposes,
+        # which can split "fallback.txt" across a newline on narrow Linux CI
+        # runners. Normalize line breaks before matching so the assertion is
+        # about *content*, not Rich's layout.
+        normalized_output = result.output.replace("\n", "")
+        assert "fallback.txt" in normalized_output

--- a/tests/scripts/test_check_pypi_versions.py
+++ b/tests/scripts/test_check_pypi_versions.py
@@ -197,6 +197,19 @@ def test_version_is_pre_1_handles_invalid_input() -> None:
     assert _version_is_pre_1("xyz") is False
 
 
+def test_version_is_pre_1_respects_pep_440_epoch() -> None:
+    """Regression for codex P2 review on PR #171: PEP 440 allows an epoch
+    prefix like ``0!1.2``. The epoch (``0``) is not the release major —
+    the release here is ``1.2`` (post-1.0). A naive leading-digit regex
+    would misclassify this as pre-1.0 and force a cap on a legitimate
+    post-1.0 pin.
+    """
+    # epoch 0, release 1.2 — post-1.0
+    assert _version_is_pre_1("0!1.2") is False
+    # epoch 1, release 0.9 — pre-1.0 despite epoch >= 1
+    assert _version_is_pre_1("1!0.9") is True
+
+
 def test_pre_1_bare_zero_without_cap_fails(tmp_path: Path) -> None:
     """End-to-end #164: ``foo>=0`` (bare zero, no cap) now fails the
     cap-or-marker rule. Before the fix this silently passed.
@@ -224,14 +237,14 @@ def test_constraint_satisfiable_when_match_exists() -> None:
     assert _constraint_is_satisfiable("6.1.1", ["6.0.0", "6.1.0", "6.1.1", "7.0.0"]) is True
 
 
-def test_constraint_unsatisfiable_for_fabricated_post_1_version() -> None:
-    """Regression for #165 / C8 VERSION_FABRICATION: a ``>=6.2`` pin when the
-    latest published 6.x is ``6.1.1`` and the next release is ``7.0.0`` has
-    no published version >= 6.2 that stays in-range. The helper correctly
-    reports the constraint as satisfiable by ``7.0.0`` (which is >= 6.2),
-    so the upper-bound cap is what prevents the fabrication from installing.
-    This test documents the helper's contract: it does not check caps,
-    only the lower-bound existence.
+def test_constraint_satisfiable_ignores_upper_cap_for_fabricated_post_1_version() -> None:
+    """Regression for #165 / C8 VERSION_FABRICATION: the helper only checks
+    lower-bound existence, not caps. A ``>=6.2`` pin with no published 6.2
+    but a published 7.0.0 is reported as satisfiable — the *upper-bound*
+    cap (``<7`` in the real psutil case) is what prevents the fabrication
+    from installing. This test documents the contract (renamed from the
+    earlier "unsatisfiable"-prefixed name, which contradicted its own
+    assertion and confused readers — coderabbit review on PR #171).
     """
     # `>=6.2` alone is satisfiable by 7.0.0.
     assert _constraint_is_satisfiable("6.2", ["6.0.0", "6.1.0", "6.1.1", "7.0.0"]) is True

--- a/tests/scripts/test_check_pypi_versions.py
+++ b/tests/scripts/test_check_pypi_versions.py
@@ -23,6 +23,8 @@ check_pypi_versions = importlib.util.module_from_spec(_spec)
 sys.modules["check_pypi_versions"] = check_pypi_versions
 _spec.loader.exec_module(check_pypi_versions)
 _check_caps_or_marker = check_pypi_versions._check_caps_or_marker
+_version_is_pre_1 = check_pypi_versions._version_is_pre_1
+_constraint_is_satisfiable = check_pypi_versions._constraint_is_satisfiable
 
 
 def _write_pyproject(tmp_path: Path, deps: list[str]) -> Path:
@@ -148,3 +150,104 @@ def test_script_invocation_exits_nonzero_on_failure(tmp_path: Path) -> None:
     )
     assert r.returncode == 1
     assert "pydub" in r.stderr
+
+
+# ---------------------------------------------------------------------------
+# #164 — _version_is_pre_1 must catch every pre-1.0 shape, not just "0."
+# ---------------------------------------------------------------------------
+
+
+def test_version_is_pre_1_dotted() -> None:
+    """The classic cases: dotted pre-1.0 versions."""
+    assert _version_is_pre_1("0.7.2") is True
+    assert _version_is_pre_1("0.0.19") is True
+    assert _version_is_pre_1("0.1") is True
+
+
+def test_version_is_pre_1_bare_zero() -> None:
+    """Bare ``>=0`` must be treated as pre-1.0 (regression for #164).
+
+    Previously ``version.startswith("0.")`` returned False for ``"0"``,
+    silently letting ``foo>=0`` bypass the cap-or-marker rule.
+    """
+    assert _version_is_pre_1("0") is True
+
+
+def test_version_is_pre_1_pre_release() -> None:
+    """Pre-releases with major 0: 0a1, 0b0, 0rc1 (#164)."""
+    assert _version_is_pre_1("0rc1") is True
+    assert _version_is_pre_1("0a1") is True
+    assert _version_is_pre_1("0b0") is True
+
+
+def test_version_is_pre_1_false_for_post_1() -> None:
+    """Anything with major >= 1 is post-1.0 and falls outside the pre-1.0 rule."""
+    assert _version_is_pre_1("1.0.0") is False
+    assert _version_is_pre_1("1") is False
+    assert _version_is_pre_1("2.31.0") is False
+    assert _version_is_pre_1("10.2.3") is False
+    assert _version_is_pre_1("1rc1") is False
+
+
+def test_version_is_pre_1_handles_invalid_input() -> None:
+    """Non-numeric leading garbage returns False — treat as post-1.0 so the
+    caller doesn't apply the pre-1.0 rule to something it can't classify.
+    """
+    assert _version_is_pre_1("") is False
+    assert _version_is_pre_1("xyz") is False
+
+
+def test_pre_1_bare_zero_without_cap_fails(tmp_path: Path) -> None:
+    """End-to-end #164: ``foo>=0`` (bare zero, no cap) now fails the
+    cap-or-marker rule. Before the fix this silently passed.
+    """
+    p = _write_pyproject(tmp_path, ['"foo>=0"'])
+    failures = _check_caps_or_marker(p)
+    assert len(failures) == 1, f"Bare `>=0` must fail cap-or-marker; got: {failures}"
+    assert "foo" in failures[0]
+
+
+def test_pre_1_bare_zero_with_cap_passes(tmp_path: Path) -> None:
+    """End-to-end #164: ``foo>=0,<1`` is capped — acceptable."""
+    p = _write_pyproject(tmp_path, ['"foo>=0,<1"'])
+    assert _check_caps_or_marker(p) == []
+
+
+# ---------------------------------------------------------------------------
+# #165 — PyPI satisfiability applies to every >=X.Y.Z pin, not just pre-1.0.
+# Network-free tests exercise the helper directly.
+# ---------------------------------------------------------------------------
+
+
+def test_constraint_satisfiable_when_match_exists() -> None:
+    """A post-1.0 pin with a real published version is satisfiable."""
+    assert _constraint_is_satisfiable("6.1.1", ["6.0.0", "6.1.0", "6.1.1", "7.0.0"]) is True
+
+
+def test_constraint_unsatisfiable_for_fabricated_post_1_version() -> None:
+    """Regression for #165 / C8 VERSION_FABRICATION: a ``>=6.2`` pin when the
+    latest published 6.x is ``6.1.1`` and the next release is ``7.0.0`` has
+    no published version >= 6.2 that stays in-range. The helper correctly
+    reports the constraint as satisfiable by ``7.0.0`` (which is >= 6.2),
+    so the upper-bound cap is what prevents the fabrication from installing.
+    This test documents the helper's contract: it does not check caps,
+    only the lower-bound existence.
+    """
+    # `>=6.2` alone is satisfiable by 7.0.0.
+    assert _constraint_is_satisfiable("6.2", ["6.0.0", "6.1.0", "6.1.1", "7.0.0"]) is True
+
+
+def test_constraint_unsatisfiable_when_latest_below_minimum() -> None:
+    """The real C8 catch: every published version is below the declared
+    minimum. Example from rule C8 / PR #846: ``rank-bm25>=0.7.2`` when
+    the latest release is 0.2.2.
+    """
+    assert _constraint_is_satisfiable("0.7.2", ["0.2.0", "0.2.1", "0.2.2"]) is False
+
+
+def test_constraint_skips_unparseable_versions() -> None:
+    """PyPI occasionally has non-PEP-440 version strings (e.g. legacy
+    ``2022.01-preview``). These must not crash the helper; they're just
+    skipped when checking the minimum.
+    """
+    assert _constraint_is_satisfiable("2.0.0", ["legacy-tag", "garbage", "2.1.0"]) is True


### PR DESCRIPTION
## Summary

Bundles three Epic E follow-ups and one CI regression fix.

- **#164** — `_version_is_pre_1` now catches every pre-1.0 shape (`0`, `0rc1`, `0a1`, `0b0`, `0.0.19`), not just `"0."`-prefixed strings. Cap-or-marker rule no longer lets `foo>=0` slip through.
- **#165** — PyPI satisfiability check runs on every `>=X.Y.Z` pin, not just pre-1.0. The `psutil>=6.2` fabrication from PR #846 (rule C8) was post-1.0 and got through the old gate; that class of finding is now caught.
- **#166** — `audit-dependencies-extras` job in `security.yml` installs `.[all]` and audits against a new `.github/accepted-risks-extras.yml`. Seeded with the `diskcache` advisory that Epic E couldn't keep in the base allowlist.
- **CI fix** — `TestDaemonWatch` assertions (added in #168) failed on main's post-merge CI run because Rich wrapped long paths across a newline on Linux. Normalize line breaks before substring-matching. Run [24810398231](https://github.com/curdriceaurora/fo-core/actions/runs/24810398231).

Branch is `hardening/epic-a-cli` but this is *not* A.cli — A.cli comes next. Name is unfortunate; commit message and title reflect actual scope.

## Test plan

- [x] 9 new unit tests for `_version_is_pre_1` + `_constraint_is_satisfiable` + bare-`>=0` end-to-end (21 → 30 passing in `tests/scripts/test_check_pypi_versions.py`)
- [x] `bash .claude/scripts/pre-commit-validation.sh` — all guardrails green
- [x] `ruff check` + `ruff format` clean
- [x] `python3 .claude/scripts/check_pypi_versions.py --check-pre-1-0-only` passes against the real `pyproject.toml`
- [x] YAML valid for `security.yml` and `accepted-risks-extras.yml`
- [x] `TestDaemonWatch` regression reproduced locally via Mock, fix verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate dependency security auditing for optional extras installations.

* **Chores**
  * Improved security configuration and vulnerability tracking for optional dependencies.
  * Enhanced CI workflow to enforce findings against dedicated security allowlist.
  * Improved test reliability for CLI output handling.
  * Expanded test coverage for version constraint validation and pre-release detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->