### PR TITLE
hardening(correctness): epic-b-atomic — atomic_write helpers + 19 call-site conversions

### DIFF
--- a/src/config/manager.py
+++ b/src/config/manager.py
@@ -27,6 +27,7 @@ import yaml
 from config.path_manager import get_config_dir
 from config.schema import AppConfig, ModelPreset, UpdateSettings
 from models.base import DeviceType, ModelConfig, ModelType
+from utils.atomic_write import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -141,9 +142,9 @@ class ConfigManager:
         profiles = existing.setdefault("profiles", {})
         profiles[profile] = self.config_to_dict(config)
 
-        config_path.write_text(
+        atomic_write_text(
+            config_path,
             yaml.dump(existing, default_flow_style=False, sort_keys=False),
-            encoding="utf-8",
         )
         logger.info("Saved profile '%s' to %s", profile, config_path)
 
@@ -202,9 +203,9 @@ class ConfigManager:
             return False
 
         del profiles[profile]
-        config_path.write_text(
+        atomic_write_text(
+            config_path,
             yaml.dump(raw, default_flow_style=False, sort_keys=False),
-            encoding="utf-8",
         )
         return True
 

--- a/src/config/path_migration.py
+++ b/src/config/path_migration.py
@@ -11,6 +11,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from utils.atomic_write import atomic_write_text
+
 
 def detect_legacy_paths(home: Path, config_home: Path, data_home: Path) -> list[Path]:
     """Return no legacy app paths for the hard-cut ``fo`` identity."""
@@ -88,7 +90,7 @@ class PathMigrator:
         # Persist log to audit trail for data integrity and compliance
         self.canonical_path.mkdir(parents=True, exist_ok=True)
         audit_file = self.canonical_path / ".migration-audit.json"
-        audit_file.write_text(json.dumps(log, indent=2, default=str))
+        atomic_write_text(audit_file, json.dumps(log, indent=2, default=str))
 
         # Could optionally remove legacy path here
         # For now, leave it with backup created for safety

--- a/src/events/audit.py
+++ b/src/events/audit.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from events.stream import Event
+from utils.atomic_write import append_durable
 
 logger = logging.getLogger(__name__)
 
@@ -243,8 +244,11 @@ class AuditLogger:
         """
         self._log_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(self._log_path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry.to_dict()) + "\n")
+        # B1b: append-log durability — fsync the record and the
+        # containing directory entry so the audit record survives a
+        # crash between write and fsync. Order-preserving append, so
+        # a truncate-replace pattern would be wrong here.
+        append_durable(self._log_path, json.dumps(entry.to_dict()))
 
     @staticmethod
     def _matches_filter(entry: AuditEntry, filters: AuditFilter | None) -> bool:

--- a/src/events/discovery.py
+++ b/src/events/discovery.py
@@ -15,6 +15,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from utils.atomic_write import atomic_write_text
+
 logger = logging.getLogger(__name__)
 
 # Default registry path relative to working directory
@@ -134,9 +136,9 @@ class ServiceDiscovery:
         """Persist the current registry to disk."""
         self._path.parent.mkdir(parents=True, exist_ok=True)
         payload = {name: info.to_dict() for name, info in self._services.items()}
-        self._path.write_text(
+        atomic_write_text(
+            self._path,
             json.dumps(payload, indent=2, sort_keys=True),
-            encoding="utf-8",
         )
         logger.debug("Saved %d services to %s", len(self._services), self._path)
 

--- a/src/integrations/vscode.py
+++ b/src/integrations/vscode.py
@@ -13,6 +13,7 @@ from integrations.base import (
     IntegrationStatus,
     IntegrationType,
 )
+from utils.atomic_write import append_durable
 
 
 class VSCodeIntegration(Integration):
@@ -73,8 +74,9 @@ class VSCodeIntegration(Integration):
             "metadata": metadata or {},
             "created_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         }
-        with output.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(payload, sort_keys=True) + "\n")
+        # B1b: durable append — fsync the record so the VS Code
+        # command stream survives a crash between write and fsync.
+        append_durable(output, json.dumps(payload, sort_keys=True))
         return True
 
     async def get_status(self) -> IntegrationStatus:

--- a/src/methodologies/johnny_decimal/config.py
+++ b/src/methodologies/johnny_decimal/config.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from utils.atomic_write import atomic_write_with
+
 from .categories import AreaDefinition, CategoryDefinition, NumberingScheme
 
 logger = logging.getLogger(__name__)
@@ -191,8 +193,12 @@ class JohnnyDecimalConfig:
         """
         path.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(path, "w") as f:
-            json.dump(self.to_dict(), f, indent=2)
+        data = self.to_dict()
+        atomic_write_with(
+            path,
+            lambda fh: json.dump(data, fh, indent=2),
+            mode="w",
+        )
 
         logger.info(f"Configuration saved to {path}")
 

--- a/src/methodologies/johnny_decimal/migrator.py
+++ b/src/methodologies/johnny_decimal/migrator.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
+from utils.atomic_write import atomic_write_with
+
 from .categories import NumberingScheme, get_default_scheme
 from .numbering import JohnnyDecimalGenerator
 from .scanner import FolderScanner, ScanResult
@@ -323,8 +325,11 @@ class JohnnyDecimalMigrator:
             "backup_path": str(rollback_info.backup_path) if rollback_info.backup_path else None,
         }
 
-        with open(rollback_file, "w") as f:
-            json.dump(data, f, indent=2)
+        atomic_write_with(
+            rollback_file,
+            lambda fh: json.dump(data, fh, indent=2),
+            mode="w",
+        )
 
         logger.debug(f"Saved rollback info to {rollback_file}")
 

--- a/src/methodologies/johnny_decimal/system.py
+++ b/src/methodologies/johnny_decimal/system.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from core.path_guard import safe_walk
+from utils.atomic_write import atomic_write_with
 
 from .categories import (
     AreaDefinition,
@@ -409,8 +410,11 @@ class JohnnyDecimalSystem:
 
         save_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(save_path, "w") as f:
-            json.dump(config, f, indent=2)
+        atomic_write_with(
+            save_path,
+            lambda fh: json.dump(config, fh, indent=2),
+            mode="w",
+        )
 
         logger.info(f"Saved configuration to {save_path}")
 

--- a/src/methodologies/para/ai/feedback.py
+++ b/src/methodologies/para/ai/feedback.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from config.path_manager import get_config_dir
 from config.path_migration import resolve_legacy_path
+from utils.atomic_write import atomic_write_with
 
 from ..categories import PARACategory
 from ..config import HeuristicWeights
@@ -304,8 +305,11 @@ class FeedbackCollector:
         try:
             self._storage_dir.mkdir(parents=True, exist_ok=True)
             data = [event.to_dict() for event in self._events]
-            with open(self._feedback_file, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2, ensure_ascii=False)
+            atomic_write_with(
+                self._feedback_file,
+                lambda fh: json.dump(data, fh, indent=2, ensure_ascii=False),
+                mode="w",
+            )
         except OSError as e:
             logger.error("Failed to save feedback events: %s", e, exc_info=True)
 

--- a/src/methodologies/para/ai/feedback.py
+++ b/src/methodologies/para/ai/feedback.py
@@ -305,10 +305,17 @@ class FeedbackCollector:
         try:
             self._storage_dir.mkdir(parents=True, exist_ok=True)
             data = [event.to_dict() for event in self._events]
+            # Explicit UTF-8: ``json.dump(..., ensure_ascii=False)``
+            # can emit raw non-ASCII characters; on non-UTF-8 locales
+            # (common on Windows), a locale-default open would raise
+            # ``UnicodeEncodeError`` or write bytes that later fail to
+            # decode as UTF-8 in ``_load_events`` (codex P1
+            # PRRT_kwDOR_Rkws59ML8K).
             atomic_write_with(
                 self._feedback_file,
                 lambda fh: json.dump(data, fh, indent=2, ensure_ascii=False),
                 mode="w",
+                encoding="utf-8",
             )
         except OSError as e:
             logger.error("Failed to save feedback events: %s", e, exc_info=True)

--- a/src/methodologies/para/config.py
+++ b/src/methodologies/para/config.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 import yaml
 
+from utils.atomic_write import atomic_write_with
+
 from .categories import PARACategory
 
 logger = logging.getLogger(__name__)
@@ -267,8 +269,11 @@ class PARAConfig:
 
         try:
             config_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(config_path, "w") as f:
-                yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+            atomic_write_with(
+                config_path,
+                lambda fh: yaml.dump(data, fh, default_flow_style=False, sort_keys=False),
+                mode="w",
+            )
 
             logger.info(f"Configuration saved to {config_path}")
 

--- a/src/methodologies/para/migration_manager.py
+++ b/src/methodologies/para/migration_manager.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from config.path_manager import PathManager
+from utils.atomic_write import atomic_write_with
 
 from .categories import PARACategory
 from .config import PARAConfig
@@ -390,25 +391,28 @@ class PARAMigrationManager:
             manifest_checksum = self._calculate_manifest_checksum(file_entries)
             manifest.checksum = manifest_checksum
 
-            # Save manifest
+            # Save manifest (atomic — temp + os.replace so a crash can't
+            # leave the backup referencing a truncated manifest).
             manifest_file = backup_dir / "manifest.json"
-            with open(manifest_file, "w") as f:
-                # Serialize with custom JSON encoder for datetime and Path
-                manifest_data = {
-                    "backup_id": manifest.backup_id,
-                    "migration_id": manifest.migration_id,
-                    "created_at": manifest.created_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                    "files_backed_up": manifest.files_backed_up,
-                    "total_size": manifest.total_size,
-                    "checksum": manifest.checksum,
-                    "source_root": str(manifest.source_root),
-                    "status": manifest.status,
-                    "restored_at": manifest.restored_at.strftime("%Y-%m-%dT%H:%M:%SZ")
-                    if manifest.restored_at
-                    else None,
-                    "file_entries": manifest.file_entries,
-                }
-                json.dump(manifest_data, f, indent=2)
+            manifest_data = {
+                "backup_id": manifest.backup_id,
+                "migration_id": manifest.migration_id,
+                "created_at": manifest.created_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "files_backed_up": manifest.files_backed_up,
+                "total_size": manifest.total_size,
+                "checksum": manifest.checksum,
+                "source_root": str(manifest.source_root),
+                "status": manifest.status,
+                "restored_at": manifest.restored_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+                if manifest.restored_at
+                else None,
+                "file_entries": manifest.file_entries,
+            }
+            atomic_write_with(
+                manifest_file,
+                lambda fh: json.dump(manifest_data, fh, indent=2),
+                mode="w",
+            )
 
             # Verify backup integrity (only check files that were actually backed up)
             if file_entries:
@@ -511,8 +515,11 @@ class PARAMigrationManager:
             manifest_data["status"] = "restored"
             manifest_data["restored_at"] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-            with open(manifest_file, "w") as f:
-                json.dump(manifest_data, f, indent=2)
+            atomic_write_with(
+                manifest_file,
+                lambda fh: json.dump(manifest_data, fh, indent=2),
+                mode="w",
+            )
 
             logger.info(f"Rollback completed successfully: {restored_count} files restored")
             return True

--- a/src/services/auto_tagging/tag_learning.py
+++ b/src/services/auto_tagging/tag_learning.py
@@ -14,6 +14,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from utils.atomic_write import atomic_write_with
+
 logger = logging.getLogger(__name__)
 
 
@@ -449,8 +451,11 @@ class TagLearningEngine:
             }
 
             storage_path = self.storage_path
-            with open(storage_path, "w") as f:
-                json.dump(data, f, indent=2)
+            atomic_write_with(
+                storage_path,
+                lambda fh: json.dump(data, fh, indent=2),
+                mode="w",
+            )
 
             logger.debug(f"Saved learning data to {storage_path}")
 

--- a/src/services/copilot/rules/rule_manager.py
+++ b/src/services/copilot/rules/rule_manager.py
@@ -14,6 +14,7 @@ from loguru import logger
 from config.path_manager import get_config_dir
 from config.path_migration import resolve_legacy_path
 from services.copilot.rules.models import Rule, RuleSet
+from utils.atomic_write import atomic_write_text
 
 _DEFAULT_RULES_DIR = resolve_legacy_path(
     get_config_dir() / "rules",
@@ -96,7 +97,7 @@ class RuleManager:
             default_flow_style=False,
             sort_keys=False,
         )
-        path.write_text(content, encoding="utf-8")
+        atomic_write_text(path, content)
         logger.info("Saved rule set '{}' to {}", rule_set.name, path)
         return path
 

--- a/src/services/deduplication/embedder.py
+++ b/src/services/deduplication/embedder.py
@@ -14,6 +14,8 @@ from typing import Any
 import numpy as np
 from numpy.typing import NDArray
 
+from utils.atomic_write import atomic_write_with
+
 logger = logging.getLogger(__name__)
 
 
@@ -268,8 +270,12 @@ class DocumentEmbedder:
             return
 
         try:
-            with open(path, "wb") as f:
-                pickle.dump(self.vectorizer, f)
+            # Streaming pickle (multi-MB vectorizer) — atomic_write_with
+            # avoids buffering the full pickle in RAM. Satisfies S6
+            # (cache TOCTOU): temp-file + os.replace so a mid-write crash
+            # can't leave a half-written pickle that raises
+            # ``UnpicklingError`` when next loaded.
+            atomic_write_with(path, lambda fh: pickle.dump(self.vectorizer, fh))
 
             logger.info(f"Saved vectorizer to {path}")
 
@@ -311,8 +317,13 @@ class DocumentEmbedder:
             return
 
         try:
-            with open(self.cache_path, "wb") as f:
-                pickle.dump(self.embedding_cache, f)
+            # Atomic streaming pickle — see ``save_model`` above for the
+            # rationale (S6 cache-TOCTOU, avoids in-RAM buffering of the
+            # multi-MB embedding cache).
+            atomic_write_with(
+                self.cache_path,
+                lambda fh: pickle.dump(self.embedding_cache, fh),
+            )
 
             logger.debug(f"Saved {len(self.embedding_cache)} embeddings to cache")
 

--- a/src/services/intelligence/folder_learner.py
+++ b/src/services/intelligence/folder_learner.py
@@ -13,6 +13,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from utils.atomic_write import atomic_write_with
+
 logger = logging.getLogger(__name__)
 
 
@@ -300,8 +302,11 @@ class FolderPreferenceLearner:
             "total_choices": self.total_choices,
         }
 
-        with open(storage_path, "w") as f:
-            json.dump(data, f, indent=2)
+        atomic_write_with(
+            storage_path,
+            lambda fh: json.dump(data, fh, indent=2),
+            mode="w",
+        )
 
     def _load_preferences(self) -> None:
         """Load preferences from disk."""

--- a/src/services/suggestion_feedback.py
+++ b/src/services/suggestion_feedback.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from models.suggestion_types import Suggestion, SuggestionType
+from utils.atomic_write import atomic_write_with
 
 logger = logging.getLogger(__name__)
 
@@ -365,8 +366,11 @@ class SuggestionFeedback:
                 "last_updated": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
             }
 
-            with open(self.feedback_file, "w") as f:
-                json.dump(data, f, indent=2)
+            atomic_write_with(
+                self.feedback_file,
+                lambda fh: json.dump(data, fh, indent=2),
+                mode="w",
+            )
 
             logger.debug(f"Saved {len(self.feedback_entries)} feedback entries")
 

--- a/src/utils/atomic_write.py
+++ b/src/utils/atomic_write.py
@@ -94,8 +94,11 @@ def _write_via_temp(
     *,
     encoding: str | None = None,
 ) -> None:
-    """Create a temp file in ``target.parent``, run ``write_fn(handle)``,
-    fsync, atomically replace ``target``. Clean up temp on any exception.
+    """Atomically write via temp file + fsync + ``os.replace``.
+
+    Creates a temp file in ``target.parent``, runs ``write_fn(handle)``,
+    fsyncs, atomically replaces ``target``. Cleans up the temp on any
+    exception (writer error, KeyboardInterrupt, failed ``os.replace``).
     """
     # ``NamedTemporaryFile(delete=False)`` leaves the temp around so we
     # can ``os.replace`` it into place. ``dir=target.parent`` is
@@ -234,13 +237,13 @@ def atomic_write_with(
 
 
 def append_durable(path: Path, line: str, *, encoding: str = "utf-8") -> None:
-    """Append one record to ``path`` with flush + fsync durability.
+    r"""Append one record to ``path`` with flush + fsync durability.
 
     For log-style files where order matters and truncate-replace is
     wrong (audit log, VS Code JSONL command stream). The helper:
 
     1. Opens ``path`` in append mode, creating it if absent.
-    2. Writes ``line``, terminating with ``\\n`` if not already.
+    2. Writes ``line``, terminating with ``\n`` if not already.
     3. Flushes the Python-level buffer and fsyncs the OS descriptor.
 
     Same-line atomicity for small (< PIPE_BUF) writes is a Linux

--- a/src/utils/atomic_write.py
+++ b/src/utils/atomic_write.py
@@ -1,0 +1,272 @@
+"""Crash-safe atomic state-file writers (Epic B.atomic / B1a + B1b).
+
+Every persistent state file this project writes (config YAML, suggestion
+feedback, rule manager, JD system, PARA migration manifest, embedder
+pickle cache, event discovery state, audit log, VS Code command stream,
+...) must be crash-safe: a mid-write crash or a concurrent writer must
+never leave the file truncated or half-written.
+
+The fix is the temp-file-plus-``os.replace()`` pattern, exposed here via
+four helpers:
+
+- :func:`atomic_write_text`  — UTF-8 (or caller-specified) text payload.
+- :func:`atomic_write_bytes` — in-memory binary payload.
+- :func:`atomic_write_with`  — streaming-callback form for writers that
+  stream into the handle (e.g. :func:`pickle.dump`) and would otherwise
+  require buffering the full payload in RAM.
+- :func:`append_durable`     — single-record fsynced append, for log-
+  style files where order matters and truncate-replace is wrong (audit
+  log, VS Code JSONL).
+
+All four write to a temp file *in the destination's parent directory*,
+``fsync`` the contents, ``os.replace`` into the final name (atomic on
+POSIX and Windows for same-filesystem renames), then fsync the parent
+directory on POSIX so the rename itself is durable. Directory fsync is a
+no-op on Windows — see :func:`utils.atomic_io.fsync_directory`.
+
+Invariants upheld by every helper:
+
+1. **Atomicity.** A reader opening the target at any point during the
+   write either sees the old contents or the new contents, never a
+   mixture or an empty file.
+2. **No temp-file residue.** On success *or* failure, no ``*.tmp``
+   artifact is left in the destination directory.
+3. **Surface missing parents.** The helpers do NOT auto-create parent
+   directories. Callers that need ``mkdir -p`` must do it explicitly
+   (preserves the existing :meth:`pathlib.Path.mkdir` discipline at
+   every site and prevents silent masking of config-path bugs).
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Literal
+
+from utils.atomic_io import fsync_directory
+
+# Writer callback signature for ``atomic_write_with``. ``Any`` here is
+# an intentional boundary type: the caller passes the correct
+# text/binary IO object based on the ``mode`` they chose, and mypy
+# can't track the mode-dependent handle type through a generic
+# callable. The ``mode`` validation in ``atomic_write_with`` keeps
+# misuse observable.
+_WriterCallback = Callable[[Any], None]
+
+# Permitted ``mode`` values for ``atomic_write_with`` — writable text
+# or binary only. ``"a"`` / ``"r*"`` are rejected because an atomic
+# writer that preserved prior contents would defeat the temp-file
+# pattern (the point is to replace, not append; append-durable uses a
+# separate helper).
+_ATOMIC_WRITE_MODES = ("w", "wb")
+
+
+def _fsync_and_replace(tmp_path: Path, target: Path) -> None:
+    """Flush + fsync a temp file, atomically rename to target, fsync parent.
+
+    Shared tail of every helper. Deliberately minimal — the surface
+    helpers own mode selection and payload marshalling; this owns only
+    the durability pattern.
+    """
+    # Caller is responsible for closing the handle before calling
+    # this (we need the content flushed to disk before replacing).
+    # ``os.replace`` is atomic on same-filesystem POSIX and Windows;
+    # if it raises (cross-device EXDEV, permission denied, etc.) we
+    # unlink the temp file so operators don't find orphan ``*.tmp``
+    # files next to real state.
+    try:
+        os.replace(str(tmp_path), str(target))
+    except OSError:
+        # Best-effort cleanup. ``missing_ok=True`` swallows the race
+        # where another process already removed the temp file.
+        tmp_path.unlink(missing_ok=True)
+        raise
+    fsync_directory(target)
+
+
+def _write_via_temp(
+    target: Path,
+    mode: str,
+    write_fn: Callable[[Any], None],
+    *,
+    encoding: str | None = None,
+) -> None:
+    """Create a temp file in ``target.parent``, run ``write_fn(handle)``,
+    fsync, atomically replace ``target``. Clean up temp on any exception.
+    """
+    # ``NamedTemporaryFile(delete=False)`` leaves the temp around so we
+    # can ``os.replace`` it into place. ``dir=target.parent`` is
+    # essential — cross-device renames raise ``EXDEV``.
+    tmp_file = tempfile.NamedTemporaryFile(
+        mode=mode,
+        dir=str(target.parent),
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+        delete=False,
+        encoding=encoding,
+    )
+    tmp_path = Path(tmp_file.name)
+    try:
+        try:
+            write_fn(tmp_file)
+            # Flush Python-level buffer, then fsync the OS-level
+            # file descriptor. Without the fsync, the content may
+            # still live only in the kernel's page cache when the
+            # subsequent ``os.replace`` runs — a power loss right
+            # after the rename can then leave the destination
+            # pointing at an inode with zero-length contents.
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+        finally:
+            tmp_file.close()
+    except BaseException:
+        # Any exception from the writer (including KeyboardInterrupt)
+        # means we must not replace the target — unlink the partial
+        # temp file and re-raise. ``missing_ok=True`` covers the
+        # race where the writer itself already cleaned up.
+        tmp_path.unlink(missing_ok=True)
+        raise
+    _fsync_and_replace(tmp_path, target)
+
+
+def atomic_write_text(
+    path: Path,
+    content: str,
+    *,
+    encoding: str = "utf-8",
+) -> None:
+    """Atomically write ``content`` to ``path`` as text.
+
+    Replaces the classic ``path.write_text(content, encoding=...)``
+    pattern used across config / rule-manager / JD / PARA / suggestion-
+    feedback state files. A mid-write crash leaves ``path`` pointing
+    at the *prior* contents, never a truncated file.
+
+    Args:
+        path: Destination. Parent directory must already exist.
+        content: UTF-8 (or ``encoding``-specified) text to write.
+        encoding: Text encoding; ``"utf-8"`` by default. Passed through
+            to the temp-file handle and used verbatim when writing.
+
+    Raises:
+        FileNotFoundError: Parent directory does not exist.
+        OSError: Underlying filesystem error (permission, no space,
+            cross-device rename, etc.). The target is never left in a
+            partial state; no temp file remains.
+    """
+
+    def _writer(fh: io.TextIOBase) -> None:
+        fh.write(content)
+
+    _write_via_temp(path, "w", _writer, encoding=encoding)
+
+
+def atomic_write_bytes(path: Path, content: bytes) -> None:
+    """Atomically write ``content`` to ``path`` as bytes.
+
+    For binary state files whose payload already lives in memory
+    (small caches, serialized headers, etc.). For streaming writers
+    (``pickle.dump`` into a multi-MB cache), use
+    :func:`atomic_write_with` instead so the full payload isn't
+    duplicated in RAM.
+
+    Args:
+        path: Destination. Parent directory must already exist.
+        content: Byte payload. Empty ``b""`` is valid and produces a
+            zero-byte file.
+
+    Raises:
+        FileNotFoundError: Parent directory does not exist.
+        OSError: Underlying filesystem error.
+    """
+
+    def _writer(fh: io.BufferedWriter) -> None:
+        fh.write(content)
+
+    _write_via_temp(path, "wb", _writer)
+
+
+def atomic_write_with(
+    path: Path,
+    writer: _WriterCallback,
+    *,
+    mode: Literal["w", "wb"] = "wb",
+) -> None:
+    """Atomically write via a caller-supplied streaming ``writer`` callback.
+
+    Use when the payload must stream directly into a file handle — most
+    importantly :func:`pickle.dump` — rather than being fully
+    materialised in memory first. The helper owns the temp-file /
+    fsync / ``os.replace`` ceremony; the callback only sees the open
+    handle.
+
+    Mirrors the real usage site in
+    ``src/services/deduplication/embedder.py`` where a multi-MB
+    vectorizer or embedding cache is pickled out per save.
+
+    Args:
+        path: Destination. Parent directory must already exist.
+        writer: Called with an open, writable file handle. The handle
+            is closed by the helper after the callback returns; the
+            callback MUST NOT close it.
+        mode: ``"wb"`` (default, binary) or ``"w"`` (text). Any other
+            value raises :class:`ValueError` — append / read modes do
+            not fit the atomic-replace contract.
+
+    Raises:
+        ValueError: ``mode`` is not ``"w"`` or ``"wb"``.
+        FileNotFoundError: Parent directory does not exist.
+        OSError: Underlying filesystem error. Target is unchanged on
+            failure; temp file is cleaned up.
+        Exception: Any exception raised by ``writer`` propagates
+            unchanged *after* the temp file is unlinked. The target
+            is never replaced on writer failure.
+    """
+    if mode not in _ATOMIC_WRITE_MODES:
+        raise ValueError(
+            f"atomic_write_with mode must be 'w' or 'wb', got {mode!r}. "
+            "Append / read modes are incompatible with the atomic-replace contract."
+        )
+    _write_via_temp(path, mode, writer)
+
+
+def append_durable(path: Path, line: str, *, encoding: str = "utf-8") -> None:
+    """Append one record to ``path`` with flush + fsync durability.
+
+    For log-style files where order matters and truncate-replace is
+    wrong (audit log, VS Code JSONL command stream). The helper:
+
+    1. Opens ``path`` in append mode, creating it if absent.
+    2. Writes ``line``, terminating with ``\\n`` if not already.
+    3. Flushes the Python-level buffer and fsyncs the OS descriptor.
+
+    Same-line atomicity for small (< PIPE_BUF) writes is a Linux
+    guarantee when using O_APPEND; on other kernels a single
+    ``write()`` call for the full record is still durable via the
+    fsync. Records larger than PIPE_BUF (~4 KiB) across concurrent
+    writers may interleave — callers that need strict ordering across
+    processes should wrap this helper with a file lock.
+
+    Args:
+        path: Destination. Parent directory must already exist.
+        line: Record text; ``\\n`` is auto-appended if absent.
+        encoding: Text encoding; ``"utf-8"`` by default.
+
+    Raises:
+        FileNotFoundError: Parent directory does not exist.
+        OSError: Underlying filesystem error.
+    """
+    terminated = line if line.endswith("\n") else line + "\n"
+    # ``O_APPEND`` on POSIX makes every ``write()`` call atomic with
+    # respect to other appenders — the kernel atomically advances the
+    # write offset to EOF before each write. Pair with the fsync for
+    # crash durability (flush alone leaves the record in the kernel
+    # page cache).
+    with path.open("a", encoding=encoding) as fh:
+        fh.write(terminated)
+        fh.flush()
+        os.fsync(fh.fileno())
+    fsync_directory(path)

--- a/src/utils/atomic_write.py
+++ b/src/utils/atomic_write.py
@@ -120,7 +120,22 @@ def _write_via_temp(
     Creates a temp file in ``target.parent``, runs ``write_fn(handle)``,
     fsyncs, atomically replaces ``target``. Cleans up the temp on any
     exception (writer error, KeyboardInterrupt, failed ``os.replace``).
+
+    Follows symlinks: if ``target`` is a symlink, the write goes
+    through to the link target — matches the pre-existing
+    ``path.write_text()`` / ``open(path, "w")`` semantics so users
+    who symlink config/state files to shared storage don't have
+    their links silently replaced with regular files on save (codex
+    P2 PRRT_kwDOR_Rkws59MXyc).
     """
+    # Resolve symlinks so ``os.replace`` updates the link's target
+    # rather than replacing the link itself. ``strict=False`` tolerates
+    # a broken / dangling symlink by returning the resolved path it
+    # would point at, which is then created by the temp+replace
+    # sequence (matching ``write_text`` behavior of creating the file
+    # at the symlink's target location).
+    if target.is_symlink():
+        target = target.resolve(strict=False)
     # ``NamedTemporaryFile(delete=False)`` leaves the temp around so we
     # can ``os.replace`` it into place. ``dir=target.parent`` is
     # essential — cross-device renames raise ``EXDEV``.

--- a/src/utils/atomic_write.py
+++ b/src/utils/atomic_write.py
@@ -77,8 +77,29 @@ def _fsync_and_replace(tmp_path: Path, target: Path) -> None:
     # if it raises (cross-device EXDEV, permission denied, etc.) we
     # unlink the temp file so operators don't find orphan ``*.tmp``
     # files next to real state.
+    #
+    # Permission preservation: ``tempfile.NamedTemporaryFile`` creates
+    # the temp file with mode 0o600 (via ``mkstemp``). After
+    # ``os.replace`` the destination inherits the temp inode's mode,
+    # which would silently drop any non-default bits a user had on the
+    # pre-existing target (e.g. group-readable config). Mirror the
+    # pre-existing target's mode onto the temp file before the rename
+    # so ``chmod`` settings survive the save (coderabbit Minor
+    # PRRT_kwDOR_Rkws59MONs). First-time writes keep the safer 0o600
+    # default because there's no pre-existing mode to inherit.
     try:
-        os.replace(str(tmp_path), str(target))
+        existing_mode: int | None = target.stat().st_mode & 0o7777
+    except FileNotFoundError:
+        existing_mode = None
+    if existing_mode is not None:
+        try:
+            os.chmod(tmp_path, existing_mode)
+        except OSError:
+            # chmod failure is non-fatal — proceed with the save and
+            # accept the 0o600 fallback rather than lose the write.
+            pass
+    try:
+        os.replace(tmp_path, target)
     except OSError:
         # Best-effort cleanup. ``missing_ok=True`` swallows the race
         # where another process already removed the temp file.
@@ -197,6 +218,7 @@ def atomic_write_with(
     writer: _WriterCallback,
     *,
     mode: Literal["w", "wb"] = "wb",
+    encoding: str | None = None,
 ) -> None:
     """Atomically write via a caller-supplied streaming ``writer`` callback.
 
@@ -218,9 +240,16 @@ def atomic_write_with(
         mode: ``"wb"`` (default, binary) or ``"w"`` (text). Any other
             value raises :class:`ValueError` — append / read modes do
             not fit the atomic-replace contract.
+        encoding: Text encoding for ``mode="w"``. When omitted, text
+            mode defaults to ``"utf-8"`` (NOT the process locale — a
+            locale-default open on Windows can produce bytes that
+            later fail to decode under UTF-8, breaking cross-platform
+            persistence). Must be ``None`` for binary mode; supplying
+            a value with ``mode="wb"`` raises :class:`ValueError`.
 
     Raises:
-        ValueError: ``mode`` is not ``"w"`` or ``"wb"``.
+        ValueError: ``mode`` is not ``"w"`` or ``"wb"``, or
+            ``encoding`` was supplied with ``mode="wb"``.
         FileNotFoundError: Parent directory does not exist.
         OSError: Underlying filesystem error. Target is unchanged on
             failure; temp file is cleaned up.
@@ -233,7 +262,19 @@ def atomic_write_with(
             f"atomic_write_with mode must be 'w' or 'wb', got {mode!r}. "
             "Append / read modes are incompatible with the atomic-replace contract."
         )
-    _write_via_temp(path, mode, writer)
+    if mode == "wb" and encoding is not None:
+        raise ValueError(
+            f"encoding={encoding!r} is invalid for binary mode 'wb'; "
+            "pass encoding only with mode='w'."
+        )
+    # Text mode without explicit encoding defaults to UTF-8 to match
+    # the project-wide default and avoid Windows/locale pitfalls that
+    # break ``json.dump(..., ensure_ascii=False)`` and similar
+    # non-ASCII writers (codex P1 PRRT_kwDOR_Rkws59ML8K).
+    resolved_encoding = encoding
+    if mode == "w" and resolved_encoding is None:
+        resolved_encoding = "utf-8"
+    _write_via_temp(path, mode, writer, encoding=resolved_encoding)
 
 
 def append_durable(path: Path, line: str, *, encoding: str = "utf-8") -> None:

--- a/tests/methodologies/para/test_migration_recovery.py
+++ b/tests/methodologies/para/test_migration_recovery.py
@@ -687,15 +687,19 @@ class TestMigrationManagerEdgeCases:
         """Test backup creation cleans up on exception."""
         plan = migration_manager.analyze_source(temp_source, temp_target, recursive=False)
 
-        # Mock to raise exception during manifest creation
-        original_open = open
-
-        def mock_open(file, *args, **kwargs):
-            if "manifest.json" in str(file) and "w" in args:
+        # Mock to raise during the atomic manifest write. The manifest
+        # write now goes through ``atomic_write_with`` (B1a hardening),
+        # so the injection point lives at the wrapper, not at
+        # ``builtins.open``.
+        def _failing_atomic_write(path, _writer, *, mode="wb"):
+            if path.name == "manifest.json":
                 raise OSError("Simulated write error")
-            return original_open(file, *args, **kwargs)
+            raise AssertionError(f"unexpected atomic_write_with target: {path}")
 
-        monkeypatch.setattr("builtins.open", mock_open)
+        monkeypatch.setattr(
+            "methodologies.para.migration_manager.atomic_write_with",
+            _failing_atomic_write,
+        )
 
         # Should raise and cleanup
         with pytest.raises(OSError):

--- a/tests/methodologies/para/test_para_migration_manager_branches.py
+++ b/tests/methodologies/para/test_para_migration_manager_branches.py
@@ -1133,15 +1133,20 @@ class TestCreateBackupEdgeCases:
             created_at=datetime.now(UTC),
         )
 
-        # Inject failure in manifest writing by mocking open
-        original_open = open
-
-        def _failing_open(file_arg: object, *args: object, **kwargs: object) -> object:
-            if isinstance(file_arg, Path) and file_arg.name == "manifest.json":
+        # Inject failure in manifest write (now goes through
+        # ``atomic_write_with`` — temp-file + os.replace; patch the
+        # wrapper directly).
+        def _failing_atomic_write(
+            path: Path, _writer: object, *, mode: str = "wb"
+        ) -> None:
+            if path.name == "manifest.json":
                 raise OSError("injected manifest write failure")
-            return original_open(file_arg, *args, **kwargs)
+            raise AssertionError(f"unexpected atomic_write_with target: {path}")
 
-        monkeypatch.setattr("builtins.open", _failing_open)
+        monkeypatch.setattr(
+            "methodologies.para.migration_manager.atomic_write_with",
+            _failing_atomic_write,
+        )
 
         with pytest.raises(IOError, match="injected manifest write failure"):
             manager._create_backup(plan)
@@ -1172,18 +1177,22 @@ class TestCreateBackupEdgeCases:
             created_at=datetime.now(UTC),
         )
 
-        # Inject failure in both manifest writing and cleanup
-        original_open = open
-
-        def _failing_open(file_arg: object, *args: object, **kwargs: object) -> object:
-            if isinstance(file_arg, Path) and file_arg.name == "manifest.json":
+        # Inject failure in both manifest writing (via the
+        # ``atomic_write_with`` wrapper) and cleanup.
+        def _failing_atomic_write(
+            path: Path, _writer: object, *, mode: str = "wb"
+        ) -> None:
+            if path.name == "manifest.json":
                 raise OSError("injected manifest write failure")
-            return original_open(file_arg, *args, **kwargs)
+            raise AssertionError(f"unexpected atomic_write_with target: {path}")
 
         def _failing_rmtree(*args: object, **kwargs: object) -> None:
             raise PermissionError("injected cleanup failure")
 
-        monkeypatch.setattr("builtins.open", _failing_open)
+        monkeypatch.setattr(
+            "methodologies.para.migration_manager.atomic_write_with",
+            _failing_atomic_write,
+        )
         monkeypatch.setattr(shutil, "rmtree", _failing_rmtree)
 
         # When cleanup fails, the cleanup exception is raised (lines 428-430)
@@ -1212,11 +1221,12 @@ class TestCreateBackupEdgeCases:
             created_at=datetime.now(UTC),
         )
 
-        # Inject failure in manifest writing and delete backup_dir before cleanup
-        original_open = open
+        # Inject failure at the ``atomic_write_with`` wrapper layer and
+        # delete backup_dir just before the manifest write raises — so the
+        # subsequent cleanup branch sees a missing directory (covers the
+        # line 428->430 path).
         original_mkdir = Path.mkdir
-
-        backup_dir_ref = [None]
+        backup_dir_ref: list[Path | None] = [None]
 
         def _track_mkdir(self: Path, *args: object, **kwargs: object) -> None:
             result = original_mkdir(self, *args, **kwargs)
@@ -1224,16 +1234,20 @@ class TestCreateBackupEdgeCases:
                 backup_dir_ref[0] = self
             return result
 
-        def _failing_open(file_arg: object, *args: object, **kwargs: object) -> object:
-            if isinstance(file_arg, Path) and file_arg.name == "manifest.json":
-                # Delete backup_dir before raising exception
+        def _failing_atomic_write(
+            path: Path, _writer: object, *, mode: str = "wb"
+        ) -> None:
+            if path.name == "manifest.json":
                 if backup_dir_ref[0] and backup_dir_ref[0].exists():
                     shutil.rmtree(backup_dir_ref[0])
                 raise OSError("injected manifest write failure")
-            return original_open(file_arg, *args, **kwargs)
+            raise AssertionError(f"unexpected atomic_write_with target: {path}")
 
         monkeypatch.setattr(Path, "mkdir", _track_mkdir)
-        monkeypatch.setattr("builtins.open", _failing_open)
+        monkeypatch.setattr(
+            "methodologies.para.migration_manager.atomic_write_with",
+            _failing_atomic_write,
+        )
 
         # Should raise original exception without trying to cleanup non-existent dir
         with pytest.raises(IOError, match="injected manifest write failure"):

--- a/tests/methodologies/para/test_para_migration_manager_branches.py
+++ b/tests/methodologies/para/test_para_migration_manager_branches.py
@@ -1136,9 +1136,7 @@ class TestCreateBackupEdgeCases:
         # Inject failure in manifest write (now goes through
         # ``atomic_write_with`` — temp-file + os.replace; patch the
         # wrapper directly).
-        def _failing_atomic_write(
-            path: Path, _writer: object, *, mode: str = "wb"
-        ) -> None:
+        def _failing_atomic_write(path: Path, _writer: object, *, mode: str = "wb") -> None:
             if path.name == "manifest.json":
                 raise OSError("injected manifest write failure")
             raise AssertionError(f"unexpected atomic_write_with target: {path}")
@@ -1179,9 +1177,7 @@ class TestCreateBackupEdgeCases:
 
         # Inject failure in both manifest writing (via the
         # ``atomic_write_with`` wrapper) and cleanup.
-        def _failing_atomic_write(
-            path: Path, _writer: object, *, mode: str = "wb"
-        ) -> None:
+        def _failing_atomic_write(path: Path, _writer: object, *, mode: str = "wb") -> None:
             if path.name == "manifest.json":
                 raise OSError("injected manifest write failure")
             raise AssertionError(f"unexpected atomic_write_with target: {path}")
@@ -1234,9 +1230,7 @@ class TestCreateBackupEdgeCases:
                 backup_dir_ref[0] = self
             return result
 
-        def _failing_atomic_write(
-            path: Path, _writer: object, *, mode: str = "wb"
-        ) -> None:
+        def _failing_atomic_write(path: Path, _writer: object, *, mode: str = "wb") -> None:
             if path.name == "manifest.json":
                 if backup_dir_ref[0] and backup_dir_ref[0].exists():
                     shutil.rmtree(backup_dir_ref[0])

--- a/tests/utils/test_atomic_write.py
+++ b/tests/utils/test_atomic_write.py
@@ -1,0 +1,300 @@
+"""Tests for ``utils.atomic_write`` — crash-safe state-file writers (B1a/B1b).
+
+Epic B.atomic of the hardening roadmap: every persistent state file this
+project writes (config YAML, suggestion feedback, rule manager, JD system,
+PARA migration manifest, embedder pickle cache, event discovery state,
+…) currently uses ``path.write_text(...)`` or ``with open(path, "w"/"wb")``.
+That pattern truncates the file *before* the new content lands — a crash
+or concurrent writer in the window between truncation and close leaves
+the file half-written or empty, and the downstream tool reads garbage.
+
+The fix landed in this module is the temp-file-plus-``os.replace()``
+pattern, exposed via four helpers:
+
+- ``atomic_write_text``  — for the 15 YAML / JSON state files.
+- ``atomic_write_bytes`` — in-memory payload.
+- ``atomic_write_with``  — streaming callback (e.g. ``pickle.dump(obj, f)``).
+- ``append_durable``     — single-line fsynced append for audit / VS Code logs.
+
+All three share the same implementation; only the surface API differs.
+Temp file is created in the destination's *parent directory* so the
+``os.replace`` is same-filesystem atomic on POSIX and Windows.
+
+These tests cover:
+
+- Happy path (content lands, temp file cleaned up).
+- Crash injection — writer raises mid-stream, destination unchanged,
+  no temp file lingers.
+- Idempotency — repeated writes leave one canonical file.
+- Pre-existing target is overwritten atomically (pre-existing reader
+  of old content during write never sees a truncated file).
+- Concurrent writers — last writer wins, no partial state.
+- Parent-directory creation — helper does NOT auto-create missing
+  parents (surfaces the bug instead of silently swallowing).
+- Append durability — ``append_durable`` preserves prior content,
+  appends one newline-terminated record, and fsyncs.
+
+``utils.atomic_io.fsync_directory`` (already in the tree from a prior
+PR) is reused to persist the directory entry on POSIX.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import pickle
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+from utils.atomic_write import (
+    append_durable,
+    atomic_write_bytes,
+    atomic_write_text,
+    atomic_write_with,
+)
+
+pytestmark = [pytest.mark.ci, pytest.mark.unit, pytest.mark.integration]
+
+
+# ---------------------------------------------------------------------------
+# atomic_write_text
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicWriteText:
+    """The YAML/JSON state-file path (15 B1a sites)."""
+
+    def test_writes_content_utf8_by_default(self, tmp_path: Path) -> None:
+        target = tmp_path / "config.yaml"
+        atomic_write_text(target, "key: valué\n")
+        assert target.read_text(encoding="utf-8") == "key: valué\n"
+
+    def test_respects_encoding_kwarg(self, tmp_path: Path) -> None:
+        target = tmp_path / "latin.txt"
+        atomic_write_text(target, "café", encoding="latin-1")
+        assert target.read_bytes() == "café".encode("latin-1")
+
+    def test_overwrites_pre_existing_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "state.yaml"
+        target.write_text("old contents")
+        atomic_write_text(target, "new contents")
+        assert target.read_text() == "new contents"
+
+    def test_no_temp_files_remain_after_success(self, tmp_path: Path) -> None:
+        target = tmp_path / "s.yaml"
+        atomic_write_text(target, "payload")
+        # Only the target itself should exist in the directory; no
+        # lingering ``*.tmp`` artifacts from the helper.
+        entries = list(tmp_path.iterdir())
+        assert entries == [target]
+
+    def test_rejects_missing_parent_directory(self, tmp_path: Path) -> None:
+        target = tmp_path / "nonexistent" / "s.yaml"
+        # Helper must NOT silently ``mkdir -p`` — callers that need the
+        # directory auto-created have always done it themselves.
+        # Surface the bug so missing-parent issues get caught early.
+        with pytest.raises((FileNotFoundError, OSError)):
+            atomic_write_text(target, "payload")
+
+
+# ---------------------------------------------------------------------------
+# atomic_write_bytes
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicWriteBytes:
+    """In-memory binary payload path (no streaming writer needed)."""
+
+    def test_writes_payload(self, tmp_path: Path) -> None:
+        target = tmp_path / "blob.bin"
+        atomic_write_bytes(target, b"\x00\xff\x01\xfe")
+        assert target.read_bytes() == b"\x00\xff\x01\xfe"
+
+    def test_overwrites_pre_existing(self, tmp_path: Path) -> None:
+        target = tmp_path / "blob.bin"
+        target.write_bytes(b"old")
+        atomic_write_bytes(target, b"new")
+        assert target.read_bytes() == b"new"
+
+    def test_empty_payload_produces_empty_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "empty.bin"
+        atomic_write_bytes(target, b"")
+        assert target.read_bytes() == b""
+
+
+# ---------------------------------------------------------------------------
+# atomic_write_with
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicWriteWith:
+    """Callback / streaming writer path.
+
+    Mirrors the real usage site in ``src/services/deduplication/embedder.py``
+    where ``pickle.dump(obj, f)`` streams directly into the handle without
+    buffering the full pickle into RAM.
+    """
+
+    def test_writer_receives_binary_handle_by_default(self, tmp_path: Path) -> None:
+        target = tmp_path / "cache.pkl"
+        payload = {"embedding": [1.0, 2.0, 3.0], "model": "sentence-bert"}
+
+        def _writer(fh: io.BufferedWriter) -> None:
+            pickle.dump(payload, fh)
+
+        atomic_write_with(target, _writer)
+        with target.open("rb") as fh:
+            assert pickle.load(fh) == payload
+
+    def test_text_mode_opens_text_handle(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.txt"
+
+        def _writer(fh: io.TextIOBase) -> None:
+            fh.write("line 1\n")
+            fh.write("line 2\n")
+
+        atomic_write_with(target, _writer, mode="w")
+        assert target.read_text() == "line 1\nline 2\n"
+
+    def test_writer_exception_leaves_target_untouched(self, tmp_path: Path) -> None:
+        target = tmp_path / "cache.pkl"
+        target.write_bytes(b"ORIGINAL")
+
+        def _broken_writer(_fh: io.BufferedWriter) -> None:
+            raise RuntimeError("pickle failed halfway")
+
+        with pytest.raises(RuntimeError, match="pickle failed halfway"):
+            atomic_write_with(target, _broken_writer)
+
+        # Crash-safety invariant: destination unchanged, NO temp file
+        # left behind for operators to puzzle over.
+        assert target.read_bytes() == b"ORIGINAL"
+        assert list(tmp_path.iterdir()) == [target]
+
+    def test_invalid_mode_raises(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.bin"
+
+        def _writer(_fh: io.BufferedWriter) -> None:
+            pass  # pragma: no cover — should not be called
+
+        with pytest.raises(ValueError):
+            atomic_write_with(target, _writer, mode="r")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# append_durable
+# ---------------------------------------------------------------------------
+
+
+class TestAppendDurable:
+    """The audit/VS Code JSONL log path (2 B1b sites)."""
+
+    def test_appends_single_line_and_terminates_with_newline(self, tmp_path: Path) -> None:
+        target = tmp_path / "audit.jsonl"
+        append_durable(target, '{"event":"ORGANIZE"}')
+        assert target.read_text(encoding="utf-8") == '{"event":"ORGANIZE"}\n'
+
+    def test_appends_do_not_truncate_prior_content(self, tmp_path: Path) -> None:
+        target = tmp_path / "audit.jsonl"
+        target.write_text('{"event":"OLD"}\n', encoding="utf-8")
+        append_durable(target, '{"event":"NEW"}')
+        assert target.read_text(encoding="utf-8") == '{"event":"OLD"}\n{"event":"NEW"}\n'
+
+    def test_line_already_newline_terminated_is_not_double_terminated(self, tmp_path: Path) -> None:
+        target = tmp_path / "audit.jsonl"
+        append_durable(target, '{"event":"A"}\n')
+        assert target.read_text(encoding="utf-8") == '{"event":"A"}\n'
+
+    def test_creates_file_if_absent(self, tmp_path: Path) -> None:
+        target = tmp_path / "fresh.jsonl"
+        append_durable(target, "hello")
+        assert target.read_text() == "hello\n"
+
+    def test_rejects_missing_parent_directory(self, tmp_path: Path) -> None:
+        target = tmp_path / "nonexistent" / "audit.jsonl"
+        with pytest.raises((FileNotFoundError, OSError)):
+            append_durable(target, "line")
+
+
+# ---------------------------------------------------------------------------
+# Shared cross-cutting invariants
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicityInvariants:
+    """Cross-cutting guarantees the entire module must uphold."""
+
+    def test_concurrent_writers_leave_one_canonical_file(self, tmp_path: Path) -> None:
+        """Two threads racing ``atomic_write_text`` must produce one file.
+
+        Last-writer-wins is acceptable; half-written / truncated is not.
+        Verifies the ``os.replace`` final step is actually used (rather
+        than a naive truncate-then-write loop).
+        """
+        target = tmp_path / "race.yaml"
+        payloads = [f"writer-{i}:{'x' * 1024}" for i in range(20)]
+
+        def _writer(payload: str) -> None:
+            atomic_write_text(target, payload)
+
+        threads = [threading.Thread(target=_writer, args=(p,)) for p in payloads]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # The final content must match exactly one of the payloads —
+        # no interleaving, no truncation.
+        final = target.read_text()
+        assert final in payloads
+
+    def test_temp_file_removed_when_replace_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If ``os.replace`` fails (e.g. cross-device EXDEV), the temp file
+        must be cleaned up — otherwise repeated failures accumulate garbage
+        next to the target, which operators then confuse for real state.
+        """
+        target = tmp_path / "s.yaml"
+
+        real_replace = os.replace
+
+        def _broken_replace(src: str, dst: str) -> None:
+            _ = real_replace  # keep reference
+            raise OSError("simulated cross-device replace failure")
+
+        monkeypatch.setattr(os, "replace", _broken_replace)
+
+        with pytest.raises(OSError, match="simulated cross-device"):
+            atomic_write_text(target, "payload")
+
+        # Nothing left behind — no target, no temp file.
+        assert list(tmp_path.iterdir()) == []
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Directory fsync is POSIX-only; atomic_io.fsync_directory is a no-op on Windows",
+    )
+    def test_directory_fsync_invoked_on_posix(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verifies the helper delegates durability to
+        ``atomic_io.fsync_directory`` rather than silently skipping it —
+        the whole point of the B1a work is that the new state survives
+        a mid-write crash, which requires a directory fsync on POSIX.
+        """
+        from utils import atomic_write as aw
+
+        called: list[Path] = []
+
+        def _fake_fsync_directory(path: Path) -> None:
+            called.append(path)
+
+        monkeypatch.setattr(aw, "fsync_directory", _fake_fsync_directory)
+
+        target = tmp_path / "s.yaml"
+        atomic_write_text(target, "payload")
+        assert target in called or any(p == target for p in called)

--- a/tests/utils/test_atomic_write.py
+++ b/tests/utils/test_atomic_write.py
@@ -183,6 +183,51 @@ class TestAtomicWriteWith:
         with pytest.raises(ValueError):
             atomic_write_with(target, _writer, mode="r")  # type: ignore[arg-type]
 
+    def test_text_mode_defaults_to_utf8(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """codex P1 (PRRT_kwDOR_Rkws59ML8K): ``atomic_write_with(mode="w")``
+        must default to UTF-8, not the process locale. On non-UTF-8
+        locales (common on Windows), a locale-default open would emit
+        bytes that later fail to decode as UTF-8. Simulate a non-UTF-8
+        locale by forcing ``locale.getpreferredencoding`` and confirm
+        the written bytes are valid UTF-8 regardless.
+        """
+        import locale as _locale
+
+        monkeypatch.setattr(_locale, "getpreferredencoding", lambda _do_setlocale=True: "cp1252")
+
+        target = tmp_path / "unicode.json"
+
+        def _writer(fh: io.TextIOBase) -> None:
+            fh.write('{"key": "café ñ 你好"}')
+
+        atomic_write_with(target, _writer, mode="w")
+        # Round-trip through UTF-8 — must not raise and must match.
+        assert target.read_text(encoding="utf-8") == '{"key": "café ñ 你好"}'
+
+    def test_text_mode_respects_explicit_encoding(self, tmp_path: Path) -> None:
+        """Caller-supplied ``encoding`` overrides the UTF-8 default."""
+        target = tmp_path / "latin.txt"
+
+        def _writer(fh: io.TextIOBase) -> None:
+            fh.write("café")
+
+        atomic_write_with(target, _writer, mode="w", encoding="latin-1")
+        assert target.read_bytes() == "café".encode("latin-1")
+
+    def test_binary_mode_rejects_encoding(self, tmp_path: Path) -> None:
+        """Passing ``encoding`` with binary mode is a caller bug —
+        surface it as ``ValueError`` rather than silently ignoring.
+        """
+        target = tmp_path / "x.bin"
+
+        def _writer(_fh: io.BufferedWriter) -> None:
+            pass  # pragma: no cover — should not be called
+
+        with pytest.raises(ValueError, match="invalid for binary mode"):
+            atomic_write_with(target, _writer, mode="wb", encoding="utf-8")
+
 
 # ---------------------------------------------------------------------------
 # append_durable
@@ -250,6 +295,9 @@ class TestAtomicityInvariants:
         # no interleaving, no truncation.
         final = target.read_text()
         assert final in payloads
+        # And no racing-writer ``*.tmp`` artifact survives the storm
+        # (coderabbit PRRT_kwDOR_Rkws59MONu).
+        assert list(tmp_path.iterdir()) == [target]
 
     def test_temp_file_removed_when_replace_fails(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -260,10 +308,7 @@ class TestAtomicityInvariants:
         """
         target = tmp_path / "s.yaml"
 
-        real_replace = os.replace
-
-        def _broken_replace(src: str, dst: str) -> None:
-            _ = real_replace  # keep reference
+        def _broken_replace(_src: object, _dst: object) -> None:
             raise OSError("simulated cross-device replace failure")
 
         monkeypatch.setattr(os, "replace", _broken_replace)
@@ -273,6 +318,42 @@ class TestAtomicityInvariants:
 
         # Nothing left behind — no target, no temp file.
         assert list(tmp_path.iterdir()) == []
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX file-mode bits not meaningful on Windows",
+    )
+    def test_preserves_existing_target_permissions(self, tmp_path: Path) -> None:
+        """coderabbit Minor (PRRT_kwDOR_Rkws59MONs): ``tempfile.NamedTemporaryFile``
+        creates the temp file with 0o600, and ``os.replace`` inherits
+        the temp inode's mode. Without explicit preservation, a user
+        who chmodded their config file to 0o644 would silently lose
+        that on every save. Pre-existing target mode must survive the
+        atomic replace.
+        """
+        target = tmp_path / "config.yaml"
+        target.write_text("initial")
+        # User customised to group-readable.
+        target.chmod(0o640)
+
+        atomic_write_text(target, "updated")
+        new_mode = target.stat().st_mode & 0o7777
+        assert new_mode == 0o640, f"mode drifted: expected 0o640, got {oct(new_mode)}"
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX file-mode bits not meaningful on Windows",
+    )
+    def test_new_target_gets_default_safe_mode(self, tmp_path: Path) -> None:
+        """First-time writes have no pre-existing mode to inherit, so
+        they retain the tempfile default of 0o600 — safer than the
+        locale-default umask-derived mode and acceptable for the state
+        files this module is used for.
+        """
+        target = tmp_path / "new.yaml"
+        atomic_write_text(target, "first write")
+        new_mode = target.stat().st_mode & 0o7777
+        assert new_mode == 0o600
 
     @pytest.mark.skipif(
         sys.platform == "win32",
@@ -297,4 +378,6 @@ class TestAtomicityInvariants:
 
         target = tmp_path / "s.yaml"
         atomic_write_text(target, "payload")
-        assert target in called or any(p == target for p in called)
+        # ``atomic_io.fsync_directory`` is called with the target path
+        # (it internally opens ``target.parent`` for the fsync).
+        assert called == [target]

--- a/tests/utils/test_atomic_write.py
+++ b/tests/utils/test_atomic_write.py
@@ -321,6 +321,33 @@ class TestAtomicityInvariants:
 
     @pytest.mark.skipif(
         sys.platform == "win32",
+        reason="Symlink semantics on Windows require elevated privileges",
+    )
+    def test_follows_symlinks_instead_of_replacing_link(self, tmp_path: Path) -> None:
+        """codex P2 (PRRT_kwDOR_Rkws59MXyc): the pre-existing
+        ``path.write_text`` / ``open(path, "w")`` sites followed
+        symlinks — users who symlink config/state files to shared
+        storage expect a save to write through to the real target, not
+        replace the symlink with a regular file. Regression guard:
+        when the target is a symlink, the write must update the
+        symlink's target, and the symlink itself must remain a
+        symlink pointing at the same real path.
+        """
+        real_target = tmp_path / "real_config.yaml"
+        real_target.write_text("original")
+        link = tmp_path / "link.yaml"
+        link.symlink_to(real_target)
+
+        atomic_write_text(link, "updated")
+
+        # Link still exists and still points to the same real target.
+        assert link.is_symlink()
+        assert link.resolve() == real_target.resolve()
+        # The real file (not the link) now has the new content.
+        assert real_target.read_text() == "updated"
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
         reason="POSIX file-mode bits not meaningful on Windows",
     )
     def test_preserves_existing_target_permissions(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Epic B.atomic of the hardening roadmap (#155). Replaces every
truncate-then-write state-file pattern with crash-safe atomic
writes, and every append-log pattern with fsynced durable appends.

- **New module**: `src/utils/atomic_write.py` — four helpers
  (`atomic_write_text`, `atomic_write_bytes`, `atomic_write_with`,
  `append_durable`) that wrap the temp-file + fsync + `os.replace`
  + directory-fsync pattern.
- **17 B1a call-site conversions** — every YAML/JSON/pickle state
  file listed in spec §3 B1a is now crash-safe.
- **2 B1b call-site conversions** — audit log + VS Code JSONL
  command stream use `append_durable` so a crash between write and
  fsync can't lose the most recent record.

All commits are structured per the "one commit per finding" rule
(§4 of the spec):

1. `feat(utils): add atomic_write helpers for Epic B.atomic (B1a + B1b)`
2. `refactor(B1a): convert 17 state-file writes to atomic_write helpers`
3. `refactor(B1b): convert audit + VS Code append logs to durable writes`

## What changed

### `src/utils/atomic_write.py` (new)

| Helper | Shape | Used by |
|--------|-------|---------|
| `atomic_write_text(path, content, *, encoding="utf-8")` | replaces `path.write_text(...)` | 4 YAML/JSON state files |
| `atomic_write_bytes(path, content)` | in-memory binary payload | (reserved for future use) |
| `atomic_write_with(path, writer, *, mode="wb")` | streaming callback (`pickle.dump`, `json.dump`) | 11 JSON/YAML + 2 pickle sites |
| `append_durable(path, line, *, encoding="utf-8")` | fsynced append | 2 log-style sites |

All four write to a temp file in the destination's parent directory,
fsync the contents, `os.replace` into place (atomic on POSIX and
Windows for same-filesystem renames), then fsync the parent directory
on POSIX via the pre-existing `utils.atomic_io.fsync_directory` helper
(no-op on Windows).

Invariants the module upholds:

1. **Atomicity** — a reader opening the target at any point during the
   write sees either the old contents or the new contents, never a
   mixture or an empty file.
2. **No temp-file residue** — on success *or* failure (writer
   exceptions, failed `os.replace`, KeyboardInterrupt), no `*.tmp`
   artifact remains.
3. **Surface missing parents** — helpers do NOT auto-create parent
   directories. Preserves existing `path.mkdir(parents=True, ...)`
   discipline at every site and prevents silent masking of config
   path bugs.

20 new tests cover all four helpers, the crash-injection path (writer
raises → target unchanged, no temp file lingers), the `os.replace`
failure path, concurrent writers (last writer wins, no partial state),
and the POSIX directory-fsync invocation.

### B1a call-site conversions (17 sites)

Text YAML/JSON state files:

- `src/config/manager.py:144,205` — profile save + delete
- `src/config/path_migration.py:91` — migration audit log
- `src/services/suggestion_feedback.py:368` — feedback entries
- `src/services/copilot/rules/rule_manager.py:99` — rule set YAML
- `src/methodologies/para/migration_manager.py:395,514` — backup
  manifest + rollback update
- `src/methodologies/para/config.py:270` — PARA config YAML
- `src/methodologies/johnny_decimal/config.py:194` — JD config
- `src/methodologies/johnny_decimal/migrator.py:326` — rollback info
- `src/methodologies/johnny_decimal/system.py:410` — JD system state
- `src/services/intelligence/folder_learner.py:303` — folder prefs
- `src/services/auto_tagging/tag_learning.py:452` — tag learning
- `src/events/discovery.py:137` — service registry
- `src/methodologies/para/ai/feedback.py:307` — PARA AI feedback

Binary pickle streams:

- `src/services/deduplication/embedder.py:271` — vectorizer pickle
- `src/services/deduplication/embedder.py:314` — embedding cache
  (both were flagged by S6 CACHE_TOCTOU — this PR closes it)

### B1b call-site conversions (2 sites)

Durable appends:

- `src/events/audit.py:246` — audit log JSONL
- `src/integrations/vscode.py:76` — VS Code command stream JSONL

### Test adaptations (4 tests)

The pre-existing failure-injection tests for the PARA backup manifest
path patched `builtins.open` to raise `OSError` on `manifest.json`
writes. The manifest write now goes through `atomic_write_with`
internally (temp-file + `os.replace`), so the injection moved one
layer up — now patches
`methodologies.para.migration_manager.atomic_write_with` directly.
Invariants the tests verify (raise propagates, backup dir cleaned up,
cleanup-also-fails raises the cleanup error) are unchanged; only the
injection site shifted.

## Out of scope (intentional)

- **Daemon PID file** (`src/daemon/pid.py:50`) — handled separately
  under F2 (lockfile redesign), tagged in the spec to prevent
  double-patching.
- **One-shot user exports / reports** (`src/history/export.py`,
  `src/services/analytics/analytics_service.py`, reports, video
  output, install artifacts) — not state files; truncate-replace is
  correct, see §3 B1a out-of-scope list.

## Test plan

- [x] `pytest tests/utils/test_atomic_write.py` — 20 new tests pass
- [x] `pytest tests/methodologies/para/test_migration_recovery.py
      tests/methodologies/para/test_para_migration_manager_branches.py`
      — 94 tests pass (includes the 4 adapted tests)
- [x] `pytest tests/events/ tests/integrations/` — 529 tests pass
- [x] `bash .claude/scripts/pre-commit-validation.sh` — green
- [x] `mypy src/` — clean (288 source files)
- [x] `ruff check src/` — clean

## Follow-ups for Epic B

- `hardening/epic-b-errors` — B2 error-boundary hygiene
- `hardening/epic-b-undo-db` — B3 undo DB transaction wrap

Both are parallel-safe after this lands. `hardening/epic-f-integrity`
will reuse `atomic_write_with` when building F7's `durable_move`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced data durability and crash-safety for all file persistence operations across the application, preventing corrupted or partially-written files if the application terminates unexpectedly during save operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->