### PR TITLE
feat(dedupe): add --include-hidden flag (closes #170)

### DIFF
--- a/src/cli/dedupe_v2.py
+++ b/src/cli/dedupe_v2.py
@@ -67,11 +67,28 @@ def _build_scan_options(
 # the hash index, so a backup-directory duplicate could cascade into a
 # credential deletion. The prompt forces a conscious second-click.
 _HIDDEN_RESOLVE_WARNING = (
-    "You are running ``dedupe resolve --include-hidden``. Hidden files "
-    "(``.env``, ``.ssh/*``, ``.config/*``, etc.) will be hashed and may be "
+    "You are about to [bold]dedupe resolve[/bold] a scan that includes hidden "
+    "files ([yellow].env[/yellow], [yellow].ssh/*[/yellow], "
+    "[yellow].config/*[/yellow], etc.). These will be hashed and may be "
     "deleted as duplicates — including potentially sensitive credentials. "
     "Continue?"
 )
+
+
+def _hidden_files_will_be_scanned(directory: Path, *, include_hidden: bool) -> bool:
+    """Return True when the scan is likely to touch hidden files.
+
+    The `resolve` confirmation gate must fire not only when ``--include-hidden``
+    is set, but also when the scan *root itself* is a hidden directory
+    (`fo dedupe resolve ~/.ssh --strategy oldest`). ``safe_walk``'s hidden
+    filter is relative to `root`: a root of `~/.ssh` means `id_rsa` has no
+    hidden component *under* the root, and would be scanned even with
+    `include_hidden=False`. Either condition is enough to warrant the prompt.
+    """
+    if include_hidden:
+        return True
+    resolved = directory.resolve()
+    return any(part.startswith(".") and part not in (".", "..") for part in resolved.parts)
 
 
 def _display_groups_table(
@@ -204,12 +221,17 @@ def resolve(
 ) -> None:
     """Scan and resolve duplicates using a strategy."""
     directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
-    # #170: opting into hidden-file inclusion on a command that DELETES files
-    # requires an explicit confirmation — `--yes` / `--no-interactive` still
-    # honour their usual semantics via `confirm_action`.
-    if include_hidden and not confirm_action(_HIDDEN_RESOLVE_WARNING, default=False):
+    # #170: any `resolve` that will actually traverse hidden files (either via
+    # ``--include-hidden`` OR because the scan root itself is a hidden dir
+    # like ``~/.ssh``) requires an explicit credential-risk confirmation.
+    # ``--yes`` / ``--no-interactive`` still honour their usual semantics via
+    # ``confirm_action``. User-cancellation exits with code 1 so shell scripts
+    # and ``&&`` chains can distinguish "aborted" from "no duplicates found".
+    if _hidden_files_will_be_scanned(
+        directory, include_hidden=include_hidden
+    ) and not confirm_action(_HIDDEN_RESOLVE_WARNING, default=False):
         console.print("[yellow]Aborted.[/yellow]")
-        raise typer.Exit()
+        raise typer.Exit(code=1)
     detector = _get_detector()
     options = _build_scan_options(
         directory,

--- a/src/cli/dedupe_v2.py
+++ b/src/cli/dedupe_v2.py
@@ -15,6 +15,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from cli.interactive import confirm_action
 from cli.path_validation import resolve_cli_path
 
 console = Console()
@@ -41,6 +42,7 @@ def _build_scan_options(
     max_size: int | None,
     include: str | None,
     exclude: str | None,
+    include_hidden: bool = False,
 ) -> Any:
     """Build ``ScanOptions`` from CLI flags."""
     from services.deduplication.detector import ScanOptions
@@ -51,11 +53,25 @@ def _build_scan_options(
     return ScanOptions(
         algorithm=cast("HashAlgorithm", algorithm),
         recursive=recursive,
+        include_hidden=include_hidden,
         min_file_size=min_size,
         max_file_size=max_size,
         file_patterns=include_patterns,
         exclude_patterns=exclude_patterns,
     )
+
+
+# #170: shown to the user when they pass ``--include-hidden`` to
+# ``fo dedupe resolve``. The resolve path can DELETE files; opting into
+# hidden-file inclusion means dotfiles like ``.env`` / ``.ssh/id_rsa`` enter
+# the hash index, so a backup-directory duplicate could cascade into a
+# credential deletion. The prompt forces a conscious second-click.
+_HIDDEN_RESOLVE_WARNING = (
+    "You are running ``dedupe resolve --include-hidden``. Hidden files "
+    "(``.env``, ``.ssh/*``, ``.config/*``, etc.) will be hashed and may be "
+    "deleted as duplicates — including potentially sensitive credentials. "
+    "Continue?"
+)
 
 
 def _display_groups_table(
@@ -126,13 +142,29 @@ def scan(
     max_size: int | None = typer.Option(None, help="Maximum file size in bytes."),
     include: str | None = typer.Option(None, help="Comma-separated glob include patterns."),
     exclude: str | None = typer.Option(None, help="Comma-separated glob exclude patterns."),
+    include_hidden: bool = typer.Option(
+        False,
+        "--include-hidden",
+        help=(
+            "Include dotfiles and files under hidden directories "
+            "(.env, .ssh, .config). Off by default — hidden paths often "
+            "contain credentials."
+        ),
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON."),
 ) -> None:
     """Scan a directory and display duplicate file groups."""
     directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
     detector = _get_detector()
     options = _build_scan_options(
-        directory, algorithm, recursive, min_size, max_size, include, exclude
+        directory,
+        algorithm,
+        recursive,
+        min_size,
+        max_size,
+        include,
+        exclude,
+        include_hidden=include_hidden,
     )
 
     with console.status("Scanning for duplicates…"):
@@ -161,12 +193,33 @@ def resolve(
     max_size: int | None = typer.Option(None, help="Maximum file size in bytes."),
     include: str | None = typer.Option(None, help="Comma-separated include patterns."),
     exclude: str | None = typer.Option(None, help="Comma-separated exclude patterns."),
+    include_hidden: bool = typer.Option(
+        False,
+        "--include-hidden",
+        help=(
+            "Include dotfiles / hidden directories. Off by default; when "
+            "on, a confirmation prompt appears before any deletion."
+        ),
+    ),
 ) -> None:
     """Scan and resolve duplicates using a strategy."""
     directory = resolve_cli_path(directory, must_exist=True, must_be_dir=True)
+    # #170: opting into hidden-file inclusion on a command that DELETES files
+    # requires an explicit confirmation — `--yes` / `--no-interactive` still
+    # honour their usual semantics via `confirm_action`.
+    if include_hidden and not confirm_action(_HIDDEN_RESOLVE_WARNING, default=False):
+        console.print("[yellow]Aborted.[/yellow]")
+        raise typer.Exit()
     detector = _get_detector()
     options = _build_scan_options(
-        directory, algorithm, recursive, min_size, max_size, include, exclude
+        directory,
+        algorithm,
+        recursive,
+        min_size,
+        max_size,
+        include,
+        exclude,
+        include_hidden=include_hidden,
     )
 
     with console.status("Scanning for duplicates…"):
@@ -217,6 +270,11 @@ def report(
     directory: Path = typer.Argument(..., help="Directory to scan."),
     algorithm: str = typer.Option("sha256", help="Hash algorithm."),
     recursive: bool = typer.Option(True, help="Scan subdirectories."),
+    include_hidden: bool = typer.Option(
+        False,
+        "--include-hidden",
+        help="Include dotfiles and files under hidden directories in the report.",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON."),
 ) -> None:
     """Scan and display a summary report of duplicates."""
@@ -225,7 +283,11 @@ def report(
     from services.deduplication.detector import ScanOptions
     from services.deduplication.hasher import HashAlgorithm
 
-    options = ScanOptions(algorithm=cast("HashAlgorithm", algorithm), recursive=recursive)
+    options = ScanOptions(
+        algorithm=cast("HashAlgorithm", algorithm),
+        recursive=recursive,
+        include_hidden=include_hidden,
+    )
 
     with console.status("Scanning…"):
         detector.scan_directory(directory, options)

--- a/src/services/deduplication/detector.py
+++ b/src/services/deduplication/detector.py
@@ -27,6 +27,12 @@ class ScanOptions:
     algorithm: HashAlgorithm = "sha256"
     recursive: bool = True
     follow_symlinks: bool = False
+    # #170: default False keeps `.env` / `.ssh/*` / `.config/*` out of the
+    # dedupe hash index. `fo dedupe resolve` can DELETE files, so including
+    # hidden entries in the index means a backup-directory duplicate could
+    # trigger deletion of a credential file. Flipping this to True is the
+    # opt-in, CLI-prompted path — see `cli.dedupe_v2`.
+    include_hidden: bool = False
     min_file_size: int = 0  # Minimum file size to consider (bytes)
     max_file_size: int | None = None  # Maximum file size (None = no limit)
     file_patterns: list[str] | None = None  # Glob patterns to include
@@ -107,14 +113,15 @@ class DuplicateDetector:
 
         # Secure defaults: dedupe can DELETE files (`fo dedupe resolve`),
         # so never hash / index entries under `.env`, `.ssh/*`, etc. by
-        # default — a later `resolve` call shouldn't be able to delete a
-        # user's credential file because its duplicate was found in a
-        # backup directory. Legacy rglob behavior (include hidden) is
-        # tracked for an opt-in `--include-hidden` flag in follow-up.
+        # default. Users who genuinely want to dedupe their `.cache/` or
+        # `.config/` trees opt in via `fo dedupe … --include-hidden`, which
+        # the CLI layer (cli.dedupe_v2) confirms with an explicit prompt
+        # for the resolve path because the hidden set may include secrets.
         walker = safe_walk(
             directory,
             recursive=options.recursive,
             follow_symlinks=options.follow_symlinks,
+            include_hidden=options.include_hidden,
         )
         for path in walker:
             # Check file size constraints

--- a/tests/cli/test_cli_dedupe_v2.py
+++ b/tests/cli/test_cli_dedupe_v2.py
@@ -226,3 +226,122 @@ class TestDedupeReport:
         result = runner.invoke(app, ["dedupe", "report", str(tmp_path), "--json"])
         assert result.exit_code == 0
         assert "50" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --include-hidden opt-in (#170)
+# ---------------------------------------------------------------------------
+
+
+class TestDedupeIncludeHidden:
+    """#170: ``--include-hidden`` opts into dotfile / hidden-dir traversal.
+
+    Default behaviour keeps credential-bearing paths (``.env``, ``.ssh/*``)
+    out of the dedupe hash index so ``dedupe resolve`` can't delete them by
+    accident. These tests verify the flag plumbs from the CLI into
+    ``ScanOptions.include_hidden``, and that ``resolve --include-hidden``
+    prompts for an explicit confirmation before touching hidden files.
+    """
+
+    @patch("cli.dedupe_v2._get_detector")
+    def test_scan_default_sets_include_hidden_false(
+        self, mock_get_det: MagicMock, tmp_path: Path
+    ) -> None:
+        """Without the flag, the ScanOptions handed to the detector must
+        have ``include_hidden=False``."""
+        mock_det = MagicMock()
+        mock_get_det.return_value = mock_det
+        mock_det.get_duplicate_groups.return_value = {}
+
+        result = runner.invoke(app, ["dedupe", "scan", str(tmp_path)])
+        assert result.exit_code == 0
+        mock_det.scan_directory.assert_called_once()
+        options = mock_det.scan_directory.call_args[0][1]
+        assert options.include_hidden is False
+
+    @patch("cli.dedupe_v2._get_detector")
+    def test_scan_with_include_hidden_flag(
+        self, mock_get_det: MagicMock, tmp_path: Path
+    ) -> None:
+        """``scan --include-hidden`` → ``ScanOptions.include_hidden=True``."""
+        mock_det = MagicMock()
+        mock_get_det.return_value = mock_det
+        mock_det.get_duplicate_groups.return_value = {}
+
+        result = runner.invoke(app, ["dedupe", "scan", str(tmp_path), "--include-hidden"])
+        assert result.exit_code == 0
+        options = mock_det.scan_directory.call_args[0][1]
+        assert options.include_hidden is True
+
+    @patch("cli.dedupe_v2._get_detector")
+    def test_report_with_include_hidden_flag(
+        self, mock_get_det: MagicMock, tmp_path: Path
+    ) -> None:
+        """``report --include-hidden`` plumbs through ScanOptions."""
+        mock_det = MagicMock()
+        mock_get_det.return_value = mock_det
+        mock_det.get_statistics.return_value = {"total_files": 0, "duplicate_files": 0}
+        mock_det.get_duplicate_groups.return_value = {}
+
+        result = runner.invoke(
+            app, ["dedupe", "report", str(tmp_path), "--include-hidden"]
+        )
+        assert result.exit_code == 0
+        options = mock_det.scan_directory.call_args[0][1]
+        assert options.include_hidden is True
+
+    @patch("cli.dedupe_v2.confirm_action")
+    @patch("cli.dedupe_v2._get_detector")
+    def test_resolve_include_hidden_prompts_for_confirmation(
+        self,
+        mock_get_det: MagicMock,
+        mock_confirm: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """``resolve --include-hidden`` must prompt before deleting hidden
+        files, with a message explicitly mentioning credential risk.
+        """
+        mock_confirm.return_value = False  # user declines → bail out
+        mock_det = MagicMock()
+        mock_get_det.return_value = mock_det
+
+        result = runner.invoke(
+            app,
+            [
+                "dedupe",
+                "resolve",
+                str(tmp_path),
+                "--strategy",
+                "oldest",
+                "--include-hidden",
+            ],
+        )
+
+        assert mock_confirm.called, "confirm_action was not invoked"
+        message = mock_confirm.call_args[0][0]
+        assert "hidden" in message.lower()
+        assert "credential" in message.lower() or "sensitive" in message.lower()
+        # Declined → command exits before scanning; detector.scan_directory
+        # must NOT be called.
+        mock_det.scan_directory.assert_not_called()
+        assert result.exit_code == 0
+
+    @patch("cli.dedupe_v2.confirm_action")
+    @patch("cli.dedupe_v2._get_detector")
+    def test_resolve_without_include_hidden_skips_prompt(
+        self,
+        mock_get_det: MagicMock,
+        mock_confirm: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Default ``resolve`` (no ``--include-hidden``) must NOT invoke the
+        hidden-file confirmation. Only the hidden flag triggers the extra
+        gate.
+        """
+        mock_det = MagicMock()
+        mock_get_det.return_value = mock_det
+        mock_det.get_duplicate_groups.return_value = {}
+
+        result = runner.invoke(app, ["dedupe", "resolve", str(tmp_path), "--strategy", "oldest"])
+        assert result.exit_code == 0
+        mock_confirm.assert_not_called()

--- a/tests/cli/test_cli_dedupe_v2.py
+++ b/tests/cli/test_cli_dedupe_v2.py
@@ -365,9 +365,7 @@ class TestDedupeIncludeHidden:
         mock_det = MagicMock()
         mock_get_det.return_value = mock_det
 
-        result = runner.invoke(
-            app, ["dedupe", "resolve", str(hidden_root), "--strategy", "oldest"]
-        )
+        result = runner.invoke(app, ["dedupe", "resolve", str(hidden_root), "--strategy", "oldest"])
 
         mock_confirm.assert_called_once()
         mock_det.scan_directory.assert_not_called()

--- a/tests/cli/test_cli_dedupe_v2.py
+++ b/tests/cli/test_cli_dedupe_v2.py
@@ -234,6 +234,7 @@ class TestDedupeReport:
 
 
 @pytest.mark.ci
+@pytest.mark.integration
 class TestDedupeIncludeHidden:
     """#170: ``--include-hidden`` opts into dotfile / hidden-dir traversal.
 

--- a/tests/cli/test_cli_dedupe_v2.py
+++ b/tests/cli/test_cli_dedupe_v2.py
@@ -233,6 +233,7 @@ class TestDedupeReport:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.ci
 class TestDedupeIncludeHidden:
     """#170: ``--include-hidden`` opts into dotfile / hidden-dir traversal.
 
@@ -260,9 +261,7 @@ class TestDedupeIncludeHidden:
         assert options.include_hidden is False
 
     @patch("cli.dedupe_v2._get_detector")
-    def test_scan_with_include_hidden_flag(
-        self, mock_get_det: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_scan_with_include_hidden_flag(self, mock_get_det: MagicMock, tmp_path: Path) -> None:
         """``scan --include-hidden`` → ``ScanOptions.include_hidden=True``."""
         mock_det = MagicMock()
         mock_get_det.return_value = mock_det
@@ -274,18 +273,14 @@ class TestDedupeIncludeHidden:
         assert options.include_hidden is True
 
     @patch("cli.dedupe_v2._get_detector")
-    def test_report_with_include_hidden_flag(
-        self, mock_get_det: MagicMock, tmp_path: Path
-    ) -> None:
+    def test_report_with_include_hidden_flag(self, mock_get_det: MagicMock, tmp_path: Path) -> None:
         """``report --include-hidden`` plumbs through ScanOptions."""
         mock_det = MagicMock()
         mock_get_det.return_value = mock_det
         mock_det.get_statistics.return_value = {"total_files": 0, "duplicate_files": 0}
         mock_det.get_duplicate_groups.return_value = {}
 
-        result = runner.invoke(
-            app, ["dedupe", "report", str(tmp_path), "--include-hidden"]
-        )
+        result = runner.invoke(app, ["dedupe", "report", str(tmp_path), "--include-hidden"])
         assert result.exit_code == 0
         options = mock_det.scan_directory.call_args[0][1]
         assert options.include_hidden is True

--- a/tests/cli/test_cli_dedupe_v2.py
+++ b/tests/cli/test_cli_dedupe_v2.py
@@ -313,14 +313,17 @@ class TestDedupeIncludeHidden:
             ],
         )
 
-        assert mock_confirm.called, "confirm_action was not invoked"
+        # Exactly one prompt — catches accidental double-prompting regressions.
+        mock_confirm.assert_called_once()
         message = mock_confirm.call_args[0][0]
         assert "hidden" in message.lower()
         assert "credential" in message.lower() or "sensitive" in message.lower()
         # Declined → command exits before scanning; detector.scan_directory
         # must NOT be called.
         mock_det.scan_directory.assert_not_called()
-        assert result.exit_code == 0
+        # Non-zero exit so shell scripts (`&&` chains, CI gates) can
+        # distinguish user-cancellation from "no duplicates found".
+        assert result.exit_code == 1
 
     @patch("cli.dedupe_v2.confirm_action")
     @patch("cli.dedupe_v2._get_detector")
@@ -330,9 +333,8 @@ class TestDedupeIncludeHidden:
         mock_confirm: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Default ``resolve`` (no ``--include-hidden``) must NOT invoke the
-        hidden-file confirmation. Only the hidden flag triggers the extra
-        gate.
+        """Default ``resolve`` (no ``--include-hidden``) over a non-hidden
+        root must NOT invoke the hidden-file confirmation.
         """
         mock_det = MagicMock()
         mock_get_det.return_value = mock_det
@@ -341,3 +343,32 @@ class TestDedupeIncludeHidden:
         result = runner.invoke(app, ["dedupe", "resolve", str(tmp_path), "--strategy", "oldest"])
         assert result.exit_code == 0
         mock_confirm.assert_not_called()
+
+    @patch("cli.dedupe_v2.confirm_action")
+    @patch("cli.dedupe_v2._get_detector")
+    def test_resolve_hidden_root_triggers_prompt_without_flag(
+        self,
+        mock_get_det: MagicMock,
+        mock_confirm: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """codex P1: ``fo dedupe resolve ~/.ssh --strategy oldest`` traverses
+        the scan root even without ``--include-hidden`` — ``safe_walk``'s
+        hidden filter is relative to root. The confirmation gate must fire
+        based on whether hidden files will actually be scanned, not just the
+        flag. A scan root whose path contains a dot-prefixed component
+        (``.ssh``) qualifies.
+        """
+        hidden_root = tmp_path / ".ssh"
+        hidden_root.mkdir()
+        mock_confirm.return_value = False  # decline
+        mock_det = MagicMock()
+        mock_get_det.return_value = mock_det
+
+        result = runner.invoke(
+            app, ["dedupe", "resolve", str(hidden_root), "--strategy", "oldest"]
+        )
+
+        mock_confirm.assert_called_once()
+        mock_det.scan_directory.assert_not_called()
+        assert result.exit_code == 1

--- a/tests/services/deduplication/test_dedup_detector.py
+++ b/tests/services/deduplication/test_dedup_detector.py
@@ -32,6 +32,10 @@ class TestScanOptions(unittest.TestCase):
         self.assertEqual(opts.algorithm, "sha256")
         self.assertTrue(opts.recursive)
         self.assertFalse(opts.follow_symlinks)
+        # #170: default `include_hidden=False` keeps `.ssh/*` / `.env` out of
+        # the dedupe hash index; `dedupe resolve` can DELETE files, so this
+        # default is load-bearing.
+        self.assertFalse(opts.include_hidden)
         self.assertEqual(opts.min_file_size, 0)
         self.assertIsNone(opts.max_file_size)
         self.assertIsNone(opts.file_patterns)
@@ -199,6 +203,41 @@ class TestDuplicateDetector(unittest.TestCase):
         names = [f.name for f in files]
         self.assertIn("a.txt", names)
         self.assertNotIn("b.log", names)
+
+    def test_find_files_excludes_hidden_by_default(self):
+        """#170: default (``include_hidden=False``) skips dotfiles and files
+        under hidden directories. Hashes of ``.env`` / ``.ssh/id_rsa`` never
+        enter the index so ``dedupe resolve`` can't accidentally delete them.
+        """
+        (self.test_dir / "visible.txt").write_text("v")
+        (self.test_dir / ".env").write_text("SECRET=x")
+        hidden_dir = self.test_dir / ".ssh"
+        hidden_dir.mkdir()
+        (hidden_dir / "id_rsa").write_text("PRIVATE KEY")
+
+        detector = DuplicateDetector()
+        files = detector._find_files(self.test_dir, ScanOptions())
+        names = [f.name for f in files]
+        self.assertIn("visible.txt", names)
+        self.assertNotIn(".env", names)
+        self.assertNotIn("id_rsa", names)
+
+    def test_find_files_includes_hidden_when_opted_in(self):
+        """#170: ``ScanOptions(include_hidden=True)`` plumbs through to
+        ``safe_walk(include_hidden=True)`` — dotfiles and files under hidden
+        directories are indexed."""
+        (self.test_dir / "visible.txt").write_text("v")
+        (self.test_dir / ".env").write_text("k=v")
+        hidden_dir = self.test_dir / ".cache"
+        hidden_dir.mkdir()
+        (hidden_dir / "blob").write_text("cached")
+
+        detector = DuplicateDetector()
+        files = detector._find_files(self.test_dir, ScanOptions(include_hidden=True))
+        names = [f.name for f in files]
+        self.assertIn("visible.txt", names)
+        self.assertIn(".env", names)
+        self.assertIn("blob", names)
 
     def test_group_by_size(self):
         """Test _group_by_size groups correctly."""


### PR DESCRIPTION
Closes #170.

## Summary

PR [#168](https://github.com/curdriceaurora/fo-core/pull/168) switched the dedupe walker to `safe_walk(include_hidden=False)`, removing `.env` / `.ssh/*` / `.config/*` from the dedupe hash index by default. The hardening roadmap (`docs/superpowers/specs/2026-04-22-hardening-roadmap-design.md:80`) explicitly tracked `--include-hidden` as "the first future command that legitimately needs dotfile traversal" — this PR lands that opt-in.

## Plumbing

- `ScanOptions.include_hidden: bool = False` — matches secure post-#168 behaviour.
- `DuplicateDetector._find_files` passes `options.include_hidden` into `safe_walk`.
- `fo dedupe scan|resolve|report` grow a `--include-hidden` flag.

## Safety gate for `resolve`

`resolve --include-hidden` invokes `confirm_action` with:

> Hidden files (`.env`, `.ssh/*`, `.config/*`, etc.) will be hashed and may be deleted as duplicates — including potentially sensitive credentials. Continue?

`--yes` / `--no-interactive` honour their usual semantics. Declining aborts before scanning (`scan_directory` is not called).

## Rationale

Resolves the #168 review split:
- codex P2 wanted `include_hidden=True` to preserve pre-migration behaviour.
- coderabbit MAJOR wanted secure defaults because `resolve` DELETES files.

Secure default (coderabbit) + explicit opt-in with credential-risk prompt (covers codex's legitimate-workflow use case).

## Test plan

- [x] `TestScanOptions.test_defaults` asserts `include_hidden is False`.
- [x] `test_find_files_excludes_hidden_by_default` / `test_find_files_includes_hidden_when_opted_in` exercise the detector plumbing.
- [x] `TestDedupeIncludeHidden` (new class) covers all three commands + the resolve confirmation gate (`confirm_action` invoked, `scan_directory` NOT called on decline).
- [x] Pre-commit validation passes (all gates green locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--include-hidden` option to the scan, resolve, and report commands to explicitly include hidden files and directories in deduplication operations.

* **Improvements**
  * Hidden files are now excluded from deduplication by default for improved safety; a confirmation prompt appears when running resolve with `--include-hidden` before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->