### PR TITLE
hardening(test-quality): epic-c-mechanical — C4 vacuous-assertion fix

### DIFF
--- a/tests/test_cli_config_integration.py
+++ b/tests/test_cli_config_integration.py
@@ -57,9 +57,20 @@ class TestConfigList:
     def test_list_shows_profiles_or_empty_message(self) -> None:
         result = runner.invoke(app, ["config", "list"])
         assert result.exit_code == 0
-        # Either shows profile names or an empty-state message
+        # Either shows profile names or an empty-state message.
+        #
+        # T9 fix (roadmap §3 C4): the pre-existing trailing
+        # ``or len(result.output.strip()) >= 0`` clause was always
+        # ``True`` (``len`` is non-negative by definition), making
+        # the whole disjunction vacuous — the test passed regardless
+        # of what the CLI printed, including an empty string. Removed
+        # so the assertion actually verifies one of the two allowed
+        # outputs was produced.
         output = result.output.lower()
-        assert ("default" in output) or ("no profiles" in output) or len(result.output.strip()) >= 0
+        assert ("default" in output) or ("no profiles" in output), (
+            f"`fo config list` produced neither a profile name nor an "
+            f"empty-state message; got: {result.output!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_config_integration.py
+++ b/tests/test_cli_config_integration.py
@@ -57,19 +57,25 @@ class TestConfigList:
     def test_list_shows_profiles_or_empty_message(self) -> None:
         result = runner.invoke(app, ["config", "list"])
         assert result.exit_code == 0
-        # Either shows profile names or an empty-state message.
-        #
         # T9 fix (roadmap §3 C4): the pre-existing trailing
         # ``or len(result.output.strip()) >= 0`` clause was always
         # ``True`` (``len`` is non-negative by definition), making
         # the whole disjunction vacuous — the test passed regardless
-        # of what the CLI printed, including an empty string. Removed
-        # so the assertion actually verifies one of the two allowed
-        # outputs was produced.
-        output = result.output.lower()
-        assert ("default" in output) or ("no profiles" in output), (
-            f"`fo config list` produced neither a profile name nor an "
-            f"empty-state message; got: {result.output!r}"
+        # of what the CLI printed, including an empty string.
+        #
+        # The first revision of this fix asserted ``"default"`` OR
+        # ``"no profiles"`` was in the output, but ``fo config list``
+        # iterates whatever profiles the user actually has (see
+        # ``src/cli/config_cli.py::config_list``). A user whose config
+        # only contains custom profiles like ``work`` / ``personal``
+        # — valid state — would fail this test (codex P2
+        # PRRT_kwDOR_Rkws59Nq6G). The invariant we actually want is
+        # "the command produced visible output": both branches (the
+        # empty-state message and the per-profile loop) emit at least
+        # one non-whitespace character, so an empty string signals a
+        # real regression.
+        assert result.output.strip(), (
+            f"`fo config list` produced empty output; got: {result.output!r}"
         )
 
 


### PR DESCRIPTION
## Summary

Epic C.mechanical of the hardening roadmap (#156). Ships the C4
one-line T9 fix called out in the spec; C1 (T1 residual backlog) is
already empty so nothing to cleanup there.

## What changed

### `tests/test_cli_config_integration.py:62`

The assertion was:

```python
assert (
    ("default" in output)
    or ("no profiles" in output)
    or len(result.output.strip()) >= 0
)
```

The third clause is always `True` (`len` is non-negative by
definition), so the whole disjunction was vacuous — the test
passed regardless of what the CLI produced, including blank output
or an error message. Dropped the vacuous clause and added a failure
message so a regression surfaces the actual output diff.

## Scope note — C1 already drained

The roadmap estimated ~135 sole-isinstance violations requiring
phased cleanup by directory. A full-suite scan using the detector
at `tests/ci/test_test_quality_guardrails.py::_find_sole_isinstance_assertions`
returns **0** violations. Same for the T9 detectors
(`len(x) <= N` and `len(x) >= 0`):

```
T1 sole-isinstance:      0
T9 len(x) <= N (vacuous): 0
T9 len(x) >= 0 (vacuous): 0
```

Backlog already drained by prior work (PRs #140 and earlier). No
per-directory cleanup commits needed.

## Follow-up unblocked

**G4** — promote T1 / T9 guardrails from diff-scoped to full-suite
enforcement — can ship in `hardening/epic-g-rails` immediately
after this merges, since the prerequisite (empty full-suite
backlog) is already satisfied.

## Test plan

- [x] `pytest tests/test_cli_config_integration.py::TestConfigList::test_list_shows_profiles_or_empty_message` — passes
- [x] `bash .claude/scripts/pre-commit-validation.sh` — green
- [x] `uvx ruff@0.15.11 format . --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)