### PR TITLE
fix(scripts): pre-commit-validation uses branch diff vs origin/main

### DIFF
--- a/.claude/scripts/pre-commit-validation.sh
+++ b/.claude/scripts/pre-commit-validation.sh
@@ -11,6 +11,14 @@ set -euo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
 
+# Declared up-front so ``set -u`` doesn't trip when ``collect_changed_files``
+# produces an empty array (only possible when you run this script directly on
+# ``main`` with a clean worktree, which isn't a supported scenario but
+# shouldn't crash either). Older bash (macOS 3.2) treats an empty
+# ``array[@]`` as unbound without this guard.
+changed_files=()
+changed_mode=""
+
 run_step() {
   local label="$1"
   shift
@@ -35,24 +43,51 @@ print_files() {
 }
 
 collect_changed_files() {
-  local tracked_files=()
+  # The script exists for PR validation — "what will land if this branch
+  # merges to main". That means the interesting set is
+  # ``git diff origin/main...HEAD`` (three-dot: files changed on this
+  # branch since it diverged from main) *plus* any uncommitted /
+  # untracked files in the working tree (the current edit session).
+  #
+  # This replaces the pre-2026-04-24 logic that compared the working tree
+  # against HEAD. That logic produced an empty file list immediately
+  # after a commit, which hid regressions on code that had just been
+  # committed but not yet pushed — exactly when the validator is most
+  # useful. (User feedback on PR #192.)
+  local branch_files=()
+  local working_tree_files=()
   local untracked_files=()
   changed_files=()
 
-  if git diff --cached --quiet; then
-    while IFS= read -r line; do [[ -n "$line" ]] && tracked_files+=("$line"); done \
-      < <(git diff --name-only --diff-filter=ACMR HEAD 2>/dev/null || true)
-    while IFS= read -r line; do [[ -n "$line" ]] && untracked_files+=("$line"); done \
-      < <(git ls-files --others --exclude-standard)
-    changed_files=()
-    [[ ${#tracked_files[@]} -gt 0 ]] && changed_files+=("${tracked_files[@]}")
-    [[ ${#untracked_files[@]} -gt 0 ]] && changed_files+=("${untracked_files[@]}")
-    changed_mode="working tree vs HEAD + untracked"
-  else
-    while IFS= read -r line; do [[ -n "$line" ]] && changed_files+=("$line"); done \
-      < <(git diff --cached --name-only --diff-filter=ACMR)
-    changed_mode="staged diff"
+  local base="origin/main"
+  if ! git rev-parse --verify "$base" >/dev/null 2>&1; then
+    base="main"
   fi
+
+  # Files committed on this branch since it diverged from the base.
+  while IFS= read -r line; do [[ -n "$line" ]] && branch_files+=("$line"); done \
+    < <(git diff --name-only --diff-filter=ACMR "${base}...HEAD" 2>/dev/null || true)
+
+  # Uncommitted changes in the working tree (staged or unstaged).
+  while IFS= read -r line; do [[ -n "$line" ]] && working_tree_files+=("$line"); done \
+    < <(git diff --name-only --diff-filter=ACMR HEAD 2>/dev/null || true)
+
+  # Untracked files (new files the user hasn't added yet).
+  while IFS= read -r line; do [[ -n "$line" ]] && untracked_files+=("$line"); done \
+    < <(git ls-files --others --exclude-standard)
+
+  local combined=()
+  [[ ${#branch_files[@]} -gt 0 ]] && combined+=("${branch_files[@]}")
+  [[ ${#working_tree_files[@]} -gt 0 ]] && combined+=("${working_tree_files[@]}")
+  [[ ${#untracked_files[@]} -gt 0 ]] && combined+=("${untracked_files[@]}")
+
+  # Dedupe while preserving order.
+  if [[ ${#combined[@]} -gt 0 ]]; then
+    while IFS= read -r line; do changed_files+=("$line"); done \
+      < <(printf '%s\n' "${combined[@]}" | awk '!seen[$0]++')
+  fi
+
+  changed_mode="branch diff vs $base + working tree + untracked"
 }
 
 collect_changed_files


### PR DESCRIPTION
## Summary

\`.claude/scripts/pre-commit-validation.sh\` exists for PR validation — \"what will land if this branch merges to main\". Its pre-2026-04-24 logic compared the working tree against HEAD, which produced an **empty file list immediately after a commit** — precisely when the validator is most useful. On macOS bash 3.2 that empty array also triggered a \`set -u\` unbound-variable crash.

**User feedback on first draft of this PR**: adding a `set -u` guard for the empty array treats the symptom, not the cause. The fix is to source the file list from something that isn't empty by construction — i.e. compare against `origin/main`, not HEAD.

## Fix

\`collect_changed_files\` now unions three sources:

1. **Branch diff vs origin/main** — `git diff --name-only origin/main...HEAD` (three-dot form: files changed on this branch since it diverged). This is the PR scope; never empty for a legitimate feature branch.
2. **Working tree vs HEAD** — uncommitted changes (staged or unstaged) so edit-in-progress work still validates before the first commit.
3. **Untracked files** — new files the user hasn't `git add`ed yet.

Result is deduped via `awk '!seen[$0]++'`. The module-level `changed_files=()` declaration stays as a safety net for the one remaining edge case (running the script directly on `main` with a clean tree — unsupported but shouldn't crash).

## Impact

Concrete cost of the old logic: PR #186 dropped integration coverage of `heuristics.py` from 84% → 78%. I ran the validator locally before push and saw green — the file list was empty (post-commit), so nothing was actually validated. Main CI caught it, costing two follow-up PRs. PR #191 hit the same shape (4 CI failures that would have been caught locally) because the validator was still reporting an empty diff.

## Test plan

- [x] `bash .claude/scripts/pre-commit-validation.sh` on this branch now lists `.claude/scripts/pre-commit-validation.sh` (the actual branch change) and runs all gates to completion.
- [x] Tested the three-dot diff semantics: correctly reports files changed on the branch vs `origin/main`, excluding changes that landed on main after the branch was created.