### PR TITLE
refactor(D3): inject AIInferenceAdapter seam into AIHeuristic (epic-d-pipeline, D2 deferred)

### DIFF
--- a/src/methodologies/para/detection/heuristics.py
+++ b/src/methodologies/para/detection/heuristics.py
@@ -34,6 +34,120 @@ from ..config import AIHeuristicConfig, CategoryThresholds
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# AIInferenceAdapter — D3 seam for decoupling AIHeuristic from Ollama.
+# ---------------------------------------------------------------------------
+#
+# Epic D.pipeline (hardening roadmap #157 — D3): Before D3 the heuristic
+# engine instantiated ``ollama.Client`` directly, making tests mock the
+# module globals ``OLLAMA_AVAILABLE`` and ``ollama`` for every case.
+# The adapter factors the "available + infer" surface into a single
+# protocol so alternative backends (local vLLM, OpenAI-compatible,
+# deterministic fakes for tests) can be injected without touching
+# AIHeuristic's body.
+#
+# Backward compat: if no adapter is passed to ``AIHeuristic(...)`` the
+# default ``OllamaInferenceAdapter`` is used, which reads the same
+# ``OLLAMA_AVAILABLE`` / ``ollama`` module globals the existing tests
+# monkey-patch. Pre-D3 tests keep passing verbatim.
+
+
+class AIInferenceAdapter(Protocol):
+    """Transport-agnostic surface for AI PARA classification.
+
+    Implementations must provide ``is_available()`` (cheap check + lazy
+    init) and ``infer()`` (one-shot inference call). Both must be
+    thread-safe.
+
+    The adapter owns its own connection lifecycle, timeout, and cache-key
+    concerns are NOT its responsibility — the heuristic layer handles
+    caching on top of the adapter.
+    """
+
+    def is_available(self) -> bool:
+        """Return ``True`` if the backend is installed and reachable.
+
+        Cached after the first call so the external check (e.g. TCP
+        connect) runs at most once per adapter instance.
+        """
+        ...
+
+    def infer(self, *, prompt: str, system: str) -> str | None:
+        """Run one-shot inference and return the raw response text.
+
+        Returns ``None`` on any transport-level failure (backend
+        unreachable, timeout, HTTP error). Parse errors are the caller's
+        responsibility — raw text is returned verbatim on success.
+        """
+        ...
+
+
+class OllamaInferenceAdapter:
+    """Default ``AIInferenceAdapter`` — wraps ``ollama.Client``.
+
+    Reads the module-level ``OLLAMA_AVAILABLE`` / ``ollama`` globals so
+    pre-D3 tests that patch those continue to work without change.
+    """
+
+    def __init__(self, config: AIHeuristicConfig) -> None:
+        """Store config; defer client creation to the first ``is_available`` call."""
+        self._config = config
+        self._client: Any = None
+        self._available: bool | None = None
+        self._init_lock = threading.Lock()
+
+    def is_available(self) -> bool:
+        """Lazily create the Ollama client with double-checked locking.
+
+        See the module docstring for ``AIHeuristic._ensure_client``
+        (kept for documentation of the race window this method closes).
+        """
+        if self._available is not None:
+            return self._available
+
+        with self._init_lock:
+            if self._available is not None:
+                return self._available
+
+            if not OLLAMA_AVAILABLE:
+                self._available = False
+                return False
+
+            try:
+                self._client = ollama.Client(
+                    host=self._config.ollama_url,
+                    timeout=self._config.timeout,
+                )
+                self._client.list()
+                self._available = True
+            except Exception:
+                logger.warning("Ollama unavailable at %s", self._config.ollama_url, exc_info=True)
+                self._available = False
+
+        return self._available
+
+    def infer(self, *, prompt: str, system: str) -> str | None:
+        """Call ``ollama.Client.generate`` and return the raw response text."""
+        if not self.is_available() or self._client is None:
+            return None
+        try:
+            response = self._client.generate(
+                model=self._config.model,
+                system=system,
+                prompt=prompt,
+                options={
+                    "temperature": self._config.temperature,
+                    "num_predict": self._config.max_tokens,
+                },
+                stream=False,
+            )
+        except Exception:
+            logger.warning("Ollama generate failed", exc_info=True)
+            return None
+        response_text = response.get("response", "") or ""
+        return response_text if isinstance(response_text, str) else None
+
+
 @dataclass
 class CategoryScore:
     """Score for a PARA category."""
@@ -504,15 +618,30 @@ class AIHeuristic(Heuristic):
         "Content preview:\n{content}\n"
     )
 
-    def __init__(self, weight: float = 1.0, config: AIHeuristicConfig | None = None) -> None:
+    def __init__(
+        self,
+        weight: float = 1.0,
+        config: AIHeuristicConfig | None = None,
+        adapter: AIInferenceAdapter | None = None,
+    ) -> None:
         """Initialize AI heuristic.
 
         Args:
             weight: Weight of this heuristic in final scoring (0.0 to 1.0)
             config: AI heuristic configuration. Uses defaults if not provided.
+            adapter: Optional inference adapter (D3 seam). Defaults to
+                ``OllamaInferenceAdapter(config)`` — which reads the same
+                module-level ``OLLAMA_AVAILABLE`` / ``ollama`` globals the
+                pre-D3 tests monkey-patch. Pass a fake adapter in tests to
+                avoid patching module globals.
         """
         super().__init__(weight=weight)
         self.config = config or AIHeuristicConfig()
+        # D3 seam: when an adapter is supplied, _invoke_inference delegates
+        # to it. When None, the pre-D3 inline ``self._client.generate(...)``
+        # path is used — preserves backward compat with tests that poke
+        # ``h._client`` and ``h._available`` directly.
+        self._adapter: AIInferenceAdapter | None = adapter
         self._client: Any = None
         self._available: bool | None = None
         self._init_lock = threading.Lock()
@@ -522,12 +651,19 @@ class AIHeuristic(Heuristic):
     def _ensure_client(self) -> bool:
         """Lazily create the Ollama client (thread-safe).
 
-        Uses a double-check locking pattern so the Ollama connectivity test
-        runs at most once per instance even under concurrent access.
+        When a D3 ``adapter`` is injected, delegates availability to it
+        instead of instantiating ``ollama.Client`` directly. Otherwise
+        uses a double-check locking pattern so the Ollama connectivity
+        test runs at most once per instance even under concurrent access.
 
         Returns:
-            True if client is available, False otherwise.
+            True if the inference backend is available, False otherwise.
         """
+        if self._adapter is not None:
+            available = self._adapter.is_available()
+            self._available = available
+            return available
+
         if self._available is not None:
             return self._available
 
@@ -553,6 +689,34 @@ class AIHeuristic(Heuristic):
                 self._available = False
 
         return self._available
+
+    def _invoke_inference(self, *, prompt: str, system: str) -> str | None:
+        """D3 seam for custom inference backends.
+
+        Default implementation calls ``self._client.generate(...)`` — the
+        pre-D3 Ollama path. Subclasses or test doubles can replace this
+        method (or pass an ``adapter`` whose ``infer`` method is
+        delegated to here) to swap in a different backend.
+
+        Returns:
+            Raw response text from the inference backend, or ``None`` on
+            transport failure. Callers convert ``None`` to a zero-result
+            with ``metadata["ai_analysis"] == "ollama_error"``.
+        """
+        if self._adapter is not None:
+            return self._adapter.infer(prompt=prompt, system=system)
+        response = self._client.generate(
+            model=self.config.model,
+            system=system,
+            prompt=prompt,
+            options={
+                "temperature": self.config.temperature,
+                "num_predict": self.config.max_tokens,
+            },
+            stream=False,
+        )
+        response_text = response.get("response", "") or ""
+        return response_text if isinstance(response_text, str) else None
 
     def _get_cache_key(self, file_path: Path) -> tuple[str, int, int] | None:
         """Return a cache key for the file, or None if stat fails.
@@ -735,19 +899,11 @@ class AIHeuristic(Heuristic):
         prompt = self._build_prompt(file_path, content)
 
         try:
-            response = self._client.generate(
-                model=self.config.model,
-                system=self._SYSTEM_MESSAGE,
-                prompt=prompt,
-                options={
-                    "temperature": self.config.temperature,
-                    "num_predict": self.config.max_tokens,
-                },
-                stream=False,
-            )
-            response_text: str = response.get("response", "") or ""
+            response_text = self._invoke_inference(prompt=prompt, system=self._SYSTEM_MESSAGE)
         except Exception:
             logger.warning("Ollama generate failed", exc_info=True)
+            return self._zero_result("ollama_error")
+        if response_text is None:
             return self._zero_result("ollama_error")
 
         try:

--- a/tests/methodologies/para/test_ai_heuristic.py
+++ b/tests/methodologies/para/test_ai_heuristic.py
@@ -1517,3 +1517,137 @@ class TestPlatformSpecificBranches:
         assert result.overall_confidence == 0.0
         assert result.recommended_category is None
         assert all(s.score == 0.0 for s in result.scores.values())
+
+
+# ---------------------------------------------------------------------------
+# D3 AIInferenceAdapter injection (test the seam, not ollama)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ci
+class TestAIHeuristicAdapterInjection:
+    """Epic D.pipeline D3 seam — AIHeuristic accepts a custom adapter so
+    tests can run without patching module globals.
+
+    Each test provides a minimal fake that satisfies ``AIInferenceAdapter``
+    protocol; the heuristic code never reaches the real ``ollama`` client.
+    """
+
+    def test_injected_adapter_controls_availability(self, tmp_path: Path) -> None:
+        """When an injected adapter reports unavailable, the heuristic
+        returns a zero result with ollama_unavailable — regardless of
+        the module-level OLLAMA_AVAILABLE flag."""
+        from methodologies.para.detection.heuristics import (
+            AIHeuristic,
+            AIInferenceAdapter,
+        )
+
+        class _UnavailableAdapter:
+            def is_available(self) -> bool:
+                return False
+
+            def infer(self, *, prompt: str, system: str) -> str | None:
+                raise AssertionError("must not be called when unavailable")
+
+        adapter: AIInferenceAdapter = _UnavailableAdapter()
+        h = AIHeuristic(weight=0.10, adapter=adapter)
+        test_file = tmp_path / "notes.txt"
+        test_file.write_text("content")
+
+        with patch(f"{_HEURISTICS_MODULE}.OLLAMA_AVAILABLE", True):
+            result = h.evaluate(test_file)
+
+        assert result.metadata["ai_analysis"] == "ollama_unavailable"
+        assert result.overall_confidence == 0.0
+        assert result.abstained is True
+
+    def test_injected_adapter_infer_is_called_with_prompt_and_system(self, tmp_path: Path) -> None:
+        """The heuristic routes both prompt and system message through
+        ``adapter.infer(prompt=..., system=...)`` — exact kwargs so a
+        future refactor that drops one arg is caught."""
+        from methodologies.para.detection.heuristics import (
+            AIHeuristic,
+            AIInferenceAdapter,
+        )
+
+        calls: list[dict[str, str]] = []
+
+        class _FakeAdapter:
+            def is_available(self) -> bool:
+                return True
+
+            def infer(self, *, prompt: str, system: str) -> str | None:
+                calls.append({"prompt": prompt, "system": system})
+                return json.dumps(
+                    {
+                        "project": 0.8,
+                        "area": 0.1,
+                        "resource": 0.05,
+                        "archive": 0.05,
+                        "reasoning": "fake adapter",
+                    }
+                )
+
+        adapter: AIInferenceAdapter = _FakeAdapter()
+        h = AIHeuristic(weight=0.10, adapter=adapter)
+        test_file = tmp_path / "proposal.txt"
+        test_file.write_text("Project proposal with deadline next week")
+
+        with patch(f"{_HEURISTICS_MODULE}.OLLAMA_AVAILABLE", True):
+            result = h.evaluate(test_file)
+
+        assert len(calls) == 1
+        assert "proposal.txt" in calls[0]["prompt"]
+        assert calls[0]["system"] == AIHeuristic._SYSTEM_MESSAGE
+        assert result.metadata["ai_analysis"] == "complete"
+        assert result.recommended_category == PARACategory.PROJECT
+
+    def test_injected_adapter_none_response_yields_ollama_error(self, tmp_path: Path) -> None:
+        """Adapter returning None (transport failure) → ollama_error."""
+        from methodologies.para.detection.heuristics import (
+            AIHeuristic,
+            AIInferenceAdapter,
+        )
+
+        class _FailingAdapter:
+            def is_available(self) -> bool:
+                return True
+
+            def infer(self, *, prompt: str, system: str) -> str | None:
+                return None
+
+        adapter: AIInferenceAdapter = _FailingAdapter()
+        h = AIHeuristic(weight=0.10, adapter=adapter)
+        test_file = tmp_path / "x.txt"
+        test_file.write_text("content")
+
+        with patch(f"{_HEURISTICS_MODULE}.OLLAMA_AVAILABLE", True):
+            result = h.evaluate(test_file)
+
+        assert result.metadata["ai_analysis"] == "ollama_error"
+
+
+@pytest.mark.ci
+class TestOllamaInferenceAdapter:
+    """The default adapter wraps ollama.Client; verify it reads module
+    globals so pre-D3 tests that patch OLLAMA_AVAILABLE still work."""
+
+    def test_is_available_returns_false_when_ollama_missing(self) -> None:
+        from methodologies.para.detection.heuristics import (
+            OllamaInferenceAdapter,
+        )
+
+        cfg = AIHeuristicConfig()
+        adapter = OllamaInferenceAdapter(cfg)
+        with patch(f"{_HEURISTICS_MODULE}.OLLAMA_AVAILABLE", False):
+            assert adapter.is_available() is False
+
+    def test_infer_returns_none_when_unavailable(self) -> None:
+        from methodologies.para.detection.heuristics import (
+            OllamaInferenceAdapter,
+        )
+
+        cfg = AIHeuristicConfig()
+        adapter = OllamaInferenceAdapter(cfg)
+        with patch(f"{_HEURISTICS_MODULE}.OLLAMA_AVAILABLE", False):
+            assert adapter.infer(prompt="x", system="y") is None


### PR DESCRIPTION
## Summary

Lands **D3** only from Epic D.pipeline (hardening roadmap #157). D2 (``pipeline/orchestrator.py`` 881-LOC split) is deferred to a follow-up PR — splitting keeps review surface manageable and lets D3 land on its own timeline.

### D3 — AIInferenceAdapter seam

Factors the Ollama-specific transport surface out of ``AIHeuristic`` into a minimal ``AIInferenceAdapter`` protocol with a default ``OllamaInferenceAdapter`` wrapper.

- **Protocol**: ``is_available()`` + ``infer(prompt=, system=)``. Thread-safe, adapter owns its connection lifecycle.
- **Default adapter** reads the module-level ``OLLAMA_AVAILABLE`` / ``ollama`` globals so pre-D3 tests that patch those work verbatim.
- **AIHeuristic gains optional ``adapter=`` kwarg** — when ``None`` (default), uses the pre-D3 inline path, preserving backward compat with tests that poke ``h._client`` / ``h._available`` directly.

## Why this matters

Before D3, every AI-heuristic test had to monkey-patch two module globals (``OLLAMA_AVAILABLE``, ``ollama``) plus set three instance attributes (``h._client``, ``h._available``, ``h._init_lock``). The adapter seam lets test code inject a small fake that implements the protocol — no global patching, no private-attribute pokes.

## Test plan

- [x] 74 pre-existing ``tests/methodologies/para/test_ai_heuristic.py`` tests pass verbatim (no migration)
- [x] 5 new adapter-injection tests:
  - Unavailable adapter yields ``ollama_unavailable``
  - Adapter's ``infer(prompt=, system=)`` receives exact kwargs
  - ``None`` response yields ``ollama_error``
  - ``OllamaInferenceAdapter`` honors ``OLLAMA_AVAILABLE`` at the module level
  - ``OllamaInferenceAdapter.infer`` returns ``None`` when unavailable
- [x] Full suite: 79 passed locally
- [x] ``pre-commit run --all-files`` — all gates Passed
- [x] Rebased on latest main (includes PR #182)

## Scope — D2 deferred

``pipeline/orchestrator.py`` is 881 LOC with 25+ methods spanning buffer pool management, batch prefetch, stage execution, and watch mode. A clean ``ResourceAwareExecutor`` extraction needs dedicated review surface. It'll land as a follow-up PR (``hardening/epic-d-pipeline-d2``) once this D3 seam is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)