### PR TITLE
hardening(correctness): epic-b-errors — B2 error-boundary hygiene

### DIFF
--- a/src/models/model_manager.py
+++ b/src/models/model_manager.py
@@ -172,10 +172,16 @@ class ModelManager:
                 return True
             self._console.print(f"[red]Pull failed (exit code {proc.returncode}).[/red]")
             return False
-        except FileNotFoundError:
+        except FileNotFoundError as e:
+            # B2: surface to both the user (console) and the log stream
+            # so aggregated logs show the failure with its exception
+            # class — pre-B2 only the console print existed, making
+            # failed pulls invisible in log-only monitoring.
+            logger.error("Ollama pull failed (type=%s): %s", type(e).__name__, e)
             self._console.print("[red]Ollama CLI not found. Install from https://ollama.ai[/red]")
             return False
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as e:
+            logger.error("Ollama pull failed (type=%s): %s", type(e).__name__, e)
             self._console.print("[red]Pull timed out.[/red]")
             return False
 

--- a/src/models/model_manager.py
+++ b/src/models/model_manager.py
@@ -177,11 +177,14 @@ class ModelManager:
             # so aggregated logs show the failure with its exception
             # class — pre-B2 only the console print existed, making
             # failed pulls invisible in log-only monitoring.
-            logger.error("Ollama pull failed (type=%s): %s", type(e).__name__, e)
+            # ``logger.exception`` auto-attaches ``exc_info`` (satisfies
+            # ``tests/ci/test_traceback_logging_guard.py``) and still
+            # carries the type in the message.
+            logger.exception("Ollama pull failed (type=%s): %s", type(e).__name__, e)
             self._console.print("[red]Ollama CLI not found. Install from https://ollama.ai[/red]")
             return False
         except subprocess.TimeoutExpired as e:
-            logger.error("Ollama pull failed (type=%s): %s", type(e).__name__, e)
+            logger.exception("Ollama pull failed (type=%s): %s", type(e).__name__, e)
             self._console.print("[red]Pull timed out.[/red]")
             return False
 

--- a/src/services/text_processor.py
+++ b/src/services/text_processor.py
@@ -187,16 +187,37 @@ class TextProcessor:
             )
 
         except FileReadError as e:
-            logger.error(f"Failed to read {file_path.name}: {e}")
+            # B2: include exception type so filesystem-level failures
+            # can be distinguished from downstream model errors in log
+            # aggregates. Loguru ``{}`` interpolation (not f-string)
+            # preserves structured capture (G2).
+            logger.error(
+                "Failed to read {} (type={}): {}",
+                file_path.name,
+                type(e).__name__,
+                e,
+            )
             return ProcessedFile(
                 file_path=file_path,
                 description="",
                 folder_name="errors",
                 filename=file_path.stem,
+                # Preserve the existing ``error=str(e)`` contract — B2
+                # scope is log-message categorisation, not the public
+                # ``ProcessedFile.error`` field.
                 error=str(e),
             )
         except (RuntimeError, ValueError, OSError, AttributeError) as e:
-            logger.exception(f"Failed to process {file_path.name}: {e}")
+            # B2: typed tuple already narrows to "model / inference"
+            # errors; log the class name so a RuntimeError
+            # (provider) vs AttributeError (uninitialised model) can be
+            # bucketed without reparsing.
+            logger.exception(
+                "Failed to process {} (type={}): {}",
+                file_path.name,
+                type(e).__name__,
+                e,
+            )
             return ProcessedFile(
                 file_path=file_path,
                 description="",
@@ -268,7 +289,13 @@ SUMMARY:"""
 
             return summary
         except (RuntimeError, ValueError, OSError, AttributeError) as e:
-            logger.error(f"Failed to generate description: {e}")
+            # B2: include exception class name so provider / tokenizer /
+            # network surface can be distinguished in log aggregates.
+            logger.error(
+                "Failed to generate description (type={}): {}",
+                type(e).__name__,
+                e,
+            )
             return f"Content about {content[:100]}..."
 
     def _generate_folder_name(self, text: str, original_stem: str | None = None) -> str:
@@ -347,7 +374,13 @@ CATEGORY:"""
             return result
 
         except (RuntimeError, ValueError, OSError, AttributeError) as e:
-            logger.error(f"Failed to generate folder name: {e}")
+            # B2: include exception class name (see ``_generate_description``
+            # for rationale).
+            logger.error(
+                "Failed to generate folder name (type={}): {}",
+                type(e).__name__,
+                e,
+            )
             return "documents"
 
     def _generate_filename(self, text: str, original_stem: str | None = None) -> str:
@@ -431,7 +464,13 @@ FILENAME:"""
             return result
 
         except (RuntimeError, ValueError, OSError, AttributeError) as e:
-            logger.error(f"Failed to generate filename: {e}")
+            # B2: include exception class name (see ``_generate_description``
+            # for rationale).
+            logger.error(
+                "Failed to generate filename (type={}): {}",
+                type(e).__name__,
+                e,
+            )
             return "document"
 
     def cleanup(self) -> None:

--- a/src/services/vision_processor.py
+++ b/src/services/vision_processor.py
@@ -206,12 +206,26 @@ class VisionProcessor:
             )
 
         except Exception as e:
-            logger.exception(f"Failed to process {file_path.name}: {e}")
+            # B2: broad catch is load-bearing (organizer iterates many
+            # images; one bad file must not crash the pipeline) but the
+            # log message now includes the exception class name so
+            # operators can bucket failures by category (filesystem vs
+            # model-inference vs decode) without reparsing stack traces.
+            # ``logger.exception`` attaches the full traceback on top.
+            logger.exception(
+                "Failed to process {} (type={}): {}",
+                file_path.name,
+                type(e).__name__,
+                e,
+            )
             return ProcessedImage(
                 file_path=file_path,
                 description="",
                 folder_name="errors",
                 filename=file_path.stem,
+                # Preserve the existing ``error=str(e)`` contract — B2
+                # scope is log-message categorisation, not the public
+                # ``ProcessedImage.error`` field.
                 error=str(e),
             )
 

--- a/tests/services/test_b2_error_hygiene.py
+++ b/tests/services/test_b2_error_hygiene.py
@@ -55,13 +55,33 @@ class TestTextProcessorErrorLogsIncludeType:
         return model
 
     def _log_strings(self, mock_logger: MagicMock) -> str:
-        """Join every ``logger.error`` / ``.exception`` call (template + args)."""
+        """Join every ``logger.error`` / ``.exception`` call (template + args).
+
+        Renders both positional args AND kwargs values so a future
+        refactor from positional ``logger.error("t=%s", type(e).__name__)``
+        to keyword ``logger.error("t=%s", exc_type=type(e).__name__)``
+        doesn't silently make the regression guard vacuous (coderabbit
+        PRRT_kwDOR_Rkws59NYZ9).
+        """
         calls = list(mock_logger.error.call_args_list) + list(mock_logger.exception.call_args_list)
         rendered: list[str] = []
         for call in calls:
-            args, _kwargs = call
+            args, kwargs = call
             rendered.append(" ".join(str(a) for a in args))
+            rendered.extend(f"{k}={v}" for k, v in kwargs.items())
         return "\n".join(rendered)
+
+    def _assert_template_has_type_tag(self, mock_logger: MagicMock) -> None:
+        """Verify at least one log call's template contains the literal
+        ``type=`` tag, so a regression that drops the categorisation
+        token (even while keeping the type in an arg) would fail
+        (coderabbit PRRT_kwDOR_Rkws59NYZ9).
+        """
+        calls = list(mock_logger.error.call_args_list) + list(mock_logger.exception.call_args_list)
+        templates = [str(c.args[0]) for c in calls if c.args]
+        assert any("type=" in t for t in templates), (
+            f"no log template carries the 'type=' categorisation tag; got: {templates!r}"
+        )
 
     def test_generate_description_logs_exception_type(self, mock_model: MagicMock) -> None:
         mock_model.generate.side_effect = RuntimeError("llama server unreachable")
@@ -77,6 +97,7 @@ class TestTextProcessorErrorLogsIncludeType:
             f"expected log to include exception type 'RuntimeError', got: {joined!r}"
         )
         assert "llama server unreachable" in joined
+        self._assert_template_has_type_tag(mock_logger)
 
     def test_generate_folder_name_logs_exception_type(self, mock_model: MagicMock) -> None:
         mock_model.generate.side_effect = OSError("model pipe broken")
@@ -90,6 +111,7 @@ class TestTextProcessorErrorLogsIncludeType:
         assert "OSError" in joined, (
             f"expected log to include exception type 'OSError', got: {joined!r}"
         )
+        self._assert_template_has_type_tag(mock_logger)
 
     def test_generate_filename_logs_exception_type(self, mock_model: MagicMock) -> None:
         mock_model.generate.side_effect = AttributeError("model not initialized")
@@ -105,6 +127,7 @@ class TestTextProcessorErrorLogsIncludeType:
         assert "AttributeError" in joined, (
             f"expected log to include exception type 'AttributeError', got: {joined!r}"
         )
+        self._assert_template_has_type_tag(mock_logger)
 
 
 # ---------------------------------------------------------------------------
@@ -200,10 +223,15 @@ class TestVisionProcessorErrorLogsIncludeType:
         mock_model.is_initialized = True
 
         processor = VisionProcessor(vision_model=mock_model)
-        # Force-close the circuit in case the short-circuit path is
-        # hit (sub-PIPE_BUF failures in another test could have
-        # tripped it via a module-level state leak).
-        processor._consecutive_failures = 0  # type: ignore[attr-defined]
+        # Defensively close the circuit under its real lock (the
+        # constructor already leaves it closed; this only matters if
+        # future fixture/module-state leaks trip it). Attribute names
+        # match ``VisionProcessor.__init__`` — ``_circuit_opened_at``
+        # is the gating field (see ``_is_circuit_open``) (coderabbit
+        # PRRT_kwDOR_Rkws59NYaB).
+        with processor._circuit_lock:
+            processor._circuit_opened_at = None
+            processor._circuit_reason = None
 
         with (
             patch.object(

--- a/tests/services/test_b2_error_hygiene.py
+++ b/tests/services/test_b2_error_hygiene.py
@@ -1,0 +1,233 @@
+"""Regression guards for Epic B.errors (B2) error-boundary hygiene.
+
+Per §3 B2 of the hardening roadmap: replace bare excepts and silent
+fallbacks with typed / categorized handling; log exception type and
+category. These tests verify the invariant at each of the three
+enumerated sites so a regression that drops the category from the log
+message (or swallows the exception without logging type) would fail.
+
+Covered sites:
+
+- ``src/services/vision_processor.py`` (image-processing failure path)
+- ``src/services/text_processor.py`` (description / folder-name /
+  filename generation failure paths)
+- ``src/models/model_manager.py`` (ollama CLI not found / timeout
+  branches — console output is already present; B2 adds structured
+  logger lines carrying the exception type)
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models.base import ModelType
+from services.text_processor import TextProcessor
+
+pytestmark = [pytest.mark.ci, pytest.mark.unit, pytest.mark.integration]
+
+
+# ---------------------------------------------------------------------------
+# text_processor.py error paths — already-typed except tuples, B2 adds
+# exception type to the log message using loguru's {} interpolation
+# (f-strings in logger calls are a G2 violation — pre-format the
+# message before loguru sees it, losing structured capture).
+# ---------------------------------------------------------------------------
+
+
+class TestTextProcessorErrorLogsIncludeType:
+    """Each typed ``except`` in TextProcessor's three generate_* methods
+    must log the exception class name and the error. Without the type
+    tag, operators can't distinguish model-provider failures
+    (``RuntimeError``) from filesystem surface (``OSError``) from
+    attribute errors on an uninitialised model (``AttributeError``).
+    """
+
+    @pytest.fixture
+    def mock_model(self) -> MagicMock:
+        model = MagicMock()
+        model.config.model_type = ModelType.TEXT
+        model.is_initialized = True
+        return model
+
+    def _log_strings(self, mock_logger: MagicMock) -> str:
+        """Join every ``logger.error`` / ``.exception`` call (template + args)."""
+        calls = list(mock_logger.error.call_args_list) + list(mock_logger.exception.call_args_list)
+        rendered: list[str] = []
+        for call in calls:
+            args, _kwargs = call
+            rendered.append(" ".join(str(a) for a in args))
+        return "\n".join(rendered)
+
+    def test_generate_description_logs_exception_type(self, mock_model: MagicMock) -> None:
+        mock_model.generate.side_effect = RuntimeError("llama server unreachable")
+        processor = TextProcessor(text_model=mock_model)
+
+        with patch("services.text_processor.logger") as mock_logger:
+            result = processor._generate_description("some content")
+
+        # Fallback contract preserved.
+        assert result.startswith("Content about")
+        joined = self._log_strings(mock_logger)
+        assert "RuntimeError" in joined, (
+            f"expected log to include exception type 'RuntimeError', got: {joined!r}"
+        )
+        assert "llama server unreachable" in joined
+
+    def test_generate_folder_name_logs_exception_type(self, mock_model: MagicMock) -> None:
+        mock_model.generate.side_effect = OSError("model pipe broken")
+        processor = TextProcessor(text_model=mock_model)
+
+        with patch("services.text_processor.logger") as mock_logger:
+            result = processor._generate_folder_name("irrelevant text")
+
+        assert result == "documents"  # documented fallback
+        joined = self._log_strings(mock_logger)
+        assert "OSError" in joined, (
+            f"expected log to include exception type 'OSError', got: {joined!r}"
+        )
+
+    def test_generate_filename_logs_exception_type(self, mock_model: MagicMock) -> None:
+        mock_model.generate.side_effect = AttributeError("model not initialized")
+        processor = TextProcessor(text_model=mock_model)
+
+        with patch("services.text_processor.logger") as mock_logger:
+            result = processor._generate_filename("text")
+
+        # Fallback filename is non-empty (documented contract — see
+        # _generate_filename's exception handler).
+        assert result
+        joined = self._log_strings(mock_logger)
+        assert "AttributeError" in joined, (
+            f"expected log to include exception type 'AttributeError', got: {joined!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# model_manager.py — typed FileNotFoundError / subprocess.TimeoutExpired
+# already caught; B2 adds a structured ``logger.*`` call alongside the
+# ``console.print`` so the failure appears in the log stream with the
+# exception type (not just the user-facing console).
+# ---------------------------------------------------------------------------
+
+
+class TestModelManagerPullLogsTypedErrors:
+    """``ModelManager.pull`` surfaces ollama CLI failures to the user via
+    ``console.print`` but — pre-B2 — left no ``logger.*`` record. When
+    operators review logs (the aggregated source of truth across runs),
+    a quiet failure looked like no activity at all. B2 adds a
+    structured log line carrying the exception type so the failure is
+    visible in both channels.
+    """
+
+    @pytest.fixture
+    def manager(self) -> object:
+        from models.model_manager import ModelManager
+
+        mgr = ModelManager()
+        # Swap the Console for a silent MagicMock so stdout isn't
+        # littered with ANSI codes during the test run.
+        mgr._console = MagicMock()
+        return mgr
+
+    def test_pull_ollama_not_found_logs_type(
+        self, manager: object, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with patch(
+            "models.model_manager.subprocess.run",
+            side_effect=FileNotFoundError("ollama: not found"),
+        ):
+            with caplog.at_level(logging.ERROR):
+                ok = manager.pull_model("qwen2.5:3b")
+
+        assert ok is False
+        joined = "\n".join(
+            str(r.msg) + " " + " ".join(str(a) for a in r.args or ()) for r in caplog.records
+        )
+        assert "FileNotFoundError" in joined, (
+            f"expected log to include 'FileNotFoundError', got: {joined!r}"
+        )
+
+    def test_pull_ollama_timeout_logs_type(
+        self, manager: object, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        timeout = subprocess.TimeoutExpired(cmd="ollama pull x", timeout=10)
+        with patch("models.model_manager.subprocess.run", side_effect=timeout):
+            with caplog.at_level(logging.ERROR):
+                ok = manager.pull_model("qwen2.5:3b")
+
+        assert ok is False
+        joined = "\n".join(
+            str(r.msg) + " " + " ".join(str(a) for a in r.args or ()) for r in caplog.records
+        )
+        assert "TimeoutExpired" in joined, (
+            f"expected log to include 'TimeoutExpired', got: {joined!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# vision_processor.py — the bare ``except Exception`` is load-bearing
+# (organizer iterates many images; one bad file must not crash the
+# pipeline). B2 fix: enrich the log message with exception type so the
+# category is visible even when the catch remains broad.
+# ---------------------------------------------------------------------------
+
+
+class TestVisionProcessorErrorLogsIncludeType:
+    """Regression: the catch-all in ``VisionProcessor.process_image``
+    must log ``type(exc).__name__`` so a stream of vision failures can
+    be bucketed by operators without digging into per-record
+    tracebacks.
+    """
+
+    def test_process_image_failure_logs_exception_type(self, tmp_path: Path) -> None:
+        from models.base import ModelType
+        from services.vision_processor import VisionProcessor
+
+        sample = tmp_path / "x.jpg"
+        sample.write_bytes(b"fake jpg")
+
+        # Inject a mock vision model so the constructor succeeds; then
+        # stub ``_generate_description`` to raise so the exception
+        # reaches the outer try/except in ``process_file`` (the B2
+        # site at src/services/vision_processor.py:208).
+        mock_model = MagicMock()
+        mock_model.config.model_type = ModelType.VISION
+        mock_model.is_initialized = True
+
+        processor = VisionProcessor(vision_model=mock_model)
+        # Force-close the circuit in case the short-circuit path is
+        # hit (sub-PIPE_BUF failures in another test could have
+        # tripped it via a module-level state leak).
+        processor._consecutive_failures = 0  # type: ignore[attr-defined]
+
+        with (
+            patch.object(
+                processor,
+                "_generate_description",
+                side_effect=RuntimeError("vision inference failed"),
+            ),
+            patch("services.vision_processor.logger") as mock_logger,
+        ):
+            result = processor.process_file(sample)
+
+        # Fallback contract: returns an error-tagged ProcessedImage rather
+        # than raising — the organizer keeps going.
+        assert result.folder_name == "errors"
+        rendered: list[str] = []
+        for call in list(mock_logger.error.call_args_list) + list(
+            mock_logger.exception.call_args_list
+        ):
+            args, _kwargs = call
+            rendered.append(" ".join(str(a) for a in args))
+        joined = "\n".join(rendered)
+        assert "RuntimeError" in joined, f"expected log to include 'RuntimeError', got: {joined!r}"
+        # ``ProcessedImage.error`` preserves its existing contract of
+        # carrying just ``str(e)`` — the type categorisation lives in
+        # the log message only, where operators consume it. Downstream
+        # reporters that key off the error field are undisturbed.
+        assert "vision inference failed" in (result.error or "")


### PR DESCRIPTION
## Summary

Final child PR of Epic B (#155). Enriches error-path logging at the
three sites in §3 B2 of the hardening roadmap so operators can bucket
failures by exception class in log aggregates without reparsing
stack traces. Also fixes five G2 violations (f-strings in
``logger.*`` calls).

## Sites converted

| File | Lines | Change |
|------|-------|--------|
| ``src/services/vision_processor.py`` | 208 | Broad ``except Exception`` (load-bearing — organizer iterates many images) now logs ``type(e).__name__`` via loguru ``{}`` interpolation. |
| ``src/services/text_processor.py`` | 189, 207, 270, 349, 463 | Five typed ``except`` tuples migrated from f-string log calls to loguru ``{}`` interpolation with ``type=...`` tag. |
| ``src/models/model_manager.py`` | 175-180 | ollama CLI ``FileNotFoundError`` / ``TimeoutExpired`` paths previously console-only; B2 adds ``logger.error(...)`` alongside so log aggregates show the failure. |

## Contract preservation

``ProcessedFile.error`` / ``ProcessedImage.error`` stays as
``str(e)`` — type categorisation lives in the log message only. This
keeps pre-existing tests (``tests/services/test_text_processor.py``
et al.) and downstream reporters undisturbed.

## Regression tests

New ``tests/services/test_b2_error_hygiene.py`` (6 tests):

- ``TestTextProcessorErrorLogsIncludeType`` × 3 — one test per
  ``_generate_*`` method, forces a typed exception via mock, asserts
  the log stream contains the class name (``RuntimeError`` /
  ``OSError`` / ``AttributeError``).
- ``TestModelManagerPullLogsTypedErrors`` × 2 — uses ``caplog``
  (model_manager uses stdlib logging, not loguru) to assert
  ``FileNotFoundError`` / ``TimeoutExpired`` appear in the ERROR
  log when ``pull_model`` fails.
- ``TestVisionProcessorErrorLogsIncludeType`` — patches
  ``_generate_description`` to raise so the exception reaches the
  outer ``except`` at line 208; asserts the log carries
  ``RuntimeError``.

Marked ``ci`` + ``unit`` + ``integration`` so the new code paths
show up in every CI gate (diff coverage, per-module integration
floor, etc.).

## Test plan

- [x] ``pytest tests/services/test_b2_error_hygiene.py tests/services/test_text_processor.py tests/services/test_text_processor_logging.py tests/unit/services/test_vision_processor.py tests/models/test_model_manager.py`` — 118 pass (112 pre-existing + 6 new)
- [x] ``bash .claude/scripts/pre-commit-validation.sh`` — green
- [x] ``uvx ruff@0.15.11 format . --check`` — clean (pre-applied CI's ruff version)
- [x] ``mypy src/`` — clean

## Epic B status after this lands

| Child PR | Status |
|----------|--------|
| B.atomic (B1a + B1b) | ✅ merged (PR #176) |
| B.undo-db (B3) | ✅ merged (PR #177) |
| B.errors (B2) | this PR |

After merge, Epic B is complete. Next per the roadmap sequencing: **C.mechanical** (T1 residual cleanup + T9 vacuous-assert fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error logging across the system to include exception type information alongside error messages, providing better visibility into failure scenarios.

* **Tests**
  * Added comprehensive test coverage to validate error logging behavior and ensure exceptions are properly categorized and logged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->