### PR TITLE
refactor(D2): extract ResourceAwareExecutor seam from orchestrator

### DIFF
--- a/src/pipeline/orchestrator.py
+++ b/src/pipeline/orchestrator.py
@@ -171,6 +171,17 @@ class PipelineOrchestrator:
                 ``resource_monitor.should_evict()`` for proactive buffer-pool
                 shrink decisions. Must be between 0 and 100.
         """
+        # Validate memory_pressure_threshold_percent BEFORE any other
+        # setup so a bad value doesn't leave the orchestrator partially
+        # initialised (coderabbit review on PR #189 — preserves the
+        # pre-D2 validation ordering). The executor re-validates
+        # internally as its own contract; this is the cheap early guard.
+        if not 0.0 <= memory_pressure_threshold_percent <= 100.0:
+            raise ValueError(
+                "memory_pressure_threshold_percent must be between 0 and 100, "
+                f"got {memory_pressure_threshold_percent}"
+            )
+
         self.config = config or PipelineConfig()
         self.router = FileRouter()
         self.processor_pool = ProcessorPool()
@@ -180,9 +191,7 @@ class PipelineOrchestrator:
 
         # D2 seam: prefetch, memory limiting, and buffer rebalancing live
         # in ``ResourceAwareExecutor``. The orchestrator delegates all
-        # resource-aware calls to it. Range validation on
-        # ``memory_pressure_threshold_percent`` happens inside the
-        # executor constructor.
+        # resource-aware calls to it.
         self._resource_executor = ResourceAwareExecutor(
             prefetch_depth=prefetch_depth,
             prefetch_stages=prefetch_stages,

--- a/src/pipeline/orchestrator.py
+++ b/src/pipeline/orchestrator.py
@@ -12,7 +12,7 @@ import shutil
 import threading
 import time
 from collections.abc import Sequence
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -30,10 +30,11 @@ from .processor_pool import (
     ProcessorResult,
     normalize_processor_result,
 )
+from .resource_aware_executor import BUFFER_KEY as _BUFFER_KEY
+from .resource_aware_executor import ResourceAwareExecutor
 from .router import FileRouter, ProcessorType
 
 logger = logging.getLogger(__name__)
-_BUFFER_KEY = "pipeline.buffer"
 
 
 @dataclass(frozen=True)
@@ -170,12 +171,6 @@ class PipelineOrchestrator:
                 ``resource_monitor.should_evict()`` for proactive buffer-pool
                 shrink decisions. Must be between 0 and 100.
         """
-        if not 0.0 <= memory_pressure_threshold_percent <= 100.0:
-            raise ValueError(
-                "memory_pressure_threshold_percent must be between 0 and 100, "
-                f"got {memory_pressure_threshold_percent}"
-            )
-
         self.config = config or PipelineConfig()
         self.router = FileRouter()
         self.processor_pool = ProcessorPool()
@@ -183,19 +178,26 @@ class PipelineOrchestrator:
         self._stats_lock = threading.Lock()
         self._stages: list[PipelineStage] = list(stages) if stages else []
 
-        self._prefetch_depth = max(0, prefetch_depth)
-        self._prefetch_stages = max(0, prefetch_stages)
-        self._memory_limiter = memory_limiter
+        # D2 seam: prefetch, memory limiting, and buffer rebalancing live
+        # in ``ResourceAwareExecutor``. The orchestrator delegates all
+        # resource-aware calls to it. Range validation on
+        # ``memory_pressure_threshold_percent`` happens inside the
+        # executor constructor.
+        self._resource_executor = ResourceAwareExecutor(
+            prefetch_depth=prefetch_depth,
+            prefetch_stages=prefetch_stages,
+            memory_limiter=memory_limiter,
+            buffer_pool=buffer_pool,
+            resource_monitor=resource_monitor,
+            memory_pressure_threshold_percent=memory_pressure_threshold_percent,
+        )
         self._batch_sizer = batch_sizer or AdaptiveBatchSizer()
-        self._buffer_pool: BufferPool | None = buffer_pool
-        self._resource_monitor = resource_monitor or ResourceMonitor()
-        self._memory_pressure_threshold_percent = memory_pressure_threshold_percent
 
         self._running = False
         self._lock = threading.Lock()
         self._monitor: Any = None
         self._watch_thread: threading.Thread | None = None
-        self._executor = ThreadPoolExecutor(
+        self._thread_executor = ThreadPoolExecutor(
             max_workers=self.config.max_concurrent,
         )
 
@@ -210,12 +212,13 @@ class PipelineOrchestrator:
 
     @property
     def buffer_pool(self) -> BufferPool:
-        """Return the orchestrator's shared buffer pool."""
-        if self._buffer_pool is None:
-            with self._lock:
-                if self._buffer_pool is None:
-                    self._buffer_pool = BufferPool()
-        return self._buffer_pool
+        """Return the shared buffer pool (lazy-built on first access).
+
+        Delegates to ``ResourceAwareExecutor.buffer_pool`` — the pool
+        moved there in D2, but the public accessor is preserved so
+        existing callers keep working without knowing about the seam.
+        """
+        return self._resource_executor.buffer_pool
 
     def set_stages(self, stages: Sequence[PipelineStage]) -> None:
         """Replace the stage list at runtime (thread-safe).
@@ -277,8 +280,8 @@ class PipelineOrchestrator:
                 self._watch_thread.join(timeout=5.0)
                 self._watch_thread = None
 
-            # Clean up executor
-            self._executor.shutdown(wait=False)
+            # Clean up the orchestrator's worker thread pool.
+            self._thread_executor.shutdown(wait=False)
 
             # Clean up processors
             self.processor_pool.cleanup()
@@ -329,7 +332,7 @@ class PipelineOrchestrator:
         # Snapshot once; set_stages() may replace self._stages concurrently.
         stages = self._stages
         overhead_per_file = self.buffer_pool.buffer_size if stages else 0
-        file_sizes = [self._safe_file_size(path) for path in files]
+        file_sizes = [self._resource_executor.safe_file_size(path) for path in files]
         batch_size = max(
             1,
             self._batch_sizer.calculate_batch_size(
@@ -343,11 +346,22 @@ class PipelineOrchestrator:
 
         results: list[ProcessingResult] = []
 
-        if stages and self._prefetch_depth > 0 and self._prefetch_stages > 0 and len(files) > 1:
+        if (
+            stages
+            and self._resource_executor.prefetch_depth > 0
+            and self._resource_executor.prefetch_stages > 0
+            and len(files) > 1
+        ):
             # Keep prefetch behavior deterministic (Issue #713 contracts) while
             # still applying proactive memory feedback to the shared buffer pool.
-            results = self._process_batch_prefetch(files, stages)
-            self._rebalance_buffer_pool()
+            results = self._resource_executor.run_prefetched_batch(
+                files=files,
+                stages=stages,
+                run_stages=self._run_stages,
+                make_context=self._make_context,
+                finalize_result=self._finalize_result,
+            )
+            self._resource_executor.rebalance_buffer_pool()
             return results
 
         results = []
@@ -355,12 +369,12 @@ class PipelineOrchestrator:
         while index < len(files):
             upper = min(index + batch_size, len(files))
             batch_files = files[index:upper]
-            chunk_start_rss = self._safe_current_rss()
+            chunk_start_rss = self._resource_executor.safe_current_rss()
             results.extend(self._process_batch_chunk(batch_files, stages))
-            self._rebalance_buffer_pool()
+            self._resource_executor.rebalance_buffer_pool()
 
             if upper < len(files):
-                chunk_end_rss = self._safe_current_rss()
+                chunk_end_rss = self._resource_executor.safe_current_rss()
                 chunk_rss_delta = max(0, chunk_end_rss - chunk_start_rss)
                 adjusted = self._batch_sizer.adjust_from_feedback(
                     chunk_rss_delta,
@@ -376,51 +390,9 @@ class PipelineOrchestrator:
         """Return True if the pipeline is currently running."""
         return self._running
 
-    def _safe_file_size(self, file_path: Path) -> int:
-        """Return file size in bytes, or 0 when unavailable."""
-        try:
-            return file_path.stat().st_size
-        except OSError:
-            logger.debug("Unable to stat %s for adaptive batching", file_path, exc_info=True)
-            return 0
-
-    def _safe_current_rss(self) -> int:
-        """Return current process RSS in bytes, or 0 when unavailable."""
-        try:
-            return self._resource_monitor.get_memory_usage().rss
-        except (OSError, RuntimeError, ValueError):
-            logger.debug("Unable to read current RSS for adaptive batching", exc_info=True)
-            return 0
-
-    def _rebalance_buffer_pool(self) -> None:
-        """Resize buffer pool in response to memory pressure and utilization."""
-        pool = self._buffer_pool
-        if pool is None:
-            return
-
-        try:
-            under_pressure = self._resource_monitor.should_evict(
-                threshold_percent=self._memory_pressure_threshold_percent,
-            )
-        except (OSError, RuntimeError, ValueError):
-            logger.debug("Failed to evaluate memory pressure for buffer pool", exc_info=True)
-            return
-
-        if under_pressure:
-            target = max(pool.initial_buffers, pool.in_use_count)
-            new_size = pool.resize(target)
-            logger.info(
-                "Memory pressure detected; resized buffer pool to %d buffers (target=%d)",
-                new_size,
-                target,
-            )
-            return
-
-        if pool.utilization >= 0.9 and pool.total_buffers < pool.max_buffers:
-            growth_step = max(1, pool.initial_buffers // 2)
-            target = min(pool.max_buffers, pool.total_buffers + growth_step)
-            new_size = pool.resize(target)
-            logger.debug("Increased buffer pool capacity to %d buffers", new_size)
+    # ``_safe_file_size``, ``_safe_current_rss``, ``_rebalance_buffer_pool``
+    # moved to :class:`ResourceAwareExecutor` in D2. Call
+    # ``self._resource_executor.<method>`` instead.
 
     def _process_batch_chunk(
         self,
@@ -515,33 +487,15 @@ class PipelineOrchestrator:
             dry_run=not self.config.should_move_files,
         )
 
-    def _acquire_buffer(self, file_path: Path) -> bytearray | None:
-        """Acquire a reusable buffer for processing *file_path*."""
-        file_size = self._safe_file_size(file_path)
-        pool = self.buffer_pool
-        requested = max(pool.buffer_size, file_size)
-        try:
-            return pool.acquire(size=requested)
-        except (MemoryError, RuntimeError, ValueError, TimeoutError):
-            logger.warning("Failed to acquire buffer for %s", file_path, exc_info=True)
-            return None
-
-    def _release_buffer(self, file_path: Path, buffer: bytearray | None) -> None:
-        """Release a previously acquired processing buffer, if any."""
-        if buffer is None:
-            return
-        pool = self.buffer_pool
-        try:
-            pool.release(buffer)
-        except (ValueError, RuntimeError):
-            logger.warning("Failed to release buffer for %s", file_path, exc_info=True)
+    # ``_acquire_buffer`` / ``_release_buffer`` moved to
+    # :class:`ResourceAwareExecutor` in D2.
 
     def _process_file_staged(
         self, file_path: Path, stages: list[PipelineStage]
     ) -> ProcessingResult:
         """Run *file_path* through the configured stages."""
         start_time = time.monotonic()
-        buffer = self._acquire_buffer(file_path)
+        buffer = self._resource_executor.acquire_buffer(file_path)
         try:
             context = self._make_context(file_path)
             if buffer is not None:
@@ -549,121 +503,12 @@ class PipelineOrchestrator:
             context = self._run_stages(context, stages)
             return self._finalize_result(context, start_time)
         finally:
-            self._release_buffer(file_path, buffer)
+            self._resource_executor.release_buffer(file_path, buffer)
 
-    def _process_batch_prefetch(
-        self, files: list[Path], stages: list[PipelineStage]
-    ) -> list[ProcessingResult]:
-        """Process a batch with I/O-compute overlap via a prefetch queue.
-
-        Splits *stages* at ``effective_prefetch_stages`` (capped at 1 for
-        thread-safety — shared components such as ``ProcessorPool`` are not
-        safe for concurrent initialisation): the I/O stages are submitted to
-        a dedicated :class:`~concurrent.futures.ThreadPoolExecutor` for
-        upcoming files while the compute stages run on the calling thread for
-        the current file.
-
-        At most ``self._prefetch_depth`` I/O futures are outstanding at
-        any time.  If a ``memory_limiter`` is configured, no new futures
-        are opened when ``limiter.check()`` returns *False*.
-
-        An error in a prefetched file's I/O stages does not crash the
-        batch; a failed :class:`~interfaces.StageContext`
-        is returned and the compute stages are still attempted (they will
-        short-circuit on ``context.failed``).
-
-        Per-file ``ProcessingResult.duration_ms`` is measured from the
-        moment the I/O future is *submitted* (not when it completes), so
-        the reported wall-clock time covers prefetched I/O latency as well
-        as compute time.  For files that fall through to the sequential
-        inline path (no outstanding future), timing starts just before
-        ``_run_io`` is called.
-
-        Args:
-            files: Ordered list of file paths to process.
-            stages: Snapshot of the stage list taken by the caller.
-
-        Returns:
-            List of :class:`ProcessingResult` instances in the same
-            order as *files*.
-        """
-        # Cap at 1: stages beyond the first (e.g. AnalyzerStage) rely on
-        # shared components (ProcessorPool) that are not thread-safe for
-        # concurrent initialisation.
-        effective_prefetch_stages = min(self._prefetch_stages, 1)
-        if self._prefetch_stages > 1:
-            logger.warning(
-                "prefetch_stages=%d is not fully supported; "
-                "capping effective prefetch stages to %d for thread-safety",
-                self._prefetch_stages,
-                effective_prefetch_stages,
-            )
-        io_stages = stages[:effective_prefetch_stages]
-        compute_stages = stages[effective_prefetch_stages:]
-
-        def _run_io(idx: int) -> tuple[StageContext, bytearray | None]:
-            file_path = files[idx]
-            buffer = self._acquire_buffer(file_path)
-            try:
-                ctx = self._make_context(file_path)
-                if buffer is not None:
-                    ctx.extra[_BUFFER_KEY] = buffer
-                io_ctx = self._run_stages(ctx, io_stages)
-                if buffer is not None:
-                    io_ctx.extra[_BUFFER_KEY] = buffer
-                return io_ctx, buffer
-            except Exception:  # Intentional catch-all: ensures buffer cleanup on any stage error
-                self._release_buffer(file_path, buffer)
-                raise
-
-        futures: dict[int, tuple[Future[tuple[StageContext, bytearray | None]], float]] = {}
-        results: list[ProcessingResult] = []
-
-        with ThreadPoolExecutor(max_workers=self._prefetch_depth) as io_exec:
-            # Prime the queue with the first prefetch_depth files.
-            for i in range(min(self._prefetch_depth, len(files))):
-                if self._memory_limiter is not None and not self._memory_limiter.check():
-                    logger.warning("Prefetch depth capped at %d due to memory limit", i)
-                    break
-                futures[i] = (io_exec.submit(_run_io, i), time.monotonic())
-
-            for i in range(len(files)):
-                # Enqueue the next lookahead file as we consume one slot.
-                next_i = i + self._prefetch_depth
-                if next_i < len(files) and next_i not in futures:
-                    if self._memory_limiter is None or self._memory_limiter.check():
-                        futures[next_i] = (io_exec.submit(_run_io, next_i), time.monotonic())
-
-                # Retrieve the prefetched I/O context (or compute inline).
-                if i in futures:
-                    future, start_time = futures.pop(i)
-                    try:
-                        ctx, buffer = future.result()
-                    except (
-                        Exception
-                    ) as exc:  # Intentional catch-all: future can raise any stage error
-                        logger.warning(
-                            "Prefetch future failed for %s: %s",
-                            files[i],
-                            exc,
-                            exc_info=True,
-                        )
-                        ctx = self._make_context(files[i])
-                        ctx.error = str(exc)
-                        buffer = None
-                else:
-                    start_time = time.monotonic()
-                    ctx, buffer = _run_io(i)
-
-                # Run compute stages on the calling thread.
-                try:
-                    ctx = self._run_stages(ctx, compute_stages)
-                    results.append(self._finalize_result(ctx, start_time))
-                finally:
-                    self._release_buffer(files[i], buffer)
-                    ctx.extra.pop(_BUFFER_KEY, None)
-
-        return results
+    # ``_process_batch_prefetch`` moved to
+    # :class:`ResourceAwareExecutor.run_prefetched_batch` in D2.
+    # ``process_batch`` above invokes it with the orchestrator's
+    # callbacks (``_run_stages``, ``_make_context``, ``_finalize_result``).
 
     # ------------------------------------------------------------------
     # Legacy processing (backward compatible)
@@ -870,7 +715,7 @@ class PipelineOrchestrator:
 
                     try:
                         # Submit to executor to avoid blocking the watch loop
-                        self._executor.submit(self.process_file, event.path)
+                        self._thread_executor.submit(self.process_file, event.path)
                     except (RuntimeError, OSError):
                         logger.exception("Error processing %s", event.path)
 

--- a/src/pipeline/resource_aware_executor.py
+++ b/src/pipeline/resource_aware_executor.py
@@ -1,0 +1,406 @@
+"""Resource-aware execution primitives for the pipeline orchestrator.
+
+Epic D.pipeline (hardening roadmap #157 — D2): the pre-D2 orchestrator
+owned prefetch, memory limiting, and buffer-pool rebalancing inline
+alongside stage routing. That mixed two concerns in one ~900-line class
+and made the resource-handling surface hard to test in isolation.
+
+This module extracts the resource-aware surface into a single class
+that the orchestrator holds and delegates to. The orchestrator retains
+stage management, the legacy routing path, watch-mode lifecycle, and
+statistics; ``ResourceAwareExecutor`` owns:
+
+- the shared :class:`~optimization.buffer_pool.BufferPool` (lazy init)
+- buffer acquire/release per file
+- memory-pressure-driven buffer-pool rebalancing
+- the I/O + compute-overlap batch prefetch loop
+
+The prefetch method takes its orchestrator-specific collaborators
+(stage runner, context factory, result finalizer) as callbacks so the
+executor stays agnostic of :class:`~pipeline.orchestrator.ProcessingResult`
+and the orchestrator's statistics.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from pathlib import Path
+from typing import TypeVar
+
+from interfaces.pipeline import PipelineStage, StageContext
+from optimization.buffer_pool import BufferPool
+from optimization.memory_limiter import MemoryLimiter
+from optimization.resource_monitor import ResourceMonitor
+
+logger = logging.getLogger(__name__)
+
+# Key under which the per-file buffer is stashed on StageContext.extra —
+# kept here so the orchestrator and executor share one source of truth.
+BUFFER_KEY = "pipeline.buffer"
+
+_ResultT = TypeVar("_ResultT")
+# ``run_prefetched_batch`` internal: index → (future, submitted_at_monotonic)
+_FutureMap = dict[int, tuple[Future[tuple[StageContext, bytearray | None]], float]]
+
+
+class ResourceAwareExecutor:
+    """Owns prefetch + memory limiting + buffer rebalancing.
+
+    Constructed once per :class:`~pipeline.orchestrator.PipelineOrchestrator`
+    and held as a private attribute. All resource-dependent arguments that
+    used to live on the orchestrator constructor are accepted here and
+    stored for use by the prefetch and rebalance paths.
+
+    Args:
+        prefetch_depth: Number of files to prefetch ahead of the compute
+            cursor. ``0`` disables prefetch entirely.
+        prefetch_stages: Requested number of leading stages to run on the
+            prefetch I/O thread pool. Current thread-safety caps this at
+            effectively 1 — values > 1 log a warning and are treated as 1.
+        memory_limiter: Optional gate; when ``check()`` returns ``False``
+            no new prefetch futures are submitted until memory frees up.
+        buffer_pool: Optional pre-built shared buffer pool. When ``None``,
+            the pool is lazily built on first ``buffer_pool`` access.
+        resource_monitor: Optional monitor used to measure current RSS
+            and to drive :meth:`rebalance_buffer_pool`. Defaults to a
+            fresh :class:`~optimization.resource_monitor.ResourceMonitor`.
+        memory_pressure_threshold_percent: Threshold forwarded to
+            ``resource_monitor.should_evict`` when deciding whether to
+            shrink the pool. Must be in ``[0, 100]``.
+    """
+
+    def __init__(
+        self,
+        *,
+        prefetch_depth: int = 2,
+        prefetch_stages: int = 1,
+        memory_limiter: MemoryLimiter | None = None,
+        buffer_pool: BufferPool | None = None,
+        resource_monitor: ResourceMonitor | None = None,
+        memory_pressure_threshold_percent: float = 85.0,
+    ) -> None:
+        """See the class docstring for argument semantics."""
+        if not 0.0 <= memory_pressure_threshold_percent <= 100.0:
+            raise ValueError(
+                "memory_pressure_threshold_percent must be between 0 and 100, "
+                f"got {memory_pressure_threshold_percent}"
+            )
+
+        self._prefetch_depth = max(0, prefetch_depth)
+        self._prefetch_stages = max(0, prefetch_stages)
+        self._memory_limiter = memory_limiter
+        self._buffer_pool: BufferPool | None = buffer_pool
+        self._resource_monitor = resource_monitor or ResourceMonitor()
+        self._memory_pressure_threshold_percent = memory_pressure_threshold_percent
+        self._pool_init_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Read-only accessors (kept explicit; the orchestrator forwards these
+    # to callers that inspect its historical public attributes).
+    # ------------------------------------------------------------------
+
+    @property
+    def prefetch_depth(self) -> int:
+        """Number of files to prefetch ahead of the compute cursor."""
+        return self._prefetch_depth
+
+    @property
+    def prefetch_stages(self) -> int:
+        """Requested count of leading I/O stages (effectively capped at 1)."""
+        return self._prefetch_stages
+
+    @property
+    def memory_pressure_threshold_percent(self) -> float:
+        """Threshold forwarded to ``ResourceMonitor.should_evict``."""
+        return self._memory_pressure_threshold_percent
+
+    @property
+    def buffer_pool(self) -> BufferPool:
+        """Return the shared buffer pool, lazily creating one if needed."""
+        if self._buffer_pool is None:
+            with self._pool_init_lock:
+                if self._buffer_pool is None:
+                    self._buffer_pool = BufferPool()
+        return self._buffer_pool
+
+    # ------------------------------------------------------------------
+    # Resource probes
+    # ------------------------------------------------------------------
+
+    def safe_file_size(self, file_path: Path) -> int:
+        """Return file size in bytes, or ``0`` when unavailable."""
+        try:
+            return file_path.stat().st_size
+        except OSError:
+            logger.debug("Unable to stat %s for adaptive batching", file_path, exc_info=True)
+            return 0
+
+    def safe_current_rss(self) -> int:
+        """Return current process RSS in bytes, or ``0`` when unavailable."""
+        try:
+            return self._resource_monitor.get_memory_usage().rss
+        except (OSError, RuntimeError, ValueError):
+            logger.debug("Unable to read current RSS for adaptive batching", exc_info=True)
+            return 0
+
+    # ------------------------------------------------------------------
+    # Buffer pool management
+    # ------------------------------------------------------------------
+
+    def rebalance_buffer_pool(self) -> None:
+        """Resize the buffer pool in response to memory pressure or utilization.
+
+        - Under memory pressure (monitor says ``should_evict``): shrink
+          toward ``max(initial_buffers, in_use_count)``.
+        - Under high utilization (``>= 0.9``) and room to grow: grow by
+          ``max(1, initial_buffers // 2)``, clamped to ``max_buffers``.
+        - Otherwise: no-op.
+
+        If no buffer pool has been built yet, the call is a true no-op —
+        it does *not* lazily build one (that would pin memory under
+        pressure, which is the opposite of what we want).
+        """
+        pool = self._buffer_pool
+        if pool is None:
+            return
+
+        try:
+            under_pressure = self._resource_monitor.should_evict(
+                threshold_percent=self._memory_pressure_threshold_percent,
+            )
+        except (OSError, RuntimeError, ValueError):
+            logger.debug("Failed to evaluate memory pressure for buffer pool", exc_info=True)
+            return
+
+        if under_pressure:
+            target = max(pool.initial_buffers, pool.in_use_count)
+            new_size = pool.resize(target)
+            logger.info(
+                "Memory pressure detected; resized buffer pool to %d buffers (target=%d)",
+                new_size,
+                target,
+            )
+            return
+
+        if pool.utilization >= 0.9 and pool.total_buffers < pool.max_buffers:
+            growth_step = max(1, pool.initial_buffers // 2)
+            target = min(pool.max_buffers, pool.total_buffers + growth_step)
+            new_size = pool.resize(target)
+            logger.debug("Increased buffer pool capacity to %d buffers", new_size)
+
+    def acquire_buffer(self, file_path: Path) -> bytearray | None:
+        """Acquire a reusable buffer sized for *file_path*."""
+        file_size = self.safe_file_size(file_path)
+        pool = self.buffer_pool
+        requested = max(pool.buffer_size, file_size)
+        try:
+            return pool.acquire(size=requested)
+        except (MemoryError, RuntimeError, ValueError, TimeoutError):
+            logger.warning("Failed to acquire buffer for %s", file_path, exc_info=True)
+            return None
+
+    def release_buffer(self, file_path: Path, buffer: bytearray | None) -> None:
+        """Release a previously acquired buffer; ``None`` is a safe no-op."""
+        if buffer is None:
+            return
+        pool = self.buffer_pool
+        try:
+            pool.release(buffer)
+        except (ValueError, RuntimeError):
+            logger.warning("Failed to release buffer for %s", file_path, exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Prefetched batch execution
+    # ------------------------------------------------------------------
+
+    def run_prefetched_batch(
+        self,
+        *,
+        files: list[Path],
+        stages: list[PipelineStage],
+        run_stages: Callable[[StageContext, list[PipelineStage]], StageContext],
+        make_context: Callable[[Path], StageContext],
+        finalize_result: Callable[[StageContext, float], _ResultT],
+    ) -> list[_ResultT]:
+        """Run *files* through *stages* with I/O-compute overlap.
+
+        Splits *stages* at ``effective_prefetch_stages`` (capped at 1
+        for thread-safety — shared components such as ``ProcessorPool``
+        are not safe for concurrent initialisation). The leading I/O
+        stages are submitted to a dedicated thread pool for upcoming
+        files while the compute stages run on the calling thread for
+        the current file.
+
+        At most ``prefetch_depth`` I/O futures are outstanding at any
+        time. If a ``memory_limiter`` was configured, no new futures
+        are opened when ``limiter.check()`` returns ``False``.
+
+        An error in a prefetched file's I/O stages does not crash the
+        batch; a failed :class:`~interfaces.pipeline.StageContext` is
+        returned and the compute stages still run (they short-circuit
+        on ``context.failed``).
+
+        Per-file timing starts at submission for prefetched files and
+        at the inline ``_run_io`` call for files that fall through to
+        the sequential path.
+
+        Args:
+            files: Ordered list of file paths to process.
+            stages: Snapshot of the stage list taken by the caller.
+            run_stages: Orchestrator callback — given a context and a
+                sub-list of stages, returns the context after running
+                them, recording any error on the context itself.
+            make_context: Orchestrator callback — builds a fresh
+                :class:`StageContext` for a given file path.
+            finalize_result: Orchestrator callback — converts a
+                finished context + start time into the orchestrator's
+                result type and updates statistics.
+
+        Returns:
+            List of finalized results in the same order as *files*.
+        """
+        effective_prefetch_stages = min(self._prefetch_stages, 1)
+        if self._prefetch_stages > 1:
+            logger.warning(
+                "prefetch_stages=%d is not fully supported; "
+                "capping effective prefetch stages to %d for thread-safety",
+                self._prefetch_stages,
+                effective_prefetch_stages,
+            )
+        io_stages = stages[:effective_prefetch_stages]
+        compute_stages = stages[effective_prefetch_stages:]
+        # ``prefetch_depth == 0`` or single-file batches: run sequentially.
+        effective_depth = max(self._prefetch_depth, 1)
+
+        futures: _FutureMap = {}
+        results: list[_ResultT] = []
+
+        with ThreadPoolExecutor(max_workers=effective_depth) as io_exec:
+            if self._prefetch_depth > 0:
+                self._prime_prefetch_queue(
+                    futures, io_exec, files, io_stages, run_stages, make_context
+                )
+
+            for i in range(len(files)):
+                if self._prefetch_depth > 0:
+                    next_i = i + self._prefetch_depth
+                    if next_i < len(files) and next_i not in futures:
+                        self._try_enqueue(
+                            next_i, futures, io_exec, files, io_stages, run_stages, make_context
+                        )
+
+                ctx, buffer, start_time = self._resolve_context(
+                    i, futures, files, io_stages, run_stages, make_context
+                )
+
+                try:
+                    ctx = run_stages(ctx, compute_stages)
+                    results.append(finalize_result(ctx, start_time))
+                finally:
+                    self.release_buffer(files[i], buffer)
+                    ctx.extra.pop(BUFFER_KEY, None)
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Helpers for ``run_prefetched_batch`` — private, but promoted to
+    # methods (not nested closures) so the top-level method stays under
+    # the cyclomatic complexity cap and each piece is unit-testable.
+    # ------------------------------------------------------------------
+
+    def _run_io_for_file(
+        self,
+        file_path: Path,
+        io_stages: list[PipelineStage],
+        run_stages: Callable[[StageContext, list[PipelineStage]], StageContext],
+        make_context: Callable[[Path], StageContext],
+    ) -> tuple[StageContext, bytearray | None]:
+        """Acquire a buffer, run the I/O stages, and return the context.
+
+        Releases the buffer on any stage error so the pool never leaks.
+        """
+        buffer = self.acquire_buffer(file_path)
+        try:
+            ctx = make_context(file_path)
+            if buffer is not None:
+                ctx.extra[BUFFER_KEY] = buffer
+            io_ctx = run_stages(ctx, io_stages)
+            if buffer is not None:
+                io_ctx.extra[BUFFER_KEY] = buffer
+            return io_ctx, buffer
+        except Exception:
+            self.release_buffer(file_path, buffer)
+            raise
+
+    def _try_enqueue(
+        self,
+        idx: int,
+        futures: _FutureMap,
+        io_exec: ThreadPoolExecutor,
+        files: list[Path],
+        io_stages: list[PipelineStage],
+        run_stages: Callable[[StageContext, list[PipelineStage]], StageContext],
+        make_context: Callable[[Path], StageContext],
+    ) -> None:
+        """Submit file *idx* for prefetch unless the memory limiter refuses."""
+        if self._memory_limiter is not None and not self._memory_limiter.check():
+            logger.warning("Prefetch skipped for index %d due to memory limit", idx)
+            return
+        future = io_exec.submit(
+            self._run_io_for_file, files[idx], io_stages, run_stages, make_context
+        )
+        futures[idx] = (future, time.monotonic())
+
+    def _prime_prefetch_queue(
+        self,
+        futures: _FutureMap,
+        io_exec: ThreadPoolExecutor,
+        files: list[Path],
+        io_stages: list[PipelineStage],
+        run_stages: Callable[[StageContext, list[PipelineStage]], StageContext],
+        make_context: Callable[[Path], StageContext],
+    ) -> None:
+        """Seed the prefetch queue with the first ``prefetch_depth`` files."""
+        for i in range(min(self._prefetch_depth, len(files))):
+            self._try_enqueue(i, futures, io_exec, files, io_stages, run_stages, make_context)
+            if i not in futures:
+                break  # limiter refused — stop priming
+
+    def _resolve_context(
+        self,
+        idx: int,
+        futures: _FutureMap,
+        files: list[Path],
+        io_stages: list[PipelineStage],
+        run_stages: Callable[[StageContext, list[PipelineStage]], StageContext],
+        make_context: Callable[[Path], StageContext],
+    ) -> tuple[StageContext, bytearray | None, float]:
+        """Return ``(ctx, buffer, start_time)`` for file *idx*.
+
+        Uses a completed prefetch future when available; falls back to
+        inline I/O. Any exception from either path is recorded on a
+        fresh failed context so the batch loop keeps moving.
+        """
+        if idx in futures:
+            future, start_time = futures.pop(idx)
+            try:
+                ctx, buffer = future.result()
+                return ctx, buffer, start_time
+            except Exception as exc:
+                logger.warning("Prefetch future failed for %s: %s", files[idx], exc, exc_info=True)
+                ctx = make_context(files[idx])
+                ctx.error = str(exc)
+                return ctx, None, start_time
+        start_time = time.monotonic()
+        try:
+            ctx, buffer = self._run_io_for_file(files[idx], io_stages, run_stages, make_context)
+            return ctx, buffer, start_time
+        except Exception as exc:
+            logger.warning("Inline I/O stage failed for %s: %s", files[idx], exc, exc_info=True)
+            ctx = make_context(files[idx])
+            ctx.error = str(exc)
+            return ctx, None, start_time

--- a/tests/pipeline/test_orchestrator_branches.py
+++ b/tests/pipeline/test_orchestrator_branches.py
@@ -152,10 +152,10 @@ class TestMemoryPressureThresholdValidation:
     def test_boundary_values_are_accepted(self) -> None:
         """Threshold values of exactly 0.0 and 100.0 are accepted without error."""
         orch_zero = PipelineOrchestrator(memory_pressure_threshold_percent=0.0)
-        assert orch_zero._memory_pressure_threshold_percent == 0.0
+        assert orch_zero._resource_executor.memory_pressure_threshold_percent == 0.0
 
         orch_hundred = PipelineOrchestrator(memory_pressure_threshold_percent=100.0)
-        assert orch_hundred._memory_pressure_threshold_percent == 100.0
+        assert orch_hundred._resource_executor.memory_pressure_threshold_percent == 100.0
 
 
 # ---------------------------------------------------------------------------
@@ -190,7 +190,9 @@ class TestBufferPoolLazyInit:
         assert len(results) == 2
         assert results[0] is not None
         assert results[1] is not None
-        assert orch._buffer_pool is not None
+        # D2: buffer pool lives on the executor; orchestrator exposes it
+        # via ``buffer_pool`` property which delegates.
+        assert orch._resource_executor._buffer_pool is not None
         assert results[0] is results[1]
 
     def test_supplied_buffer_pool_is_returned_directly(self) -> None:
@@ -388,21 +390,22 @@ class TestFinalizeResult:
 
 @pytest.mark.integration
 class TestSafeFileSizeFallback:
-    """_safe_file_size returns 0 when stat() raises OSError."""
+    """Orchestrator delegates ``safe_file_size`` to its resource executor
+    (D2 seam); this class pins the delegation + zero-on-error contract."""
 
     def test_safe_file_size_returns_zero_on_oserror(self) -> None:
-        """_safe_file_size returns 0 when stat() raises OSError for a nonexistent path."""
+        """``safe_file_size`` returns 0 when stat() raises OSError for a nonexistent path."""
         orch = PipelineOrchestrator()
         ghost = Path("/nonexistent/totally/made/up.bin")
-        size = orch._safe_file_size(ghost)
+        size = orch._resource_executor.safe_file_size(ghost)
         assert size == 0
 
     def test_safe_file_size_returns_actual_size_for_real_file(self, tmp_path: Path) -> None:
-        """_safe_file_size returns the correct byte count for an existing file."""
+        """``safe_file_size`` returns the correct byte count for an existing file."""
         f = tmp_path / "data.bin"
         f.write_bytes(b"x" * 100)
         orch = PipelineOrchestrator()
-        size = orch._safe_file_size(f)
+        size = orch._resource_executor.safe_file_size(f)
         assert size == 100
 
 
@@ -413,44 +416,42 @@ class TestSafeFileSizeFallback:
 
 @pytest.mark.integration
 class TestSafeCurrentRssFallback:
-    """_safe_current_rss returns 0 when ResourceMonitor raises."""
+    """``ResourceAwareExecutor.safe_current_rss`` returns 0 when
+    ResourceMonitor raises; swapping the executor's monitor simulates
+    platform failure."""
 
     def test_safe_current_rss_returns_zero_on_oserror(self) -> None:
-        """_safe_current_rss returns 0 when get_memory_usage raises OSError."""
         orch = PipelineOrchestrator()
         mock_monitor = MagicMock()
         mock_monitor.get_memory_usage.side_effect = OSError("no /proc")
-        orch._resource_monitor = mock_monitor
-        rss = orch._safe_current_rss()
+        orch._resource_executor._resource_monitor = mock_monitor
+        rss = orch._resource_executor.safe_current_rss()
         assert rss == 0
 
     def test_safe_current_rss_returns_zero_on_runtime_error(self) -> None:
-        """_safe_current_rss returns 0 when get_memory_usage raises RuntimeError."""
         orch = PipelineOrchestrator()
         mock_monitor = MagicMock()
         mock_monitor.get_memory_usage.side_effect = RuntimeError("platform unsupported")
-        orch._resource_monitor = mock_monitor
-        rss = orch._safe_current_rss()
+        orch._resource_executor._resource_monitor = mock_monitor
+        rss = orch._resource_executor.safe_current_rss()
         assert rss == 0
 
     def test_safe_current_rss_returns_zero_on_value_error(self) -> None:
-        """_safe_current_rss returns 0 when get_memory_usage raises ValueError."""
         orch = PipelineOrchestrator()
         mock_monitor = MagicMock()
         mock_monitor.get_memory_usage.side_effect = ValueError("bad format")
-        orch._resource_monitor = mock_monitor
-        rss = orch._safe_current_rss()
+        orch._resource_executor._resource_monitor = mock_monitor
+        rss = orch._resource_executor.safe_current_rss()
         assert rss == 0
 
     def test_safe_current_rss_returns_actual_value_on_success(self) -> None:
-        """_safe_current_rss returns the rss value from get_memory_usage on success."""
         orch = PipelineOrchestrator()
         mock_monitor = MagicMock()
         mock_rss_info = MagicMock()
         mock_rss_info.rss = 123_456_789
         mock_monitor.get_memory_usage.return_value = mock_rss_info
-        orch._resource_monitor = mock_monitor
-        rss = orch._safe_current_rss()
+        orch._resource_executor._resource_monitor = mock_monitor
+        rss = orch._resource_executor.safe_current_rss()
         assert rss == 123_456_789
 
 
@@ -461,18 +462,18 @@ class TestSafeCurrentRssFallback:
 
 @pytest.mark.integration
 class TestRebalanceBufferPool:
-    """_rebalance_buffer_pool: skip when None, shrink under pressure, grow on high utilisation."""
+    """``ResourceAwareExecutor.rebalance_buffer_pool``: skip when None,
+    shrink under pressure, grow on high utilisation (integration-level
+    through the orchestrator's executor)."""
 
     def test_no_pool_skips_rebalance(self) -> None:
-        """When _buffer_pool is None, _rebalance_buffer_pool is a no-op."""
         orch = PipelineOrchestrator()
         # Ensure pool is None (no lazy-init has fired yet)
-        assert orch._buffer_pool is None
+        assert orch._resource_executor._buffer_pool is None
         # Must not raise
-        orch._rebalance_buffer_pool()
+        orch._resource_executor.rebalance_buffer_pool()
 
     def test_under_memory_pressure_shrinks_pool(self) -> None:
-        """should_evict=True triggers a resize down to initial_buffers."""
         pool = BufferPool(buffer_size=256, initial_buffers=2, max_buffers=8)
         pool.resize(6)
         assert pool.total_buffers == 6
@@ -481,51 +482,45 @@ class TestRebalanceBufferPool:
         mock_monitor.should_evict.return_value = True
 
         orch = PipelineOrchestrator(buffer_pool=pool, resource_monitor=mock_monitor)
-        orch._rebalance_buffer_pool()
+        orch._resource_executor.rebalance_buffer_pool()
 
         # Pool should have been resized down to initial_buffers (2)
         assert pool.total_buffers == pool.initial_buffers
         mock_monitor.should_evict.assert_called_once_with(
-            threshold_percent=orch._memory_pressure_threshold_percent
+            threshold_percent=orch._resource_executor.memory_pressure_threshold_percent
         )
 
     def test_high_utilisation_grows_pool(self, tmp_path: Path) -> None:
-        """utilization >= 0.9 and room to grow triggers a resize up."""
         pool = BufferPool(buffer_size=256, initial_buffers=2, max_buffers=8)
-        # Acquire buffers to push utilisation to 100%
         acquired = [pool.acquire() for _ in range(2)]
         assert pool.utilization == 1.0
 
         mock_monitor = MagicMock()
-        mock_monitor.should_evict.return_value = False  # no pressure
+        mock_monitor.should_evict.return_value = False
 
         orch = PipelineOrchestrator(buffer_pool=pool, resource_monitor=mock_monitor)
         before = pool.total_buffers
-        orch._rebalance_buffer_pool()
+        orch._resource_executor.rebalance_buffer_pool()
 
         assert pool.total_buffers > before
-        # Cleanup
         for buf in acquired:
             pool.release(buf)
 
     def test_monitor_exception_in_rebalance_is_swallowed(self) -> None:
-        """OSError from should_evict must not propagate from _rebalance_buffer_pool."""
         pool = BufferPool(buffer_size=256, initial_buffers=2, max_buffers=4)
         mock_monitor = MagicMock()
         mock_monitor.should_evict.side_effect = OSError("no metrics")
 
         orch = PipelineOrchestrator(buffer_pool=pool, resource_monitor=mock_monitor)
-        # Should not raise
-        orch._rebalance_buffer_pool()
+        orch._resource_executor.rebalance_buffer_pool()
 
     def test_runtime_error_in_rebalance_is_swallowed(self) -> None:
-        """RuntimeError from should_evict is swallowed and does not propagate."""
         pool = BufferPool(buffer_size=256, initial_buffers=2, max_buffers=4)
         mock_monitor = MagicMock()
         mock_monitor.should_evict.side_effect = RuntimeError("crash")
 
         orch = PipelineOrchestrator(buffer_pool=pool, resource_monitor=mock_monitor)
-        orch._rebalance_buffer_pool()
+        orch._resource_executor.rebalance_buffer_pool()
 
 
 # ---------------------------------------------------------------------------
@@ -535,10 +530,11 @@ class TestRebalanceBufferPool:
 
 @pytest.mark.integration
 class TestAcquireReleaseBuffer:
-    """_acquire_buffer and _release_buffer error path coverage."""
+    """Buffer acquire/release error path coverage (delegated to
+    ``ResourceAwareExecutor`` under D2)."""
 
     def test_acquire_returns_none_on_pool_exception(self, tmp_path: Path) -> None:
-        """Processing continues successfully even when pool.acquire() raises an exception."""
+        """Processing continues successfully even when pool.acquire() raises."""
         f = tmp_path / "a.txt"
         f.write_text("x")
         pool = MagicMock()
@@ -551,15 +547,14 @@ class TestAcquireReleaseBuffer:
         assert result.success is True
 
     def test_release_none_buffer_is_no_op(self, tmp_path: Path) -> None:
-        """_release_buffer(path, None) must not call pool.release."""
+        """``release_buffer(path, None)`` must not call ``pool.release``."""
         pool = MagicMock(spec=BufferPool)
         pool.buffer_size = 1024
         pool.acquire.return_value = bytearray(1024)
         orch = PipelineOrchestrator(buffer_pool=pool)
         f = tmp_path / "a.txt"
         f.write_text("x")
-        # Call with None buffer directly
-        orch._release_buffer(f, None)
+        orch._resource_executor.release_buffer(f, None)
         pool.release.assert_not_called()
 
     def test_release_exception_is_swallowed(self, tmp_path: Path) -> None:

--- a/tests/pipeline/test_orchestrator_watch_loop.py
+++ b/tests/pipeline/test_orchestrator_watch_loop.py
@@ -201,7 +201,7 @@ class TestWatchLoopExecutor:
 
         mock_monitor.get_events = fake_get_events
 
-        with patch.object(orch._executor, "submit") as mock_submit:
+        with patch.object(orch._thread_executor, "submit") as mock_submit:
             orch._watch_loop()
             # submit should have been called with process_file and the path
             mock_submit.assert_called_once_with(orch.process_file, test_path)
@@ -211,7 +211,7 @@ class TestWatchLoopExecutor:
         config = PipelineConfig(dry_run=True, max_concurrent=8)
         orch = PipelineOrchestrator(config)
         # Verify executor exists and was initialized (don't access private _max_workers)
-        assert orch._executor is not None, "Executor should be initialized"
+        assert orch._thread_executor is not None, "Executor should be initialized"
         # Verify the config value is what we set
         assert config.max_concurrent == 8, (
             f"Config max_concurrent should be 8, got {config.max_concurrent}"
@@ -223,6 +223,6 @@ class TestWatchLoopExecutor:
         orch._running = True
         orch._watch_thread = MagicMock()
 
-        with patch.object(orch._executor, "shutdown") as mock_shutdown:
+        with patch.object(orch._thread_executor, "shutdown") as mock_shutdown:
             orch.stop()
             mock_shutdown.assert_called_once_with(wait=False)

--- a/tests/pipeline/test_resource_aware_executor.py
+++ b/tests/pipeline/test_resource_aware_executor.py
@@ -39,19 +39,23 @@ class _StageResult:
 
 
 class _RecordingStage:
-    """PipelineStage test double that records every ``process`` call."""
+    """PipelineStage test double that records every ``process`` call.
+
+    ``test_preserves_file_order`` relies on ``run_prefetched_batch``
+    assembling results in input-index order rather than completion
+    order; no artificial delay is needed. The project's C1 CI
+    guardrail (see ``.claude/rules/ci-generation-patterns.md``)
+    forbids ``time.sleep`` in changed tests.
+    """
 
     name = "recorder"
 
-    def __init__(self, label: str, *, delay_s: float = 0.0) -> None:
+    def __init__(self, label: str) -> None:
         self.label = label
-        self.delay_s = delay_s
         self.calls: list[Path] = []
 
     def process(self, context: StageContext) -> StageContext:
         self.calls.append(context.file_path)
-        if self.delay_s:
-            time.sleep(self.delay_s)
         context.extra.setdefault("stages_seen", []).append(self.label)
         return context
 
@@ -280,23 +284,26 @@ class TestRunPrefetchedBatch:
         assert all(r.success for r in results)
 
     def test_preserves_file_order(self, tmp_path: Path) -> None:
-        # Use varying delays to shuffle completion order; results must
-        # still return in input order.
+        # Results must come back in input-index order regardless of future
+        # completion order from the prefetch thread pool. ``prefetch_depth=3``
+        # means up to three files have outstanding I/O futures at any time —
+        # the loop consumes them in input order, not completion order.
         files = [tmp_path / f"f{i}.txt" for i in range(4)]
         for f in files:
             f.write_text("x")
-        delayed_stage = _RecordingStage("delayed", delay_s=0.0)
+        stage = _RecordingStage("io")
         executor = ResourceAwareExecutor(prefetch_depth=3, prefetch_stages=1)
 
         results = executor.run_prefetched_batch(
             files=files,
-            stages=[delayed_stage],
+            stages=[stage],
             run_stages=_run_stages,
             make_context=_make_context,
             finalize_result=_finalize_result,
         )
 
         assert [r.file_path for r in results] == files
+        assert stage.calls == files or sorted(stage.calls) == sorted(files)
 
     def test_respects_memory_limiter(self, tmp_path: Path) -> None:
         files = [tmp_path / f"f{i}.txt" for i in range(4)]
@@ -321,8 +328,20 @@ class TestRunPrefetchedBatch:
         )
 
         assert len(results) == len(files)
-        # Limiter must have been consulted at least once.
-        assert limiter.check.called
+        assert all(r.success for r in results)
+        # Every file must have traversed the inline fallback — the stage
+        # ran once per file exactly. (``limiter.check.called`` alone would
+        # pass even if the executor silently dropped files.)
+        assert sorted(stage.calls) == sorted(files)
+        assert len(stage.calls) == len(files)
+        # Priming attempts one enqueue, breaks on denial; the main loop
+        # then attempts one lookahead per iteration while the index is
+        # in range (len(files) - prefetch_depth attempts total). For
+        # len=4, prefetch_depth=2 that's 1 (prime) + 2 (lookahead) = 3.
+        # ``>= 2`` is the minimum viable signal: priming + at least one
+        # lookahead enforcement. Lower would mean the limiter was never
+        # actually enforced per file.
+        assert limiter.check.call_count >= 2
 
     def test_stage_error_surfaces_on_context(self, tmp_path: Path) -> None:
         files = [tmp_path / "f.txt"]

--- a/tests/pipeline/test_resource_aware_executor.py
+++ b/tests/pipeline/test_resource_aware_executor.py
@@ -1,0 +1,431 @@
+"""Tests for ``ResourceAwareExecutor`` (D2 seam, hardening roadmap §3 D).
+
+The executor owns prefetch, memory limiting, and buffer rebalancing —
+concerns the orchestrator previously held inline. These tests exercise
+each responsibility in isolation so the seam is regression-resistant
+and integration-coverage-preserving.
+
+See ``test_orchestrator*.py`` for the integrated orchestrator-level
+behaviour; this file targets the executor contract directly.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from interfaces.pipeline import PipelineStage, StageContext
+from optimization.buffer_pool import BufferPool
+from optimization.memory_limiter import MemoryLimiter
+from optimization.resource_monitor import MemoryInfo
+from pipeline.resource_aware_executor import ResourceAwareExecutor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StageResult:
+    """Minimal shape returned by ``finalize_result`` callback in tests."""
+
+    file_path: Path
+    success: bool
+    duration_ms: float
+
+
+class _RecordingStage:
+    """PipelineStage test double that records every ``process`` call."""
+
+    name = "recorder"
+
+    def __init__(self, label: str, *, delay_s: float = 0.0) -> None:
+        self.label = label
+        self.delay_s = delay_s
+        self.calls: list[Path] = []
+
+    def process(self, context: StageContext) -> StageContext:
+        self.calls.append(context.file_path)
+        if self.delay_s:
+            time.sleep(self.delay_s)
+        context.extra.setdefault("stages_seen", []).append(self.label)
+        return context
+
+
+def _make_context(file_path: Path) -> StageContext:
+    return StageContext(file_path=file_path, dry_run=True)
+
+
+def _run_stages(context: StageContext, stages: list[PipelineStage]) -> StageContext:
+    """Trivial stage runner — matches the orchestrator's semantics for tests."""
+    for stage in stages:
+        if context.failed:
+            break
+        returned = stage.process(context)
+        if returned is None:
+            context.error = f"Stage {stage.name!r} returned None"
+            break
+        context = returned
+    return context
+
+
+def _finalize_result(context: StageContext, start_time: float) -> _StageResult:
+    duration_ms = (time.monotonic() - start_time) * 1000
+    return _StageResult(
+        file_path=context.file_path,
+        success=not context.failed,
+        duration_ms=duration_ms,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: construction + parameter validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestConstruction:
+    def test_accepts_resource_dependencies(self) -> None:
+        limiter = MagicMock(spec=MemoryLimiter)
+        pool = BufferPool()
+        monitor = MagicMock()
+        executor = ResourceAwareExecutor(
+            prefetch_depth=3,
+            prefetch_stages=1,
+            memory_limiter=limiter,
+            buffer_pool=pool,
+            resource_monitor=monitor,
+            memory_pressure_threshold_percent=75.0,
+        )
+        assert executor.prefetch_depth == 3
+        assert executor.prefetch_stages == 1
+        assert executor.buffer_pool is pool
+        assert executor.memory_pressure_threshold_percent == 75.0
+
+    def test_clamps_negative_prefetch_to_zero(self) -> None:
+        executor = ResourceAwareExecutor(prefetch_depth=-5, prefetch_stages=-1)
+        assert executor.prefetch_depth == 0
+        assert executor.prefetch_stages == 0
+
+    def test_rejects_out_of_range_memory_threshold(self) -> None:
+        with pytest.raises(ValueError, match="between 0 and 100"):
+            ResourceAwareExecutor(memory_pressure_threshold_percent=150.0)
+        with pytest.raises(ValueError, match="between 0 and 100"):
+            ResourceAwareExecutor(memory_pressure_threshold_percent=-1.0)
+
+    def test_buffer_pool_lazily_created_when_none(self) -> None:
+        executor = ResourceAwareExecutor()
+        # Access triggers lazy creation.
+        pool = executor.buffer_pool
+        assert isinstance(pool, BufferPool)
+        # Second access returns the same pool (not a fresh one).
+        assert executor.buffer_pool is pool
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: buffer acquire / release
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestBufferAcquireRelease:
+    def test_acquires_buffer_sized_for_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.bin"
+        f.write_bytes(b"x" * 4096)
+        pool = BufferPool(buffer_size=1024, initial_buffers=1, max_buffers=2)
+        executor = ResourceAwareExecutor(buffer_pool=pool)
+
+        buffer = executor.acquire_buffer(f)
+
+        assert buffer is not None
+        assert len(buffer) >= 4096
+
+    def test_release_returns_buffer_to_pool(self, tmp_path: Path) -> None:
+        f = tmp_path / "data.bin"
+        f.write_bytes(b"x" * 512)
+        pool = BufferPool(buffer_size=1024, initial_buffers=1, max_buffers=2)
+        executor = ResourceAwareExecutor(buffer_pool=pool)
+
+        before_in_use = pool.in_use_count
+        buffer = executor.acquire_buffer(f)
+        assert pool.in_use_count == before_in_use + 1
+        executor.release_buffer(f, buffer)
+        assert pool.in_use_count == before_in_use
+
+    def test_release_none_is_noop(self, tmp_path: Path) -> None:
+        executor = ResourceAwareExecutor()
+        # Must not raise; must not disturb the pool.
+        executor.release_buffer(tmp_path / "nope", None)
+
+    def test_missing_file_yields_safe_zero_size(self, tmp_path: Path) -> None:
+        missing = tmp_path / "nonexistent"
+        executor = ResourceAwareExecutor()
+        assert executor.safe_file_size(missing) == 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: buffer pool rebalancing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestRebalanceBufferPool:
+    def test_no_op_when_no_pool(self) -> None:
+        monitor = MagicMock()
+        executor = ResourceAwareExecutor(resource_monitor=monitor, buffer_pool=None)
+        # No buffer pool access has happened; calling rebalance must not
+        # lazily build one.
+        executor.rebalance_buffer_pool()
+        monitor.should_evict.assert_not_called()
+
+    def test_shrinks_pool_under_memory_pressure(self) -> None:
+        pool = BufferPool(initial_buffers=2, max_buffers=8)
+        # Grow the pool first so there's room to shrink.
+        pool.resize(8)
+        assert pool.total_buffers == 8
+        monitor = MagicMock()
+        monitor.should_evict.return_value = True
+        executor = ResourceAwareExecutor(
+            buffer_pool=pool,
+            resource_monitor=monitor,
+            memory_pressure_threshold_percent=80.0,
+        )
+        executor.rebalance_buffer_pool()
+        monitor.should_evict.assert_called_once_with(threshold_percent=80.0)
+        assert pool.total_buffers <= 2 + pool.in_use_count
+
+    def test_grows_pool_at_high_utilization(self) -> None:
+        pool = BufferPool(initial_buffers=2, max_buffers=8)
+        # Acquire buffers to push utilization to 100% (forces >= 0.9).
+        b1 = pool.acquire()
+        b2 = pool.acquire()
+        assert pool.utilization >= 0.9
+        monitor = MagicMock()
+        monitor.should_evict.return_value = False
+        executor = ResourceAwareExecutor(
+            buffer_pool=pool,
+            resource_monitor=monitor,
+        )
+        before = pool.total_buffers
+        executor.rebalance_buffer_pool()
+        assert pool.total_buffers > before
+        # Clean up acquired buffers.
+        pool.release(b1)
+        pool.release(b2)
+
+    def test_swallows_should_evict_exception(self) -> None:
+        pool = BufferPool()
+        monitor = MagicMock()
+        monitor.should_evict.side_effect = OSError("sysfs blip")
+        executor = ResourceAwareExecutor(buffer_pool=pool, resource_monitor=monitor)
+        # Must not raise — logs and returns.
+        executor.rebalance_buffer_pool()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: prefetched batch execution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestRunPrefetchedBatch:
+    def test_single_stage_runs_each_file_once(self, tmp_path: Path) -> None:
+        files = [tmp_path / f"f{i}.txt" for i in range(3)]
+        for f in files:
+            f.write_text("x")
+        stage = _RecordingStage("io")
+        executor = ResourceAwareExecutor(prefetch_depth=2, prefetch_stages=1)
+
+        results = executor.run_prefetched_batch(
+            files=files,
+            stages=[stage],
+            run_stages=_run_stages,
+            make_context=_make_context,
+            finalize_result=_finalize_result,
+        )
+
+        assert [r.file_path for r in results] == files
+        assert all(r.success for r in results)
+        assert sorted(stage.calls) == sorted(files)
+        assert len(stage.calls) == len(files)
+
+    def test_caps_prefetch_stages_at_one(self, tmp_path: Path) -> None:
+        files = [tmp_path / f"f{i}.txt" for i in range(2)]
+        for f in files:
+            f.write_text("x")
+        io_stage = _RecordingStage("io")
+        compute_stage = _RecordingStage("compute")
+        executor = ResourceAwareExecutor(prefetch_depth=2, prefetch_stages=5)
+
+        results = executor.run_prefetched_batch(
+            files=files,
+            stages=[io_stage, compute_stage],
+            run_stages=_run_stages,
+            make_context=_make_context,
+            finalize_result=_finalize_result,
+        )
+
+        # Both stages run for both files; prefetch_stages=5 is clamped to 1
+        # but compute stage still runs on the calling thread.
+        assert len(io_stage.calls) == 2
+        assert len(compute_stage.calls) == 2
+        assert all(r.success for r in results)
+
+    def test_preserves_file_order(self, tmp_path: Path) -> None:
+        # Use varying delays to shuffle completion order; results must
+        # still return in input order.
+        files = [tmp_path / f"f{i}.txt" for i in range(4)]
+        for f in files:
+            f.write_text("x")
+        delayed_stage = _RecordingStage("delayed", delay_s=0.0)
+        executor = ResourceAwareExecutor(prefetch_depth=3, prefetch_stages=1)
+
+        results = executor.run_prefetched_batch(
+            files=files,
+            stages=[delayed_stage],
+            run_stages=_run_stages,
+            make_context=_make_context,
+            finalize_result=_finalize_result,
+        )
+
+        assert [r.file_path for r in results] == files
+
+    def test_respects_memory_limiter(self, tmp_path: Path) -> None:
+        files = [tmp_path / f"f{i}.txt" for i in range(4)]
+        for f in files:
+            f.write_text("x")
+        stage = _RecordingStage("io")
+        limiter = MagicMock(spec=MemoryLimiter)
+        # Deny every check — forces sequential inline fallback.
+        limiter.check.return_value = False
+        executor = ResourceAwareExecutor(
+            prefetch_depth=2,
+            prefetch_stages=1,
+            memory_limiter=limiter,
+        )
+
+        results = executor.run_prefetched_batch(
+            files=files,
+            stages=[stage],
+            run_stages=_run_stages,
+            make_context=_make_context,
+            finalize_result=_finalize_result,
+        )
+
+        assert len(results) == len(files)
+        # Limiter must have been consulted at least once.
+        assert limiter.check.called
+
+    def test_stage_error_surfaces_on_context(self, tmp_path: Path) -> None:
+        files = [tmp_path / "f.txt"]
+        files[0].write_text("x")
+
+        class _Explode:
+            name = "explode"
+
+            def process(self, context: StageContext) -> StageContext:
+                raise RuntimeError("boom")
+
+        executor = ResourceAwareExecutor(prefetch_depth=1, prefetch_stages=1)
+        results = executor.run_prefetched_batch(
+            files=files,
+            stages=[_Explode()],
+            run_stages=_run_stages,
+            make_context=_make_context,
+            finalize_result=_finalize_result,
+        )
+        # Executor must not propagate the error — the batch should complete
+        # and the failing file surfaces via ``success=False``.
+        assert len(results) == 1
+        assert results[0].success is False
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: executor + real pool + real resource monitor
+#
+# These tests guarantee that the D2 extraction does not drop integration
+# coverage of the resource-aware surface when orchestrator.py delegates
+# to this class.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.xdist_group(name="resource-aware-executor")
+class TestResourceAwareExecutorIntegration:
+    def test_end_to_end_prefetch_with_real_pool(self, tmp_path: Path) -> None:
+        """Full prefetch path with a real BufferPool + real stages."""
+        files = [tmp_path / f"doc_{i}.txt" for i in range(4)]
+        for i, f in enumerate(files):
+            f.write_text(f"content {i}" * 20)
+        stage = _RecordingStage("io")
+        pool = BufferPool(buffer_size=256, initial_buffers=2, max_buffers=6)
+        executor = ResourceAwareExecutor(
+            prefetch_depth=2,
+            prefetch_stages=1,
+            buffer_pool=pool,
+        )
+
+        results = executor.run_prefetched_batch(
+            files=files,
+            stages=[stage],
+            run_stages=_run_stages,
+            make_context=_make_context,
+            finalize_result=_finalize_result,
+        )
+
+        assert [r.file_path for r in results] == files
+        assert all(r.success for r in results)
+        assert len(stage.calls) == len(files)
+
+    def test_rebalance_grows_under_utilization_and_shrinks_on_pressure(self) -> None:
+        pool = BufferPool(initial_buffers=2, max_buffers=8)
+        monitor = MagicMock()
+        executor = ResourceAwareExecutor(
+            buffer_pool=pool,
+            resource_monitor=monitor,
+            memory_pressure_threshold_percent=85.0,
+        )
+
+        # Phase 1: drive utilization high; monitor reports no pressure.
+        b1, b2 = pool.acquire(), pool.acquire()
+        monitor.should_evict.return_value = False
+        before = pool.total_buffers
+        executor.rebalance_buffer_pool()
+        after_growth = pool.total_buffers
+        assert after_growth > before
+
+        # Phase 2: release buffers and flip pressure to True.
+        pool.release(b1)
+        pool.release(b2)
+        monitor.should_evict.return_value = True
+        executor.rebalance_buffer_pool()
+        after_shrink = pool.total_buffers
+        assert after_shrink <= after_growth
+
+    def test_safe_current_rss_reads_monitor(self) -> None:
+        monitor = MagicMock()
+        monitor.get_memory_usage.return_value = MemoryInfo(
+            rss=1024 * 1024 * 100,
+            vms=1024 * 1024 * 200,
+            percent=12.5,
+        )
+        executor = ResourceAwareExecutor(resource_monitor=monitor)
+
+        rss = executor.safe_current_rss()
+
+        assert rss == 1024 * 1024 * 100
+        monitor.get_memory_usage.assert_called_once()
+
+    def test_safe_current_rss_swallows_monitor_error(self) -> None:
+        monitor = MagicMock()
+        monitor.get_memory_usage.side_effect = OSError("proc vanished")
+        executor = ResourceAwareExecutor(resource_monitor=monitor)
+        assert executor.safe_current_rss() == 0


### PR DESCRIPTION
## Summary

Epic D.pipeline D2 (hardening roadmap #157). Extracts prefetch, memory limiting, and buffer-pool rebalancing from \`src/pipeline/orchestrator.py\` (881 LOC) into a new \`ResourceAwareExecutor\` class. Orchestrator drops to 726 LOC and is materially easier to reason about.

## What moves into \`ResourceAwareExecutor\`

| Surface | Before (orchestrator) | After |
|---|---|---|
| \`buffer_pool\` property | \`PipelineOrchestrator\` | \`ResourceAwareExecutor\` (orchestrator delegates via property for back-compat) |
| \`safe_file_size\` / \`safe_current_rss\` | \`_safe_file_size\` / \`_safe_current_rss\` | Public methods on executor |
| \`rebalance_buffer_pool\` | \`_rebalance_buffer_pool\` | Public method |
| \`acquire_buffer\` / \`release_buffer\` | \`_acquire_buffer\` / \`_release_buffer\` | Public methods |
| Prefetched batch loop | \`_process_batch_prefetch\` (114 LOC, C901=16) | \`run_prefetched_batch\`, decomposed into 4 helpers each under the complexity cap |

Orchestrator retains: stage management, public API, legacy routing, watch-mode lifecycle, and statistics. The executor knows nothing about \`ProcessingResult\` or the orchestrator's stats — collaborators (\`run_stages\`, \`make_context\`, \`finalize_result\`) are passed as callables.

## Backward compat

- Constructor signature on \`PipelineOrchestrator\` is unchanged; all resource arguments are forwarded to the executor.
- \`buffer_pool\` property preserved (delegates).
- \`memory_pressure_threshold_percent\` range validation moved but same \`ValueError\` message.
- One worker pool rename: \`_executor\` → \`_thread_executor\` to disambiguate from the new resource executor. The four test sites that poked \`orch._executor\` are updated.

## Integration coverage (measured locally before push — MEMORY rule, lesson from PR #186)

| Module | Before | After | Floor |
|---|---|---|---|
| \`src/pipeline/orchestrator.py\` | 79% | **88%** (+9) | 78.5% |
| \`src/pipeline/resource_aware_executor.py\` | — | **86%** | 71.9% new-module floor |

Both clear the per-module floor gate with headroom. The orchestrator's integration coverage went UP because the extraction reduced the lines the existing integration tests need to exercise.

## Tests

**New**: \`tests/pipeline/test_resource_aware_executor.py\` — 21 tests (4 construction, 4 buffer acquire/release, 4 rebalancing, 6 prefetched-batch scenarios, 3 integration-marked end-to-end).

**Migrated**: 21 call-sites in \`test_orchestrator_branches.py\` / \`test_orchestrator_watch_loop.py\` that poked orchestrator private attributes — now go through \`orch._resource_executor.*\` to pin the delegation.

## Test plan

- [x] \`pytest tests/pipeline/\` — 296 tests pass
- [x] \`pytest tests/ -m integration\` — 7038 pass, 3 skipped
- [x] \`python3 scripts/check_module_coverage_floor.py\` — D2 files clear the floors (pre-existing environmental drifts on memory_profiler/image_dedup are unrelated; CI reports them at 82%/88%)
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] No C901 complexity violations
- [ ] CI: full suite green on this branch
- [ ] CI: main integration gate green after merge

⚠️ **Do not auto-merge.** Wait for reviewer signoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized pipeline orchestration architecture. Resource-aware operations (buffer management, memory monitoring, file I/O prefetching) are now centralized in a dedicated executor component. Tests updated to reflect the new structure. Public APIs remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->