### PR TITLE
fix(daemon): close missed-signal race in scheduler stop/restart

### DIFF
--- a/src/daemon/scheduler.py
+++ b/src/daemon/scheduler.py
@@ -100,9 +100,14 @@ class DaemonScheduler:
         Processes all registered tasks, firing each one when its
         interval has elapsed. Blocks until ``stop()`` is called
         from another thread.
+
+        The caller must ensure ``_stop_event`` is clear before invoking
+        (``run_in_background`` handles this; direct foreground callers
+        are responsible). Clearing inside this method races with ``stop()``
+        set from another thread between ``thread.start()`` and the first
+        instruction of ``run``, and would silently drop the stop signal.
         """
         self._running = True
-        self._stop_event.clear()
         logger.info("Scheduler started with %d tasks", len(self._tasks))
 
         try:
@@ -126,6 +131,11 @@ class DaemonScheduler:
         if self._running:
             raise RuntimeError("Scheduler is already running")
 
+        # Clear the stop event synchronously BEFORE starting the thread.
+        # Clearing inside run() creates a missed-signal race: if stop() is
+        # called between thread.start() and run() getting CPU time, the
+        # clear wipes the stop signal and the scheduler loops forever.
+        self._stop_event.clear()
         self._thread = threading.Thread(
             target=self.run,
             name="daemon-scheduler",

--- a/tests/daemon/test_scheduler.py
+++ b/tests/daemon/test_scheduler.py
@@ -7,6 +7,7 @@ All time-sensitive operations are mocked for fast, deterministic tests.
 
 from __future__ import annotations
 
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -404,17 +405,30 @@ class TestRun:
 
         assert scheduler.is_running is False
 
-    def test_run_clears_stop_event_at_start(self, scheduler: DaemonScheduler) -> None:
-        """run() clears the stop event so a previous stop() doesn't prevent starting."""
+    def test_run_does_not_clear_stop_event_at_start(
+        self,
+        scheduler: DaemonScheduler,
+    ) -> None:
+        """run() must NOT clear ``_stop_event`` at entry.
+
+        The caller (``run_in_background`` or a direct foreground caller) is
+        responsible for clearing the event before invoking ``run()``.
+        Clearing inside ``run()`` creates a missed-signal race with
+        ``stop()`` — see ``TestStopEventRaceRegression``.
+
+        This test verifies the new contract: if the event is set before
+        ``run()`` executes, the loop exits immediately without calling
+        ``_tick``.
+        """
         scheduler._stop_event.set()
 
-        _make_run_terminate_after(scheduler, 1)
-
-        with patch.object(scheduler, "_tick"):
+        with patch.object(scheduler, "_tick") as mock_tick:
             scheduler.run()
 
-        # It ran successfully despite the pre-set event
+        mock_tick.assert_not_called()
         assert scheduler.is_running is False
+        # The event must remain set — run() did not wipe it.
+        assert scheduler._stop_event.is_set()
 
 
 # ---------------------------------------------------------------------------
@@ -513,6 +527,120 @@ class TestStop:
         with patch("daemon.scheduler.logger") as mock_logger:
             scheduler.stop()
             mock_logger.debug.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Race regression tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+@pytest.mark.integration
+class TestStopEventRaceRegression:
+    """Regression tests for the missed-signal race that caused the
+    ``test_restart_cycles_daemon`` flake (daemon PR #179 CI, run
+    24857093314 attempt 1).
+
+    Before the fix, ``run()`` called ``self._stop_event.clear()`` as its
+    second instruction. If ``stop()`` set the event between
+    ``thread.start()`` and ``run()`` getting CPU time — a very real
+    scenario under xdist CI contention — the clear wiped the stop signal
+    and the scheduler loop never exited. The subsequent
+    ``run_in_background()`` from the daemon's restart path then saw
+    ``self._running == True`` and raised
+    ``RuntimeError("Scheduler is already running")``.
+    """
+
+    def test_stop_signal_set_before_run_body_is_honored(
+        self,
+        scheduler: DaemonScheduler,
+    ) -> None:
+        """``run()`` must observe ``_stop_event`` as set when the event is
+        signalled before ``run()`` body executes — never call ``_tick``.
+
+        Uses a ``threading.Event`` gate to deterministically block the
+        scheduler thread between ``thread.start()`` and the first
+        instruction of ``run()``. The test then sets ``_stop_event`` and
+        releases the gate. With the bug (``run()`` clearing ``_stop_event``
+        on entry), the scheduler wipes the signal and calls ``_tick`` in a
+        loop. With the fix, ``run()`` inherits the set event and the loop
+        body never executes.
+
+        Uses ``_tick`` call count as the signal (more deterministic than
+        watching ``is_running``, which flashes True-then-False in microseconds
+        under the fix).
+        """
+        scheduler.schedule_task("noop", 60.0, lambda: None)
+        original_run = scheduler.run
+        gate = threading.Event()
+        tick_called = threading.Event()
+        original_tick = scheduler._tick
+
+        def gated_run() -> None:
+            # Block scheduler thread until test thread opens the gate —
+            # simulating the xdist-contention window where the thread is
+            # alive but run() has not been scheduled for CPU yet.
+            assert gate.wait(timeout=5.0), "test harness: gate never opened"
+            original_run()
+
+        def spy_tick() -> None:
+            tick_called.set()
+            original_tick()
+
+        scheduler.run = gated_run  # type: ignore[method-assign]
+        scheduler._tick = spy_tick  # type: ignore[method-assign]
+        scheduler.run_in_background()
+
+        # Simulate what DaemonService._cleanup()'s scheduler.stop() does:
+        # set the stop event while the scheduler thread is blocked.
+        scheduler._stop_event.set()
+        gate.set()
+
+        # Give the scheduler thread time to proceed past the gate and
+        # reach the while-loop. Under the fix the loop body never runs;
+        # under the bug _tick is called within the first 0.1s iteration.
+        triggered = tick_called.wait(timeout=1.0)
+        assert not triggered, (
+            "run() wiped _stop_event and entered the loop body — missed-signal "
+            "race is present"
+        )
+        assert scheduler._stop_event.is_set(), (
+            "run() must not clear _stop_event; the caller owns that invariant"
+        )
+
+        # Ensure the scheduler thread exits cleanly for fixture teardown.
+        assert scheduler._thread is not None
+        scheduler._thread.join(timeout=2.0)
+        assert scheduler.is_running is False
+
+    def test_run_in_background_clears_stop_event_before_start(
+        self,
+        scheduler: DaemonScheduler,
+    ) -> None:
+        """A stale ``_stop_event`` from a prior ``stop()`` must not block
+        the next ``run_in_background()`` cycle.
+
+        Simulates a restart: first cycle leaves the event set (as
+        ``stop()`` does); the next ``run_in_background()`` must clear it
+        synchronously before starting the thread, so the new scheduler
+        thread observes the event as unset whenever it eventually runs.
+        """
+        scheduler.stop()
+        assert scheduler._stop_event.is_set()
+
+        # run_in_background must clear the event before thread.start()
+        with patch("daemon.scheduler.threading.Thread") as mock_thread_cls:
+            mock_thread_cls.return_value = MagicMock()
+
+            def assert_cleared_at_start_call(*args: object, **kwargs: object) -> None:
+                assert not scheduler._stop_event.is_set(), (
+                    "run_in_background must clear _stop_event BEFORE starting "
+                    "the thread, to avoid a missed-signal race with stop()"
+                )
+
+            mock_thread_cls.return_value.start.side_effect = assert_cleared_at_start_call
+            scheduler.run_in_background()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/daemon/test_service.py
+++ b/tests/daemon/test_service.py
@@ -124,6 +124,36 @@ class TestDaemonLifecycle:
 
         assert daemon.is_running is True
 
+    def test_repeated_restart_cycles_do_not_leave_scheduler_zombie(
+        self,
+        daemon: DaemonService,
+    ) -> None:
+        """Repeated start/stop cycles must not leave the scheduler in a
+        zombied ``_running=True`` state.
+
+        Regression for the ``test_restart_cycles_daemon`` flake (PR #179 CI):
+        ``DaemonScheduler.run()`` used to clear ``_stop_event`` inside itself,
+        which races with ``_cleanup()``'s ``scheduler.stop()`` call. Under
+        xdist CI contention this caused the next ``run_in_background()`` in
+        ``_background_run`` to raise ``RuntimeError("Scheduler is already
+        running")``, leaving the daemon with ``is_running=False`` after
+        restart.
+        """
+        for _ in range(5):
+            daemon.start_background()
+            assert daemon.is_running is True
+            daemon.restart()
+
+            # restart() already waits for the background thread to reach
+            # _started_event.set(). is_running must be True immediately.
+            assert daemon.is_running is True
+
+            daemon.stop()
+            deadline = time.monotonic() + 5.0
+            while daemon.is_running and time.monotonic() < deadline:
+                pass
+            assert daemon.is_running is False
+
 
 class TestPidFileManagement:
     """Tests for PID file lifecycle with the daemon."""


### PR DESCRIPTION
## Summary

- Fixes the `test_restart_cycles_daemon` flake surfaced on PR #179's Integration tests (PR) run 24857093314 attempt 1 (`assert False is True`).
- Root cause: `DaemonScheduler.run()` called `self._stop_event.clear()` at entry, wiping any stop signal that arrived between `thread.start()` and `run()` getting CPU. The scheduler then looped forever, `stop()` hit its 5s join timeout, and the next `run_in_background()` in the daemon's restart path raised `RuntimeError("Scheduler is already running")` — which tripped `_cleanup()` and reset `DaemonService._running = False`.
- Fix: clear `_stop_event` synchronously in `run_in_background()` BEFORE `thread.start()`. `run()` no longer clears the event — the caller owns that invariant. Documented in `run()`'s docstring.

## CI failure evidence

Run 24857093314 attempt 1 showed:

```
PytestUnhandledThreadExceptionWarning: Exception in thread daemon-service
  File ".../src/daemon/service.py", line 246, in _background_run
      self._scheduler.run_in_background()
  File ".../src/daemon/scheduler.py", line 127, in run_in_background
      raise RuntimeError("Scheduler is already running")
FAILED tests/daemon/test_service.py::TestDaemonLifecycle::test_restart_cycles_daemon
  - assert False is True
```

Unrelated to PR #171's daemon-watch flake (that one was Rich line-wrap in the CLI `watch` command's test; this one is a threading race in `DaemonService` / `DaemonScheduler`).

## Reproduction (against pre-fix source)

Insert a 0.15s delay at the top of `scheduler.run`, call `run_in_background()` then `stop()`:

```
$ python3 -c "..."  # see commit message
scheduler.stop() took 5.00s (bug: ~5s; fixed: ~0s)
scheduler.is_running = True  (bug: True; fixed: False)
```

With the fix: `stop()` returns in 0.16s, `is_running` is False.

## Test plan

- [x] `tests/daemon/test_scheduler.py::TestStopEventRaceRegression::test_stop_signal_set_before_run_body_is_honored` — deterministic race via `threading.Event` gate; asserts `_tick` never called when signal pre-set
- [x] `tests/daemon/test_scheduler.py::TestStopEventRaceRegression::test_run_in_background_clears_stop_event_before_start` — asserts clear happens BEFORE `thread.start()`
- [x] `tests/daemon/test_service.py::TestDaemonLifecycle::test_repeated_restart_cycles_do_not_leave_scheduler_zombie` — 5 rapid start/restart/stop cycles at the service level
- [x] Rewrote stale `test_run_clears_stop_event_at_start` → `test_run_does_not_clear_stop_event_at_start` to match new contract
- [x] Both regression tests fail pre-fix, pass post-fix (verified via `git stash`)
- [x] Full daemon suite: 117 passed
- [x] Pre-commit validation: all gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a race condition in the daemon scheduler that could cause shutdown signals to be lost during startup, preventing proper daemon termination.

* **Tests**
  * Added regression tests for daemon lifecycle management to ensure correct state transitions across repeated start/restart/stop cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->