### PR TITLE
fix(tests): whitespace-tolerant match in analyze directory error test

### DIFF
--- a/tests/cli/test_analyze.py
+++ b/tests/cli/test_analyze.py
@@ -107,12 +107,20 @@ def test_analyze_directory_not_regular_file(tmp_path: Path):
     the binary/text detection path — surface a clear "not a regular file"
     error (exit 1 from the inline is_file guard, distinct from A.cli's
     usage-error exit 2 for non-existent paths).
+
+    Whitespace is collapsed before matching: Click's error formatter
+    wraps long paths at ~80 columns, which on CI runners splits the
+    phrase across ``"is not\\na regular file"`` so a naive substring
+    check fails on long ``tmp_path`` values. Real users see the message
+    rendered by their terminal regardless of the line break — the test
+    should pin the semantic, not the byte-for-byte wrapping.
     """
     d = tmp_path / "some_dir"
     d.mkdir()
     result = runner.invoke(app, ["analyze", str(d)])
     assert result.exit_code == 1
-    assert "not a regular file" in result.stdout.lower()
+    collapsed = " ".join(result.stdout.lower().split())
+    assert "not a regular file" in collapsed
 
 
 def test_analyze_empty_file(tmp_path: Path):


### PR DESCRIPTION
## Summary

\`tests/cli/test_analyze.py::test_analyze_directory_not_regular_file\` has been failing on every main-branch CI run since PR #172 (epic-a-cli) landed — the red only shows up on the main-push integration gate because PR CI runs \`-m \"ci\"\` which skips integration markers.

**Root cause**: Click's error formatter wraps long lines at ~80 cols. Locally (\`/private/var/folders/…\`) the wrap lands between the path and \`is not\`; on GitHub-hosted Linux runners (\`/tmp/pytest-of-runner/…\`) it wraps between \`is not\` and \`a regular file\`, so \`\"not a regular file\"\` is no longer a contiguous substring of \`result.stdout.lower()\`.

**Fix**: collapse whitespace before the substring match. Real users see the rendered message regardless of the embedded line break — the test should pin the semantic, not the byte-for-byte wrapping.

## Evidence

- Failure string in CI log: \`\"Error: File \\n'/tmp/.../some_dir' is not\\na regular file.\\n\"\`
- Red on every main CI since **c18e7ca3** (PR #172, 2026-04-23) through **80598950** (PR #186, 2026-04-24) — 11+ consecutive main runs.

## Test plan

- [x] Test passes locally
- [x] The exact CI failure string (\`\"…is not\\\\na regular file…\"\`) passes the whitespace-collapsed match when asserted directly
- [ ] CI: integration gate green