### PR TITLE
[codex] fix(log-redact): handle quoted placeholder suffixes

### DIFF
--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -91,8 +91,9 @@ _CRED_KEY_FULL = re.compile(r"(?i)^(?:" + "|".join(_CRED_KEY_FULL_NAMES) + r")$"
 #    placeholders don't leak suffixes when the substituted credential
 #    contains the same quote character as the template wrapper (codex
 #    P1 PRRT_kwDOR_Rkws59JVLj) while still preserving trailing context in
-#    shapes like ``password="secret". user=alice`` and
-#    ``token='secret': next``.
+#    shapes like ``password="secret". user=alice``,
+#    ``token='secret': next``, ``password="secret"/ user=alice``, and
+#    ``token='secret'?next=1``.
 # 2. Single-quoted, closed — mirror case.
 # 3. Double-quoted, UNCLOSED (``password="super secret``, truncated log
 #    or malformed template) — eats everything up to end of line so the
@@ -107,9 +108,9 @@ _CRED_KEY_FULL = re.compile(r"(?i)^(?:" + "|".join(_CRED_KEY_FULL_NAMES) + r")$"
 _KV_PATTERN = re.compile(
     r"(?i)(?P<key>(?:" + "|".join(_CRED_KEYS) + r")[\"']?\s*[:=]\s*)"
     r"(?:"
-    r'"(?P<qvalue_dq>(?:[^"\\]|\\.|"(?![\s,;:.&}\])]|$))*)"(?=[\s,;:.&}\])]|$)'
+    r'"(?P<qvalue_dq>(?:[^"\\]|\\.|"(?![\s,;:./?&}\])]|$))*)"(?=[\s,;:./?&}\])]|$)'
     r"|"
-    r"'(?P<qvalue_sq>(?:[^'\\]|\\.|'(?![\s,;:.&}\])]|$))*)'(?=[\s,;:.&}\])]|$)"
+    r"'(?P<qvalue_sq>(?:[^'\\]|\\.|'(?![\s,;:./?&}\])]|$))*)'(?=[\s,;:./?&}\])]|$)"
     r"|"
     r'"(?P<mvalue_dq>[^\r\n]*)'
     r"|"

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -84,7 +84,13 @@ _CRED_KEY_FULL = re.compile(r"(?i)^(?:" + "|".join(_CRED_KEY_FULL_NAMES) + r")$"
 # five alternatives ordered so each form stops on the correct delimiter:
 #
 # 1. Double-quoted, closed (``password="abc'def"``) — allows single
-#    quotes and ``\\"`` escapes inside; terminates on unescaped ``"``.
+#    quotes, ``\\"`` escapes, and even raw interior ``"`` characters
+#    inserted by ``logger.info('token="%s"', 'abc"def')``. A quote only
+#    counts as the closer when the next char is a normal value boundary
+#    (whitespace / punctuation / end-of-string), so quoted placeholders
+#    don't leak suffixes when the substituted credential contains the
+#    same quote character as the template wrapper (codex P1
+#    PRRT_kwDOR_Rkws59JVLj).
 # 2. Single-quoted, closed — mirror case.
 # 3. Double-quoted, UNCLOSED (``password="super secret``, truncated log
 #    or malformed template) — eats everything up to end of line so the
@@ -99,9 +105,9 @@ _CRED_KEY_FULL = re.compile(r"(?i)^(?:" + "|".join(_CRED_KEY_FULL_NAMES) + r")$"
 _KV_PATTERN = re.compile(
     r"(?i)(?P<key>(?:" + "|".join(_CRED_KEYS) + r")[\"']?\s*[:=]\s*)"
     r"(?:"
-    r'"(?P<qvalue_dq>(?:[^"\\]|\\.)*)"'
+    r'"(?P<qvalue_dq>(?:[^"\\]|\\.|"(?![\s,;&}\])]|$))*)"(?=[\s,;&}\])]|$)'
     r"|"
-    r"'(?P<qvalue_sq>(?:[^'\\]|\\.)*)'"
+    r"'(?P<qvalue_sq>(?:[^'\\]|\\.|'(?![\s,;&}\])]|$))*)'(?=[\s,;&}\])]|$)"
     r"|"
     r'"(?P<mvalue_dq>[^\r\n]*)'
     r"|"

--- a/src/utils/log_redact.py
+++ b/src/utils/log_redact.py
@@ -87,10 +87,12 @@ _CRED_KEY_FULL = re.compile(r"(?i)^(?:" + "|".join(_CRED_KEY_FULL_NAMES) + r")$"
 #    quotes, ``\\"`` escapes, and even raw interior ``"`` characters
 #    inserted by ``logger.info('token="%s"', 'abc"def')``. A quote only
 #    counts as the closer when the next char is a normal value boundary
-#    (whitespace / punctuation / end-of-string), so quoted placeholders
-#    don't leak suffixes when the substituted credential contains the
-#    same quote character as the template wrapper (codex P1
-#    PRRT_kwDOR_Rkws59JVLj).
+#    (whitespace / field punctuation / end-of-string), so quoted
+#    placeholders don't leak suffixes when the substituted credential
+#    contains the same quote character as the template wrapper (codex
+#    P1 PRRT_kwDOR_Rkws59JVLj) while still preserving trailing context in
+#    shapes like ``password="secret". user=alice`` and
+#    ``token='secret': next``.
 # 2. Single-quoted, closed — mirror case.
 # 3. Double-quoted, UNCLOSED (``password="super secret``, truncated log
 #    or malformed template) — eats everything up to end of line so the
@@ -105,9 +107,9 @@ _CRED_KEY_FULL = re.compile(r"(?i)^(?:" + "|".join(_CRED_KEY_FULL_NAMES) + r")$"
 _KV_PATTERN = re.compile(
     r"(?i)(?P<key>(?:" + "|".join(_CRED_KEYS) + r")[\"']?\s*[:=]\s*)"
     r"(?:"
-    r'"(?P<qvalue_dq>(?:[^"\\]|\\.|"(?![\s,;&}\])]|$))*)"(?=[\s,;&}\])]|$)'
+    r'"(?P<qvalue_dq>(?:[^"\\]|\\.|"(?![\s,;:.&}\])]|$))*)"(?=[\s,;:.&}\])]|$)'
     r"|"
-    r"'(?P<qvalue_sq>(?:[^'\\]|\\.|'(?![\s,;&}\])]|$))*)'(?=[\s,;&}\])]|$)"
+    r"'(?P<qvalue_sq>(?:[^'\\]|\\.|'(?![\s,;:.&}\])]|$))*)'(?=[\s,;:.&}\])]|$)"
     r"|"
     r'"(?P<mvalue_dq>[^\r\n]*)'
     r"|"

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -159,6 +159,29 @@ class TestRedactsKeyValueForms:
         assert "def inside" not in rendered
         assert REDACTED in rendered
 
+    def test_single_quoted_placeholder_value_containing_single_quote(self) -> None:
+        """codex P1: ``logger.info(\"password='%s'\", \"abc'def\")`` must
+        redact the whole quoted placeholder expansion, not stop at the
+        first interior single quote and leak the suffix.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record("password='%s'", "abc'def")
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "abc'def" not in rendered
+        assert "def" not in rendered
+        assert rendered == f"password='{REDACTED}'"
+
+    def test_double_quoted_placeholder_value_containing_double_quote(self) -> None:
+        """Mirror case: ``logger.info('token=\"%s\"', 'abc\"def')``."""
+        f = CredentialRedactingFilter()
+        record = _make_record('token="%s"', 'abc"def')
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert 'abc"def' not in rendered
+        assert "def" not in rendered
+        assert rendered == f'token="{REDACTED}"'
+
     def test_malformed_unclosed_double_quote_redacted(self) -> None:
         """codex P1 (PRRT_kwDOR_Rkws59IsZr): malformed quoted credential
         (opening quote with no matching close — e.g. truncated log, or

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -203,6 +203,24 @@ class TestRedactsKeyValueForms:
         assert "secret" not in rendered
         assert rendered == f"token='{REDACTED}': next"
 
+    def test_quoted_value_followed_by_slash_preserves_suffix(self) -> None:
+        """URL-ish separators after the closing quote must preserve suffix."""
+        f = CredentialRedactingFilter()
+        record = _make_record('password="secret"/ user=alice')
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "secret" not in rendered
+        assert rendered == f'password="{REDACTED}"/ user=alice'
+
+    def test_quoted_value_followed_by_question_mark_preserves_suffix(self) -> None:
+        """Query-string separators after the closing quote must preserve suffix."""
+        f = CredentialRedactingFilter()
+        record = _make_record("token='secret'?next=1")
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "secret" not in rendered
+        assert rendered == f"token='{REDACTED}'?next=1"
+
     def test_malformed_unclosed_double_quote_redacted(self) -> None:
         """codex P1 (PRRT_kwDOR_Rkws59IsZr): malformed quoted credential
         (opening quote with no matching close — e.g. truncated log, or

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -182,6 +182,27 @@ class TestRedactsKeyValueForms:
         assert "def" not in rendered
         assert rendered == f'token="{REDACTED}"'
 
+    def test_quoted_value_followed_by_period_preserves_suffix(self) -> None:
+        """codex P2: punctuation after a closed quoted value must not force
+        the regex into the unclosed-quote fallback and swallow later
+        fields.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record('password="secret". user=alice')
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "secret" not in rendered
+        assert rendered == f'password="{REDACTED}". user=alice'
+
+    def test_quoted_value_followed_by_colon_preserves_suffix(self) -> None:
+        """Mirror case: closing quote followed by ``:`` keeps later text."""
+        f = CredentialRedactingFilter()
+        record = _make_record("token='secret': next")
+        assert f.filter(record) is True
+        rendered = record.getMessage()
+        assert "secret" not in rendered
+        assert rendered == f"token='{REDACTED}': next"
+
     def test_malformed_unclosed_double_quote_redacted(self) -> None:
         """codex P1 (PRRT_kwDOR_Rkws59IsZr): malformed quoted credential
         (opening quote with no matching close — e.g. truncated log, or


### PR DESCRIPTION
## Summary

Follow-up to #174 for the quoted-placeholder leak in `CredentialRedactingFilter`.

When a templated quoted field was logged like `logger.info("password='%s'", "abc'def")` or `logger.info('token="%s"', 'abc"def')`, the closed-quote regex branch stopped at the first matching quote character. That produced partially scrubbed output such as `password='[REDACTED]'def'` and leaked the credential suffix.

This PR makes the quoted-value matcher treat a quote as the closing delimiter only when it is followed by a normal boundary or end-of-string, so interior same-quote characters inside placeholder-expanded secrets stay inside the redacted span.

## What Changed

- tightened the quoted `key=value` redaction regex in `src/utils/log_redact.py`
- added regression tests for both leaking shapes:
  - `password='%s'` with `abc'def`
  - `token="%s"` with `abc"def`

## Coverage / Gates

- Docstring coverage: unchanged by this patch in practice; no new public functions/classes were added. Verified the real project gate with `interrogate -v src/ --fail-under 95` -> **98.9%**.
- Integration coverage: this test module is already marked `integration`, so the new regression cases participate in the integration-marked suite. Verified with `pytest tests/utils/test_log_redact.py -m integration --override-ini=addopts=`.

## Validation

- `pytest tests/utils/test_log_redact.py --override-ini=addopts=`
- `pytest tests/utils/test_log_redact.py -m integration --override-ini=addopts=`
- `pytest tests/utils/test_log_redact.py::TestCLIIntegration::test_filter_installed_by_cli_main_callback --override-ini=addopts=`
- `interrogate -v src/ --fail-under 95`
- `python3 -m compileall src/utils/log_redact.py tests/utils/test_log_redact.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log message redaction to correctly handle quoted placeholders containing the same quote character as the surrounding delimiter, preventing premature redaction termination.

* **Tests**
  * Added unit tests validating redaction behavior for placeholder-based logging with quote-containing substituted values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->