### PR TITLE
fix(post-merge): address codex P1/P2 findings on PRs #184 + #185

### DIFF
--- a/scripts/check_cli_path_validation.py
+++ b/scripts/check_cli_path_validation.py
@@ -97,9 +97,11 @@ def _collect_validator_call_targets(body: list[ast.stmt]) -> set[str]:
     """Return the set of argument names passed positionally to any
     allowed validator call anywhere in ``body``.
 
-    Handles nested function bodies too (a validator call inside a
-    helper defined alongside the main logic still counts — the name
-    is validated somewhere in the function's scope).
+    Does NOT descend into nested ``def``/``async def``/``class``/lambda
+    blocks — those are separate scopes. Without this exclusion, an
+    unused dead helper that happens to call ``resolve_cli_path(param)``
+    would make the rail accept a command that never actually validates
+    ``param``. (Codex finding on PR #184.)
     """
     targets: set[str] = set()
 
@@ -120,6 +122,22 @@ def _collect_validator_call_targets(body: list[ast.stmt]) -> set[str]:
                     if isinstance(arg, ast.Name):
                         targets.add(arg.id)
             self.generic_visit(node)
+
+        # Nested scopes are NOT part of the command body's execution
+        # path. A validator call inside a nested def / class / lambda
+        # only runs if someone calls that nested name — which might
+        # never happen.
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            return
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            return
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            return
+
+        def visit_Lambda(self, node: ast.Lambda) -> None:
+            return
 
     visitor = _Visitor()
     for stmt in body:

--- a/scripts/check_xdist_loadgroup.py
+++ b/scripts/check_xdist_loadgroup.py
@@ -11,9 +11,9 @@ where xdist spreads work across multiple workers (see
 
 This script scans YAML (CI configs, pre-commit), shell, Makefile, and
 Python files for ``-n auto`` / ``-n=auto`` / ``-n"auto"`` pytest
-invocations. For each file, every command that contains ``-n auto`` must
-also contain ``--dist=loadgroup`` within a 5-line window following the
-``-n`` flag (accounting for backslash line continuations).
+invocations. For each match, ``--dist=loadgroup`` must appear within the
+SAME pytest command — where "same command" is defined by contiguous
+lines joined by shell ``\\`` line-continuation.
 
 Scan scope (commands only matter inside a pytest invocation):
 
@@ -57,11 +57,6 @@ _SCANNABLE_SUFFIXES = {".yml", ".yaml", ".toml", ".sh", ".bash", ".zsh", ".mk", 
 _N_AUTO_RE = re.compile(r'-n[\s=]+[\'"]?auto[\'"]?\b(?!\w)')
 _LOADGROUP_RE = re.compile(r'--dist[\s=]+[\'"]?loadgroup[\'"]?|-dloadgroup')
 _NOQA_G5_RE = re.compile(r"#\s*noqa:\s*G5\b")
-
-# A pytest invocation can span up to this many lines after ``-n auto`` via
-# backslash continuations or YAML block scalars. Five lines covers all
-# known real-world cases in this repo without being unboundedly greedy.
-_LOADGROUP_WINDOW = 5
 
 
 def _iter_candidate_files() -> list[Path]:
@@ -108,9 +103,41 @@ def _is_reference_not_command(line: str, path: Path) -> bool:
     return False
 
 
+def _ends_continuation(line: str) -> bool:
+    """True if ``line`` uses a shell line-continuation (trailing ``\\``)."""
+    return line.rstrip().endswith("\\")
+
+
+def _command_range(lines: list[str], n_auto_idx: int) -> tuple[int, int]:
+    """Return the [start, end] line indices (inclusive) of the single
+    pytest command that contains the ``-n auto`` match at ``n_auto_idx``.
+
+    Walks backward while the preceding line ends with ``\\``, and
+    forward while the current line ends with ``\\``. Stops at the
+    first line without a trailing ``\\``.
+
+    Replaces the prior ±5-line window, which let ``--dist=loadgroup``
+    from a neighbouring command or comment satisfy the rail for an
+    unrelated ``-n auto`` match (codex finding on PR #184).
+    """
+    start = n_auto_idx
+    while start > 0 and _ends_continuation(lines[start - 1]):
+        start -= 1
+    end = n_auto_idx
+    while end < len(lines) - 1 and _ends_continuation(lines[end]):
+        end += 1
+    return start, end
+
+
 def find_violations(path: Path) -> list[tuple[int, str]]:
     """Return [(lineno, line_text)] for every ``-n auto`` without a
-    nearby ``--dist=loadgroup`` in ``path``."""
+    ``--dist=loadgroup`` in the SAME pytest command.
+
+    "Same command" is defined by shell line-continuation: the range
+    spans contiguous lines linked by trailing ``\\``. This prevents a
+    ``--dist=loadgroup`` from a neighbouring command or comment from
+    satisfying the rail for an unrelated ``-n auto`` match.
+    """
     violations: list[tuple[int, str]] = []
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
@@ -124,14 +151,9 @@ def find_violations(path: Path) -> list[tuple[int, str]]:
             continue
         if _is_reference_not_command(line, path):
             continue
-        # Look for --dist=loadgroup on the same line OR within a
-        # _LOADGROUP_WINDOW-line window around it (covers backslash
-        # continuations in shell and YAML block scalars, plus the
-        # occasional ``--dist`` preceding the ``-n`` flag).
-        window_end = min(i + _LOADGROUP_WINDOW + 1, len(lines))
-        window_start = max(i - _LOADGROUP_WINDOW, 0)
-        window = "\n".join(lines[window_start:window_end])
-        if _LOADGROUP_RE.search(window):
+        start, end = _command_range(lines, i)
+        command_text = "\n".join(lines[start : end + 1])
+        if _LOADGROUP_RE.search(command_text):
             continue
         violations.append((i + 1, line.rstrip()))
     return violations
@@ -152,11 +174,11 @@ def main() -> int:
 
     print(
         "ERROR (G5): pytest `-n auto` found without `--dist=loadgroup` "
-        "nearby.\n"
+        "in the same command.\n"
         "Without `--dist=loadgroup`, `@pytest.mark.xdist_group` markers are "
         "silently non-enforcing and singleton-sharing tests will race "
         "under xdist.\n"
-        "Add `--dist=loadgroup` to the same command, or append "
+        "Add `--dist=loadgroup` to the same pytest command, or append "
         "`# noqa: G5 (reason)` if xdist-group serialization is genuinely "
         "not needed.\n",
         file=sys.stderr,

--- a/src/methodologies/para/detection/heuristics.py
+++ b/src/methodologies/para/detection/heuristics.py
@@ -881,7 +881,12 @@ class AIHeuristic(Heuristic):
         Returns:
             HeuristicResult with per-category scores from the LLM.
         """
-        if not OLLAMA_AVAILABLE:
+        # The OLLAMA_AVAILABLE short-circuit only applies when no custom
+        # adapter is injected. An injected adapter (OpenAI, vLLM, test
+        # fake) is responsible for its own availability and MUST be able
+        # to run on systems where the ``ollama`` package is not installed
+        # — that's the entire point of the D3 seam.
+        if self._adapter is None and not OLLAMA_AVAILABLE:
             logger.debug("ollama package not installed — skipping AI heuristic")
             return self._zero_result("ollama_not_installed")
 

--- a/tests/ci/test_g3_cli_path_validation_rail.py
+++ b/tests/ci/test_g3_cli_path_validation_rail.py
@@ -250,3 +250,88 @@ class TestFullCliEnforcement:
         assert result.returncode == 0, (
             f"G3 rail reported unvalidated Path parameters in src/cli/:\n\n{result.stderr}"
         )
+
+
+class TestNestedScopeIsolation:
+    """A validator call that lives inside a nested ``def``/``class``/
+    ``lambda`` MUST NOT satisfy the rail for an unrelated outer-scope
+    Path parameter. Regression for codex P2 finding on PR #184: the
+    visitor walked every Call node in the body including those inside
+    dead inner functions, so an unused helper that called
+    ``resolve_cli_path(p)`` would make the outer command appear to
+    validate ``p`` even when the outer body never actually did.
+    """
+
+    def test_nested_def_does_not_satisfy_outer_param(self, tmp_path: Path) -> None:
+        f = tmp_path / "nested_def.py"
+        f.write_text(
+            dedent(
+                """
+                from pathlib import Path
+                import typer
+                from cli.path_validation import resolve_cli_path
+                app = typer.Typer()
+
+                @app.command()
+                def show(file: Path) -> None:
+                    def _unused_helper():
+                        # validator call lives in a nested function that is
+                        # never invoked — must NOT satisfy the rail for `file`
+                        return resolve_cli_path(file)
+                    print(file.read_text())
+                """
+            )
+        )
+        violations = find_violations(f)
+        assert len(violations) == 1
+        _lineno, func_name, param_name = violations[0]
+        assert func_name == "show"
+        assert param_name == "file"
+
+    def test_nested_class_does_not_satisfy_outer_param(self, tmp_path: Path) -> None:
+        f = tmp_path / "nested_class.py"
+        f.write_text(
+            dedent(
+                """
+                from pathlib import Path
+                import typer
+                from cli.path_validation import resolve_cli_path
+                app = typer.Typer()
+
+                @app.command()
+                def show(file: Path) -> None:
+                    class _Inner:
+                        def run(self):
+                            return resolve_cli_path(file)
+                    print(file.read_text())
+                """
+            )
+        )
+        violations = find_violations(f)
+        assert len(violations) == 1
+        _lineno, func_name, param_name = violations[0]
+        assert func_name == "show"
+        assert param_name == "file"
+
+    def test_lambda_body_does_not_satisfy_outer_param(self, tmp_path: Path) -> None:
+        f = tmp_path / "nested_lambda.py"
+        f.write_text(
+            dedent(
+                """
+                from pathlib import Path
+                import typer
+                from cli.path_validation import resolve_cli_path
+                app = typer.Typer()
+
+                @app.command()
+                def show(file: Path) -> None:
+                    _ = lambda: resolve_cli_path(file)
+                    print(file.read_text())
+                """
+            )
+        )
+        violations = find_violations(f)
+        assert len(violations) == 1
+        _lineno, func_name, param_name = violations[0]
+        assert func_name == "show"
+        assert param_name == "file"

--- a/tests/ci/test_g5_xdist_loadgroup_rail.py
+++ b/tests/ci/test_g5_xdist_loadgroup_rail.py
@@ -179,3 +179,53 @@ class TestFullRepoEnforcement:
         assert result.returncode == 0, (
             f"G5 check reported `-n auto` without `--dist=loadgroup`:\n\n{result.stderr}"
         )
+
+
+class TestCommandBoundaryIsolation:
+    """The detector must treat each pytest invocation as a separate
+    command — a ``--dist=loadgroup`` on a neighboring command MUST NOT
+    satisfy the rail for an unrelated ``-n auto`` in a different command.
+    Regression for codex P2 finding on PR #184: the original ±5-line
+    window let loadgroup on a nearby line silence a real violation.
+    "Same command" is now defined strictly by shell ``\\``
+    line-continuation.
+    """
+
+    def test_separate_command_does_not_share_loadgroup(self, tmp_path: Path) -> None:
+        """Two separate pytest calls on adjacent lines: the first has
+        --dist=loadgroup, the second does not. The second must flag."""
+        f = tmp_path / "run.sh"
+        f.write_text(
+            "#!/usr/bin/env bash\n"
+            "pytest tests/unit -n auto --dist=loadgroup\n"
+            "pytest tests/other -n auto\n"
+        )
+        violations = find_violations(f)
+        assert len(violations) == 1
+        assert violations[0][0] == 3
+
+    def test_continuation_spanning_loadgroup_passes(self, tmp_path: Path) -> None:
+        """``-n auto`` on one line, ``--dist=loadgroup`` three lines
+        later, joined by backslash continuations — same command."""
+        f = tmp_path / "run.sh"
+        f.write_text(
+            "#!/usr/bin/env bash\n"
+            "pytest tests/ \\\n"
+            "  -n auto \\\n"
+            "  --timeout=30 \\\n"
+            "  --dist=loadgroup\n"
+        )
+        assert find_violations(f) == []
+
+    def test_comment_loadgroup_does_not_silence_violation(self, tmp_path: Path) -> None:
+        """A ``--dist=loadgroup`` inside a comment near the violating
+        line must not count as part of the same command."""
+        f = tmp_path / "run.sh"
+        f.write_text(
+            "#!/usr/bin/env bash\n"
+            "# Prior runs used: pytest -n auto --dist=loadgroup\n"
+            "pytest tests/ -n auto --timeout=30\n"
+        )
+        violations = find_violations(f)
+        assert len(violations) == 1
+        assert violations[0][0] == 3

--- a/tests/methodologies/para/test_ai_heuristic.py
+++ b/tests/methodologies/para/test_ai_heuristic.py
@@ -1651,3 +1651,69 @@ class TestOllamaInferenceAdapter:
         adapter = OllamaInferenceAdapter(cfg)
         with patch(f"{_HEURISTICS_MODULE}.OLLAMA_AVAILABLE", False):
             assert adapter.infer(prompt="x", system="y") is None
+
+
+@pytest.mark.ci
+class TestAdapterBypassesOllamaAvailableGate:
+    """Codex P1 regression (PR #185): the ``if not OLLAMA_AVAILABLE``
+    short-circuit at the top of ``evaluate`` previously fired before the
+    adapter's ``is_available()`` check — defeating the entire D3 seam
+    on systems without the ``ollama`` package. The fix gates the
+    short-circuit on ``self._adapter is None`` so an injected adapter
+    (OpenAI, vLLM, test fake) runs regardless of module-level state.
+    """
+
+    def test_adapter_runs_when_ollama_available_is_false(self, tmp_path: Path) -> None:
+        from methodologies.para.detection.heuristics import (
+            AIHeuristic,
+            AIInferenceAdapter,
+        )
+
+        calls: list[dict[str, str]] = []
+
+        class _FakeAdapter:
+            def is_available(self) -> bool:
+                return True
+
+            def infer(self, *, prompt: str, system: str) -> str | None:
+                calls.append({"prompt": prompt, "system": system})
+                return json.dumps(
+                    {
+                        "project": 0.75,
+                        "area": 0.15,
+                        "resource": 0.05,
+                        "archive": 0.05,
+                        "reasoning": "adapter used despite no ollama",
+                    }
+                )
+
+        adapter: AIInferenceAdapter = _FakeAdapter()
+        h = AIHeuristic(weight=0.10, adapter=adapter)
+        test_file = tmp_path / "spec.txt"
+        test_file.write_text("Project spec for Q4 launch")
+
+        # Simulate a system where the ollama package is not installed.
+        with patch(f"{_HEURISTICS_MODULE}.OLLAMA_AVAILABLE", False):
+            result = h.evaluate(test_file)
+
+        # The adapter MUST have been called — the short-circuit was
+        # gated on ``self._adapter is None`` after the fix.
+        assert len(calls) == 1
+        assert result.metadata["ai_analysis"] == "complete"
+        assert result.recommended_category == PARACategory.PROJECT
+
+    def test_no_adapter_short_circuits_when_ollama_unavailable(self, tmp_path: Path) -> None:
+        """The pre-D3 behavior is preserved when no adapter is injected:
+        if ``ollama`` is not installed the heuristic short-circuits with
+        ``ollama_not_installed`` before any client construction attempt."""
+        from methodologies.para.detection.heuristics import AIHeuristic
+
+        h = AIHeuristic(weight=0.10)  # no adapter injected
+        test_file = tmp_path / "spec.txt"
+        test_file.write_text("content")
+
+        with patch(f"{_HEURISTICS_MODULE}.OLLAMA_AVAILABLE", False):
+            result = h.evaluate(test_file)
+
+        assert result.metadata["ai_analysis"] == "ollama_not_installed"
+        assert result.abstained is True


### PR DESCRIPTION
## Summary

Three post-merge review findings on recently-landed PRs that warranted a follow-up — all three are code correctness issues (not style), so they ship together with regression tests.

- **P1 on #185** (D3 seam): \`if not OLLAMA_AVAILABLE\` in \`AIHeuristic.evaluate\` fired before the adapter check, defeating the entire D3 seam on systems without ollama. Now gated on \`self._adapter is None\`.
- **P2 on #184** (G3 rail): \`_collect_validator_call_targets\` walked nested \`def\` / \`class\` / \`lambda\` bodies, so an unused helper calling \`resolve_cli_path(p)\` silently satisfied the rail for an outer command. Now skips nested scopes.
- **P2 on #184** (G5 rail): ±5-line window let a neighbouring command's \`--dist=loadgroup\` (or a loadgroup reference in a comment) silence real violations. Replaced with a backslash-continuation-based \`_command_range\` helper — \"same command\" now has a precise definition.

## Regression tests (8 new)

| Class | File | What it pins |
|---|---|---|
| \`TestNestedScopeIsolation\` | \`tests/ci/test_g3_cli_path_validation_rail.py\` | Nested def / class / lambda calling \`resolve_cli_path(p)\` must NOT satisfy the rail for outer param \`p\` |
| \`TestCommandBoundaryIsolation\` | \`tests/ci/test_g5_xdist_loadgroup_rail.py\` | Two separate commands don't share loadgroup; backslash-joined continuation does; comment-only loadgroup does NOT |
| \`TestAdapterBypassesOllamaAvailableGate\` | \`tests/methodologies/para/test_ai_heuristic.py\` | Adapter runs when \`OLLAMA_AVAILABLE=False\`; pre-D3 short-circuit preserved when no adapter injected |

## Test plan

- [x] G2/G3/G5 detector scripts all exit 0 against the repo tree
- [x] 128 rail + heuristic unit tests pass (up from 120 pre-fix; 8 new)
- [x] 3485 CI guardrail tests pass (full \`-m ci\` suite)
- [x] \`ruff check\` + \`ruff format --check\` clean on all six modified files
- [ ] CI: pre-commit, unit, integration all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * CLI path validation now correctly isolates validator checks within nested function scopes.
  * xdist loadgroup detection improved to recognize proper pytest command boundaries, including line continuations.
  * AI heuristic evaluation enhanced to work with custom inference adapters when unavailable.

* **Tests**
  * Added test coverage for nested scope isolation in CLI validation.
  * Added test coverage for pytest command boundary recognition in validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->