### PR TITLE
fix(scripts): measure-integration-coverage uses --cov=src

### DIFF
--- a/.claude/scripts/measure-integration-coverage.sh
+++ b/.claude/scripts/measure-integration-coverage.sh
@@ -1,4 +1,15 @@
 #!/usr/bin/env bash
+# Measure integration-test coverage against the same targets CI uses.
+#
+# Rebased to ``--cov=src`` after the flatten in PR #104 removed the
+# top-level ``fo`` package. The previous ``--cov=fo`` path collected
+# zero files because the package no longer exists, which silently
+# masked per-module coverage drift — an entire class of D2-style
+# regressions (PR #186) went undetected locally until main CI caught
+# them.
+#
+# Always run this before opening a PR that changes code under ``src/``,
+# per the MEMORY rule "Run integration gate locally before first push".
 set -euo pipefail
 
 # Install optional search extras so rank-bm25 / sklearn tests run (not skip).
@@ -8,7 +19,7 @@ pip install -e ".[search]" --quiet
 coverage erase
 pytest tests/ -m "integration" \
     --strict-markers \
-    --cov=fo \
+    --cov=src \
     --cov-branch \
     --cov-report=term-missing \
     --override-ini="addopts=" \


### PR DESCRIPTION
## Summary

The \`measure-integration-coverage.sh\` helper has been silently useless since PR #104 (the src/ flatten) removed the top-level \`fo\` package — \`--cov=fo\` now collects zero files. Anyone who ran it before a PR per the MEMORY rule \"run integration gate locally before first push\" got zero measurements.

**Concrete impact**: on PR #186, I ran this script locally and saw green. The script collected no coverage, so there was nothing to be red. Main CI then caught a per-module integration coverage regression on \`heuristics.py\` (84% → 78%), costing two follow-up PRs (#187 closed the test-assertion wrap; #188 restored coverage via new integration tests).

## Fix

Rebase to \`--cov=src\` — the same target CI's \`Integration coverage gate\` job uses:

\`\`\`yaml
# .github/workflows/ci.yml:481
pytest tests/ -m \"integration\" --strict-markers --cov=src --cov-branch ...
\`\`\`

Also documents the rationale inline so the next flatten doesn't re-break this silently.

## Test plan

- [x] \`bash -n\` syntax check passes
- [x] \`--cov=src\` grep matches ci.yml's three integration-gate invocations
- [x] No other scripts or docs reference the stale \`--cov=fo\` path