### PR TITLE
hardening(security): epic-a-creds — log-redacting filter (A3)

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -85,6 +85,15 @@ def main_callback(
     )
 
     from cli.interactive import set_flags
+    from utils.log_redact import install_on_root
+
+    # A.creds: attach the credential-redacting log filter to the root logger
+    # so every ``logging.getLogger(__name__)`` in ``src/`` inherits protection
+    # against api_key / token / secret / password / bearer leaks — even when
+    # a future code path accidentally stuffs a secret into a log message or
+    # exception args. Installed at the CLI entry point so the filter exists
+    # before any command runs.
+    install_on_root()
 
     set_flags(yes=yes, no_interactive=no_interactive)
 

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -185,10 +185,14 @@ def _install_on_loguru(instance: CredentialRedactingFilter) -> bool:
         # scrubbed message + exception message caught at emission.
         if exc is not None:
             try:
-                exc_text = "".join(
-                    traceback.format_exception(exc.type, exc.value, exc.traceback)
-                )
+                exc_text = "".join(traceback.format_exception(exc.type, exc.value, exc.traceback))
             except Exception:
+                # Buggy ``__str__``/``__repr__`` on the exception itself.
+                # Surface the redacted sentinel so consumers know the
+                # exception was suppressed for safety rather than silently
+                # dropped (the silent-broad-except CI guardrail requires a
+                # non-silent statement in the handler body).
+                record["extra"]["redacted_exception"] = REDACTED
                 return
             # Loguru emits the exception block separately from the message;
             # stash the scrubbed text on the record under a dedicated key

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -98,46 +98,47 @@ class CredentialRedactingFilter(logging.Filter):
         so the formatted-and-redacted string is what ``getMessage()``
         returns.
         """
+        # --- Message redaction (args-present and no-args paths) ---
+        # ``getMessage()`` runs ``record.msg % record.args`` which invokes
+        # each arg's ``__str__`` / ``__repr__``. A bug in any of those
+        # (custom ``Exception`` subclass, buggy ``__str__`` raising
+        # ``RuntimeError`` / ``AttributeError``, etc.) must NOT escape
+        # the filter — we're attached via ``setLogRecordFactory`` so this
+        # runs on EVERY ``logger.*()`` call, and escalating here would
+        # break the caller's normal execution including records that
+        # would otherwise be dropped later by level filtering. Every
+        # blind catch below leaves the record untouched and returns
+        # ``True`` so ``logging`` surfaces the error via its own handler.
         if record.args:
             try:
                 formatted = record.getMessage()
             except Exception:
-                # ``getMessage()`` runs ``record.msg % record.args`` which
-                # invokes each arg's ``__str__`` / ``__repr__``. A bug in
-                # either (custom ``Exception`` subclass, buggy ``__str__``
-                # that raises ``RuntimeError`` / ``AttributeError``, etc.)
-                # must NOT escape the filter. We're attached via
-                # ``setLogRecordFactory`` so this runs on EVERY
-                # ``logger.*()`` call — escalating here would break the
-                # caller's normal execution, including records that would
-                # otherwise be dropped later by level filtering. Swallow
-                # any exception, leave the record untouched, and let
-                # ``logging`` surface the error via its own handler path
-                # when the downstream ``emit()`` re-attempts the format.
                 return True
             record.msg = _redact_text(formatted)
             record.args = None
-            return True
-        # No-args branch. Always stringify ``record.msg`` before redacting —
-        # callers can pass non-string objects (``logger.info({"api_key":
-        # "..."})`` or any custom object whose ``__str__`` returns
-        # ``"token=..."``). ``LogRecord.getMessage()`` would ``str()`` them
-        # at emission time and leak the credential; we must redact that
-        # same string representation here. Same blind-catch rationale as
-        # above — a buggy ``__str__`` must not escape.
-        try:
-            rendered = str(record.msg)
-        except Exception:
-            return True
-        record.msg = _redact_text(rendered)
-        # codex P1: ``logger.exception()`` / ``logger.*(..., exc_info=True)``
-        # attaches a ``(type, value, traceback)`` tuple at ``record.exc_info``.
-        # The default formatter later calls ``formatException`` and caches
-        # the result in ``record.exc_text`` — at which point the raw
-        # exception message (e.g. ``RuntimeError("api_key=sk-xxx")``) is
-        # rendered verbatim into the log output. Pre-format and redact the
-        # traceback now so the formatter's "use cached exc_text if already
-        # set" branch picks up our scrubbed version instead.
+        else:
+            # No-args branch. Always stringify ``record.msg`` before
+            # redacting — callers can pass non-string objects
+            # (``logger.info({"api_key": "..."})`` or any custom object
+            # whose ``__str__`` returns ``"token=..."``).
+            try:
+                rendered = str(record.msg)
+            except Exception:
+                return True
+            record.msg = _redact_text(rendered)
+
+        # --- Traceback redaction (applies to BOTH branches) ---
+        # ``logger.exception()`` / ``logger.*(..., exc_info=True)``
+        # attaches a ``(type, value, traceback)`` tuple at
+        # ``record.exc_info``. The default formatter later calls
+        # ``formatException`` and caches the result in ``record.exc_text``
+        # — at which point the raw exception message (e.g.
+        # ``RuntimeError("api_key=sk-xxx")``) is rendered verbatim into
+        # the log output. Pre-format and redact the traceback now so the
+        # formatter's "use cached exc_text if already set" branch picks
+        # up our scrubbed version instead. Critical: this must run even
+        # in the args branch (codex P1:
+        # ``logger.error("msg: %s", value, exc_info=True)``).
         if record.exc_info:
             try:
                 exc_text = "".join(traceback.format_exception(*record.exc_info))
@@ -187,17 +188,32 @@ def _install_on_loguru(instance: CredentialRedactingFilter) -> bool:
             try:
                 exc_text = "".join(traceback.format_exception(exc.type, exc.value, exc.traceback))
             except Exception:
-                # Buggy ``__str__``/``__repr__`` on the exception itself.
-                # Surface the redacted sentinel so consumers know the
-                # exception was suppressed for safety rather than silently
-                # dropped (the silent-broad-except CI guardrail requires a
-                # non-silent statement in the handler body).
-                record["extra"]["redacted_exception"] = REDACTED
+                # Buggy ``__str__`` / ``__repr__`` on the exception itself.
+                # Can't safely format, so drop the exception payload
+                # entirely rather than let loguru render the original via
+                # the same buggy call path. Non-silent statement satisfies
+                # the silent-broad-except CI guardrail.
+                record["exception"] = None
                 return
-            # Loguru emits the exception block separately from the message;
-            # stash the scrubbed text on the record under a dedicated key
-            # that the default formatter appends via ``{exception}``.
-            record["extra"]["redacted_exception"] = _redact_text(exc_text)
+            redacted = _redact_text(exc_text)
+            # codex P1 (PRRT_kwDOR_Rkws59HjtX): the default loguru
+            # formatter renders the exception block from
+            # ``record["exception"]`` via ``traceback.format_exception`` —
+            # a stashed ``record["extra"][...]`` is never consumed.
+            # Replace the entire exception payload with a sanitized
+            # ``RecordException`` whose value is a plain
+            # ``Exception(redacted)`` and whose traceback is stripped (we
+            # already formatted+scrubbed it into the exception's message).
+            try:
+                from loguru._recattrs import RecordException  # type: ignore[import-untyped]
+            except ImportError:
+                # Internal API moved — fall back to dropping the exception
+                # block entirely. Still prevents the leak while degrading
+                # gracefully. Non-silent statement.
+                record["exception"] = None
+                return
+            sanitized = Exception(redacted)
+            record["exception"] = RecordException(type(sanitized), sanitized, None)
 
     # ``patcher`` runs on every record; installing twice would stack, so
     # configure with a single canonical patcher. ``logger.configure``

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -100,9 +100,19 @@ class CredentialRedactingFilter(logging.Filter):
         if record.args:
             try:
                 formatted = record.getMessage()
-            except (TypeError, ValueError):
-                # Malformed template — let ``logging`` surface the error
-                # via its own handler rather than swallow it here.
+            except Exception:  # noqa: BLE001 — see rationale below
+                # ``getMessage()`` runs ``record.msg % record.args`` which
+                # invokes each arg's ``__str__`` / ``__repr__``. A bug in
+                # either (custom ``Exception`` subclass, buggy ``__str__``
+                # that raises ``RuntimeError`` / ``AttributeError``, etc.)
+                # must NOT escape the filter. We're attached via
+                # ``setLogRecordFactory`` so this runs on EVERY
+                # ``logger.*()`` call — escalating here would break the
+                # caller's normal execution, including records that would
+                # otherwise be dropped later by level filtering. Swallow
+                # any exception, leave the record untouched, and let
+                # ``logging`` surface the error via its own handler path
+                # when the downstream ``emit()`` re-attempts the format.
                 return True
             record.msg = _redact_text(formatted)
             record.args = None

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -60,7 +60,13 @@ _KV_PATTERN = re.compile(
 
 # ``Authorization: Bearer <token>`` HTTP header shape. Distinct from the
 # ``key=value`` pattern because the separator is whitespace rather than ``=``.
-_BEARER_PATTERN = re.compile(r"(?i)(?P<prefix>authorization:\s*bearer\s+)(?P<value>[^\s,;}]+)")
+# Allows optional quotes around both the key and the separator so dict-repr
+# (``{'Authorization': 'Bearer abc'}``) and JSON (``"Authorization":
+# "Bearer abc"``) forms also match — logger calls that pass header dicts
+# are a real leak path (codex P1 PRRT_kwDOR_Rkws59IB5U).
+_BEARER_PATTERN = re.compile(
+    r"(?i)(?P<prefix>authorization[\"']?\s*:\s*[\"']?bearer\s+)(?P<value>[^\"'\s,;}]+)"
+)
 
 
 def _redact_text(text: str) -> str:

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import re
+import traceback
 from collections.abc import Iterable
 
 REDACTED = "[REDACTED]"
@@ -129,7 +130,78 @@ class CredentialRedactingFilter(logging.Filter):
         except Exception:
             return True
         record.msg = _redact_text(rendered)
+        # codex P1: ``logger.exception()`` / ``logger.*(..., exc_info=True)``
+        # attaches a ``(type, value, traceback)`` tuple at ``record.exc_info``.
+        # The default formatter later calls ``formatException`` and caches
+        # the result in ``record.exc_text`` — at which point the raw
+        # exception message (e.g. ``RuntimeError("api_key=sk-xxx")``) is
+        # rendered verbatim into the log output. Pre-format and redact the
+        # traceback now so the formatter's "use cached exc_text if already
+        # set" branch picks up our scrubbed version instead.
+        if record.exc_info:
+            try:
+                exc_text = "".join(traceback.format_exception(*record.exc_info))
+            except Exception:
+                return True
+            record.exc_text = _redact_text(exc_text)
         return True
+
+
+def _install_on_loguru(instance: CredentialRedactingFilter) -> bool:
+    """Register a patcher on the Loguru logger that redacts every record.
+
+    Parts of the codebase (``src/models/_openai_client.py``,
+    ``src/models/_claude_client.py``) use Loguru rather than the stdlib
+    ``logging`` module. Loguru records don't go through
+    ``setLogRecordFactory``, so a stdlib-only install leaves Loguru paths
+    unprotected. Loguru's patcher API (``logger.configure(patcher=fn)``
+    since 0.6) runs ``fn`` on every record dict before emission, which is
+    the symmetric hook point.
+
+    Returns ``True`` if loguru was installed, ``False`` if loguru is
+    unavailable (the dep is declared as a base requirement in
+    ``pyproject.toml`` but importing can still fail in minimal test envs).
+    """
+    try:
+        from loguru import logger as loguru_logger
+    except ImportError:  # pragma: no cover — loguru is a base dep
+        return False
+
+    from typing import Any
+
+    def _patcher(record: Any) -> None:
+        # Loguru record: ``{'message': str, 'exception': RecordException | None, ...}``.
+        # Redact the main message and the exception repr (which loguru
+        # stringifies during emission just like logging's exc_info path).
+        msg = record.get("message")
+        if isinstance(msg, str):
+            record["message"] = _redact_text(msg)
+        exc = record.get("exception")
+        # ``RecordException`` is a namedtuple-ish object with ``type``,
+        # ``value``, ``traceback``. We redact ``value``'s str representation
+        # by replacing the exception with a re-formatted version, but the
+        # simplest safe thing is to scrub the message via loguru's built-in
+        # pre-formatted repr. Best-effort: stringify and rely on the
+        # scrubbed message + exception message caught at emission.
+        if exc is not None:
+            try:
+                exc_text = "".join(
+                    traceback.format_exception(exc.type, exc.value, exc.traceback)
+                )
+            except Exception:
+                return
+            # Loguru emits the exception block separately from the message;
+            # stash the scrubbed text on the record under a dedicated key
+            # that the default formatter appends via ``{exception}``.
+            record["extra"]["redacted_exception"] = _redact_text(exc_text)
+
+    # ``patcher`` runs on every record; installing twice would stack, so
+    # configure with a single canonical patcher. ``logger.configure``
+    # replaces the patcher rather than appending, making this idempotent.
+    loguru_logger.configure(patcher=_patcher)
+    # Keep a reference for potential teardown by tests.
+    instance._loguru_patcher = _patcher  # type: ignore[attr-defined]
+    return True
 
 
 def install_on_root(extra_loggers: Iterable[str] = ()) -> CredentialRedactingFilter:
@@ -180,4 +252,8 @@ def install_on_root(extra_loggers: Iterable[str] = ()) -> CredentialRedactingFil
     logging.getLogger().addFilter(instance)
     for name in extra_loggers:
         logging.getLogger(name).addFilter(instance)
+    # codex P1: Loguru has its own record pipeline that doesn't go through
+    # ``setLogRecordFactory``. Install a symmetric patcher so loguru-based
+    # log sites (``_openai_client.py``, ``_claude_client.py``) are covered.
+    _install_on_loguru(instance)
     return instance

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -100,7 +100,7 @@ class CredentialRedactingFilter(logging.Filter):
         if record.args:
             try:
                 formatted = record.getMessage()
-            except Exception:  # noqa: BLE001 — see rationale below
+            except Exception:
                 # ``getMessage()`` runs ``record.msg % record.args`` which
                 # invokes each arg's ``__str__`` / ``__repr__``. A bug in
                 # either (custom ``Exception`` subclass, buggy ``__str__``

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -100,10 +100,30 @@ class CredentialRedactingFilter(logging.Filter):
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
-        if isinstance(record.msg, str):
-            record.msg = _redact_text(record.msg)
+        """Redact ``record`` in-place. Always returns ``True`` (never drops).
+
+        When ``record.args`` is non-empty, the record is a template +
+        arguments pair (e.g. ``logger.info("api_key=%s", secret)``).
+        Running the redact pattern on ``record.msg`` alone can strip ``%s``
+        placeholders while leaving ``record.args`` intact, and the
+        downstream ``record.getMessage()`` then raises ``TypeError`` —
+        Python's logging error handler would print the raw ``args`` tuple
+        (including the unredacted secret) to stderr. Avoid that by
+        formatting first and redacting the result, then clearing ``args``
+        so the formatted-and-redacted string is what ``getMessage()``
+        returns.
+        """
         if record.args:
-            record.args = _redact_args(record.args)  # type: ignore[assignment]
+            try:
+                formatted = record.getMessage()
+            except (TypeError, ValueError):
+                # Malformed template — let ``logging`` surface the error
+                # via its own handler rather than swallow it here.
+                return True
+            record.msg = _redact_text(formatted)
+            record.args = None
+        elif isinstance(record.msg, str):
+            record.msg = _redact_text(record.msg)
         return True
 
 

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -116,8 +116,19 @@ class CredentialRedactingFilter(logging.Filter):
                 return True
             record.msg = _redact_text(formatted)
             record.args = None
-        elif isinstance(record.msg, str):
-            record.msg = _redact_text(record.msg)
+            return True
+        # No-args branch. Always stringify ``record.msg`` before redacting —
+        # callers can pass non-string objects (``logger.info({"api_key":
+        # "..."})`` or any custom object whose ``__str__`` returns
+        # ``"token=..."``). ``LogRecord.getMessage()`` would ``str()`` them
+        # at emission time and leak the credential; we must redact that
+        # same string representation here. Same blind-catch rationale as
+        # above — a buggy ``__str__`` must not escape.
+        try:
+            rendered = str(record.msg)
+        except Exception:
+            return True
+        record.msg = _redact_text(rendered)
         return True
 
 

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -54,30 +54,31 @@ _CRED_KEYS = (
     "credential",
 )
 # ``key`` + optional quotes + ``=`` or ``:`` + value. The value arm has
-# three alternatives so each form stops on the correct delimiter:
+# five alternatives ordered so each form stops on the correct delimiter:
 #
-# 1. Double-quoted (``password="abc'def"``) — allows single quotes and
-#    backslash-escaped double quotes inside (``password="abc\\"def"``);
-#    terminates on the first UNESCAPED ``"``.
-# 2. Single-quoted (``password='abc"def'``) — mirror case with escape
-#    support; terminates on the first unescaped ``'``.
-# 3. Unquoted — stops at whitespace / delimiter.
+# 1. Double-quoted, closed (``password="abc'def"``) — allows single
+#    quotes and ``\\"`` escapes inside; terminates on unescaped ``"``.
+# 2. Single-quoted, closed — mirror case.
+# 3. Double-quoted, UNCLOSED (``password="super secret``, truncated log
+#    or malformed template) — eats everything up to end of line so the
+#    remainder of the credential doesn't leak (codex P1
+#    PRRT_kwDOR_Rkws59IsZr). Over-redaction here is safer than leak.
+# 4. Single-quoted, unclosed — mirror case.
+# 5. Unquoted — stops at whitespace / delimiter.
 #
-# The quoted alternatives use the classic ``(?:[^Q\\]|\\.)*`` tokenizer
-# idiom — a sequence of non-delimiter / non-backslash characters OR
-# a backslash followed by any character. Without this, JSON-escaped
-# secrets leak (codex P1 PRRT_kwDOR_Rkws59IhT6:
-# ``password="abc\\"def secret"`` previously became
-# ``password="[REDACTED]"def secret"``).
-#
-# The key is kept in the replacement so the log line still tells you
-# *which* credential leaked — just not what.
+# The alternation order matters: the closed variants must come before
+# the unclosed ones so well-formed quoted values don't accidentally get
+# consumed by the greedy unclosed fallback.
 _KV_PATTERN = re.compile(
     r"(?i)(?P<key>(?:" + "|".join(_CRED_KEYS) + r")[\"']?\s*[:=]\s*)"
     r"(?:"
     r'"(?P<qvalue_dq>(?:[^"\\]|\\.)*)"'
     r"|"
     r"'(?P<qvalue_sq>(?:[^'\\]|\\.)*)'"
+    r"|"
+    r'"(?P<mvalue_dq>[^\r\n]*)'
+    r"|"
+    r"'(?P<mvalue_sq>[^\r\n]*)"
     r"|"
     r"(?P<value>[^\"'\s,;&}\])]+)"
     r")"
@@ -101,15 +102,21 @@ _BEARER_PATTERN = re.compile(
 def _kv_replace(match: re.Match[str]) -> str:
     """``_KV_PATTERN`` callback: preserve the quote shape when redacting.
 
-    When a quoted branch matched, wrap ``REDACTED`` in the matching quote
-    character so the output keeps a valid quoted form. The ``is not None``
-    check (rather than truthy) matters for empty-string values —
+    Five branches, ordered the same as the pattern: closed dq/sq first
+    (wrap REDACTED in matching quotes), then unclosed dq/sq (preserve the
+    opening quote, emit REDACTED but no close — output stays recognisable
+    as a truncated quoted value), then unquoted. The ``is not None`` check
+    (rather than truthy) matters for empty-string values —
     ``password=""`` has ``qvalue_dq = ""`` which is falsy but not None.
     """
     if match.group("qvalue_dq") is not None:
         return f'{match.group("key")}"{REDACTED}"'
     if match.group("qvalue_sq") is not None:
         return f"{match.group('key')}'{REDACTED}'"
+    if match.group("mvalue_dq") is not None:
+        return f'{match.group("key")}"{REDACTED}'
+    if match.group("mvalue_sq") is not None:
+        return f"{match.group('key')}'{REDACTED}"
     return f"{match.group('key')}{REDACTED}"
 
 

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -1,0 +1,158 @@
+"""Credential-redacting ``logging.Filter`` (A3, hardening roadmap).
+
+Project-wide safety net for the common shapes in which API keys, tokens,
+passwords and bearer credentials accidentally end up in log records. The
+existing model-client code already avoids logging the key directly (see
+``models/_openai_client.py:74`` and ``models/_claude_client.py:69``, both of
+which log ``type(e).__name__`` rather than the exception message), but
+future code paths can still reach a ``logger.info("api_key=%s", ...)`` by
+accident — the filter exists so the mistake fails closed.
+
+Contract:
+
+- ``CredentialRedactingFilter.filter`` always returns ``True``. The filter's
+  job is redaction, not level-based suppression — handler levels and
+  downstream filters still decide emission.
+- Both the inline message (``record.msg``) and the positional format args
+  (``record.args``) are scrubbed. ``record.getMessage()`` continues to work.
+- ``REDACTED`` is a module-level public constant so tests and integration
+  assertions can reference the exact replacement token without duplicating
+  its string form.
+
+The filter is attached to the root logger in ``cli.main`` so every
+``logging.getLogger(__name__)`` inherits the protection.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterable
+
+REDACTED = "[REDACTED]"
+
+# Keys that, when seen as the left-hand side of ``key=value`` / ``key: value``
+# / ``key="value"`` in a log message, should have their right-hand side
+# replaced with ``REDACTED``. Hyphen and underscore spellings both covered
+# (api_key vs api-key). Matched case-insensitively via the ``(?i)`` in the
+# assembled pattern below.
+_CRED_KEYS = (
+    "api[_-]?key",
+    "api[_-]?token",
+    "access[_-]?token",
+    "auth[_-]?token",
+    "bearer[_-]?token",
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "credential",
+)
+# ``key`` + optional quotes + ``=`` or ``:`` + optional quotes, followed by
+# the value we want to capture (everything up to whitespace / a quote /
+# a delimiter). The key is kept in the replacement so the log line still
+# tells you *which* credential leaked — just not what.
+_KV_PATTERN = re.compile(
+    r"(?i)(?P<key>(?:" + "|".join(_CRED_KEYS) + r")[\"']?\s*[:=]\s*[\"']?)"
+    r"(?P<value>[^\"'\s,;&}\])]+)"
+)
+
+# ``Authorization: Bearer <token>`` HTTP header shape. Distinct from the
+# ``key=value`` pattern because the separator is whitespace rather than ``=``.
+_BEARER_PATTERN = re.compile(r"(?i)(?P<prefix>authorization:\s*bearer\s+)(?P<value>[^\s,;}]+)")
+
+
+def _redact_text(text: str) -> str:
+    """Apply all credential patterns to ``text``.
+
+    Returns a new string; the original is not mutated. Order of application
+    doesn't matter because the patterns don't overlap.
+    """
+    text = _KV_PATTERN.sub(lambda m: f"{m.group('key')}{REDACTED}", text)
+    text = _BEARER_PATTERN.sub(lambda m: f"{m.group('prefix')}{REDACTED}", text)
+    return text
+
+
+def _redact_args(args: object) -> object:
+    """Redact each positional format arg.
+
+    ``record.args`` is either a tuple, a mapping (``%(name)s`` style), or a
+    single value. Preserve the shape — ``logging`` will try to format with
+    whatever we return.
+    """
+    if isinstance(args, tuple):
+        return tuple(_redact_text(str(a)) if isinstance(a, str) else a for a in args)
+    if isinstance(args, dict):
+        return {k: _redact_text(str(v)) if isinstance(v, str) else v for k, v in args.items()}
+    if isinstance(args, str):
+        return _redact_text(args)
+    return args
+
+
+class CredentialRedactingFilter(logging.Filter):
+    """Redact credential-shaped substrings in log records. Never drops.
+
+    Attach to the root logger (or any parent logger) so every child logger
+    inherits the filter. Per the ``logging`` module semantics, a filter on
+    a logger applies to records that *originate* at that logger; filters
+    on a handler apply to records routed through it. For maximum coverage
+    the attachment point is the root logger in ``cli.main``.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.msg, str):
+            record.msg = _redact_text(record.msg)
+        if record.args:
+            record.args = _redact_args(record.args)  # type: ignore[assignment]
+        return True
+
+
+def install_on_root(extra_loggers: Iterable[str] = ()) -> CredentialRedactingFilter:
+    """Install the redacting filter process-wide via ``setLogRecordFactory``.
+
+    Python ``logging`` applies ``Logger`` filters only at the logger where a
+    record *originates*; propagation to ancestor handlers does not re-run
+    ancestor filters. Attaching a filter to the root logger therefore does
+    NOT cover records emitted by child loggers (the common case — every
+    ``logging.getLogger(__name__)`` in ``src/``).
+
+    The fix is to wrap the global ``LogRecordFactory`` so redaction happens
+    at record construction time, before any logger/handler sees it. Every
+    record — regardless of originating logger or handler chain — is
+    redacted. For symmetry we also add the filter to the root logger and
+    any ``extra_loggers`` so ``logger.filter(record)`` continues to apply
+    the same sanitisation to records constructed outside our factory
+    (rare, but possible).
+
+    Idempotent: calling twice installs exactly one factory wrapper (the
+    second call is a no-op if our wrapper is already the active factory).
+    Tests that need to restore the original factory can read
+    ``filter_instance._original_factory`` and pass it back to
+    ``logging.setLogRecordFactory``.
+
+    Args:
+        extra_loggers: Additional named loggers to attach the filter to
+            as a belt-and-suspenders symmetric install.
+
+    Returns:
+        The installed filter instance. Callers may hold it for teardown.
+    """
+    instance = CredentialRedactingFilter()
+    current_factory = logging.getLogRecordFactory()
+    # Detect our own wrapper by a sentinel attribute so repeated installs
+    # don't stack wrappers.
+    if not getattr(current_factory, "_fo_log_redact_installed", False):
+
+        def _redacting_factory(*args: object, **kwargs: object) -> logging.LogRecord:
+            record = current_factory(*args, **kwargs)
+            instance.filter(record)
+            return record
+
+        _redacting_factory._fo_log_redact_installed = True  # type: ignore[attr-defined]
+        instance._original_factory = current_factory  # type: ignore[attr-defined]
+        logging.setLogRecordFactory(_redacting_factory)
+
+    logging.getLogger().addFilter(instance)
+    for name in extra_loggers:
+        logging.getLogger(name).addFilter(instance)
+    return instance

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -53,6 +53,14 @@ _CRED_KEYS = (
     "passwd",
     "credential",
 )
+# Full-match form of the credential-key list, for matching dict-arg names
+# in mapping-style format logs (``logger.info("%(api_key)s", {"api_key":
+# ...})``). ``_KV_PATTERN`` catches the ``key=value`` text shape, but
+# mapping-style interpolation strips the key name before emission —
+# ``getMessage()`` returns only the raw value, which doesn't match any
+# text pattern. So we scrub credential-named dict keys BEFORE formatting
+# (codex P1 PRRT_kwDOR_Rkws59I2zc).
+_CRED_KEY_FULL = re.compile(r"(?i)^(?:" + "|".join(_CRED_KEYS) + r")$")
 # ``key`` + optional quotes + ``=`` or ``:`` + value. The value arm has
 # five alternatives ordered so each form stops on the correct delimiter:
 #
@@ -197,6 +205,16 @@ class CredentialRedactingFilter(logging.Filter):
         # open") is wrong for a credential safety net — the whole point
         # is that unknown-shape inputs get masked, not passed through.
         if record.args:
+            # Pre-scrub mapping-style args: ``logger.info("%(api_key)s",
+            # {"api_key": secret})`` interpolates just the raw value, so
+            # post-format text redaction has no key=value shape to match.
+            # Replace credential-named dict values with the REDACTED
+            # sentinel before ``getMessage()`` sees them.
+            if isinstance(record.args, dict):
+                record.args = {
+                    k: (REDACTED if isinstance(k, str) and _CRED_KEY_FULL.match(k) else v)
+                    for k, v in record.args.items()
+                }
             try:
                 formatted = record.getMessage()
             except Exception:

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -43,6 +43,10 @@ _CRED_KEYS = (
     "access[_-]?token",
     "auth[_-]?token",
     "bearer[_-]?token",
+    # Bare ``auth`` is a common shorthand (``logger.info("auth=%s", secret)``).
+    # Won't false-positive on ``author=`` etc. because the pattern requires
+    # the key to be immediately followed by ``=``/``:`` (optional quote).
+    "auth",
     "token",
     "secret",
     "password",
@@ -78,6 +82,21 @@ def _redact_text(text: str) -> str:
     text = _KV_PATTERN.sub(lambda m: f"{m.group('key')}{REDACTED}", text)
     text = _BEARER_PATTERN.sub(lambda m: f"{m.group('prefix')}{REDACTED}", text)
     return text
+
+
+def _sanitize_args(args: object) -> object:
+    """Replace every arg with ``REDACTED`` (fail-closed fallback).
+
+    Used on exception paths where we couldn't format the template safely —
+    logging's own error handler would otherwise print the raw ``record.args``
+    tuple to stderr on format failure, which could leak a secret. Return a
+    same-shape (tuple / dict / scalar) value with sentinels.
+    """
+    if isinstance(args, tuple):
+        return tuple(REDACTED for _ in args)
+    if isinstance(args, dict):
+        return dict.fromkeys(args, REDACTED)
+    return REDACTED
 
 
 class CredentialRedactingFilter(logging.Filter):
@@ -122,16 +141,29 @@ class CredentialRedactingFilter(logging.Filter):
         # the filter — we're attached via ``setLogRecordFactory`` so this
         # runs on EVERY ``logger.*()`` call, and escalating here would
         # break the caller's normal execution including records that
-        # would otherwise be dropped later by level filtering. Every
-        # blind catch below leaves the record untouched and returns
-        # ``True`` so ``logging`` surfaces the error via its own handler.
+        # would otherwise be dropped later by level filtering.
+        #
+        # Fail-CLOSED posture: on exception paths, clear ``record.args``
+        # to sentinel REDACTED entries so logging's own error handler
+        # (which prints the raw args tuple to stderr on format failure)
+        # can't leak the secret. Preserving the original args ("fail
+        # open") is wrong for a credential safety net — the whole point
+        # is that unknown-shape inputs get masked, not passed through.
         if record.args:
             try:
                 formatted = record.getMessage()
             except Exception:
-                return True
-            record.msg = _redact_text(formatted)
-            record.args = None
+                try:
+                    record.msg = _redact_text(str(record.msg))
+                except Exception:
+                    record.msg = REDACTED
+                # ``record.args`` is typed as ``tuple | Mapping | None``;
+                # ``_sanitize_args`` preserves the shape (tuple→tuple,
+                # dict→dict, scalar→str). Cast covers the fallback scalar.
+                record.args = _sanitize_args(record.args)  # type: ignore[assignment]
+            else:
+                record.msg = _redact_text(formatted)
+                record.args = None
         else:
             # No-args branch. Always stringify ``record.msg`` before
             # redacting — callers can pass non-string objects
@@ -140,8 +172,9 @@ class CredentialRedactingFilter(logging.Filter):
             try:
                 rendered = str(record.msg)
             except Exception:
-                return True
-            record.msg = _redact_text(rendered)
+                record.msg = REDACTED
+            else:
+                record.msg = _redact_text(rendered)
 
         # --- Traceback redaction (applies to BOTH branches) ---
         # ``logger.exception()`` / ``logger.*(..., exc_info=True)``

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -87,6 +87,14 @@ class CredentialRedactingFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         """Redact ``record`` in-place. Always returns ``True`` (never drops).
 
+        Idempotent: a sentinel attribute ``_fo_redacted`` is set on the
+        record after the first pass so subsequent invocations (e.g. from
+        both the ``setLogRecordFactory`` wrapper AND a duplicate
+        logger-level filter attachment) short-circuit. Without this guard,
+        the non-idempotent redact pattern would double-bracket already-
+        scrubbed values (``api_key=[REDACTED]`` → ``api_key=[REDACTED]]``)
+        for root-originated records, corrupting output.
+
         When ``record.args`` is non-empty, the record is a template +
         arguments pair (e.g. ``logger.info("api_key=%s", secret)``).
         Running the redact pattern on ``record.msg`` alone can strip ``%s``
@@ -98,6 +106,8 @@ class CredentialRedactingFilter(logging.Filter):
         so the formatted-and-redacted string is what ``getMessage()``
         returns.
         """
+        if getattr(record, "_fo_redacted", False):
+            return True
         # --- Message redaction (args-present and no-args paths) ---
         # ``getMessage()`` runs ``record.msg % record.args`` which invokes
         # each arg's ``__str__`` / ``__repr__``. A bug in any of those
@@ -145,6 +155,11 @@ class CredentialRedactingFilter(logging.Filter):
             except Exception:
                 return True
             record.exc_text = _redact_text(exc_text)
+        # Mark the record so subsequent filter invocations (duplicate
+        # logger-level filter attachment, factory + filter combo) skip the
+        # re-redact pass. Essential because ``_KV_PATTERN`` isn't
+        # idempotent on already-bracketed ``[REDACTED]`` values.
+        record._fo_redacted = True
         return True
 
 
@@ -171,6 +186,11 @@ def _install_on_loguru(instance: CredentialRedactingFilter) -> bool:
     from typing import Any
 
     def _patcher(record: Any) -> None:
+        # Idempotency: a prior pass (duplicate install) marked this record,
+        # skip to avoid double-redaction corrupting ``[REDACTED]`` brackets.
+        extra = record.get("extra") or {}
+        if extra.get("_fo_redacted"):
+            return
         # Loguru record: ``{'message': str, 'exception': RecordException | None, ...}``.
         # Redact the main message and the exception repr (which loguru
         # stringifies during emission just like logging's exc_info path).
@@ -214,6 +234,8 @@ def _install_on_loguru(instance: CredentialRedactingFilter) -> bool:
                 return
             sanitized = Exception(redacted)
             record["exception"] = RecordException(type(sanitized), sanitized, None)
+        # Mark this record so duplicate patcher installs skip the rewrite.
+        record["extra"]["_fo_redacted"] = True
 
     # ``patcher`` runs on every record; installing twice would stack, so
     # configure with a single canonical patcher. ``logger.configure``

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -205,7 +205,7 @@ def _install_on_loguru(instance: CredentialRedactingFilter) -> bool:
             # ``Exception(redacted)`` and whose traceback is stripped (we
             # already formatted+scrubbed it into the exception's message).
             try:
-                from loguru._recattrs import RecordException  # type: ignore[import-untyped]
+                from loguru._recattrs import RecordException
             except ImportError:
                 # Internal API moved — fall back to dropping the exception
                 # block entirely. Still prevents the leak while degrading

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import logging
 import re
 import traceback
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 
 REDACTED = "[REDACTED]"
 
@@ -208,9 +208,13 @@ class CredentialRedactingFilter(logging.Filter):
             # Pre-scrub mapping-style args: ``logger.info("%(api_key)s",
             # {"api_key": secret})`` interpolates just the raw value, so
             # post-format text redaction has no key=value shape to match.
-            # Replace credential-named dict values with the REDACTED
-            # sentinel before ``getMessage()`` sees them.
-            if isinstance(record.args, dict):
+            # Replace credential-named mapping values with the REDACTED
+            # sentinel before ``getMessage()`` sees them. ``collections.
+            # abc.Mapping`` covers ``UserDict``, ``MappingProxyType``, and
+            # third-party mapping types that ``logging`` also accepts for
+            # mapping-style interpolation (codex P2
+            # PRRT_kwDOR_Rkws59JMYx).
+            if isinstance(record.args, Mapping):
                 record.args = {
                     k: (REDACTED if isinstance(k, str) and _CRED_KEY_FULL.match(k) else v)
                     for k, v in record.args.items()

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -56,26 +56,28 @@ _CRED_KEYS = (
 # ``key`` + optional quotes + ``=`` or ``:`` + value. The value arm has
 # three alternatives so each form stops on the correct delimiter:
 #
-# 1. Double-quoted (``password="abc'def"``) — allows single quotes inside,
-#    terminates on the closing ``"``.
-# 2. Single-quoted (``password='abc"def'``) — allows double quotes inside,
-#    terminates on the closing ``'``.
+# 1. Double-quoted (``password="abc'def"``) — allows single quotes and
+#    backslash-escaped double quotes inside (``password="abc\\"def"``);
+#    terminates on the first UNESCAPED ``"``.
+# 2. Single-quoted (``password='abc"def'``) — mirror case with escape
+#    support; terminates on the first unescaped ``'``.
 # 3. Unquoted — stops at whitespace / delimiter.
 #
-# Earlier versions used a single quoted alternative with ``[^\"']*`` which
-# forbade BOTH quote characters and missed mixed-punctuation secrets
-# (codex P1 PRRT_kwDOR_Rkws59IYi1). Splitting into separate dq / sq
-# branches is the standard regex-engine-agnostic fix because
-# ``[^(?P=q)]`` inside a character class isn't supported.
+# The quoted alternatives use the classic ``(?:[^Q\\]|\\.)*`` tokenizer
+# idiom — a sequence of non-delimiter / non-backslash characters OR
+# a backslash followed by any character. Without this, JSON-escaped
+# secrets leak (codex P1 PRRT_kwDOR_Rkws59IhT6:
+# ``password="abc\\"def secret"`` previously became
+# ``password="[REDACTED]"def secret"``).
 #
 # The key is kept in the replacement so the log line still tells you
 # *which* credential leaked — just not what.
 _KV_PATTERN = re.compile(
     r"(?i)(?P<key>(?:" + "|".join(_CRED_KEYS) + r")[\"']?\s*[:=]\s*)"
     r"(?:"
-    r'"(?P<qvalue_dq>[^"]*)"'
+    r'"(?P<qvalue_dq>(?:[^"\\]|\\.)*)"'
     r"|"
-    r"'(?P<qvalue_sq>[^']*)'"
+    r"'(?P<qvalue_sq>(?:[^'\\]|\\.)*)'"
     r"|"
     r"(?P<value>[^\"'\s,;&}\])]+)"
     r")"

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -53,16 +53,29 @@ _CRED_KEYS = (
     "passwd",
     "credential",
 )
-# ``key`` + optional quotes + ``=`` or ``:`` + EITHER a quoted value (where
-# we capture everything up to the matching close quote — covers secrets
-# containing spaces like ``password='correct horse battery staple'``, codex
-# P1 PRRT_kwDOR_Rkws59IQep) OR an unquoted value that stops at the first
-# whitespace / delimiter. The key is kept in the replacement so the log
-# line still tells you *which* credential leaked — just not what.
+# ``key`` + optional quotes + ``=`` or ``:`` + value. The value arm has
+# three alternatives so each form stops on the correct delimiter:
+#
+# 1. Double-quoted (``password="abc'def"``) — allows single quotes inside,
+#    terminates on the closing ``"``.
+# 2. Single-quoted (``password='abc"def'``) — allows double quotes inside,
+#    terminates on the closing ``'``.
+# 3. Unquoted — stops at whitespace / delimiter.
+#
+# Earlier versions used a single quoted alternative with ``[^\"']*`` which
+# forbade BOTH quote characters and missed mixed-punctuation secrets
+# (codex P1 PRRT_kwDOR_Rkws59IYi1). Splitting into separate dq / sq
+# branches is the standard regex-engine-agnostic fix because
+# ``[^(?P=q)]`` inside a character class isn't supported.
+#
+# The key is kept in the replacement so the log line still tells you
+# *which* credential leaked — just not what.
 _KV_PATTERN = re.compile(
     r"(?i)(?P<key>(?:" + "|".join(_CRED_KEYS) + r")[\"']?\s*[:=]\s*)"
     r"(?:"
-    r"(?P<q>[\"'])(?P<qvalue>[^\"']*)(?P=q)"
+    r'"(?P<qvalue_dq>[^"]*)"'
+    r"|"
+    r"'(?P<qvalue_sq>[^']*)'"
     r"|"
     r"(?P<value>[^\"'\s,;&}\])]+)"
     r")"
@@ -86,13 +99,15 @@ _BEARER_PATTERN = re.compile(
 def _kv_replace(match: re.Match[str]) -> str:
     """``_KV_PATTERN`` callback: preserve the quote shape when redacting.
 
-    When the quoted branch matched (``password='correct horse'``), wrap
-    ``REDACTED`` in the same quote character so the output keeps a valid
-    quoted form. Otherwise the unquoted branch is a simple substitution.
+    When a quoted branch matched, wrap ``REDACTED`` in the matching quote
+    character so the output keeps a valid quoted form. The ``is not None``
+    check (rather than truthy) matters for empty-string values —
+    ``password=""`` has ``qvalue_dq = ""`` which is falsy but not None.
     """
-    quote = match.group("q")
-    if quote is not None:
-        return f"{match.group('key')}{quote}{REDACTED}{quote}"
+    if match.group("qvalue_dq") is not None:
+        return f'{match.group("key")}"{REDACTED}"'
+    if match.group("qvalue_sq") is not None:
+        return f"{match.group('key')}'{REDACTED}'"
     return f"{match.group('key')}{REDACTED}"
 
 

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -73,22 +73,6 @@ def _redact_text(text: str) -> str:
     return text
 
 
-def _redact_args(args: object) -> object:
-    """Redact each positional format arg.
-
-    ``record.args`` is either a tuple, a mapping (``%(name)s`` style), or a
-    single value. Preserve the shape — ``logging`` will try to format with
-    whatever we return.
-    """
-    if isinstance(args, tuple):
-        return tuple(_redact_text(str(a)) if isinstance(a, str) else a for a in args)
-    if isinstance(args, dict):
-        return {k: _redact_text(str(v)) if isinstance(v, str) else v for k, v in args.items()}
-    if isinstance(args, str):
-        return _redact_text(args)
-    return args
-
-
 class CredentialRedactingFilter(logging.Filter):
     """Redact credential-shaped substrings in log records. Never drops.
 

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -32,6 +32,14 @@ from collections.abc import Iterable, Mapping
 
 REDACTED = "[REDACTED]"
 
+# Unforgeable module-level sentinel for the idempotency guard. Using a
+# truthy attribute (``record._fo_redacted = True``) is vulnerable to
+# bypass via ``logger.info(..., extra={"_fo_redacted": True})`` — an
+# attacker-controlled log-extra could mark the record as already
+# redacted and skip the scrub. Identity check on a unique ``object()``
+# instance can't be forged without a reference to our sentinel.
+_RECORD_REDACTED_SENTINEL = object()
+
 # Keys that, when seen as the left-hand side of ``key=value`` / ``key: value``
 # / ``key="value"`` in a log message, should have their right-hand side
 # replaced with ``REDACTED``. Hyphen and underscore spellings both covered
@@ -53,14 +61,25 @@ _CRED_KEYS = (
     "passwd",
     "credential",
 )
-# Full-match form of the credential-key list, for matching dict-arg names
-# in mapping-style format logs (``logger.info("%(api_key)s", {"api_key":
-# ...})``). ``_KV_PATTERN`` catches the ``key=value`` text shape, but
-# mapping-style interpolation strips the key name before emission —
-# ``getMessage()`` returns only the raw value, which doesn't match any
-# text pattern. So we scrub credential-named dict keys BEFORE formatting
-# (codex P1 PRRT_kwDOR_Rkws59I2zc).
-_CRED_KEY_FULL = re.compile(r"(?i)^(?:" + "|".join(_CRED_KEYS) + r")$")
+# ``authorization`` is NOT in ``_CRED_KEYS`` because ``_KV_PATTERN`` would
+# then preempt ``_BEARER_PATTERN`` on ``Authorization: Bearer <token>`` —
+# the kv match would capture only ``Bearer`` as the value (stops at
+# whitespace), leaving the actual token unredacted. Handle the bearer-
+# header shape exclusively via ``_BEARER_PATTERN``. But for the mapping-
+# style case (``logger.info("%(Authorization)s", {"Authorization": ...})``,
+# codex P1 PRRT_kwDOR_Rkws59JVLj) ``_BEARER_PATTERN`` can't catch it
+# post-format (the prefix is gone), so we pre-scrub by matching the dict
+# KEY name. Dict-key scrub uses a wider list than the text pattern.
+_CRED_KEY_FULL_NAMES: tuple[str, ...] = (*_CRED_KEYS, "authorization")
+# Full-match form for dict-arg key names in mapping-style format logs
+# (``logger.info("%(api_key)s", {"api_key": ...})``). ``_KV_PATTERN``
+# catches the ``key=value`` text shape, but mapping-style interpolation
+# strips the key name before emission — ``getMessage()`` returns only
+# the raw value, which doesn't match any text pattern. So we scrub
+# credential-named mapping keys BEFORE formatting (codex P1
+# PRRT_kwDOR_Rkws59I2zc). Uses the wider ``_CRED_KEY_FULL_NAMES`` list
+# which includes ``authorization`` (see comment above).
+_CRED_KEY_FULL = re.compile(r"(?i)^(?:" + "|".join(_CRED_KEY_FULL_NAMES) + r")$")
 # ``key`` + optional quotes + ``=`` or ``:`` + value. The value arm has
 # five alternatives ordered so each form stops on the correct delimiter:
 #
@@ -186,7 +205,13 @@ class CredentialRedactingFilter(logging.Filter):
         so the formatted-and-redacted string is what ``getMessage()``
         returns.
         """
-        if getattr(record, "_fo_redacted", False):
+        # Identity check on ``_RECORD_REDACTED_SENTINEL``: a truthy
+        # attribute ``record._fo_redacted = True`` reachable via
+        # ``logger.info(..., extra={"_fo_redacted": True})`` could
+        # otherwise short-circuit redaction before secrets are scrubbed.
+        # The sentinel is a fresh ``object()`` whose identity can't be
+        # reproduced from outside this module.
+        if getattr(record, "_fo_redacted", None) is _RECORD_REDACTED_SENTINEL:
             return True
         # --- Message redaction (args-present and no-args paths) ---
         # ``getMessage()`` runs ``record.msg % record.args`` which invokes
@@ -205,21 +230,24 @@ class CredentialRedactingFilter(logging.Filter):
         # open") is wrong for a credential safety net — the whole point
         # is that unknown-shape inputs get masked, not passed through.
         if record.args:
-            # Pre-scrub mapping-style args: ``logger.info("%(api_key)s",
-            # {"api_key": secret})`` interpolates just the raw value, so
-            # post-format text redaction has no key=value shape to match.
-            # Replace credential-named mapping values with the REDACTED
-            # sentinel before ``getMessage()`` sees them. ``collections.
-            # abc.Mapping`` covers ``UserDict``, ``MappingProxyType``, and
-            # third-party mapping types that ``logging`` also accepts for
-            # mapping-style interpolation (codex P2
-            # PRRT_kwDOR_Rkws59JMYx).
-            if isinstance(record.args, Mapping):
-                record.args = {
-                    k: (REDACTED if isinstance(k, str) and _CRED_KEY_FULL.match(k) else v)
-                    for k, v in record.args.items()
-                }
             try:
+                # Pre-scrub mapping-style args: ``logger.info("%(api_key)s",
+                # {"api_key": secret})`` interpolates just the raw value,
+                # so post-format text redaction has no key=value shape to
+                # match. Replace credential-named mapping values with the
+                # REDACTED sentinel before ``getMessage()`` sees them.
+                # ``collections.abc.Mapping`` covers ``UserDict``,
+                # ``MappingProxyType``, and third-party mapping types
+                # ``logging`` also accepts (codex P2
+                # PRRT_kwDOR_Rkws59JMYx). Pre-scrub is INSIDE the try so a
+                # broken ``Mapping.items()`` / ``__iter__`` implementation
+                # can't escape the filter (codex P2
+                # PRRT_kwDOR_Rkws59JVLp).
+                if isinstance(record.args, Mapping):
+                    record.args = {
+                        k: (REDACTED if isinstance(k, str) and _CRED_KEY_FULL.match(k) else v)
+                        for k, v in record.args.items()
+                    }
                 formatted = record.getMessage()
             except Exception:
                 try:
@@ -261,13 +289,36 @@ class CredentialRedactingFilter(logging.Filter):
             try:
                 exc_text = "".join(traceback.format_exception(*record.exc_info))
             except Exception:
-                return True
-            record.exc_text = _redact_text(exc_text)
+                # Fail-CLOSED on traceback formatting failure (buggy
+                # ``__str__`` / ``__repr__`` on the exception itself).
+                # Returning early leaves ``exc_text = None`` and
+                # ``exc_info`` intact, which the default ``Formatter``
+                # then re-renders via the same buggy call path — the
+                # raw exception message (including any embedded secret)
+                # ends up in the log output. Replace both with a safe
+                # placeholder: ``exc_text = REDACTED`` pre-populates
+                # the formatter cache, and clearing ``exc_info`` stops
+                # the formatter from attempting its own render
+                # (coderabbit Major PRRT_kwDOR_Rkws59II7G).
+                record.exc_text = REDACTED
+                record.exc_info = None
+            else:
+                record.exc_text = _redact_text(exc_text)
+        elif record.exc_text:
+            # Some code paths populate ``exc_text`` directly (e.g.,
+            # pre-formatted exceptions, loguru-to-stdlib bridges)
+            # without going through ``exc_info``. Redact those too so
+            # a pre-rendered traceback containing a secret doesn't
+            # reach the handler unscrubbed (coderabbit Major
+            # PRRT_kwDOR_Rkws59II7G).
+            record.exc_text = _redact_text(record.exc_text)
         # Mark the record so subsequent filter invocations (duplicate
         # logger-level filter attachment, factory + filter combo) skip the
         # re-redact pass. Essential because ``_KV_PATTERN`` isn't
-        # idempotent on already-bracketed ``[REDACTED]`` values.
-        record._fo_redacted = True
+        # idempotent on already-bracketed ``[REDACTED]`` values. Uses the
+        # module-level sentinel (see comment at the top of ``filter``) so
+        # external callers can't forge the idempotency marker.
+        record._fo_redacted = _RECORD_REDACTED_SENTINEL
         return True
 
 
@@ -296,8 +347,12 @@ def _install_on_loguru(instance: CredentialRedactingFilter) -> bool:
     def _patcher(record: Any) -> None:
         # Idempotency: a prior pass (duplicate install) marked this record,
         # skip to avoid double-redaction corrupting ``[REDACTED]`` brackets.
+        # Identity check on the module sentinel rather than a truthy value
+        # so a caller-supplied ``bind(_fo_redacted=True)`` can't bypass
+        # redaction (coderabbit Major PRRT_kwDOR_Rkws59II7G, symmetric
+        # with the stdlib filter).
         extra = record.get("extra") or {}
-        if extra.get("_fo_redacted"):
+        if extra.get("_fo_redacted") is _RECORD_REDACTED_SENTINEL:
             return
         # Loguru record: ``{'message': str, 'exception': RecordException | None, ...}``.
         # Redact the main message and the exception repr (which loguru
@@ -343,7 +398,8 @@ def _install_on_loguru(instance: CredentialRedactingFilter) -> bool:
             sanitized = Exception(redacted)
             record["exception"] = RecordException(type(sanitized), sanitized, None)
         # Mark this record so duplicate patcher installs skip the rewrite.
-        record["extra"]["_fo_redacted"] = True
+        # Uses the module sentinel (see ``filter`` for the rationale).
+        record["extra"]["_fo_redacted"] = _RECORD_REDACTED_SENTINEL
 
     # ``patcher`` runs on every record; installing twice would stack, so
     # configure with a single canonical patcher. ``logger.configure``

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -53,24 +53,47 @@ _CRED_KEYS = (
     "passwd",
     "credential",
 )
-# ``key`` + optional quotes + ``=`` or ``:`` + optional quotes, followed by
-# the value we want to capture (everything up to whitespace / a quote /
-# a delimiter). The key is kept in the replacement so the log line still
-# tells you *which* credential leaked — just not what.
+# ``key`` + optional quotes + ``=`` or ``:`` + EITHER a quoted value (where
+# we capture everything up to the matching close quote — covers secrets
+# containing spaces like ``password='correct horse battery staple'``, codex
+# P1 PRRT_kwDOR_Rkws59IQep) OR an unquoted value that stops at the first
+# whitespace / delimiter. The key is kept in the replacement so the log
+# line still tells you *which* credential leaked — just not what.
 _KV_PATTERN = re.compile(
-    r"(?i)(?P<key>(?:" + "|".join(_CRED_KEYS) + r")[\"']?\s*[:=]\s*[\"']?)"
+    r"(?i)(?P<key>(?:" + "|".join(_CRED_KEYS) + r")[\"']?\s*[:=]\s*)"
+    r"(?:"
+    r"(?P<q>[\"'])(?P<qvalue>[^\"']*)(?P=q)"
+    r"|"
     r"(?P<value>[^\"'\s,;&}\])]+)"
+    r")"
 )
 
 # ``Authorization: Bearer <token>`` HTTP header shape. Distinct from the
-# ``key=value`` pattern because the separator is whitespace rather than ``=``.
-# Allows optional quotes around both the key and the separator so dict-repr
-# (``{'Authorization': 'Bearer abc'}``) and JSON (``"Authorization":
-# "Bearer abc"``) forms also match — logger calls that pass header dicts
-# are a real leak path (codex P1 PRRT_kwDOR_Rkws59IB5U).
+# ``key=value`` pattern because the separator between the header name and
+# ``Bearer`` is usually whitespace rather than a closing quote — but the
+# separator between ``Authorization`` and the value can be either ``:``
+# (header style) or ``=`` (query / form style; codex P2
+# PRRT_kwDOR_Rkws59IQew). Allows optional quotes around both the key and
+# the separator so dict-repr (``{'Authorization': 'Bearer abc'}``) and
+# JSON (``"Authorization": "Bearer abc"``) forms also match — logger
+# calls that pass header dicts are a real leak path (codex P1
+# PRRT_kwDOR_Rkws59IB5U).
 _BEARER_PATTERN = re.compile(
-    r"(?i)(?P<prefix>authorization[\"']?\s*:\s*[\"']?bearer\s+)(?P<value>[^\"'\s,;}]+)"
+    r"(?i)(?P<prefix>authorization[\"']?\s*[:=]\s*[\"']?bearer\s+)(?P<value>[^\"'\s,;}]+)"
 )
+
+
+def _kv_replace(match: re.Match[str]) -> str:
+    """``_KV_PATTERN`` callback: preserve the quote shape when redacting.
+
+    When the quoted branch matched (``password='correct horse'``), wrap
+    ``REDACTED`` in the same quote character so the output keeps a valid
+    quoted form. Otherwise the unquoted branch is a simple substitution.
+    """
+    quote = match.group("q")
+    if quote is not None:
+        return f"{match.group('key')}{quote}{REDACTED}{quote}"
+    return f"{match.group('key')}{REDACTED}"
 
 
 def _redact_text(text: str) -> str:
@@ -79,7 +102,7 @@ def _redact_text(text: str) -> str:
     Returns a new string; the original is not mutated. Order of application
     doesn't matter because the patterns don't overlap.
     """
-    text = _KV_PATTERN.sub(lambda m: f"{m.group('key')}{REDACTED}", text)
+    text = _KV_PATTERN.sub(_kv_replace, text)
     text = _BEARER_PATTERN.sub(lambda m: f"{m.group('prefix')}{REDACTED}", text)
     return text
 

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -302,7 +302,8 @@ class TestContract:
         finally:
             logging.setLogRecordFactory(original_factory)
             for f in [
-                filt for filt in logging.getLogger().filters
+                filt
+                for filt in logging.getLogger().filters
                 if isinstance(filt, CredentialRedactingFilter)
             ]:
                 logging.getLogger().removeFilter(f)

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -1,0 +1,226 @@
+"""Tests for cli.utils.log_redact — credential-redacting logging filter (A3).
+
+A3 adds a project-wide ``logging.Filter`` that masks credential-looking
+values in log records so a future code path that naively logs
+``config.api_key`` or stuffs a secret into an exception message doesn't
+leak it to a file / stdout / collected log.
+
+The filter must cover the forms credentials commonly appear in:
+
+- ``key=value`` / ``key: value`` / ``key="value"`` / ``key='value'`` for
+  common credential keys (api_key, token, secret, password, bearer).
+- ``Authorization: Bearer <token>`` HTTP-header style.
+- Credentials passed via ``logger.info(..., extra_arg)`` substitution args.
+
+Contract: the filter *always* returns True (never drops records) — its
+job is redaction, not filtering. Downstream filters / handler levels
+still decide emission.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from utils.log_redact import REDACTED, CredentialRedactingFilter
+
+pytestmark = [pytest.mark.ci, pytest.mark.unit]
+
+
+def _make_record(msg: str, *args: object) -> logging.LogRecord:
+    """Build a minimal ``LogRecord`` for filter tests."""
+    return logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=0,
+        msg=msg,
+        args=args or None,
+        exc_info=None,
+    )
+
+
+class TestRedactsKeyValueForms:
+    """The common ``key=value`` and ``key: value`` leak shapes."""
+
+    def _assert_redacts(self, leaked: str, secret: str = "sk-super-secret-xyz123") -> None:
+        f = CredentialRedactingFilter()
+        record = _make_record(leaked)
+        assert f.filter(record) is True  # never drops records
+        assert secret not in record.getMessage()
+        assert REDACTED in record.getMessage()
+
+    def test_api_key_equals(self) -> None:
+        self._assert_redacts("Calling provider with api_key=sk-super-secret-xyz123")
+
+    def test_api_key_colon(self) -> None:
+        self._assert_redacts("config: api_key: sk-super-secret-xyz123 loaded")
+
+    def test_api_key_quoted_double(self) -> None:
+        self._assert_redacts('api_key="sk-super-secret-xyz123" provided')
+
+    def test_api_key_quoted_single(self) -> None:
+        self._assert_redacts("api_key='sk-super-secret-xyz123' provided")
+
+    def test_hyphenated_api_key(self) -> None:
+        self._assert_redacts("api-key=sk-super-secret-xyz123")
+
+    def test_token(self) -> None:
+        self._assert_redacts("token=sk-super-secret-xyz123")
+
+    def test_secret(self) -> None:
+        self._assert_redacts("secret=sk-super-secret-xyz123")
+
+    def test_password(self) -> None:
+        self._assert_redacts("password=sk-super-secret-xyz123")
+
+    def test_case_insensitive_key(self) -> None:
+        self._assert_redacts("API_KEY=sk-super-secret-xyz123")
+
+
+class TestRedactsBearerHeader:
+    """HTTP ``Authorization: Bearer <token>`` leaks."""
+
+    def test_bearer_token_redacted(self) -> None:
+        f = CredentialRedactingFilter()
+        record = _make_record("request sent: Authorization: Bearer abc123.xyz_def")
+        assert f.filter(record) is True
+        assert "abc123.xyz_def" not in record.getMessage()
+        assert REDACTED in record.getMessage()
+
+    def test_bearer_lowercase(self) -> None:
+        f = CredentialRedactingFilter()
+        record = _make_record("authorization: bearer abc123")
+        assert f.filter(record) is True
+        assert "abc123" not in record.getMessage()
+        assert REDACTED in record.getMessage()
+
+
+class TestRedactsArgs:
+    """Credentials passed as ``%s`` arguments, not inline in the message."""
+
+    def test_redacts_single_string_arg(self) -> None:
+        f = CredentialRedactingFilter()
+        record = _make_record("auth=%s", "api_key=sk-super-secret-xyz123")
+        assert f.filter(record) is True
+        assert "sk-super-secret-xyz123" not in record.getMessage()
+        assert REDACTED in record.getMessage()
+
+    def test_redacts_mixed_args(self) -> None:
+        """Only the credential-shaped arg is redacted; the other survives."""
+        f = CredentialRedactingFilter()
+        record = _make_record("user=%s auth=%s", "alice", "token=abc123.xyz")
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "alice" in rendered  # non-credential arg preserved
+        assert "abc123.xyz" not in rendered
+        assert REDACTED in rendered
+
+
+class TestPreservesNonCredentials:
+    """Boundary: the filter must not over-redact."""
+
+    def test_plain_message_unchanged(self) -> None:
+        f = CredentialRedactingFilter()
+        record = _make_record("processing file.pdf")
+        assert f.filter(record) is True
+        assert record.getMessage() == "processing file.pdf"
+
+    def test_key_equals_without_credential_key_unchanged(self) -> None:
+        """``user=alice`` is not a credential shape; must not be redacted."""
+        f = CredentialRedactingFilter()
+        record = _make_record("user=alice processed 5 files")
+        assert f.filter(record) is True
+        assert "alice" in record.getMessage()
+
+
+class TestContract:
+    """Invariants any consumer can rely on."""
+
+    def test_always_returns_true(self) -> None:
+        """The filter is redact-only, never drops. Contract for the
+        attachment site in cli.main — downstream handlers / levels still
+        decide emission.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record("anything at all")
+        assert f.filter(record) is True
+
+    def test_redacted_sentinel_is_public(self) -> None:
+        """``REDACTED`` is a module-level public constant so tests and
+        downstream consumers (e.g. log assertions in integration tests)
+        can reference the exact replacement token without duplicating it.
+        """
+        assert isinstance(REDACTED, str)
+        assert len(REDACTED) > 0
+
+    def test_record_args_after_filter_formats_without_error(self) -> None:
+        """After the filter runs, ``record.getMessage()`` must still format
+        cleanly — i.e. the filter preserves arg arity / format-string
+        compatibility.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record("auth=%s user=%s", "token=abc", "alice")
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "alice" in rendered
+        assert "abc" not in rendered
+
+
+class TestCLIIntegration:
+    """End-to-end: invoking the CLI main-callback installs the filter on root.
+
+    Regression guard for the attachment site in ``cli.main.main_callback`` —
+    without this, a refactor that drops the ``install_on_root()`` call could
+    silently regress the safety net. The test runs a trivial command that
+    logs a credential-shaped message and asserts the captured log output is
+    redacted.
+    """
+
+    def test_filter_installed_by_cli_main_callback(self) -> None:
+        from typer.testing import CliRunner
+
+        from cli.main import app
+
+        root = logging.getLogger()
+        preexisting = [f for f in root.filters if isinstance(f, CredentialRedactingFilter)]
+        original_factory = logging.getLogRecordFactory()
+        for f in preexisting:
+            root.removeFilter(f)
+        try:
+            # Invoke a real command so main_callback runs (``--help`` and
+            # ``--version`` are eager and short-circuit the callback).
+            result = CliRunner().invoke(app, ["version"])
+            assert result.exit_code == 0
+            # Filter attached to root.
+            attached = [
+                f for f in root.filters if isinstance(f, CredentialRedactingFilter)
+            ]
+            assert len(attached) >= 1, (
+                "cli.main.main_callback did not install CredentialRedactingFilter"
+            )
+            # Propagated records from any logger get redacted via the
+            # ``setLogRecordFactory`` wrapper. Drive a record through
+            # ``logging.getLogger("integration.test")`` and verify the
+            # factory-redacted message.
+            record = logging.getLogger("integration.test").makeRecord(
+                "integration.test",
+                logging.INFO,
+                __file__,
+                0,
+                "api_key=sk-leaked-secret-xyz",
+                None,
+                None,
+            )
+            rendered = record.getMessage()
+            assert "sk-leaked-secret-xyz" not in rendered
+            assert REDACTED in rendered
+        finally:
+            logging.setLogRecordFactory(original_factory)
+            for f in [
+                f for f in root.filters if isinstance(f, CredentialRedactingFilter)
+            ]:
+                root.removeFilter(f)
+            for f in preexisting:
+                root.addFilter(f)

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -167,6 +167,28 @@ class TestContract:
         assert "alice" in rendered
         assert "abc" not in rendered
 
+    def test_regression_template_placeholder_preserved_with_credential_key_in_msg(
+        self,
+    ) -> None:
+        """codex P1: ``logger.info("api_key=%s", secret)`` has a credential
+        key in ``record.msg`` with a ``%s`` placeholder and the secret in
+        ``record.args``. Naively redacting ``record.msg`` could strip the
+        ``%s`` (capture group consumes it), leaving args intact —
+        ``record.getMessage()`` then raises ``TypeError``, Python's logging
+        error handler prints the raw args tuple (including the secret) to
+        stderr, and the filter ends up LEAKING the credential it was meant
+        to mask. The filter must format first, redact the result, and
+        clear ``args`` so downstream ``getMessage()`` never raises.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record("api_key=%s", "sk-super-secret-xyz123")
+        assert f.filter(record) is True
+        # getMessage() must not raise — the classic bug symptom.
+        rendered = record.getMessage()
+        # And the secret must be absent from the rendered output.
+        assert "sk-super-secret-xyz123" not in rendered
+        assert REDACTED in rendered
+
 
 class TestCLIIntegration:
     """End-to-end: invoking the CLI main-callback installs the filter on root.
@@ -194,9 +216,7 @@ class TestCLIIntegration:
             result = CliRunner().invoke(app, ["version"])
             assert result.exit_code == 0
             # Filter attached to root.
-            attached = [
-                f for f in root.filters if isinstance(f, CredentialRedactingFilter)
-            ]
+            attached = [f for f in root.filters if isinstance(f, CredentialRedactingFilter)]
             assert len(attached) >= 1, (
                 "cli.main.main_callback did not install CredentialRedactingFilter"
             )
@@ -218,9 +238,7 @@ class TestCLIIntegration:
             assert REDACTED in rendered
         finally:
             logging.setLogRecordFactory(original_factory)
-            for f in [
-                f for f in root.filters if isinstance(f, CredentialRedactingFilter)
-            ]:
+            for f in [f for f in root.filters if isinstance(f, CredentialRedactingFilter)]:
                 root.removeFilter(f)
             for f in preexisting:
                 root.addFilter(f)

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -107,6 +107,31 @@ class TestRedactsKeyValueForms:
         assert "word" not in rendered
         assert REDACTED in rendered
 
+    def test_double_quoted_value_containing_single_quote(self) -> None:
+        """codex P1 (PRRT_kwDOR_Rkws59IYi1): ``password="abc'def"`` — the
+        secret contains a single quote inside double quotes. Previous
+        regex excluded BOTH quote chars from the value group, so this
+        shape escaped redaction entirely. The pattern must only
+        terminate on the matching delimiter.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record('password="abc\'def-secret-value"')
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "abc'def-secret-value" not in rendered
+        assert "def-secret" not in rendered
+        assert REDACTED in rendered
+
+    def test_single_quoted_value_containing_double_quote(self) -> None:
+        """Mirror case: single-quoted value with a double quote inside."""
+        f = CredentialRedactingFilter()
+        record = _make_record("token='xyz\"abc-secret-value'")
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert 'xyz"abc-secret-value' not in rendered
+        assert "abc-secret" not in rendered
+        assert REDACTED in rendered
+
 
 class TestRedactsBearerHeader:
     """HTTP ``Authorization: Bearer <token>`` leaks."""

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -252,6 +252,21 @@ class TestRedactsArgs:
         assert "sk-super-secret-xyz123" not in record.getMessage()
         assert REDACTED in record.getMessage()
 
+    def test_redacts_mapping_style_format_with_credential_key(self) -> None:
+        """codex P1 (PRRT_kwDOR_Rkws59I2zc): ``logger.info("%(api_key)s",
+        {"api_key": secret})`` — mapping-style ``%`` formatting
+        interpolates just the raw value, so ``getMessage()`` returns
+        only the secret without any ``key=value`` shape. Post-format text
+        redaction can't catch it. The filter must scrub credential-named
+        dict values BEFORE formatting.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record("%(api_key)s loaded", {"api_key": "sk-super-secret-xyz123"})
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "sk-super-secret-xyz123" not in rendered
+        assert REDACTED in rendered
+
     def test_redacts_raw_secret_arg_when_template_key_is_auth(self) -> None:
         """coderabbit Major (PRRT_kwDOR_Rkws59II7L): ``logger.info("auth=%s",
         secret)`` — after formatting, the rendered message is

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -167,6 +167,42 @@ class TestContract:
         assert "alice" in rendered
         assert "abc" not in rendered
 
+    def test_malformed_template_is_passed_through_unchanged(self) -> None:
+        """A record whose ``msg % args`` raises (wrong arg count, etc.) must
+        be left as-is so Python's logging error handler can surface the
+        original formatting error. The filter must still return ``True``
+        (never drops) and must not mutate ``record.msg`` or ``record.args``.
+        """
+        f = CredentialRedactingFilter()
+        # Template expects 2 %s, only 1 arg provided → getMessage() raises
+        # TypeError when invoked.
+        record = _make_record("need=%s and=%s", "one-arg-only")
+        original_msg = record.msg
+        original_args = record.args
+        assert f.filter(record) is True
+        assert record.msg == original_msg
+        assert record.args == original_args
+
+    def test_install_on_root_honours_extra_loggers(self) -> None:
+        """``install_on_root(extra_loggers=["foo"])`` attaches the filter to
+        each named logger so it fires for records originating there. Belt-
+        and-suspenders for the ``setLogRecordFactory`` install.
+        """
+        from utils.log_redact import install_on_root
+
+        original_factory = logging.getLogRecordFactory()
+        named = "test_log_redact_extra"
+        target_logger = logging.getLogger(named)
+        pre_filters = list(target_logger.filters)
+        try:
+            installed = install_on_root(extra_loggers=[named])
+            assert installed in target_logger.filters, (
+                "install_on_root did not attach filter to the named logger"
+            )
+        finally:
+            logging.setLogRecordFactory(original_factory)
+            target_logger.filters = pre_filters
+
     def test_regression_template_placeholder_preserved_with_credential_key_in_msg(
         self,
     ) -> None:

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -303,6 +303,24 @@ class TestContract:
         assert record.msg == original_msg
         assert record.args == original_args
 
+    def test_filter_is_idempotent_on_repeated_invocation(self) -> None:
+        """codex P2 (PRRT_kwDOR_Rkws59H2ZK): ``install_on_root`` attaches
+        the filter to both the global ``LogRecordFactory`` AND the root
+        logger, so records emitted at root are filtered twice. ``_KV_PATTERN``
+        isn't idempotent on already-bracketed ``[REDACTED]`` values —
+        ``api_key=[REDACTED]`` → ``api_key=[REDACTED]]``. The sentinel
+        ``record._fo_redacted`` short-circuits repeat passes.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record("api_key=sk-super-secret-xyz123")
+        assert f.filter(record) is True
+        first_pass = record.getMessage()
+        # Run filter AGAIN — simulates duplicate attachment.
+        assert f.filter(record) is True
+        assert record.getMessage() == first_pass
+        # Explicit shape check: no trailing ``]]`` bracket corruption.
+        assert "]]" not in record.getMessage()
+
     def test_loguru_patcher_replaces_exception_with_sanitized_version(self) -> None:
         """codex P1 (PRRT_kwDOR_Rkws59HjtX): the loguru patcher must
         overwrite ``record["exception"]`` with a sanitized

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -159,6 +159,34 @@ class TestRedactsKeyValueForms:
         assert "def inside" not in rendered
         assert REDACTED in rendered
 
+    def test_malformed_unclosed_double_quote_redacted(self) -> None:
+        """codex P1 (PRRT_kwDOR_Rkws59IsZr): malformed quoted credential
+        (opening quote with no matching close — e.g. truncated log, or
+        ``logger.info('password="%s', secret)`` where the template is
+        missing its close) must still redact. Before the fix the closed-
+        quote branches didn't match and the unquoted fallback rejected
+        values starting with a quote, so the secret leaked.
+        """
+        f = CredentialRedactingFilter()
+        # Unclosed double quote — the whole remainder after the quote
+        # must be scrubbed.
+        record = _make_record('password="super secret value never closes')
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "super secret value" not in rendered
+        assert "secret value" not in rendered
+        assert REDACTED in rendered
+
+    def test_malformed_unclosed_single_quote_redacted(self) -> None:
+        """Mirror case: unclosed single-quoted credential value."""
+        f = CredentialRedactingFilter()
+        record = _make_record("token='abc secret truncated here")
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "abc secret truncated here" not in rendered
+        assert "secret truncated" not in rendered
+        assert REDACTED in rendered
+
 
 class TestRedactsBearerHeader:
     """HTTP ``Authorization: Bearer <token>`` leaks."""

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -321,7 +321,7 @@ class TestContract:
         try:
             raise RuntimeError("api_key=sk-super-secret-xyz123 inside error")
         except RuntimeError as exc:
-            from loguru._recattrs import RecordException  # type: ignore[import-untyped]
+            from loguru._recattrs import RecordException
 
             orig_exc = RecordException(type(exc), exc, exc.__traceback__)
 

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -96,6 +96,30 @@ class TestRedactsBearerHeader:
         assert "abc123" not in record.getMessage()
         assert REDACTED in record.getMessage()
 
+    def test_bearer_in_dict_repr_shape(self) -> None:
+        """codex P1 (PRRT_kwDOR_Rkws59IB5U): ``logger.info({'Authorization':
+        'Bearer abc'})`` renders as ``{'Authorization': 'Bearer abc'}`` after
+        str(). The bearer pattern must match the quoted-key / quoted-value
+        dict-repr form, not just the bare HTTP header shape.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record(  # type: ignore[arg-type]
+            {"Authorization": "Bearer abc123.xyz_def"}
+        )
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "abc123.xyz_def" not in rendered
+        assert REDACTED in rendered
+
+    def test_bearer_in_json_shape(self) -> None:
+        """JSON-style ``{"Authorization": "Bearer ..."}`` leak shape."""
+        f = CredentialRedactingFilter()
+        record = _make_record('{"Authorization": "Bearer xyz.token.here"}')
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "xyz.token.here" not in rendered
+        assert REDACTED in rendered
+
 
 class TestRedactsArgs:
     """Credentials passed as ``%s`` arguments, not inline in the message."""

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -80,6 +80,33 @@ class TestRedactsKeyValueForms:
     def test_case_insensitive_key(self) -> None:
         self._assert_redacts("API_KEY=sk-super-secret-xyz123")
 
+    def test_quoted_value_with_spaces_redacted_through_close_quote(self) -> None:
+        """codex P1 (PRRT_kwDOR_Rkws59IQep): quoted secrets that contain
+        whitespace must be redacted through the closing quote, not
+        truncated at the first space. Before the fix
+        ``password='correct horse battery staple'`` became
+        ``password='[REDACTED] horse battery staple'`` — most of the
+        secret leaked.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record("password='correct horse battery staple'")
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "correct horse battery staple" not in rendered
+        assert "horse" not in rendered
+        assert "battery" not in rendered
+        assert REDACTED in rendered
+
+    def test_quoted_value_with_spaces_double_quotes(self) -> None:
+        """Same shape but with double quotes."""
+        f = CredentialRedactingFilter()
+        record = _make_record('token="multi word secret here"')
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "multi word secret here" not in rendered
+        assert "word" not in rendered
+        assert REDACTED in rendered
+
 
 class TestRedactsBearerHeader:
     """HTTP ``Authorization: Bearer <token>`` leaks."""
@@ -118,6 +145,20 @@ class TestRedactsBearerHeader:
         assert f.filter(record) is True
         rendered = record.getMessage()
         assert "xyz.token.here" not in rendered
+        assert REDACTED in rendered
+
+    def test_bearer_with_equals_separator(self) -> None:
+        """codex P2 (PRRT_kwDOR_Rkws59IQew): query-string / form-encoded
+        ``Authorization=Bearer <token>`` is a real logging shape —
+        ``authorization`` isn't in ``_CRED_KEYS`` so the ``key=value``
+        pattern can't catch it. The bearer pattern must accept ``=`` as
+        the separator (in addition to ``:``).
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record("Authorization=Bearer abc123.xyz_def")
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "abc123.xyz_def" not in rendered
         assert REDACTED in rendered
 
 

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -214,6 +214,28 @@ class TestContract:
         assert "sk-leaked-secret" not in rendered
         assert REDACTED in rendered
 
+    def test_redacts_exc_info_when_args_also_present(self) -> None:
+        """codex P1 (PRRT_kwDOR_Rkws59HjtQ): ``logger.error("msg: %s",
+        value, exc_info=True)`` and ``logger.exception("msg: %s", value)``
+        take the args branch. Before the fix, the args branch returned
+        before ``exc_info`` scrubbing ran, leaving the traceback
+        unredacted even though the main message was sanitized. Both
+        branches must now redact the traceback.
+        """
+        import sys
+
+        f = CredentialRedactingFilter()
+        try:
+            raise RuntimeError("api_key=sk-super-secret-xyz123 inside error")
+        except RuntimeError:
+            exc_info = sys.exc_info()
+        record = _make_record("failed to %s", "process")
+        record.exc_info = exc_info
+        assert f.filter(record) is True
+        assert record.exc_text is not None
+        assert "sk-super-secret-xyz123" not in record.exc_text
+        assert REDACTED in record.exc_text
+
     def test_redacts_exception_traceback_text(self) -> None:
         """codex P1: ``logger.exception(...)`` / ``exc_info=True`` attaches
         a ``(type, value, traceback)`` tuple. The default formatter caches
@@ -280,6 +302,44 @@ class TestContract:
         # error via its own handler chain.
         assert record.msg == original_msg
         assert record.args == original_args
+
+    def test_loguru_patcher_replaces_exception_with_sanitized_version(self) -> None:
+        """codex P1 (PRRT_kwDOR_Rkws59HjtX): the loguru patcher must
+        overwrite ``record["exception"]`` with a sanitized
+        ``RecordException`` — loguru renders ``{exception}`` from that
+        field, never from ``record["extra"][...]``. Before the fix the
+        redacted text was stashed in an unused extra and the original
+        exception still leaked.
+        """
+        from utils.log_redact import _install_on_loguru
+
+        instance = CredentialRedactingFilter()
+        _install_on_loguru(instance)
+        patcher = getattr(instance, "_loguru_patcher", None)
+        assert patcher is not None, "loguru patcher was not installed"
+
+        try:
+            raise RuntimeError("api_key=sk-super-secret-xyz123 inside error")
+        except RuntimeError as exc:
+            from loguru._recattrs import RecordException  # type: ignore[import-untyped]
+
+            orig_exc = RecordException(type(exc), exc, exc.__traceback__)
+
+        record = {
+            "message": "an error occurred",
+            "exception": orig_exc,
+            "extra": {},
+        }
+        patcher(record)
+
+        # The exception payload must be REPLACED, not left in extra.
+        new_exc = record["exception"]
+        assert new_exc is not orig_exc, (
+            "patcher left original exception in record['exception'] — leak"
+        )
+        rendered = str(new_exc.value)
+        assert "sk-super-secret-xyz123" not in rendered
+        assert REDACTED in rendered
 
     def test_install_on_root_installs_loguru_patcher(self) -> None:
         """codex P1: ``install_on_root`` must also install a patcher on the

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -267,6 +267,23 @@ class TestRedactsArgs:
         assert "sk-super-secret-xyz123" not in rendered
         assert REDACTED in rendered
 
+    def test_redacts_mapping_style_format_with_userdict(self) -> None:
+        """codex P2 (PRRT_kwDOR_Rkws59JMYx): ``logging`` accepts any
+        ``collections.abc.Mapping`` for mapping-style interpolation, not
+        just ``dict``. A ``UserDict`` with a credential key must still be
+        pre-scrubbed.
+        """
+        from collections import UserDict
+
+        f = CredentialRedactingFilter()
+        args: UserDict[str, str] = UserDict()
+        args["api_key"] = "sk-super-secret-xyz123"
+        record = _make_record("loading %(api_key)s now", args)
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "sk-super-secret-xyz123" not in rendered
+        assert REDACTED in rendered
+
     def test_redacts_raw_secret_arg_when_template_key_is_auth(self) -> None:
         """coderabbit Major (PRRT_kwDOR_Rkws59II7L): ``logger.info("auth=%s",
         secret)`` — after formatting, the rendered message is

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -25,7 +25,7 @@ import pytest
 
 from utils.log_redact import REDACTED, CredentialRedactingFilter
 
-pytestmark = [pytest.mark.ci, pytest.mark.unit]
+pytestmark = [pytest.mark.ci, pytest.mark.unit, pytest.mark.integration]
 
 
 def _make_record(msg: object, *args: object) -> logging.LogRecord:

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -132,6 +132,33 @@ class TestRedactsKeyValueForms:
         assert "abc-secret" not in rendered
         assert REDACTED in rendered
 
+    def test_quoted_value_with_escaped_quote(self) -> None:
+        """codex P1 (PRRT_kwDOR_Rkws59IhT6): JSON-escaped secrets like
+        ``password="abc\\"def secret"`` must be fully redacted. The
+        quoted alternative needs to treat ``\\"`` as an interior
+        character, not a terminator. Previously only ``abc`` was masked
+        and ``def secret`` leaked after the unescaped close.
+        """
+        f = CredentialRedactingFilter()
+        # Raw string — the \" in the record is a literal backslash + quote.
+        record = _make_record(r'password="abc\"def secret value"')
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "def secret" not in rendered
+        assert "secret value" not in rendered
+        assert REDACTED in rendered
+
+    def test_single_quoted_value_with_escaped_quote(self) -> None:
+        """Mirror case for single-quoted value with a backslash-escaped
+        single quote inside.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record(r"token='abc\'def inside'")
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "def inside" not in rendered
+        assert REDACTED in rendered
+
 
 class TestRedactsBearerHeader:
     """HTTP ``Authorization: Bearer <token>`` leaks."""

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -183,6 +183,54 @@ class TestContract:
         assert record.msg == original_msg
         assert record.args == original_args
 
+    def test_non_string_msg_dict_is_redacted(self) -> None:
+        """codex P1: ``logger.info({"api_key": "sk-xxx"})`` — ``record.msg``
+        is a ``dict``, ``record.args`` is empty. Previously the filter
+        skipped redaction because ``isinstance(record.msg, str)`` was
+        False; ``LogRecord.getMessage()`` would later ``str()`` the dict
+        and leak the credential. The filter must always stringify and
+        redact.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record({"api_key": "sk-super-secret-xyz123"})  # type: ignore[arg-type]
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "sk-super-secret-xyz123" not in rendered
+        assert REDACTED in rendered
+
+    def test_non_string_msg_with_leaking_custom_str(self) -> None:
+        """Custom object whose ``__str__`` returns a credential-shaped
+        string. Same leak shape as the dict case but via an object.
+        """
+
+        class _LeakyObj:
+            def __str__(self) -> str:
+                return "token=sk-leaked-secret"
+
+        f = CredentialRedactingFilter()
+        record = _make_record(_LeakyObj())  # type: ignore[arg-type]
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "sk-leaked-secret" not in rendered
+        assert REDACTED in rendered
+
+    def test_buggy_msg_str_does_not_escape_filter(self) -> None:
+        """If ``str(record.msg)`` itself raises (buggy custom ``__str__``
+        with no args present), the filter must swallow and return True.
+        Same contract as ``test_buggy_arg_str_does_not_escape_filter`` but
+        for the no-args branch.
+        """
+
+        class _PoisonObj:
+            def __str__(self) -> str:
+                raise RuntimeError("buggy __str__")
+
+        f = CredentialRedactingFilter()
+        original = _PoisonObj()
+        record = _make_record(original)  # type: ignore[arg-type]
+        assert f.filter(record) is True
+        assert record.msg is original  # untouched
+
     def test_buggy_arg_str_does_not_escape_filter(self) -> None:
         """codex P2: the filter is attached via ``setLogRecordFactory`` so it
         runs on every ``logger.*()`` call. If a ``%s`` arg's ``__str__`` /

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -214,6 +214,28 @@ class TestContract:
         assert "sk-leaked-secret" not in rendered
         assert REDACTED in rendered
 
+    def test_redacts_exception_traceback_text(self) -> None:
+        """codex P1: ``logger.exception(...)`` / ``exc_info=True`` attaches
+        a ``(type, value, traceback)`` tuple. The default formatter caches
+        ``formatException`` output in ``record.exc_text``. If the exception
+        message itself contains a credential (``RuntimeError("api_key=
+        sk-xxx")``), it leaks into the log output verbatim unless
+        ``exc_text`` is also redacted.
+        """
+        f = CredentialRedactingFilter()
+        try:
+            raise RuntimeError("api_key=sk-super-secret-xyz123 inside error")
+        except RuntimeError:
+            import sys
+
+            exc_info = sys.exc_info()
+        record = _make_record("caught an error")
+        record.exc_info = exc_info
+        assert f.filter(record) is True
+        assert record.exc_text is not None
+        assert "sk-super-secret-xyz123" not in record.exc_text
+        assert REDACTED in record.exc_text
+
     def test_buggy_msg_str_does_not_escape_filter(self) -> None:
         """If ``str(record.msg)`` itself raises (buggy custom ``__str__``
         with no args present), the filter must swallow and return True.
@@ -258,6 +280,32 @@ class TestContract:
         # error via its own handler chain.
         assert record.msg == original_msg
         assert record.args == original_args
+
+    def test_install_on_root_installs_loguru_patcher(self) -> None:
+        """codex P1: ``install_on_root`` must also install a patcher on the
+        Loguru logger (``src/models/_openai_client.py`` + ``_claude_client.py``
+        use loguru). Records emitted through loguru bypass
+        ``setLogRecordFactory``, so a stdlib-only install leaves loguru
+        paths unprotected. Installing via ``logger.configure(patcher=...)``
+        covers them.
+        """
+        from utils.log_redact import install_on_root
+
+        original_factory = logging.getLogRecordFactory()
+        try:
+            installed = install_on_root()
+            # The filter instance stashes the loguru patcher when the
+            # loguru integration succeeded.
+            assert getattr(installed, "_loguru_patcher", None) is not None, (
+                "install_on_root did not install the loguru patcher"
+            )
+        finally:
+            logging.setLogRecordFactory(original_factory)
+            for f in [
+                filt for filt in logging.getLogger().filters
+                if isinstance(filt, CredentialRedactingFilter)
+            ]:
+                logging.getLogger().removeFilter(f)
 
     def test_install_on_root_honours_extra_loggers(self) -> None:
         """``install_on_root(extra_loggers=["foo"])`` attaches the filter to

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -183,6 +183,34 @@ class TestContract:
         assert record.msg == original_msg
         assert record.args == original_args
 
+    def test_buggy_arg_str_does_not_escape_filter(self) -> None:
+        """codex P2: the filter is attached via ``setLogRecordFactory`` so it
+        runs on every ``logger.*()`` call. If a ``%s`` arg's ``__str__`` /
+        ``__repr__`` raises an exception unrelated to format errors
+        (``RuntimeError``, ``AttributeError``, custom ``Exception``
+        subclass), that exception must NOT propagate out of the filter —
+        otherwise the caller's normal code path breaks, including for
+        records that would later be dropped by handler level.
+        """
+
+        class _PoisonArg:
+            def __str__(self) -> str:
+                raise RuntimeError("buggy __str__")
+
+            def __repr__(self) -> str:
+                raise RuntimeError("buggy __repr__")
+
+        f = CredentialRedactingFilter()
+        record = _make_record("auth=%s", _PoisonArg())
+        original_msg = record.msg
+        original_args = record.args
+        # Must return True (never drops) and must not let RuntimeError escape.
+        assert f.filter(record) is True
+        # Record left untouched so logging's own emit() path can surface the
+        # error via its own handler chain.
+        assert record.msg == original_msg
+        assert record.args == original_args
+
     def test_install_on_root_honours_extra_loggers(self) -> None:
         """``install_on_root(extra_loggers=["foo"])`` attaches the filter to
         each named logger so it fires for records originating there. Belt-

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -267,6 +267,47 @@ class TestRedactsArgs:
         assert "sk-super-secret-xyz123" not in rendered
         assert REDACTED in rendered
 
+    def test_redacts_mapping_style_authorization_placeholder(self) -> None:
+        """codex P1 (PRRT_kwDOR_Rkws59JVLj): the mapping-style
+        ``%(Authorization)s`` template interpolates just ``Bearer <token>``
+        (the ``Authorization`` prefix is gone), so ``_BEARER_PATTERN``
+        can't match afterwards. ``authorization`` must be in the
+        credential-key list so the dict value is pre-scrubbed.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record(
+            "header %(Authorization)s sent",
+            {"Authorization": "Bearer abc123.xyz_def"},
+        )
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "abc123.xyz_def" not in rendered
+        assert REDACTED in rendered
+
+    def test_filter_survives_broken_mapping_items(self) -> None:
+        """codex P2 (PRRT_kwDOR_Rkws59JVLp): the pre-scrub comprehension
+        runs inside the try/except so a custom ``Mapping`` whose
+        ``items()`` / ``__iter__`` raises doesn't escape the filter and
+        break the caller (we're installed via ``setLogRecordFactory`` so
+        every ``logger.*()`` call hits this).
+        """
+        from collections.abc import Mapping as AbcMapping
+
+        class _PoisonMapping(AbcMapping):  # type: ignore[type-arg]
+            def __iter__(self):  # type: ignore[override]
+                raise RuntimeError("broken __iter__")
+
+            def __len__(self) -> int:
+                return 0
+
+            def __getitem__(self, key):  # type: ignore[override]
+                raise KeyError(key)
+
+        f = CredentialRedactingFilter()
+        record = _make_record("template %(k)s", _PoisonMapping())
+        # Must return True (never drops) and must not raise.
+        assert f.filter(record) is True
+
     def test_redacts_mapping_style_format_with_userdict(self) -> None:
         """codex P2 (PRRT_kwDOR_Rkws59JMYx): ``logging`` accepts any
         ``collections.abc.Mapping`` for mapping-style interpolation, not
@@ -515,6 +556,85 @@ class TestContract:
         assert record.getMessage() == first_pass
         # Explicit shape check: no trailing ``]]`` bracket corruption.
         assert "]]" not in record.getMessage()
+
+    def test_forged_idempotency_attribute_does_not_bypass_redaction(self) -> None:
+        """coderabbit Major (PRRT_kwDOR_Rkws59II7G): the idempotency guard
+        must key off an unforgeable module sentinel — identity-checked
+        against ``_RECORD_REDACTED_SENTINEL`` — rather than any truthy
+        value. A caller-supplied ``extra={"_fo_redacted": True}`` would
+        otherwise land as ``record._fo_redacted = True`` (``LogRecord``
+        applies ``extra`` as instance attributes) and short-circuit the
+        filter before secrets are scrubbed.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record("api_key=sk-super-secret-xyz123")
+        # Attacker-supplied truthy value mimicking the old idempotency
+        # marker. Must NOT be honoured.
+        record._fo_redacted = True  # type: ignore[attr-defined]
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "sk-super-secret-xyz123" not in rendered
+        assert REDACTED in rendered
+
+    def test_redacts_pre_populated_exc_text(self) -> None:
+        """coderabbit Major (PRRT_kwDOR_Rkws59II7G): some code paths
+        populate ``record.exc_text`` directly (pre-formatted exceptions
+        cached by an earlier formatter, loguru→stdlib bridges) without
+        going through ``exc_info``. The filter must redact the pre-
+        populated field so a rendered traceback carrying a secret doesn't
+        reach the handler unscrubbed.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record("caught an error")
+        record.exc_text = (
+            "Traceback (most recent call last):\n"
+            '  File "x.py", line 1, in <module>\n'
+            '    raise RuntimeError("api_key=sk-super-secret-xyz123")\n'
+            "RuntimeError: api_key=sk-super-secret-xyz123"
+        )
+        assert f.filter(record) is True
+        assert record.exc_text is not None
+        assert "sk-super-secret-xyz123" not in record.exc_text
+        assert REDACTED in record.exc_text
+
+    def test_exc_info_format_failure_fails_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """coderabbit Major (PRRT_kwDOR_Rkws59II7G): if
+        ``traceback.format_exception(*record.exc_info)`` raises (e.g. a
+        monkey-patched ``traceback`` module in a pathological test env,
+        or a custom exception subclass whose ``__traceback__`` walk
+        breaks), the filter must NOT leave ``exc_info`` intact for the
+        default ``Formatter`` to re-render via the same broken call
+        path. Fail closed: replace ``exc_text`` with the REDACTED
+        sentinel and clear ``exc_info`` so the formatter skips its own
+        render. (``traceback.format_exception`` is itself defensive
+        against buggy ``__str__`` — it renders
+        ``<exception str() failed>`` rather than raising — so the only
+        way to exercise this branch deterministically is to patch the
+        formatter.)
+        """
+        import sys
+
+        import utils.log_redact as log_redact_mod
+
+        def _boom(*_args: object, **_kwargs: object) -> list[str]:
+            raise RuntimeError("simulated traceback.format_exception failure")
+
+        monkeypatch.setattr(log_redact_mod.traceback, "format_exception", _boom)
+
+        f = CredentialRedactingFilter()
+        try:
+            raise RuntimeError("api_key=sk-super-secret-xyz123")
+        except RuntimeError:
+            exc_info = sys.exc_info()
+        record = _make_record("caught an error")
+        record.exc_info = exc_info
+        assert f.filter(record) is True
+        # Fail-closed: exc_text is the sanitized placeholder and
+        # exc_info is cleared so the default Formatter won't attempt its
+        # own render via the broken call path (which would leak the raw
+        # exception message containing the secret).
+        assert record.exc_text == REDACTED
+        assert record.exc_info is None
 
     def test_loguru_patcher_replaces_exception_with_sanitized_version(self) -> None:
         """codex P1 (PRRT_kwDOR_Rkws59HjtX): the loguru patcher must

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -28,8 +28,10 @@ from utils.log_redact import REDACTED, CredentialRedactingFilter
 pytestmark = [pytest.mark.ci, pytest.mark.unit]
 
 
-def _make_record(msg: str, *args: object) -> logging.LogRecord:
-    """Build a minimal ``LogRecord`` for filter tests."""
+def _make_record(msg: object, *args: object) -> logging.LogRecord:
+    """Build a minimal ``LogRecord`` for filter tests. ``msg`` is typed as
+    ``object`` because several tests intentionally pass dict / custom-object
+    messages through the no-args stringify path."""
     return logging.LogRecord(
         name="test",
         level=logging.INFO,
@@ -103,9 +105,7 @@ class TestRedactsBearerHeader:
         dict-repr form, not just the bare HTTP header shape.
         """
         f = CredentialRedactingFilter()
-        record = _make_record(  # type: ignore[arg-type]
-            {"Authorization": "Bearer abc123.xyz_def"}
-        )
+        record = _make_record({"Authorization": "Bearer abc123.xyz_def"})
         assert f.filter(record) is True
         rendered = record.getMessage()
         assert "abc123.xyz_def" not in rendered
@@ -127,6 +127,20 @@ class TestRedactsArgs:
     def test_redacts_single_string_arg(self) -> None:
         f = CredentialRedactingFilter()
         record = _make_record("auth=%s", "api_key=sk-super-secret-xyz123")
+        assert f.filter(record) is True
+        assert "sk-super-secret-xyz123" not in record.getMessage()
+        assert REDACTED in record.getMessage()
+
+    def test_redacts_raw_secret_arg_when_template_key_is_auth(self) -> None:
+        """coderabbit Major (PRRT_kwDOR_Rkws59II7L): ``logger.info("auth=%s",
+        secret)`` — after formatting, the rendered message is
+        ``"auth=<raw-secret>"``. The bare ``auth`` key must be in
+        ``_CRED_KEYS`` so redaction catches this shape — the raw secret
+        arg doesn't itself contain a credential key, only the template
+        does.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record("auth=%s", "sk-super-secret-xyz123")
         assert f.filter(record) is True
         assert "sk-super-secret-xyz123" not in record.getMessage()
         assert REDACTED in record.getMessage()
@@ -191,21 +205,27 @@ class TestContract:
         assert "alice" in rendered
         assert "abc" not in rendered
 
-    def test_malformed_template_is_passed_through_unchanged(self) -> None:
-        """A record whose ``msg % args`` raises (wrong arg count, etc.) must
-        be left as-is so Python's logging error handler can surface the
-        original formatting error. The filter must still return ``True``
-        (never drops) and must not mutate ``record.msg`` or ``record.args``.
+    def test_malformed_template_sanitizes_args_fail_closed(self) -> None:
+        """coderabbit Major (PRRT_kwDOR_Rkws59II7Q): on a malformed template
+        (wrong arg count, etc.) the filter must NOT preserve the raw args —
+        logging's own error handler prints them to stderr when
+        ``getMessage()`` later raises. Fail-CLOSED posture: args are
+        replaced with REDACTED sentinels so the safety net holds even on
+        unknown-shape inputs. ``filter()`` still returns ``True`` (never
+        drops) and never raises.
         """
         f = CredentialRedactingFilter()
-        # Template expects 2 %s, only 1 arg provided → getMessage() raises
-        # TypeError when invoked.
-        record = _make_record("need=%s and=%s", "one-arg-only")
-        original_msg = record.msg
-        original_args = record.args
+        # Template expects 2 %s, only 1 arg provided → getMessage() raises.
+        # The one arg is a credential-shaped secret — must be scrubbed.
+        record = _make_record("need=%s and=%s", "api_key=sk-super-secret-xyz123")
         assert f.filter(record) is True
-        assert record.msg == original_msg
-        assert record.args == original_args
+        # args sanitized to REDACTED sentinels.
+        assert record.args == (REDACTED,)
+        # msg was at least stringified + run through the redacter.
+        assert "sk-super-secret-xyz123" not in str(record.msg)
+        # None of the raw secret leaks anywhere on the record.
+        for field in (record.msg, record.args):
+            assert "sk-super-secret-xyz123" not in repr(field)
 
     def test_non_string_msg_dict_is_redacted(self) -> None:
         """codex P1: ``logger.info({"api_key": "sk-xxx"})`` — ``record.msg``
@@ -216,7 +236,7 @@ class TestContract:
         redact.
         """
         f = CredentialRedactingFilter()
-        record = _make_record({"api_key": "sk-super-secret-xyz123"})  # type: ignore[arg-type]
+        record = _make_record({"api_key": "sk-super-secret-xyz123"})
         assert f.filter(record) is True
         rendered = record.getMessage()
         assert "sk-super-secret-xyz123" not in rendered
@@ -232,7 +252,7 @@ class TestContract:
                 return "token=sk-leaked-secret"
 
         f = CredentialRedactingFilter()
-        record = _make_record(_LeakyObj())  # type: ignore[arg-type]
+        record = _make_record(_LeakyObj())
         assert f.filter(record) is True
         rendered = record.getMessage()
         assert "sk-leaked-secret" not in rendered
@@ -285,8 +305,10 @@ class TestContract:
     def test_buggy_msg_str_does_not_escape_filter(self) -> None:
         """If ``str(record.msg)`` itself raises (buggy custom ``__str__``
         with no args present), the filter must swallow and return True.
-        Same contract as ``test_buggy_arg_str_does_not_escape_filter`` but
-        for the no-args branch.
+        Fail-CLOSED: replace ``record.msg`` with REDACTED sentinel rather
+        than leaving the original object in place — a later ``str(msg)``
+        in a handler could still raise (and emit the original via
+        Python's logging error path). coderabbit PRRT_kwDOR_Rkws59II7Q.
         """
 
         class _PoisonObj:
@@ -294,19 +316,18 @@ class TestContract:
                 raise RuntimeError("buggy __str__")
 
         f = CredentialRedactingFilter()
-        original = _PoisonObj()
-        record = _make_record(original)  # type: ignore[arg-type]
+        record = _make_record(_PoisonObj())
         assert f.filter(record) is True
-        assert record.msg is original  # untouched
+        # msg replaced with the sanitized sentinel so downstream handlers
+        # can't trigger the buggy __str__.
+        assert record.msg == REDACTED
 
     def test_buggy_arg_str_does_not_escape_filter(self) -> None:
-        """codex P2: the filter is attached via ``setLogRecordFactory`` so it
-        runs on every ``logger.*()`` call. If a ``%s`` arg's ``__str__`` /
-        ``__repr__`` raises an exception unrelated to format errors
-        (``RuntimeError``, ``AttributeError``, custom ``Exception``
-        subclass), that exception must NOT propagate out of the filter —
-        otherwise the caller's normal code path breaks, including for
-        records that would later be dropped by handler level.
+        """codex P2 + coderabbit PRRT_kwDOR_Rkws59II7Q: if a ``%s`` arg's
+        ``__str__`` / ``__repr__`` raises, the filter must NOT propagate
+        (runs on every ``logger.*()`` via ``setLogRecordFactory``) AND
+        must sanitize args fail-closed so a later logging error-handler
+        print of the args tuple can't leak the value.
         """
 
         class _PoisonArg:
@@ -318,14 +339,11 @@ class TestContract:
 
         f = CredentialRedactingFilter()
         record = _make_record("auth=%s", _PoisonArg())
-        original_msg = record.msg
-        original_args = record.args
-        # Must return True (never drops) and must not let RuntimeError escape.
         assert f.filter(record) is True
-        # Record left untouched so logging's own emit() path can surface the
-        # error via its own handler chain.
-        assert record.msg == original_msg
-        assert record.args == original_args
+        # Args sanitized even though we couldn't format them — the poison
+        # arg is replaced by the REDACTED sentinel so downstream handlers
+        # can't trigger its buggy methods.
+        assert record.args == (REDACTED,)
 
     def test_filter_is_idempotent_on_repeated_invocation(self) -> None:
         """codex P2 (PRRT_kwDOR_Rkws59H2ZK): ``install_on_root`` attaches


### PR DESCRIPTION
Closes Epic A (A3) of the [hardening roadmap](docs/superpowers/specs/2026-04-22-hardening-roadmap-design.md).

## Summary

Adds `src/utils/log_redact.py::CredentialRedactingFilter` — a project-wide safety net that masks credential-looking values in log records before they hit any handler. Wraps `logging.getLogRecordFactory()` so every record (including those from child loggers) is scrubbed at construction time. Attached in `cli.main.main_callback` so the filter is active before any command runs.

## Why the factory wrapper, not just `root.addFilter()`

`Logger` filters apply only at the *originating* logger — propagation to ancestor handlers does NOT re-run ancestor filters. A filter attached to the root logger would miss every record from `logging.getLogger(__name__)` calls in `src/` (the common case). The factory wrapper runs at record construction, covering every record regardless of originating logger or handler chain.

## Coverage

The filter catches:

- `api_key=sk-...`, `api-key="..."`, `API_KEY: '...'` — case-insensitive, quoted/unquoted, underscore/hyphen spellings
- `token`, `secret`, `password`, `passwd`, `credential`, `access_token`, `auth_token`, `bearer_token`
- `Authorization: Bearer <token>` HTTP header shape
- Positional format args (`logger.info("auth=%s", secret)`) — not just inline message

Non-credential `key=value` pairs (`user=alice`) are NOT redacted.

## Test plan

- [x] 18 unit tests covering every credential shape + preservation of non-credentials
- [x] 1 CLI integration test that invokes `fo version`, verifies `install_on_root()` ran, and confirms a record from a child logger comes back redacted
- [x] Contract assertions: `filter()` always returns `True` (redact-only, never drops)
- [x] Pre-commit validation passes (all gates green locally)

## Roadmap status

With this PR, Epic A is fully landed:
- [#168](https://github.com/curdriceaurora/fo-core/pull/168) A.foundation (path_guard + walker sweep)
- [#172](https://github.com/curdriceaurora/fo-core/pull/172) A.cli (CLI path validation)
- [#173](https://github.com/curdriceaurora/fo-core/pull/173) A.cli follow-up (dedupe `--include-hidden`)
- this PR A.creds (credential-redacting log filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Process-wide credential redaction for application logs: common secret patterns (API keys, tokens, passwords, bearer tokens) are replaced with a redaction marker across standard logging and Loguru, and activated at CLI startup so all commands inherit protection.
* **Tests**
  * Comprehensive test suite validating redaction across message forms, formatting args, exceptions, idempotence, and end-to-end integration with the CLI and Loguru.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->