### PR TITLE
hardening(security): epic-a-cli — wire path validation into CLI args

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,6 +253,10 @@ warn_unused_ignores = true
 warn_no_return = true
 follow_imports = "normal"
 ignore_missing_imports = true
+# striprtf ships no stubs and its `rtf_to_text` function is unannotated; exclude
+# calls into it from `disallow_untyped_calls` (both call sites still coerce the
+# result via `str(...)` to preserve downstream types). Unblocks CI after PR #167.
+untyped_calls_exclude = ["striprtf"]
 
 # Optional-dep model wrappers: mlx_lm and llama_cpp have no stubs and their
 # type signatures are only visible when the packages are installed.  The files

--- a/scripts/coverage/integration_module_floor_baseline.json
+++ b/scripts/coverage/integration_module_floor_baseline.json
@@ -1,5 +1,5 @@
 {
-  "generated_at_utc": "2026-04-12T14:41:46.240558+00:00",
+  "generated_at_utc": "2026-04-23T10:30:00.000000+00:00",
   "source": {
     "workflow_run_id": null,
     "job_id": null,

--- a/scripts/coverage/integration_module_floor_baseline.json
+++ b/scripts/coverage/integration_module_floor_baseline.json
@@ -37,6 +37,7 @@
     "src/cli/setup.py": 94.0,
     "src/cli/suggest.py": 81.0,
     "src/cli/undo_history.py": 98.0,
+    "src/cli/path_validation.py": 100.0,
     "src/cli/undo_redo.py": 100.0,
     "src/cli/update.py": 100.0,
     "src/cli/utilities.py": 82.0,

--- a/src/cli/autotag_v2.py
+++ b/src/cli/autotag_v2.py
@@ -16,6 +16,8 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from cli.path_validation import resolve_cli_path
+
 autotag_app = typer.Typer(
     name="autotag",
     help="Auto-tagging suggestions and management.",
@@ -41,10 +43,8 @@ def suggest(
     """Suggest tags for files in a directory."""
     from services.auto_tagging import AutoTaggingService
 
-    resolved = directory.resolve()
-    if not resolved.is_dir():
-        console.print(f"[red]Error: Directory not found: {directory}[/red]")
-        raise typer.Exit(code=1)
+    # A.cli: consolidates the prior inline ``resolve() + is_dir()`` check.
+    resolved = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
 
     try:
         service = AutoTaggingService()
@@ -117,10 +117,8 @@ def apply(
     """Apply tags to a file."""
     from services.auto_tagging import AutoTaggingService
 
-    resolved = file_path.resolve()
-    if not resolved.exists():
-        console.print(f"[red]Error: File not found: {file_path}[/red]")
-        raise typer.Exit(code=1)
+    # A.cli: file arg — exists + not-dir.
+    resolved = resolve_cli_path(file_path, must_exist=True, must_be_dir=False)
 
     try:
         service = AutoTaggingService()
@@ -202,10 +200,7 @@ def batch(
     """Batch tag suggestion for directory."""
     from services.auto_tagging import AutoTaggingService
 
-    resolved = directory.resolve()
-    if not resolved.is_dir():
-        console.print(f"[red]Error: Directory not found: {directory}[/red]")
-        raise typer.Exit(code=1)
+    resolved = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
 
     try:
         service = AutoTaggingService()

--- a/src/cli/benchmark.py
+++ b/src/cli/benchmark.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 import typer
 
+from cli.path_validation import resolve_cli_path
 from core.path_guard import safe_walk
 from models.base import ModelType
 
@@ -973,11 +974,12 @@ def run(
     from rich.console import Console
 
     console = Console()
-    input_path = input_path.resolve()
-
-    if not input_path.exists():
-        console.print(f"[red]Error: Path does not exist: {input_path}[/red]")
-        raise typer.Exit(code=1)
+    # A.cli: resolve + validate the input tree. `--compare` points at a
+    # JSON baseline (a file, not a dir); validate it separately with
+    # must_be_dir=False when provided.
+    input_path = resolve_cli_path(input_path, must_exist=True, must_be_dir=True)
+    if compare_path is not None:
+        compare_path = resolve_cli_path(compare_path, must_exist=True, must_be_dir=False)
 
     # Collect files (capped to prevent OOM on pathologically large trees)
     try:

--- a/src/cli/benchmark.py
+++ b/src/cli/benchmark.py
@@ -926,6 +926,23 @@ def _maybe_attach_comparison_output(
 # ---------------------------------------------------------------------------
 
 
+def _validate_compare_path(compare_path: Path | None) -> Path | None:
+    """Resolve ``--compare`` and reject directories at the CLI boundary.
+
+    ``resolve_cli_path(must_be_dir=False)`` accepts any existing FS object;
+    an explicit ``is_file()`` guard catches directories so they fail with
+    ``typer.BadParameter`` (exit 2) instead of later at ``read_text()``
+    with ``IsADirectoryError`` (exit 1). Extracted to keep ``run()``'s
+    cyclomatic complexity within the C901 limit.
+    """
+    if compare_path is None:
+        return None
+    resolved = resolve_cli_path(compare_path, must_exist=True, must_be_dir=False)
+    if not resolved.is_file():
+        raise typer.BadParameter(f"Baseline compare path is not a regular file: {resolved!s}")
+    return resolved
+
+
 @benchmark_app.command()
 def run(
     input_path: Path = typer.Argument(
@@ -975,18 +992,10 @@ def run(
 
     console = Console()
     # A.cli: resolve + validate the input tree. `--compare` points at a
-    # JSON baseline (a file, not a dir); validate it separately with
-    # must_be_dir=False when provided.
+    # JSON baseline (a file, not a dir); validate it separately via
+    # _validate_compare_path so run()'s complexity stays within C901.
     input_path = resolve_cli_path(input_path, must_exist=True, must_be_dir=True)
-    if compare_path is not None:
-        compare_path = resolve_cli_path(compare_path, must_exist=True, must_be_dir=False)
-        # must_be_dir=False accepts any existing FS object; reject directories
-        # explicitly so --compare fails at the CLI boundary (exit 2) instead of
-        # later at read_text() with IsADirectoryError (exit 1).
-        if not compare_path.is_file():
-            raise typer.BadParameter(
-                f"Baseline compare path is not a regular file: {compare_path!s}"
-            )
+    compare_path = _validate_compare_path(compare_path)
 
     # Collect files (capped to prevent OOM on pathologically large trees)
     try:

--- a/src/cli/benchmark.py
+++ b/src/cli/benchmark.py
@@ -980,6 +980,13 @@ def run(
     input_path = resolve_cli_path(input_path, must_exist=True, must_be_dir=True)
     if compare_path is not None:
         compare_path = resolve_cli_path(compare_path, must_exist=True, must_be_dir=False)
+        # must_be_dir=False accepts any existing FS object; reject directories
+        # explicitly so --compare fails at the CLI boundary (exit 2) instead of
+        # later at read_text() with IsADirectoryError (exit 1).
+        if not compare_path.is_file():
+            raise typer.BadParameter(
+                f"Baseline compare path is not a regular file: {compare_path!s}"
+            )
 
     # Collect files (capped to prevent OOM on pathologically large trees)
     try:

--- a/src/cli/daemon.py
+++ b/src/cli/daemon.py
@@ -16,6 +16,7 @@ import typer
 from rich.console import Console
 from rich.table import Table  # pyre-ignore[21]
 
+from cli.path_validation import resolve_cli_path, validate_pair
 from config.path_manager import get_state_dir
 
 console = Console()
@@ -51,6 +52,14 @@ def start(
     from daemon.config import DaemonConfig
     from daemon.service import DaemonService
 
+    # A.cli: resolve + validate both paths when provided. watch_dir must
+    # exist; output_dir is created on demand.
+    if watch_dir is not None:
+        watch_dir = resolve_cli_path(watch_dir, must_exist=True, must_be_dir=True)
+    if output_dir is not None:
+        output_dir = resolve_cli_path(output_dir, must_exist=False, must_be_dir=True)
+    if watch_dir is not None and output_dir is not None:
+        validate_pair(watch_dir, output_dir)
     watch_dirs = [watch_dir] if watch_dir else []
     out = output_dir or Path("organized_output")
 
@@ -145,6 +154,8 @@ def watch(
     from watcher.config import WatcherConfig
     from watcher.monitor import FileMonitor
 
+    # A.cli: must exist + must be a dir — watcher would fail later otherwise.
+    watch_dir = resolve_cli_path(watch_dir, must_exist=True, must_be_dir=True)
     console.print(f"[bold]Watching[/bold] {watch_dir}  (Ctrl+C to stop)")
 
     config = WatcherConfig(
@@ -176,6 +187,10 @@ def process(
     """One-shot: organize files and display a summary."""
     from core.organizer import FileOrganizer
 
+    # A.cli: same input/output contract as `fo organize`.
+    input_dir = resolve_cli_path(input_dir, must_exist=True, must_be_dir=True)
+    output_dir = resolve_cli_path(output_dir, must_exist=False, must_be_dir=True)
+    validate_pair(input_dir, output_dir)
     console.print(f"[bold]Processing[/bold] {input_dir} -> {output_dir}")
     if dry_run:
         console.print("[yellow]Dry-run mode — no files will be moved.[/yellow]")

--- a/src/cli/daemon.py
+++ b/src/cli/daemon.py
@@ -60,9 +60,7 @@ def start(
     if watch_dir is not None:
         watch_dir = resolve_cli_path(watch_dir, must_exist=True, must_be_dir=True)
     if output_dir is None:
-        output_dir = resolve_cli_path(
-            Path("organized_output"), must_exist=False, must_be_dir=True
-        )
+        output_dir = resolve_cli_path(Path("organized_output"), must_exist=False, must_be_dir=True)
     else:
         output_dir = resolve_cli_path(output_dir, must_exist=False, must_be_dir=True)
     if watch_dir is not None:

--- a/src/cli/daemon.py
+++ b/src/cli/daemon.py
@@ -52,16 +52,23 @@ def start(
     from daemon.config import DaemonConfig
     from daemon.service import DaemonService
 
-    # A.cli: resolve + validate both paths when provided. watch_dir must
-    # exist; output_dir is created on demand.
+    # A.cli: resolve + validate both paths. watch_dir must exist;
+    # output_dir is created on demand. Default "organized_output" is
+    # resolved too so it passes through validate_pair — otherwise
+    # ``--watch-dir .`` with no ``--output-dir`` would write into the
+    # watched tree, which is exactly the nested pair we're trying to reject.
     if watch_dir is not None:
         watch_dir = resolve_cli_path(watch_dir, must_exist=True, must_be_dir=True)
-    if output_dir is not None:
+    if output_dir is None:
+        output_dir = resolve_cli_path(
+            Path("organized_output"), must_exist=False, must_be_dir=True
+        )
+    else:
         output_dir = resolve_cli_path(output_dir, must_exist=False, must_be_dir=True)
-    if watch_dir is not None and output_dir is not None:
+    if watch_dir is not None:
         validate_pair(watch_dir, output_dir)
     watch_dirs = [watch_dir] if watch_dir else []
-    out = output_dir or Path("organized_output")
+    out = output_dir
 
     config = DaemonConfig(
         watch_directories=watch_dirs,

--- a/src/cli/dedupe_v2.py
+++ b/src/cli/dedupe_v2.py
@@ -15,6 +15,8 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from cli.path_validation import resolve_cli_path
+
 console = Console()
 
 dedupe_app = typer.Typer(
@@ -127,6 +129,7 @@ def scan(
     json_output: bool = typer.Option(False, "--json", help="Output as JSON."),
 ) -> None:
     """Scan a directory and display duplicate file groups."""
+    directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
     detector = _get_detector()
     options = _build_scan_options(
         directory, algorithm, recursive, min_size, max_size, include, exclude
@@ -160,6 +163,7 @@ def resolve(
     exclude: str | None = typer.Option(None, help="Comma-separated exclude patterns."),
 ) -> None:
     """Scan and resolve duplicates using a strategy."""
+    directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
     detector = _get_detector()
     options = _build_scan_options(
         directory, algorithm, recursive, min_size, max_size, include, exclude
@@ -216,6 +220,7 @@ def report(
     json_output: bool = typer.Option(False, "--json", help="Output as JSON."),
 ) -> None:
     """Scan and display a summary report of duplicates."""
+    directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
     detector = _get_detector()
     from services.deduplication.detector import ScanOptions
     from services.deduplication.hasher import HashAlgorithm

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -222,9 +222,13 @@ def analytics(
 ) -> None:
     """Display storage analytics dashboard."""
     from cli.analytics import analytics_command
+    from cli.path_validation import resolve_cli_path
 
     args: list[str] = []
     if directory is not None:
+        # A.cli: resolve + validate the directory argument before
+        # handing the string back to the Click-compat analytics_command.
+        directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
         args.append(str(directory))
     if verbose or _get_state().verbose:
         args.append("--verbose")

--- a/src/cli/organize.py
+++ b/src/cli/organize.py
@@ -8,6 +8,7 @@ import typer
 from rich.console import Console
 from rich.panel import Panel
 
+from cli.path_validation import resolve_cli_path, validate_pair
 from cli.state import _get_state
 
 console = Console()
@@ -113,6 +114,13 @@ def organize(
     # Check if setup has been completed
     _check_setup_completed()
 
+    # A.cli: resolve + validate both path args before any filesystem work.
+    # Input must exist and be a dir; output may not exist yet (the
+    # organizer creates it), but when it does exist it must be a dir.
+    input_dir = resolve_cli_path(input_dir, must_exist=True, must_be_dir=True)
+    output_dir = resolve_cli_path(output_dir, must_exist=False, must_be_dir=True)
+    validate_pair(input_dir, output_dir)
+
     console.print(f"[bold]Organizing[/bold] {input_dir} -> {output_dir}")
     if dry_run or _get_state().dry_run:
         console.print("[yellow]Dry run mode — no files will be moved.[/yellow]")
@@ -177,6 +185,10 @@ def preview(
     """Preview how files would be organized (dry-run)."""
     # Check if setup has been completed
     _check_setup_completed()
+
+    # A.cli: single-path validation — preview never writes, so no
+    # output-dir pair check needed.
+    input_dir = resolve_cli_path(input_dir, must_exist=True, must_be_dir=True)
 
     console.print(f"[bold]Previewing[/bold] {input_dir}")
     resolved_workers, resolved_prefetch_depth = _resolve_parallel_settings(

--- a/src/cli/path_validation.py
+++ b/src/cli/path_validation.py
@@ -28,8 +28,7 @@ import typer
 
 
 def _resolve_user_path(path: Path) -> Path:
-    """``path.expanduser().resolve()`` with all resolution errors surfaced as
-    ``typer.BadParameter``.
+    """Resolve ``path`` with all resolution failures surfaced as ``BadParameter``.
 
     ``Path.resolve()`` raises ``RuntimeError`` (Python < 3.13) or ``OSError``
     (Python >= 3.13) on symlink loops and other OS-level resolution failures;

--- a/src/cli/path_validation.py
+++ b/src/cli/path_validation.py
@@ -1,0 +1,127 @@
+"""CLI-layer path validation — the user-input boundary for fo commands.
+
+Epic A.cli (hardening roadmap #154, §2.5) wires every path-taking CLI
+command through this helper before any filesystem operation. Two public
+surfaces:
+
+- ``resolve_cli_path(path, *, must_exist, must_be_dir)`` — resolve a single
+  argument, surface existence / type errors as ``typer.BadParameter``
+  (so typer prints a usage-level error rather than a traceback).
+- ``validate_pair(input_dir, output_dir)`` — cross-argument coherence
+  for commands that take both an input and an output directory. Rejects
+  the classic ``organize IN IN/sub`` footgun where output sits inside
+  input, plus the mirror case and the identity case.
+
+Neither helper uses ``core.path_guard.validate_within_roots`` directly:
+that helper is for validating *derived* paths against a pre-declared
+root set (used inside service-layer walkers). The CLI boundary doesn't
+have a pre-declared root — the user's arguments **are** the roots.
+This helper exists to resolve + sanity-check those arguments before
+they become the allowed roots for downstream code.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+
+def resolve_cli_path(
+    path: Path,
+    *,
+    must_exist: bool = True,
+    must_be_dir: bool = True,
+) -> Path:
+    """Resolve a CLI path argument and validate it at the argparse boundary.
+
+    Normalises ``..``, resolves symlinks, anchors relatives against the
+    current working directory, and — by default — asserts the path exists
+    and is a directory. Callers that accept a file (``fo analyze FILE``)
+    or a not-yet-created output directory (``fo organize IN OUT`` where
+    OUT doesn't exist yet) opt out via the two keyword flags.
+
+    Args:
+        path: The typer-delivered ``Path`` argument. May be relative,
+            contain ``..``, or be a symlink — all normalised.
+        must_exist: If True (default), raise ``typer.BadParameter`` when
+            the resolved path is not on disk. Pass False for commands
+            that intentionally create the path.
+        must_be_dir: If True (default), raise ``typer.BadParameter`` when
+            the resolved path exists but is not a directory. Pass False
+            for commands that take a file argument.
+
+    Returns:
+        The resolved absolute ``Path`` — downstream code can rely on
+        ``.is_absolute()`` and a fully-normalised form.
+
+    Raises:
+        typer.BadParameter: Missing path (when ``must_exist=True``) or
+            path-exists-but-not-a-directory (when ``must_be_dir=True``).
+            Typer renders these as ``Usage: ... Invalid value ...``
+            rather than a Python traceback.
+    """
+    resolved = path.expanduser().resolve()
+
+    if must_exist and not resolved.exists():
+        raise typer.BadParameter(f"Path does not exist: {path!s} (resolved to {resolved!s})")
+    if must_be_dir and resolved.exists() and not resolved.is_dir():
+        raise typer.BadParameter(
+            f"Path exists but is not a directory: {path!s} (resolved to {resolved!s})"
+        )
+    return resolved
+
+
+def validate_pair(input_dir: Path, output_dir: Path) -> None:
+    """Reject incoherent input/output directory pairs at the CLI boundary.
+
+    Three cases are flagged:
+
+    - **output inside input**: ``fo organize ~/docs ~/docs/sorted`` would
+      have the organizer write destination files into the same tree it's
+      reading. User almost certainly meant a sibling directory.
+    - **input inside output**: mirror image — the organizer could walk
+      into the output tree while scanning the input.
+    - **identical paths**: ``fo organize X X`` is never legitimate —
+      read-and-write on the same tree.
+
+    All three resolve both paths before comparing, so a symlink pointing
+    back into the sibling tree is caught just like a literal nested path.
+
+    Args:
+        input_dir: Already-resolved input directory (typically from
+            ``resolve_cli_path``).
+        output_dir: Already-resolved output directory.
+
+    Raises:
+        typer.BadParameter: When the pair is incoherent by any of the
+            three rules above. The message names the specific violation
+            so the user can spot the argument ordering mistake.
+    """
+    in_resolved = input_dir.resolve()
+    out_resolved = output_dir.resolve()
+
+    if in_resolved == out_resolved:
+        raise typer.BadParameter(
+            f"Input and output refer to the same path: {in_resolved!s}. Pass different directories."
+        )
+    try:
+        out_resolved.relative_to(in_resolved)
+    except ValueError:
+        pass
+    else:
+        raise typer.BadParameter(
+            f"Output directory {output_dir!s} (resolved to {out_resolved!s}) "
+            f"is inside the input directory {input_dir!s}. The organizer "
+            "would write to the same tree it's reading."
+        )
+    try:
+        in_resolved.relative_to(out_resolved)
+    except ValueError:
+        pass
+    else:
+        raise typer.BadParameter(
+            f"Input directory {input_dir!s} (resolved to {in_resolved!s}) "
+            f"is inside the output directory {output_dir!s}. The organizer "
+            "would walk the output tree while scanning the input."
+        )

--- a/src/cli/path_validation.py
+++ b/src/cli/path_validation.py
@@ -27,6 +27,22 @@ from pathlib import Path
 import typer
 
 
+def _resolve_user_path(path: Path) -> Path:
+    """``path.expanduser().resolve()`` with all resolution errors surfaced as
+    ``typer.BadParameter``.
+
+    ``Path.resolve()`` raises ``RuntimeError`` (Python < 3.13) or ``OSError``
+    (Python >= 3.13) on symlink loops and other OS-level resolution failures;
+    ``Path.expanduser()`` raises ``RuntimeError`` for unknown ``~user``. The
+    CLI contract is to surface these as ``BadParameter`` (typer usage error,
+    exit 2) rather than letting a raw traceback escape.
+    """
+    try:
+        return path.expanduser().resolve()
+    except (OSError, RuntimeError) as exc:
+        raise typer.BadParameter(f"Unable to resolve path {path!s}: {exc}") from exc
+
+
 def resolve_cli_path(
     path: Path,
     *,
@@ -56,12 +72,13 @@ def resolve_cli_path(
         ``.is_absolute()`` and a fully-normalised form.
 
     Raises:
-        typer.BadParameter: Missing path (when ``must_exist=True``) or
-            path-exists-but-not-a-directory (when ``must_be_dir=True``).
-            Typer renders these as ``Usage: ... Invalid value ...``
-            rather than a Python traceback.
+        typer.BadParameter: Missing path (when ``must_exist=True``),
+            path-exists-but-not-a-directory (when ``must_be_dir=True``), or
+            any OS-level resolution failure (symlink loop, unknown ``~user``).
+            Typer renders these as ``Usage: ... Invalid value ...`` rather
+            than a Python traceback.
     """
-    resolved = path.expanduser().resolve()
+    resolved = _resolve_user_path(path)
 
     if must_exist and not resolved.exists():
         raise typer.BadParameter(f"Path does not exist: {path!s} (resolved to {resolved!s})")
@@ -98,8 +115,8 @@ def validate_pair(input_dir: Path, output_dir: Path) -> None:
             three rules above. The message names the specific violation
             so the user can spot the argument ordering mistake.
     """
-    in_resolved = input_dir.resolve()
-    out_resolved = output_dir.resolve()
+    in_resolved = _resolve_user_path(input_dir)
+    out_resolved = _resolve_user_path(output_dir)
 
     if in_resolved == out_resolved:
         raise typer.BadParameter(

--- a/src/cli/path_validation.py
+++ b/src/cli/path_validation.py
@@ -106,14 +106,18 @@ def validate_pair(input_dir: Path, output_dir: Path) -> None:
     back into the sibling tree is caught just like a literal nested path.
 
     Args:
-        input_dir: Already-resolved input directory (typically from
-            ``resolve_cli_path``).
-        output_dir: Already-resolved output directory.
+        input_dir: Input directory — resolved defensively even though callers
+            typically pass an already-resolved path from ``resolve_cli_path``.
+            The re-resolve is load-bearing for symlink-based evasion: a caller
+            that passed ``Path("out_link")`` pointing at ``in_dir/subdir``
+            would slip past the ``relative_to`` comparison without it.
+        output_dir: Output directory — resolved defensively (same reasoning).
 
     Raises:
         typer.BadParameter: When the pair is incoherent by any of the
-            three rules above. The message names the specific violation
-            so the user can spot the argument ordering mistake.
+            three rules above, OR when resolution itself fails (symlink
+            loop, unknown ``~user``). The message names the specific
+            violation so the user can spot the argument ordering mistake.
     """
     in_resolved = _resolve_user_path(input_dir)
     out_resolved = _resolve_user_path(output_dir)

--- a/src/cli/rules.py
+++ b/src/cli/rules.py
@@ -7,6 +7,8 @@ organisation rules.
 
 from __future__ import annotations
 
+import os
+import tempfile
 from pathlib import Path
 
 import typer
@@ -223,15 +225,33 @@ def rules_export(
         # A.cli: output file may not exist (we're creating it). The parent
         # directory must exist and be a directory; if output itself already
         # exists it must be a regular file, otherwise write_text() would
-        # raise IsADirectoryError after validation.
+        # raise IsADirectoryError after validation. Project F3: write via
+        # tempfile + os.replace so a mid-write crash or concurrent writer
+        # never leaves a half-written YAML export on disk.
         output = resolve_cli_path(output, must_exist=False, must_be_dir=False)
         if not output.parent.is_dir():
             raise typer.BadParameter(f"Output directory does not exist: {output.parent}")
         if output.exists() and not output.is_file():
             raise typer.BadParameter(f"Output path is not a regular file: {output}")
+        tmp_path: Path | None = None
         try:
-            output.write_text(content, encoding="utf-8")
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=output.parent,
+                prefix=f".{output.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as tmp_file:
+                tmp_path = Path(tmp_file.name)
+                tmp_file.write(content)
+            os.replace(tmp_path, output)
         except OSError as exc:
+            if tmp_path is not None:
+                try:
+                    tmp_path.unlink()
+                except OSError:
+                    pass
             console.print(f"[red]Failed to write YAML: {exc}[/red]")
             raise typer.Exit(code=1) from exc
         console.print(f"[green]Exported '{rule_set}' to {output}[/green]")

--- a/src/cli/rules.py
+++ b/src/cli/rules.py
@@ -221,11 +221,19 @@ def rules_export(
 
     if output:
         # A.cli: output file may not exist (we're creating it). The parent
-        # directory must exist though — resolve + sanity-check the parent.
+        # directory must exist and be a directory; if output itself already
+        # exists it must be a regular file, otherwise write_text() would
+        # raise IsADirectoryError after validation.
         output = resolve_cli_path(output, must_exist=False, must_be_dir=False)
-        if not output.parent.exists():
+        if not output.parent.is_dir():
             raise typer.BadParameter(f"Output directory does not exist: {output.parent}")
-        output.write_text(content, encoding="utf-8")
+        if output.exists() and not output.is_file():
+            raise typer.BadParameter(f"Output path is not a regular file: {output}")
+        try:
+            output.write_text(content, encoding="utf-8")
+        except OSError as exc:
+            console.print(f"[red]Failed to write YAML: {exc}[/red]")
+            raise typer.Exit(code=1) from exc
         console.print(f"[green]Exported '{rule_set}' to {output}[/green]")
     else:
         console.print(content)
@@ -239,11 +247,13 @@ def rules_import(
     """Import a rule set from a YAML file."""
     import yaml
 
-    # A.cli: YAML file must exist and be a file, not a directory.
-    # `resolve_cli_path` raises typer.BadParameter (exit 2) if the file
-    # is missing, so the subsequent inline `if not file.exists()` check
-    # became dead code and was removed.
+    # A.cli: YAML file must exist and be a regular file. `must_be_dir=False`
+    # on its own only rejects directories *when must_be_dir=True*; we need
+    # an explicit is_file() guard to catch the dir-passed-to-import case
+    # before yaml.safe_load tries to read_text() it.
     file = resolve_cli_path(file, must_exist=True, must_be_dir=False)
+    if not file.is_file():
+        raise typer.BadParameter(f"Input path is not a regular file: {file}")
 
     from services.copilot.rules import RuleManager, RuleSet
 

--- a/src/cli/rules.py
+++ b/src/cli/rules.py
@@ -13,6 +13,8 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from cli.path_validation import resolve_cli_path
+
 rules_app = typer.Typer(
     name="rules",
     help="Manage copilot organisation rules.",
@@ -169,6 +171,7 @@ def rules_preview(
     """Preview what rules would do (dry-run)."""
     from services.copilot.rules import PreviewEngine, RuleManager
 
+    directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
     mgr = RuleManager()
     rs = mgr.load_rule_set(rule_set)
 
@@ -217,6 +220,11 @@ def rules_export(
     content = yaml.dump(rs.to_dict(), default_flow_style=False, sort_keys=False)
 
     if output:
+        # A.cli: output file may not exist (we're creating it). The parent
+        # directory must exist though — resolve + sanity-check the parent.
+        output = resolve_cli_path(output, must_exist=False, must_be_dir=False)
+        if not output.parent.exists():
+            raise typer.BadParameter(f"Output directory does not exist: {output.parent}")
         output.write_text(content, encoding="utf-8")
         console.print(f"[green]Exported '{rule_set}' to {output}[/green]")
     else:
@@ -231,11 +239,13 @@ def rules_import(
     """Import a rule set from a YAML file."""
     import yaml
 
-    from services.copilot.rules import RuleManager, RuleSet
+    # A.cli: YAML file must exist and be a file, not a directory.
+    # `resolve_cli_path` raises typer.BadParameter (exit 2) if the file
+    # is missing, so the subsequent inline `if not file.exists()` check
+    # became dead code and was removed.
+    file = resolve_cli_path(file, must_exist=True, must_be_dir=False)
 
-    if not file.exists():
-        console.print(f"[red]File not found: {file}[/red]")
-        raise typer.Exit(code=1)
+    from services.copilot.rules import RuleManager, RuleSet
 
     try:
         raw = yaml.safe_load(file.read_text(encoding="utf-8"))

--- a/src/cli/suggest.py
+++ b/src/cli/suggest.py
@@ -15,6 +15,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from cli.path_validation import resolve_cli_path
 from core.path_guard import safe_walk
 
 console = Console()
@@ -59,6 +60,7 @@ def files(
     dry_run: bool = typer.Option(False, "--dry-run", help="Alias for preview mode."),
 ) -> None:
     """Generate organisation suggestions for files in a directory."""
+    directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
     engine = _get_engine()
     analyzer = _get_analyzer()
     file_list = _collect_files(directory)
@@ -125,6 +127,7 @@ def apply(
     """Generate suggestions and apply them (with confirmation)."""
     from cli.interactive import confirm_action
 
+    directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
     engine = _get_engine()
     analyzer = _get_analyzer()
     file_list = _collect_files(directory)
@@ -182,6 +185,7 @@ def patterns(
     json_output: bool = typer.Option(False, "--json", help="Output as JSON."),
 ) -> None:
     """Detect and display naming/structure patterns in a directory."""
+    directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
     analyzer = _get_analyzer()
 
     with console.status("Detecting patterns…"):

--- a/src/cli/utilities.py
+++ b/src/cli/utilities.py
@@ -387,7 +387,7 @@ def analyze(
     # error rather than a later decode failure.
     file_path = resolve_cli_path(file_path, must_exist=True, must_be_dir=False)
     if not file_path.is_file():
-        console.print(f"[red]Error: File '{file_path}' not found.[/red]")
+        console.print(f"[red]Error: File '{file_path}' is not a regular file.[/red]")
         raise typer.Exit(code=1)
 
     # Detect binary files before reading as text

--- a/src/cli/utilities.py
+++ b/src/cli/utilities.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
+from cli.path_validation import resolve_cli_path
 from cli.state import _get_state
 from core.path_guard import safe_walk
 
@@ -351,6 +352,7 @@ def search(
     ),
 ) -> None:
     """Search for files by name pattern with optional type filtering."""
+    directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
     search_dir, should_exit = _validate_search_params(limit, directory, type_filter)
     if should_exit:
         _output_search_results([], json_out)
@@ -379,7 +381,11 @@ def analyze(
         truncate_content,
     )
 
-    # Check file exists and is a regular file
+    # A.cli: `resolve_cli_path(must_be_dir=False)` accepts any existing
+    # path (file, dir, socket, fifo). Keep the explicit is_file() guard so
+    # directories and special files get a clear "not a regular file"
+    # error rather than a later decode failure.
+    file_path = resolve_cli_path(file_path, must_exist=True, must_be_dir=False)
     if not file_path.is_file():
         console.print(f"[red]Error: File '{file_path}' not found.[/red]")
         raise typer.Exit(code=1)

--- a/tests/cli/test_analyze.py
+++ b/tests/cli/test_analyze.py
@@ -92,10 +92,12 @@ def test_analyze_verbose_mode(tmp_path: Path):
     assert "Content length:" in output
 
 
-def test_analyze_nonexistent_file():
+def test_analyze_nonexistent_file(tmp_path: Path):
     """A.cli: analyzing a missing file → ``typer.BadParameter`` (exit 2)
-    with a 'does not exist' usage message."""
-    result = runner.invoke(app, ["analyze", "/nonexistent/file.txt"])
+    with a 'does not exist' usage message. T13: use tmp_path, not a
+    hardcoded absolute literal."""
+    missing = tmp_path / "missing.txt"
+    result = runner.invoke(app, ["analyze", str(missing)])
     assert result.exit_code == 2
     assert "does not exist" in result.output.lower()
 
@@ -110,7 +112,7 @@ def test_analyze_directory_not_regular_file(tmp_path: Path):
     d.mkdir()
     result = runner.invoke(app, ["analyze", str(d)])
     assert result.exit_code == 1
-    assert "not found" in result.stdout.lower()
+    assert "not a regular file" in result.stdout.lower()
 
 
 def test_analyze_empty_file(tmp_path: Path):

--- a/tests/cli/test_analyze.py
+++ b/tests/cli/test_analyze.py
@@ -11,7 +11,7 @@ from typer.testing import CliRunner
 
 from cli.main import app
 
-pytestmark = [pytest.mark.unit, pytest.mark.integration]
+pytestmark = [pytest.mark.ci, pytest.mark.unit, pytest.mark.integration]
 
 runner = CliRunner()
 

--- a/tests/cli/test_analyze.py
+++ b/tests/cli/test_analyze.py
@@ -6,9 +6,12 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 from cli.main import app
+
+pytestmark = [pytest.mark.unit, pytest.mark.integration]
 
 runner = CliRunner()
 
@@ -90,8 +93,22 @@ def test_analyze_verbose_mode(tmp_path: Path):
 
 
 def test_analyze_nonexistent_file():
-    """Analyzing a file that doesn't exist exits with code 1."""
+    """A.cli: analyzing a missing file → ``typer.BadParameter`` (exit 2)
+    with a 'does not exist' usage message."""
     result = runner.invoke(app, ["analyze", "/nonexistent/file.txt"])
+    assert result.exit_code == 2
+    assert "does not exist" in result.output.lower()
+
+
+def test_analyze_directory_not_regular_file(tmp_path: Path):
+    """Pointing ``fo analyze`` at an *existing* directory must not reach
+    the binary/text detection path — surface a clear "not a regular file"
+    error (exit 1 from the inline is_file guard, distinct from A.cli's
+    usage-error exit 2 for non-existent paths).
+    """
+    d = tmp_path / "some_dir"
+    d.mkdir()
+    result = runner.invoke(app, ["analyze", str(d)])
     assert result.exit_code == 1
     assert "not found" in result.stdout.lower()
 

--- a/tests/cli/test_autotag_v2.py
+++ b/tests/cli/test_autotag_v2.py
@@ -155,13 +155,16 @@ def test_autotag_batch_mode(mock_service_cls, tmp_path):
     assert "text" in result.stdout
 
 
-def test_autotag_nonexistent_dir():
+def test_autotag_nonexistent_dir(tmp_path):
     """suggest fails with exit 2 (typer ``BadParameter``) for a non-existent
     directory. A.cli migrated from custom ``typer.Exit(1)`` to the
-    typer-native POSIX-aligned exit 2 for CLI usage errors.
+    typer-native POSIX-aligned exit 2 for CLI usage errors. T13: use
+    tmp_path, not a hardcoded absolute literal.
     """
-    result = runner.invoke(app, ["autotag", "suggest", "/nonexistent"])
+    missing = tmp_path / "missing"
+    result = runner.invoke(app, ["autotag", "suggest", str(missing)])
     assert result.exit_code == 2
+    assert "does not exist" in result.output.lower()
 
 
 @patch("services.auto_tagging.AutoTaggingService")

--- a/tests/cli/test_autotag_v2.py
+++ b/tests/cli/test_autotag_v2.py
@@ -156,9 +156,12 @@ def test_autotag_batch_mode(mock_service_cls, tmp_path):
 
 
 def test_autotag_nonexistent_dir():
-    """suggest fails with exit 1 for a non-existent directory."""
+    """suggest fails with exit 2 (typer ``BadParameter``) for a non-existent
+    directory. A.cli migrated from custom ``typer.Exit(1)`` to the
+    typer-native POSIX-aligned exit 2 for CLI usage errors.
+    """
     result = runner.invoke(app, ["autotag", "suggest", "/nonexistent"])
-    assert result.exit_code == 1
+    assert result.exit_code == 2
 
 
 @patch("services.auto_tagging.AutoTaggingService")

--- a/tests/cli/test_cli_autotag_v2_coverage.py
+++ b/tests/cli/test_cli_autotag_v2_coverage.py
@@ -31,12 +31,13 @@ class TestAutotagSuggestErrors:
     """Covers error branches in suggest command (lines 47-49, 53-54, 61-62)."""
 
     def test_suggest_dir_not_found(self, tmp_path: Path) -> None:
+        """A.cli: non-existent dir → ``typer.BadParameter`` (exit 2)."""
         from cli.autotag_v2 import autotag_app
 
         bad = tmp_path / "nonexistent"
         result = runner.invoke(autotag_app, ["suggest", str(bad)])
-        assert result.exit_code == 1
-        assert "not found" in result.output.lower()
+        assert result.exit_code == 2
+        assert "does not exist" in result.output.lower()
 
     def test_suggest_service_init_error(self, tmp_path: Path) -> None:
         from cli.autotag_v2 import autotag_app
@@ -87,11 +88,12 @@ class TestAutotagApplyErrors:
     """Covers error branches in apply command (lines 113-114, 119-121)."""
 
     def test_apply_file_not_found(self, tmp_path: Path) -> None:
+        """A.cli: non-existent file → ``typer.BadParameter`` (exit 2)."""
         from cli.autotag_v2 import autotag_app
 
         missing = tmp_path / "gone.txt"
         result = runner.invoke(autotag_app, ["apply", str(missing), "tag1", "tag2"])
-        assert result.exit_code == 1
+        assert result.exit_code == 2
 
     def test_apply_service_error(self, tmp_path: Path) -> None:
         from cli.autotag_v2 import autotag_app
@@ -181,11 +183,12 @@ class TestAutotagBatchErrors:
     """Covers error branches in batch command (lines 198-199, 203-205, 211-212, 218-220)."""
 
     def test_batch_dir_not_found(self, tmp_path: Path) -> None:
+        """A.cli: non-existent dir → ``typer.BadParameter`` (exit 2)."""
         from cli.autotag_v2 import autotag_app
 
         bad = tmp_path / "missing"
         result = runner.invoke(autotag_app, ["batch", str(bad)])
-        assert result.exit_code == 1
+        assert result.exit_code == 2
 
     def test_batch_service_init_error(self, tmp_path: Path) -> None:
         from cli.autotag_v2 import autotag_app

--- a/tests/cli/test_cli_autotag_v2_coverage.py
+++ b/tests/cli/test_cli_autotag_v2_coverage.py
@@ -94,6 +94,7 @@ class TestAutotagApplyErrors:
         missing = tmp_path / "gone.txt"
         result = runner.invoke(autotag_app, ["apply", str(missing), "tag1", "tag2"])
         assert result.exit_code == 2
+        assert "does not exist" in result.output.lower()
 
     def test_apply_service_error(self, tmp_path: Path) -> None:
         from cli.autotag_v2 import autotag_app
@@ -189,6 +190,7 @@ class TestAutotagBatchErrors:
         bad = tmp_path / "missing"
         result = runner.invoke(autotag_app, ["batch", str(bad)])
         assert result.exit_code == 2
+        assert "does not exist" in result.output.lower()
 
     def test_batch_service_init_error(self, tmp_path: Path) -> None:
         from cli.autotag_v2 import autotag_app

--- a/tests/cli/test_cli_daemon_coverage.py
+++ b/tests/cli/test_cli_daemon_coverage.py
@@ -233,17 +233,25 @@ class TestDaemonStatus:
 class TestDaemonProcess:
     """Covers lines 177-208."""
 
+    # A.cli: daemon process now rejects output-inside-input at the CLI
+    # boundary (same rule as `fo organize`). Tests use sibling dirs.
+    def _setup_dirs(self, tmp_path: Path) -> tuple[Path, Path]:
+        in_dir = tmp_path / "in"
+        in_dir.mkdir()
+        out_dir = tmp_path / "out"
+        return in_dir, out_dir
+
     def test_process_success(self, tmp_path: Path) -> None:
         from cli.daemon import daemon_app
 
-        (tmp_path / "file.txt").write_text("hello")
-        output_dir = tmp_path / "output"
+        in_dir, out_dir = self._setup_dirs(tmp_path)
+        (in_dir / "file.txt").write_text("hello")
 
         mock_organizer = MagicMock()
         mock_organizer.organize.return_value = _FakeOrganizeResult()
 
         with patch("core.organizer.FileOrganizer", return_value=mock_organizer):
-            result = runner.invoke(daemon_app, ["process", str(tmp_path), str(output_dir)])
+            result = runner.invoke(daemon_app, ["process", str(in_dir), str(out_dir)])
 
         assert result.exit_code == 0
         assert "Processing Summary" in result.output
@@ -251,14 +259,14 @@ class TestDaemonProcess:
     def test_process_dry_run(self, tmp_path: Path) -> None:
         from cli.daemon import daemon_app
 
-        output_dir = tmp_path / "output"
+        in_dir, out_dir = self._setup_dirs(tmp_path)
         mock_organizer = MagicMock()
         mock_organizer.organize.return_value = _FakeOrganizeResult()
 
         with patch("core.organizer.FileOrganizer", return_value=mock_organizer):
             result = runner.invoke(
                 daemon_app,
-                ["process", str(tmp_path), str(output_dir), "--dry-run"],
+                ["process", str(in_dir), str(out_dir), "--dry-run"],
             )
 
         assert result.exit_code == 0
@@ -267,7 +275,7 @@ class TestDaemonProcess:
     def test_process_with_errors(self, tmp_path: Path) -> None:
         from cli.daemon import daemon_app
 
-        output_dir = tmp_path / "output"
+        in_dir, out_dir = self._setup_dirs(tmp_path)
         fake_result = _FakeOrganizeResult(
             errors=[("file1.txt", "permission denied"), ("file2.pdf", "corrupt")]
         )
@@ -275,7 +283,7 @@ class TestDaemonProcess:
         mock_organizer.organize.return_value = fake_result
 
         with patch("core.organizer.FileOrganizer", return_value=mock_organizer):
-            result = runner.invoke(daemon_app, ["process", str(tmp_path), str(output_dir)])
+            result = runner.invoke(daemon_app, ["process", str(in_dir), str(out_dir)])
 
         assert result.exit_code == 0
         assert "Errors" in result.output
@@ -283,26 +291,26 @@ class TestDaemonProcess:
     def test_process_exception(self, tmp_path: Path) -> None:
         from cli.daemon import daemon_app
 
-        output_dir = tmp_path / "output"
+        in_dir, out_dir = self._setup_dirs(tmp_path)
         mock_organizer = MagicMock()
         mock_organizer.organize.side_effect = RuntimeError("boom")
 
         with patch("core.organizer.FileOrganizer", return_value=mock_organizer):
-            result = runner.invoke(daemon_app, ["process", str(tmp_path), str(output_dir)])
+            result = runner.invoke(daemon_app, ["process", str(in_dir), str(out_dir)])
 
         assert result.exit_code == 1
 
     def test_process_many_errors_truncated(self, tmp_path: Path) -> None:
         from cli.daemon import daemon_app
 
-        output_dir = tmp_path / "output"
+        in_dir, out_dir = self._setup_dirs(tmp_path)
         errors = [(f"file{i}.txt", "err") for i in range(15)]
         fake_result = _FakeOrganizeResult(errors=errors)
         mock_organizer = MagicMock()
         mock_organizer.organize.return_value = fake_result
 
         with patch("core.organizer.FileOrganizer", return_value=mock_organizer):
-            result = runner.invoke(daemon_app, ["process", str(tmp_path), str(output_dir)])
+            result = runner.invoke(daemon_app, ["process", str(in_dir), str(out_dir)])
 
         assert result.exit_code == 0
         assert "5 more" in result.output

--- a/tests/cli/test_cli_rules.py
+++ b/tests/cli/test_cli_rules.py
@@ -7,7 +7,6 @@ Tests the Typer-based rules management CLI commands including:
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/cli/test_cli_rules.py
+++ b/tests/cli/test_cli_rules.py
@@ -378,13 +378,15 @@ class TestRulesExport:
     @pytest.mark.integration
     @pytest.mark.ci
     def test_export_write_oserror_surfaces_as_exit_1(self, runner, mock_rule_manager, tmp_path):
-        """A.cli: if ``write_text()`` itself fails (e.g. permission denied),
-        surface a user-facing error (exit 1), not a raw ``OSError`` traceback.
+        """A.cli: if the atomic write itself fails (e.g. permission denied
+        on ``os.replace``), surface a user-facing error (exit 1), not a
+        raw ``OSError`` traceback. Project F3: write goes through
+        tempfile + os.replace, so patch os.replace at the import site.
         """
         output_file = tmp_path / "rules.yaml"
         with (
             patch(_RULE_MGR_PATH, return_value=mock_rule_manager),
-            patch.object(Path, "write_text", side_effect=OSError("permission denied")),
+            patch("cli.rules.os.replace", side_effect=OSError("permission denied")),
         ):
             result = runner.invoke(rules_app, ["export", "-o", str(output_file)])
         assert result.exit_code == 1

--- a/tests/cli/test_cli_rules.py
+++ b/tests/cli/test_cli_rules.py
@@ -7,6 +7,7 @@ Tests the Typer-based rules management CLI commands including:
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -345,6 +346,47 @@ class TestRulesExport:
         assert result.exit_code == 0
         assert "Exported" in result.output
 
+    @pytest.mark.integration
+    def test_export_output_is_existing_directory_rejected(
+        self, runner, mock_rule_manager, tmp_path
+    ):
+        """A.cli: passing an existing directory as ``--output`` must fail
+        at the CLI boundary (``typer.BadParameter``, exit 2) with a clear
+        "not a regular file" message, not crash inside ``write_text()``.
+        """
+        existing_dir = tmp_path / "subdir"
+        existing_dir.mkdir()
+        with patch(_RULE_MGR_PATH, return_value=mock_rule_manager):
+            result = runner.invoke(rules_app, ["export", "-o", str(existing_dir)])
+        assert result.exit_code == 2
+        assert "not a regular file" in result.output.lower()
+
+    @pytest.mark.integration
+    def test_export_parent_dir_missing_rejected(self, runner, mock_rule_manager, tmp_path):
+        """A.cli: ``--output`` under a non-existent parent must fail with
+        ``typer.BadParameter`` (exit 2). ``is_dir()`` also rejects the case
+        where the parent path exists but is a file.
+        """
+        missing_parent = tmp_path / "no-such-dir" / "out.yaml"
+        with patch(_RULE_MGR_PATH, return_value=mock_rule_manager):
+            result = runner.invoke(rules_app, ["export", "-o", str(missing_parent)])
+        assert result.exit_code == 2
+        assert "does not exist" in result.output.lower()
+
+    @pytest.mark.integration
+    def test_export_write_oserror_surfaces_as_exit_1(self, runner, mock_rule_manager, tmp_path):
+        """A.cli: if ``write_text()`` itself fails (e.g. permission denied),
+        surface a user-facing error (exit 1), not a raw ``OSError`` traceback.
+        """
+        output_file = tmp_path / "rules.yaml"
+        with (
+            patch(_RULE_MGR_PATH, return_value=mock_rule_manager),
+            patch.object(Path, "write_text", side_effect=OSError("permission denied")),
+        ):
+            result = runner.invoke(rules_app, ["export", "-o", str(output_file)])
+        assert result.exit_code == 1
+        assert "failed to write yaml" in result.output.lower()
+
 
 # ============================================================================
 # Import Tests
@@ -381,6 +423,19 @@ class TestRulesImport:
         result = runner.invoke(rules_app, ["import", str(tmp_path / "nonexistent.yaml")])
         assert result.exit_code == 2
         assert "does not exist" in result.output.lower()
+
+    @pytest.mark.integration
+    def test_import_directory_rejected(self, runner, tmp_path):
+        """A.cli: ``must_be_dir=False`` alone allows directories through, so
+        there's an explicit ``is_file()`` guard after ``resolve_cli_path``.
+        Pointing import at a directory must fail at the CLI boundary with
+        "not a regular file" (exit 2), not a YAML parse error later.
+        """
+        d = tmp_path / "not-a-file"
+        d.mkdir()
+        result = runner.invoke(rules_app, ["import", str(d)])
+        assert result.exit_code == 2
+        assert "not a regular file" in result.output.lower()
 
     def test_import_invalid_yaml(self, runner, tmp_path):
         bad_yaml = tmp_path / "bad.yaml"

--- a/tests/cli/test_cli_rules.py
+++ b/tests/cli/test_cli_rules.py
@@ -347,6 +347,7 @@ class TestRulesExport:
         assert "Exported" in result.output
 
     @pytest.mark.integration
+    @pytest.mark.ci
     def test_export_output_is_existing_directory_rejected(
         self, runner, mock_rule_manager, tmp_path
     ):
@@ -362,6 +363,7 @@ class TestRulesExport:
         assert "not a regular file" in result.output.lower()
 
     @pytest.mark.integration
+    @pytest.mark.ci
     def test_export_parent_dir_missing_rejected(self, runner, mock_rule_manager, tmp_path):
         """A.cli: ``--output`` under a non-existent parent must fail with
         ``typer.BadParameter`` (exit 2). ``is_dir()`` also rejects the case
@@ -374,6 +376,7 @@ class TestRulesExport:
         assert "does not exist" in result.output.lower()
 
     @pytest.mark.integration
+    @pytest.mark.ci
     def test_export_write_oserror_surfaces_as_exit_1(self, runner, mock_rule_manager, tmp_path):
         """A.cli: if ``write_text()`` itself fails (e.g. permission denied),
         surface a user-facing error (exit 1), not a raw ``OSError`` traceback.
@@ -425,6 +428,7 @@ class TestRulesImport:
         assert "does not exist" in result.output.lower()
 
     @pytest.mark.integration
+    @pytest.mark.ci
     def test_import_directory_rejected(self, runner, tmp_path):
         """A.cli: ``must_be_dir=False`` alone allows directories through, so
         there's an explicit ``is_file()`` guard after ``resolve_cli_path``.

--- a/tests/cli/test_cli_rules.py
+++ b/tests/cli/test_cli_rules.py
@@ -374,9 +374,13 @@ class TestRulesImport:
         assert "Imported" in result.output
 
     def test_import_file_not_found(self, runner, tmp_path):
+        """A.cli: missing file surfaces as ``typer.BadParameter`` (exit 2,
+        POSIX usage-error convention) with 'does not exist' in the usage
+        message — replacing the previous custom exit-1 'not found' path.
+        """
         result = runner.invoke(rules_app, ["import", str(tmp_path / "nonexistent.yaml")])
-        assert result.exit_code == 1
-        assert "not found" in result.output
+        assert result.exit_code == 2
+        assert "does not exist" in result.output.lower()
 
     def test_import_invalid_yaml(self, runner, tmp_path):
         bad_yaml = tmp_path / "bad.yaml"

--- a/tests/cli/test_cli_utilities_coverage.py
+++ b/tests/cli/test_cli_utilities_coverage.py
@@ -47,7 +47,9 @@ class TestSearchLimitZero:
         app = _make_app()
         missing = tmp_path / "missing"
         result = runner.invoke(app, ["search", "foo", str(missing), "--limit", "0"])
-        assert result.exit_code == 1
+        # A.cli switched invalid-path errors from `typer.Exit(1)` to
+        # `typer.BadParameter` which exits 2 (POSIX usage-error convention).
+        assert result.exit_code == 2
         assert "does not exist" in " ".join(result.output.split())
 
     def test_limit_zero_still_validates_type_filter(self, tmp_path: Path) -> None:
@@ -66,8 +68,9 @@ class TestSearchDirectoryNotExist:
         app = _make_app()
         bad = tmp_path / "nonexistent"
         result = runner.invoke(app, ["search", "foo", str(bad)])
-        assert result.exit_code == 1
-        # Typer may wrap output with extra whitespace; normalise before checking.
+        # A.cli: `typer.BadParameter` exits 2 (POSIX usage-error convention)
+        # instead of the previous custom exit 1 path.
+        assert result.exit_code == 2
         normalised = " ".join(result.output.split())
         assert "does not exist" in normalised
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
@@ -77,6 +76,8 @@ def test_organize_command_dry_run(mock_organizer_cls, _mock_setup, tmp_path):
 
     in_dir = tmp_path / "in"
     out_dir = tmp_path / "out"
+    # A.cli: input_dir must exist; output_dir may not (organizer creates it).
+    in_dir.mkdir()
 
     result = runner.invoke(app, ["organize", str(in_dir), str(out_dir), "--dry-run"])
 
@@ -89,7 +90,9 @@ def test_organize_command_dry_run(mock_organizer_cls, _mock_setup, tmp_path):
         enable_vision=True,
         no_prefetch=False,
     )
-    mock_instance.organize.assert_called_once_with(in_dir, out_dir)
+    # A.cli resolves the path args before dispatching; the service sees
+    # the canonical absolute form.
+    mock_instance.organize.assert_called_once_with(in_dir.resolve(), out_dir.resolve())
 
 
 @patch("cli.organize._check_setup_completed", return_value=True)
@@ -100,7 +103,12 @@ def test_organize_command_error(mock_organizer_cls, _mock_setup, tmp_path):
     mock_instance.organize.side_effect = RuntimeError("Something broke")
     mock_organizer_cls.return_value = mock_instance
 
-    result = runner.invoke(app, ["organize", "in", "out"])
+    # A.cli: real directories required so the service-layer error path
+    # (not CLI-arg-validation path) is exercised.
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    out_dir = tmp_path / "out"
+    result = runner.invoke(app, ["organize", str(in_dir), str(out_dir)])
 
     assert result.exit_code == 1
     assert "Error: Something broke" in result.stdout
@@ -115,7 +123,9 @@ def test_preview_command(mock_organizer_cls, _mock_setup, tmp_path):
     mock_instance.organize.return_value = mock_result
     mock_organizer_cls.return_value = mock_instance
 
-    result = runner.invoke(app, ["preview", "in_dir"])
+    in_dir = tmp_path / "in_dir"
+    in_dir.mkdir()
+    result = runner.invoke(app, ["preview", str(in_dir)])
 
     assert result.exit_code == 0
     assert "Previewing" in result.stdout
@@ -126,7 +136,8 @@ def test_preview_command(mock_organizer_cls, _mock_setup, tmp_path):
         enable_vision=True,
         no_prefetch=False,
     )
-    mock_instance.organize.assert_called_once_with(Path("in_dir"), Path("in_dir"))
+    resolved = in_dir.resolve()
+    mock_instance.organize.assert_called_once_with(resolved, resolved)
 
 
 @patch("cli.organize._check_setup_completed", return_value=True)
@@ -137,7 +148,9 @@ def test_preview_command_error(mock_organizer_cls, _mock_setup, tmp_path):
     mock_instance.organize.side_effect = ValueError("Bad input")
     mock_organizer_cls.return_value = mock_instance
 
-    result = runner.invoke(app, ["preview", "in_dir"])
+    in_dir = tmp_path / "in_dir"
+    in_dir.mkdir()
+    result = runner.invoke(app, ["preview", str(in_dir)])
 
     assert result.exit_code == 1
     assert "Error: Bad input" in result.stdout

--- a/tests/cli/test_path_validation.py
+++ b/tests/cli/test_path_validation.py
@@ -1,0 +1,208 @@
+"""Unit tests for src/cli/path_validation.py (Epic A.cli, hardening roadmap #154).
+
+The helper wraps ``core.path_guard.validate_within_roots`` with CLI-specific
+ergonomics: human-readable errors via ``typer.BadParameter`` (so argparse/typer
+surfaces them at the usage boundary rather than bubbling a raw
+``PathTraversalError`` up to an end user), plus default-on existence and
+directory-type checks for commands that take a directory argument.
+
+Covered contracts:
+
+- ``resolve_cli_path(path, *, must_exist, must_be_dir)`` normalises ``..``,
+  resolves symlinks in the root, and returns a canonical absolute ``Path``.
+- Raises ``typer.BadParameter`` when the path doesn't exist (``must_exist``)
+  or isn't a directory (``must_be_dir``) — **not** ``FileNotFoundError``
+  so typer prints the usage-level error rather than a Python traceback.
+- ``validate_pair(input_dir, output_dir)`` catches the classic footgun
+  where ``output_dir`` sits inside ``input_dir`` (the organizer would then
+  write into the tree it's reading). Raises ``typer.BadParameter``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import typer
+
+from cli.path_validation import resolve_cli_path, validate_pair
+
+# --------------------------------------------------------------------------
+# resolve_cli_path — happy paths
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+@pytest.mark.integration
+class TestResolveCliPath:
+    def test_existing_directory_is_returned_resolved(self, tmp_path: Path) -> None:
+        """A plain existing directory passes through and comes back resolved."""
+        result = resolve_cli_path(tmp_path)
+        assert result == tmp_path.resolve()
+        assert result.is_absolute()
+
+    def test_dotdot_traversal_is_normalized(self, tmp_path: Path) -> None:
+        """``/a/b/../c`` must resolve to ``/a/c``. Same security property the
+        A.foundation walker sweep relied on, but re-checked at the CLI layer
+        so downstream code sees a canonical path.
+        """
+        nested = tmp_path / "sub"
+        nested.mkdir()
+        weird = tmp_path / "sub" / ".." / "sub"
+        result = resolve_cli_path(weird)
+        assert result == nested.resolve()
+
+    def test_relative_path_resolved_against_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Typer delivers plain ``Path(arg)`` which is relative. The helper
+        anchors it to the current working directory so all downstream
+        validation works on an absolute form.
+        """
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "sub").mkdir()
+        result = resolve_cli_path(Path("sub"))
+        assert result == (tmp_path / "sub").resolve()
+
+    def test_must_exist_false_allows_missing_path(self, tmp_path: Path) -> None:
+        """Commands that *create* their output dir (e.g. ``organize OUTPUT``
+        when OUTPUT doesn't exist yet) pass ``must_exist=False`` — the
+        helper still resolves ``..`` but doesn't require the path on disk.
+        """
+        missing = tmp_path / "will_be_created"
+        result = resolve_cli_path(missing, must_exist=False)
+        assert result == missing.resolve()
+
+    def test_must_be_dir_false_allows_file_argument(self, tmp_path: Path) -> None:
+        """Commands that take a file (``fo analyze FILE``) pass
+        ``must_be_dir=False`` — directory check doesn't apply.
+        """
+        file_path = tmp_path / "target.txt"
+        file_path.write_text("x")
+        result = resolve_cli_path(file_path, must_be_dir=False)
+        assert result == file_path.resolve()
+
+
+# --------------------------------------------------------------------------
+# resolve_cli_path — error paths (F1 — every external call handled)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+@pytest.mark.integration
+class TestResolveCliPathErrors:
+    def test_missing_path_raises_bad_parameter(self, tmp_path: Path) -> None:
+        """Non-existent path with ``must_exist=True`` surfaces as
+        ``typer.BadParameter`` — typer renders this as
+        ``Usage: ... Error: Invalid value for '...': Path does not exist: ...``
+        instead of a Python traceback.
+        """
+        missing = tmp_path / "nope"
+        with pytest.raises(typer.BadParameter, match="does not exist"):
+            resolve_cli_path(missing)
+
+    def test_file_when_dir_expected_raises_bad_parameter(self, tmp_path: Path) -> None:
+        """``fo organize INPUT`` pointed at a file gets a helpful error
+        rather than a later ``NotADirectoryError`` from the service layer.
+        """
+        file_path = tmp_path / "single.txt"
+        file_path.write_text("x")
+        with pytest.raises(typer.BadParameter, match="not a directory"):
+            resolve_cli_path(file_path, must_be_dir=True)
+
+    def test_error_message_includes_original_input(self, tmp_path: Path) -> None:
+        """The user wrote ``../nope``; the error message shows that literal
+        (so they can spot the typo) and the resolved form (so they can see
+        where `..` led).
+        """
+        missing = tmp_path / ".." / "nope"
+        with pytest.raises(typer.BadParameter) as excinfo:
+            resolve_cli_path(missing)
+        assert str(missing) in str(excinfo.value) or str(missing.resolve()) in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------
+# validate_pair — input/output dir coherence
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+@pytest.mark.integration
+class TestValidatePair:
+    def test_disjoint_input_output_accepted(self, tmp_path: Path) -> None:
+        """The common case — ``fo organize IN OUT`` where the two
+        directories are unrelated — must not raise.
+        """
+        in_dir = tmp_path / "in"
+        out_dir = tmp_path / "out"
+        in_dir.mkdir()
+        out_dir.mkdir()
+        # No exception means pass.
+        validate_pair(in_dir, out_dir)
+
+    def test_output_inside_input_rejected(self, tmp_path: Path) -> None:
+        """``fo organize IN IN/subdir`` would have the organizer write
+        destination files into the same tree it's reading from — a
+        classic footgun. Reject it at the CLI boundary so the user sees
+        a typer usage error, not a partially-corrupted output tree.
+        """
+        in_dir = tmp_path / "src"
+        in_dir.mkdir()
+        out_dir = in_dir / "nested_out"
+        with pytest.raises(typer.BadParameter, match="inside the input"):
+            validate_pair(in_dir, out_dir)
+
+    def test_input_inside_output_rejected(self, tmp_path: Path) -> None:
+        """Mirror of the above: if the user declares ``fo organize SRC/a OUT``
+        where ``OUT`` is actually the parent of ``SRC/a``, the organizer
+        could walk the output tree while scanning the input tree."""
+        out_dir = tmp_path / "out"
+        in_dir = out_dir / "nested_in"
+        out_dir.mkdir()
+        in_dir.mkdir()
+        with pytest.raises(typer.BadParameter, match="inside the output"):
+            validate_pair(in_dir, out_dir)
+
+    def test_identical_input_and_output_rejected(self, tmp_path: Path) -> None:
+        """``fo organize X X`` is never a legitimate request — the organizer
+        would read + write the same tree. Reject with a clear message.
+        """
+        same = tmp_path / "same"
+        same.mkdir()
+        with pytest.raises(typer.BadParameter, match="same path"):
+            validate_pair(same, same)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only symlink semantics")
+    def test_symlink_resolution_defeats_attempted_escape(self, tmp_path: Path) -> None:
+        """A user passing ``OUT`` that's a symlink to somewhere inside ``IN``
+        must still be rejected — the check runs against the resolved path,
+        not the surface string.
+        """
+        in_dir = tmp_path / "in"
+        real_out_inside_in = in_dir / "real_out"
+        in_dir.mkdir()
+        real_out_inside_in.mkdir()
+        out_link = tmp_path / "out_link"
+        out_link.symlink_to(real_out_inside_in)
+        with pytest.raises(typer.BadParameter, match="inside the input"):
+            validate_pair(in_dir, out_link)
+
+
+# --------------------------------------------------------------------------
+# Sanity: the helper is cwd-independent so CI and local runs agree
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+@pytest.mark.integration
+def test_resolve_cli_path_works_regardless_of_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The helper resolves absolute paths internally, so changing cwd
+    shouldn't change the outcome for an absolute input.
+    """
+    monkeypatch.chdir(os.sep)  # root of filesystem
+    result = resolve_cli_path(tmp_path)
+    assert result == tmp_path.resolve()

--- a/tests/cli/test_path_validation.py
+++ b/tests/cli/test_path_validation.py
@@ -120,7 +120,28 @@ class TestResolveCliPathErrors:
         missing = tmp_path / ".." / "nope"
         with pytest.raises(typer.BadParameter) as excinfo:
             resolve_cli_path(missing)
-        assert str(missing) in str(excinfo.value) or str(missing.resolve()) in str(excinfo.value)
+        # T4: both halves must appear — disjunction would pass even if the
+        # original literal is ever dropped from the message.
+        message = str(excinfo.value)
+        assert str(missing) in message
+        assert str(missing.resolve()) in message
+
+    def test_resolution_failure_becomes_bad_parameter(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``Path.resolve`` can raise ``RuntimeError`` (py<3.13) or ``OSError``
+        (py>=3.13) on symlink loops and unresolvable ``~user``. The helper's
+        contract is to surface these as ``typer.BadParameter`` so typer emits
+        a usage error (exit 2) instead of an internal traceback.
+        """
+
+        def _boom(self: Path, *_: object, **__: object) -> Path:
+            raise OSError("ELOOP: synthetic symlink loop")
+
+        monkeypatch.setattr(Path, "resolve", _boom)
+        with pytest.raises(typer.BadParameter) as excinfo:
+            resolve_cli_path(tmp_path / "anywhere")
+        assert "Unable to resolve path" in str(excinfo.value)
 
 
 # --------------------------------------------------------------------------

--- a/tests/cli/test_path_validation.py
+++ b/tests/cli/test_path_validation.py
@@ -135,10 +135,13 @@ class TestResolveCliPathErrors:
         a usage error (exit 2) instead of an internal traceback.
         """
 
-        def _boom(self: Path, *_: object, **__: object) -> Path:
+        def _boom(_self: Path, *_: object, **__: object) -> Path:
             raise OSError("ELOOP: synthetic symlink loop")
 
-        monkeypatch.setattr(Path, "resolve", _boom)
+        # Narrow patch: only Path.resolve calls via cli.path_validation raise —
+        # leaves the rest of the test machinery (pytest internals, tmp_path,
+        # other imported modules) free to resolve paths normally.
+        monkeypatch.setattr("cli.path_validation.Path.resolve", _boom)
         with pytest.raises(typer.BadParameter) as excinfo:
             resolve_cli_path(tmp_path / "anywhere")
         assert "Unable to resolve path" in str(excinfo.value)

--- a/tests/cli/test_path_validation_wiring.py
+++ b/tests/cli/test_path_validation_wiring.py
@@ -77,3 +77,30 @@ def test_cli_command_rejects_missing_path(
         f"expected exit 2 for {argv}; got {result.exit_code}\noutput: {result.output}"
     )
     assert "does not exist" in result.output.lower()
+
+
+def test_benchmark_compare_directory_rejected(tmp_path: Path) -> None:
+    """``--compare`` points at a JSON baseline file; directories must be
+    rejected at the CLI boundary (exit 2) rather than later at read_text()
+    with IsADirectoryError (exit 1). Covers the ``_validate_compare_path``
+    helper's is_file branch.
+    """
+    input_dir = tmp_path / "in"
+    input_dir.mkdir()
+    compare_dir = tmp_path / "a_dir"
+    compare_dir.mkdir()
+    result = runner.invoke(app, ["benchmark", "run", str(input_dir), "--compare", str(compare_dir)])
+    assert result.exit_code == 2
+    assert "not a regular file" in result.output.lower()
+
+
+def test_analyze_directory_rejected_with_regular_file_message(tmp_path: Path) -> None:
+    """After ``resolve_cli_path`` accepts the directory (must_be_dir=False),
+    the explicit ``is_file()`` guard in analyze prints "not a regular file"
+    and exits 1 (distinct from exit 2's CLI-boundary usage errors).
+    """
+    d = tmp_path / "target"
+    d.mkdir()
+    result = runner.invoke(app, ["analyze", str(d)])
+    assert result.exit_code == 1
+    assert "not a regular file" in result.output.lower()

--- a/tests/cli/test_path_validation_wiring.py
+++ b/tests/cli/test_path_validation_wiring.py
@@ -70,9 +70,7 @@ def test_cli_command_rejects_missing_path(
 ) -> None:
     target = daemon_app if app_key == "daemon" else app
     bogus = _bogus(tmp_path)
-    argv = [
-        a.replace("{p}", bogus).replace("{p2}", bogus + "_other") for a in argv_template
-    ]
+    argv = [a.replace("{p}", bogus).replace("{p2}", bogus + "_other") for a in argv_template]
     result = runner.invoke(target, argv)
     # typer.BadParameter → exit code 2 (POSIX usage-error convention).
     assert result.exit_code == 2, (

--- a/tests/cli/test_path_validation_wiring.py
+++ b/tests/cli/test_path_validation_wiring.py
@@ -1,0 +1,81 @@
+"""CI-tagged smoke tests: every CLI command wired to ``resolve_cli_path``
+rejects a non-existent directory with exit code 2 (``typer.BadParameter``).
+
+The detailed helper semantics live in ``test_path_validation.py``. This file
+exists so PR-CI's diff-coverage gate sees the call sites in
+``src/cli/{daemon,organize,main,rules,utilities,benchmark,suggest,dedupe_v2,autotag_v2}.py``
+as exercised under the ``-m ci`` marker (the integration tests that drive
+these commands end-to-end run in the main-push suite, not in PR-CI).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from cli.daemon import daemon_app
+from cli.main import app
+
+pytestmark = [pytest.mark.ci, pytest.mark.unit]
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _bypass_setup_wizard() -> Iterator[None]:
+    """Skip the organize/preview setup-wizard check; the wiring test only
+    needs to reach ``resolve_cli_path``."""
+    with patch("cli.organize._check_setup_completed", return_value=True):
+        yield
+
+
+def _bogus(tmp_path: Path) -> str:
+    return str(tmp_path / "does_not_exist")
+
+
+# (app, argv-template) — each template uses ``{p}`` for the bogus path.
+# Commands that take two paths get two bogus substitutions; one rejected path
+# is enough to trigger the ``resolve_cli_path`` branch.
+_COMMANDS: list[tuple[str, list[str]]] = [
+    ("app", ["organize", "{p}", "{p2}"]),
+    ("app", ["preview", "{p}"]),
+    ("app", ["benchmark", "run", "{p}"]),
+    ("app", ["suggest", "files", "{p}"]),
+    ("app", ["suggest", "apply", "{p}"]),
+    ("app", ["suggest", "patterns", "{p}"]),
+    ("app", ["search", "{p}", "query"]),
+    ("app", ["analyze", "{p}"]),
+    ("app", ["analytics", "{p}"]),
+    ("app", ["autotag", "suggest", "{p}"]),
+    ("app", ["autotag", "apply", "{p}", "dummy-tag"]),
+    ("app", ["autotag", "batch", "{p}"]),
+    ("app", ["dedupe", "scan", "{p}"]),
+    ("app", ["dedupe", "resolve", "{p}"]),
+    ("app", ["dedupe", "report", "{p}"]),
+    ("app", ["rules", "preview", "{p}"]),
+    ("app", ["rules", "import", "{p}"]),
+    ("daemon", ["process", "{p}", "{p2}"]),
+    ("daemon", ["start", "--watch-dir", "{p}", "--output-dir", "{p2}"]),
+    ("daemon", ["watch", "{p}"]),
+]
+
+
+@pytest.mark.parametrize(("app_key", "argv_template"), _COMMANDS)
+def test_cli_command_rejects_missing_path(
+    app_key: str, argv_template: list[str], tmp_path: Path
+) -> None:
+    target = daemon_app if app_key == "daemon" else app
+    bogus = _bogus(tmp_path)
+    argv = [
+        a.replace("{p}", bogus).replace("{p2}", bogus + "_other") for a in argv_template
+    ]
+    result = runner.invoke(target, argv)
+    # typer.BadParameter → exit code 2 (POSIX usage-error convention).
+    assert result.exit_code == 2, (
+        f"expected exit 2 for {argv}; got {result.exit_code}\noutput: {result.output}"
+    )
+    assert "does not exist" in result.output.lower()

--- a/tests/cli/test_search.py
+++ b/tests/cli/test_search.py
@@ -128,9 +128,14 @@ def test_search_empty_directory(tmp_path: Path):
 
 
 def test_search_nonexistent_directory():
-    """Search in a nonexistent directory exits 1 with 'does not exist' message."""
+    """Search in a nonexistent directory exits 2 (typer ``BadParameter`` /
+    POSIX usage-error convention) with a 'does not exist' message. A.cli
+    moved invalid-path errors from a custom ``typer.Exit(1)`` path to
+    typer-native ``BadParameter`` so typer's usage-line renderer formats
+    the message consistently across commands.
+    """
     result = runner.invoke(app, ["search", "*", "/nonexistent/path/xyz"])
-    assert result.exit_code == 1
+    assert result.exit_code == 2
     assert "does not exist" in result.output.lower()
 
 

--- a/tests/integration/test_cli_autotag_v2.py
+++ b/tests/integration/test_cli_autotag_v2.py
@@ -58,10 +58,11 @@ def _make_recommendation(suggestions: list | None = None) -> MagicMock:
 
 
 class TestSuggestCommand:
-    def test_suggest_directory_not_found_exits_1(self, tmp_path) -> None:
+    def test_suggest_directory_not_found_exits_2(self, tmp_path) -> None:
+        """A.cli: non-existent dir → ``typer.BadParameter`` (exit 2)."""
         missing = tmp_path / "does_not_exist"
         result = runner.invoke(autotag_app, ["suggest", str(missing)])
-        assert result.exit_code == 1
+        assert result.exit_code == 2
 
     def test_suggest_empty_directory_exits_0(self, tmp_path) -> None:
         result = runner.invoke(autotag_app, ["suggest", str(tmp_path)])
@@ -163,10 +164,11 @@ class TestSuggestCommand:
 
 
 class TestApplyCommand:
-    def test_apply_file_not_found_exits_1(self, tmp_path) -> None:
+    def test_apply_file_not_found_exits_2(self, tmp_path) -> None:
+        """A.cli: non-existent file → ``typer.BadParameter`` (exit 2)."""
         missing = tmp_path / "missing.txt"
         result = runner.invoke(autotag_app, ["apply", str(missing), "tag1"])
-        assert result.exit_code == 1
+        assert result.exit_code == 2
 
     def test_apply_success(self, tmp_path) -> None:
         f = tmp_path / "doc.txt"
@@ -277,10 +279,11 @@ class TestRecentCommand:
 
 
 class TestBatchCommand:
-    def test_batch_directory_not_found_exits_1(self, tmp_path) -> None:
+    def test_batch_directory_not_found_exits_2(self, tmp_path) -> None:
+        """A.cli: non-existent dir → ``typer.BadParameter`` (exit 2)."""
         missing = tmp_path / "no_dir"
         result = runner.invoke(autotag_app, ["batch", str(missing)])
-        assert result.exit_code == 1
+        assert result.exit_code == 2
 
     def test_batch_no_matching_files_exits_0(self, tmp_path) -> None:
         result = runner.invoke(autotag_app, ["batch", str(tmp_path), "--pattern", "*.xyz"])

--- a/tests/integration/test_cli_benchmark_analytics_undo_display_utils.py
+++ b/tests/integration/test_cli_benchmark_analytics_undo_display_utils.py
@@ -38,13 +38,14 @@ pytestmark = pytest.mark.integration
 class TestBenchmarkRunCommand:
     """Exercise the ``benchmark run`` CLI command via typer invocation."""
 
-    def test_run_nonexistent_path_exits_1(self, cli_runner, tmp_path: Path) -> None:
+    def test_run_nonexistent_path_exits_2(self, cli_runner, tmp_path: Path) -> None:
+        """A.cli: non-existent path → ``typer.BadParameter`` (exit 2)."""
         from cli.main import app
 
         result = cli_runner.invoke(
             app, ["benchmark", "run", str(tmp_path / "gone"), "--iterations", "1", "--warmup", "0"]
         )
-        assert result.exit_code == 1
+        assert result.exit_code == 2
         assert "does not exist" in result.output.lower() or "error" in result.output.lower()
 
     def test_run_empty_dir_text_output(self, cli_runner, tmp_path: Path) -> None:
@@ -1960,10 +1961,11 @@ class TestSearchCommandLimitZero:
 
 class TestAnalyzeCommandErrorPaths:
     def test_analyze_file_not_found(self, cli_runner, tmp_path: Path) -> None:
+        """A.cli: non-existent file → ``typer.BadParameter`` (exit 2)."""
         from cli.main import app
 
         result = cli_runner.invoke(app, ["analyze", str(tmp_path / "missing.txt")])
-        assert result.exit_code == 1
+        assert result.exit_code == 2
 
     def test_analyze_binary_file_exits_1(self, cli_runner, tmp_path: Path) -> None:
         from cli.main import app

--- a/tests/integration/test_cli_rules.py
+++ b/tests/integration/test_cli_rules.py
@@ -304,10 +304,28 @@ class TestRulesExportImport:
         assert result.exit_code == 0
         assert output_file.exists()
 
-    def test_rules_import_missing_file_exits_1(self, tmp_path: Path) -> None:
+    def test_rules_export_missing_parent_dir_exits_2(self, tmp_path: Path) -> None:
+        """A.cli: ``--output`` may point at a not-yet-created file, but the
+        parent directory must exist. Writing to ``tmp/a/b/rules.yaml`` when
+        ``tmp/a/b/`` doesn't exist is rejected with ``typer.BadParameter``.
+        """
+        from services.copilot.rules.models import RuleSet
+
+        mock_mgr = MagicMock()
+        mock_rs = RuleSet(name="default", rules=[])
+        mock_mgr.load_rule_set.return_value = mock_rs
+
+        missing_parent = tmp_path / "nonexistent_dir" / "rules.yaml"
+        with patch("services.copilot.rules.RuleManager", return_value=mock_mgr):
+            result = runner.invoke(app, ["rules", "export", "--output", str(missing_parent)])
+        assert result.exit_code == 2
+        assert "does not exist" in result.output.lower()
+
+    def test_rules_import_missing_file_exits_2(self, tmp_path: Path) -> None:
+        """A.cli: non-existent file → ``typer.BadParameter`` (exit 2)."""
         result = runner.invoke(app, ["rules", "import", str(tmp_path / "nonexistent.yaml")])
-        assert result.exit_code == 1
-        assert "not found" in result.output.lower() or "file" in result.output.lower()
+        assert result.exit_code == 2
+        assert "does not exist" in result.output.lower()
 
     def test_rules_import_valid_yaml(self, tmp_path: Path) -> None:
         yaml_file = tmp_path / "rules.yaml"

--- a/tests/integration/test_cli_search_analyze.py
+++ b/tests/integration/test_cli_search_analyze.py
@@ -65,10 +65,11 @@ class TestSearchCommand:
         assert result.exit_code == 0
         assert "no files" in result.output.lower()
 
-    def test_search_nonexistent_directory_exits_1(self, tmp_path: Path) -> None:
+    def test_search_nonexistent_directory_exits_2(self, tmp_path: Path) -> None:
+        """A.cli: non-existent dir → ``typer.BadParameter`` (exit 2)."""
         result = runner.invoke(app, ["search", "anything", str(tmp_path / "gone")])
-        assert result.exit_code == 1
-        assert "error" in result.output.lower() or "does not exist" in result.output.lower()
+        assert result.exit_code == 2
+        assert "does not exist" in result.output.lower()
 
     def test_search_invalid_type_filter_exits_1(self, tmp_path: Path) -> None:
         d = _make_test_dir(tmp_path)
@@ -148,10 +149,11 @@ class TestSearchCommand:
 
 
 class TestAnalyzeCommand:
-    def test_analyze_missing_file_exits_1(self, tmp_path: Path) -> None:
+    def test_analyze_missing_file_exits_2(self, tmp_path: Path) -> None:
+        """A.cli: non-existent file → ``typer.BadParameter`` (exit 2)."""
         result = runner.invoke(app, ["analyze", str(tmp_path / "nonexistent.txt")])
-        assert result.exit_code == 1
-        assert "not found" in result.output.lower() or "error" in result.output.lower()
+        assert result.exit_code == 2
+        assert "does not exist" in result.output.lower()
 
     def test_analyze_binary_file_exits_1(self, tmp_path: Path) -> None:
         binary_file = tmp_path / "binary.bin"

--- a/tests/test_cli_daemon.py
+++ b/tests/test_cli_daemon.py
@@ -13,6 +13,7 @@ from cli.daemon import daemon_app
 runner = CliRunner()
 
 
+@pytest.mark.ci
 @pytest.mark.unit
 @pytest.mark.integration
 class TestDaemonStart:
@@ -133,6 +134,7 @@ class TestDaemonStatus:
         assert "Running" in result.output
 
 
+@pytest.mark.ci
 @pytest.mark.unit
 @pytest.mark.integration
 class TestDaemonProcess:

--- a/tests/test_cli_daemon.py
+++ b/tests/test_cli_daemon.py
@@ -41,18 +41,29 @@ class TestDaemonStart:
 
     @patch("daemon.service.DaemonService")
     @patch("daemon.config.DaemonConfig")
-    def test_start_with_dry_run(self, mock_config_cls: MagicMock, mock_svc_cls: MagicMock) -> None:
+    def test_start_with_dry_run(
+        self,
+        mock_config_cls: MagicMock,
+        mock_svc_cls: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A.cli: watch_dir must exist; use real tmp_path dirs (T13
+        HARDCODED_TEST_DATA_PATHS — now rejected by resolve_cli_path).
+        """
         mock_svc = MagicMock()
         mock_svc_cls.return_value = mock_svc
+        watch = tmp_path / "watch"
+        watch.mkdir()
+        out = tmp_path / "out"
 
         result = runner.invoke(
             daemon_app,
             [
                 "start",
                 "--watch-dir",
-                "/tmp/watch",
+                str(watch),
                 "--output-dir",
-                "/tmp/out",
+                str(out),
                 "--poll-interval",
                 "2.0",
                 "--dry-run",
@@ -128,7 +139,8 @@ class TestDaemonProcess:
     """Tests for 'daemon process' command."""
 
     @patch("core.organizer.FileOrganizer")
-    def test_process_success(self, mock_org_cls: MagicMock) -> None:
+    def test_process_success(self, mock_org_cls: MagicMock, tmp_path: Path) -> None:
+        """A.cli: use real tmp_path dirs (T13 HARDCODED_TEST_DATA_PATHS)."""
         mock_org = MagicMock()
         mock_org_cls.return_value = mock_org
 
@@ -141,12 +153,16 @@ class TestDaemonProcess:
         mock_result.errors = [("bad.txt", "Cannot read")]
         mock_org.organize.return_value = mock_result
 
-        result = runner.invoke(daemon_app, ["process", "/tmp/in", "/tmp/out"])
+        in_dir = tmp_path / "in"
+        in_dir.mkdir()
+        out_dir = tmp_path / "out"
+        result = runner.invoke(daemon_app, ["process", str(in_dir), str(out_dir)])
         assert result.exit_code == 0
         assert "10" in result.output
 
     @patch("core.organizer.FileOrganizer")
-    def test_process_dry_run(self, mock_org_cls: MagicMock) -> None:
+    def test_process_dry_run(self, mock_org_cls: MagicMock, tmp_path: Path) -> None:
+        """A.cli: use real tmp_path dirs (T13)."""
         mock_org = MagicMock()
         mock_org_cls.return_value = mock_org
 
@@ -159,7 +175,10 @@ class TestDaemonProcess:
         mock_result.errors = []
         mock_org.organize.return_value = mock_result
 
-        result = runner.invoke(daemon_app, ["process", "/tmp/in", "/tmp/out", "--dry-run"])
+        in_dir = tmp_path / "in"
+        in_dir.mkdir()
+        out_dir = tmp_path / "out"
+        result = runner.invoke(daemon_app, ["process", str(in_dir), str(out_dir), "--dry-run"])
         assert result.exit_code == 0
         assert "Dry-run" in result.output
 


### PR DESCRIPTION
## Summary

Introduces `cli.path_validation` helpers and wires them into every path-taking CLI command, landing Epic A.cli of the 7-epic MECE hardening roadmap (follows PR #168 A.foundation).

- `resolve_cli_path(path, *, must_exist=True, must_be_dir=True)` — `expanduser().resolve()`, then raise `typer.BadParameter` (exit 2) if missing or not a directory.
- `validate_pair(input_dir, output_dir)` — reject same-path and nested-path pairs (prevents "organize into the dir you're reading from" footguns).

13 commands wired: organize/preview, benchmark, suggest (files/apply/patterns), search, analyze, analytics, daemon (start/watch/process), autotag (suggest/apply/batch), dedupe (scan/resolve/report), rules (preview/export/import).

## Test plan

- [x] 14 new unit tests in `tests/cli/test_path_validation.py` (happy path, `..` traversal, cwd-independence, missing/non-dir, `validate_pair` disjoint/nested/identical/symlink)
- [x] ~20 CLI tests updated: exit code 1 → 2 for path-validation errors (POSIX usage-error convention)
- [x] Removed hardcoded `/tmp/in`, `/tmp/out`, `/tmp/watch` fixtures → `tmp_path` (T13)
- [x] Diff coverage: 100% over 69 changed source lines
- [x] All 10 touched CLI modules meet/exceed integration-floor baselines
- [x] `src/cli/path_validation.py` → 100% line/branch
- [x] Pre-commit validation passes (including G1 absolute-path check)

Epic tracker: follow-up to #168 A.foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized CLI path validation applied across commands for earlier, consistent argument checks and clearer error responses.

* **Bug Fixes**
  * Standardized handling of invalid paths and directory/file mismatches to produce consistent exit codes and user-friendly messages.

* **Tests**
  * Updated and added CLI tests to reflect the new validation behavior and error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->