### PR TITLE
fix(F1): watcher queue backpressure + dropped-event metric

### DIFF
--- a/src/watcher/queue.py
+++ b/src/watcher/queue.py
@@ -6,6 +6,7 @@ supports batch dequeuing for efficient processing.
 
 from __future__ import annotations
 
+import logging
 import threading
 from collections import deque
 from dataclasses import dataclass
@@ -13,6 +14,12 @@ from datetime import datetime
 from pathlib import Path
 
 from _compat import StrEnum
+
+logger = logging.getLogger(__name__)
+
+# Log a throttled warning every ``_DROP_LOG_INTERVAL`` drops so the signal
+# is visible without spamming at sustained overflow rates.
+_DROP_LOG_INTERVAL = 100
 
 
 class EventType(StrEnum):
@@ -49,6 +56,14 @@ class EventQueue:
     Events are enqueued individually and can be dequeued in configurable
     batch sizes for efficient downstream processing.
 
+    F1 (hardening roadmap #159): overflow is no longer silent. When the
+    queue is full, the oldest event is dropped (preserving the pre-F1
+    behaviour), a throttled warning is logged, and
+    :attr:`dropped_count` is incremented so callers can observe
+    saturation. The :attr:`is_full` property lets producers apply
+    their own backpressure (e.g. coalesce events or skip debouncing)
+    before enqueue.
+
     Attributes:
         max_size: Maximum number of events the queue can hold.
             When exceeded, oldest events are dropped. 0 means unlimited.
@@ -60,7 +75,12 @@ class EventQueue:
         Args:
             max_size: Maximum queue capacity. 0 means unlimited.
         """
-        self._queue: deque[FileEvent] = deque(maxlen=max_size if max_size > 0 else None)
+        # No ``maxlen`` here: overflow is handled explicitly in
+        # ``enqueue`` so we can count and log drops instead of silently
+        # losing events. Pre-F1 used ``deque(maxlen=...)``.
+        self._queue: deque[FileEvent] = deque()
+        self._max_size = max_size if max_size > 0 else 0
+        self._dropped_count = 0
         self._lock = threading.Lock()
         self._not_empty = threading.Condition(self._lock)
 
@@ -68,12 +88,26 @@ class EventQueue:
         """Add an event to the queue.
 
         Thread-safe. If the queue is at max capacity, the oldest event
-        is silently dropped.
+        is dropped to make room (drop-oldest policy). Each drop
+        increments :attr:`dropped_count`, and every
+        :data:`_DROP_LOG_INTERVAL` drops emit a throttled warning so
+        sustained overflow is observable without flooding the log.
 
         Args:
             event: The file event to enqueue.
         """
         with self._not_empty:
+            if self._max_size > 0 and len(self._queue) >= self._max_size:
+                self._queue.popleft()
+                self._dropped_count += 1
+                if self._dropped_count == 1 or self._dropped_count % _DROP_LOG_INTERVAL == 0:
+                    logger.warning(
+                        "EventQueue overflow at max_size=%d; dropped oldest event "
+                        "(total_dropped=%d). Consider increasing max_size or "
+                        "slowing the event producer.",
+                        self._max_size,
+                        self._dropped_count,
+                    )
             self._queue.append(event)
             self._not_empty.notify()
 
@@ -155,3 +189,31 @@ class EventQueue:
         """Return True if the queue contains no events."""
         with self._lock:
             return len(self._queue) == 0
+
+    @property
+    def is_full(self) -> bool:
+        """Return True if a bounded queue is at capacity.
+
+        Producers can check this before enqueue to apply their own
+        backpressure — e.g. coalescing events, skipping debouncing, or
+        logging at the producer side. Always False for an unbounded
+        queue (``max_size == 0``).
+        """
+        with self._lock:
+            return self._max_size > 0 and len(self._queue) >= self._max_size
+
+    @property
+    def dropped_count(self) -> int:
+        """Number of events dropped due to overflow since construction.
+
+        F1 metric: non-decreasing counter of drop events. A rising value
+        indicates the queue is under sustained pressure; a stable value
+        means overflow has stopped (even if it was hit earlier).
+        """
+        with self._lock:
+            return self._dropped_count
+
+    @property
+    def max_size(self) -> int:
+        """The configured maximum size (0 for unbounded)."""
+        return self._max_size

--- a/tests/integration/test_watcher_components.py
+++ b/tests/integration/test_watcher_components.py
@@ -278,6 +278,50 @@ class TestEventQueueMaxSize:
         assert q.size == 100
 
 
+class TestEventQueueBackpressure:
+    """F1 (hardening roadmap #159): integration coverage for the new
+    observability surface — ``dropped_count``, ``is_full``, ``max_size``
+    — so the integration-coverage floor tracks these paths."""
+
+    def test_dropped_count_tracks_overflow(self) -> None:
+        q = EventQueue(max_size=2)
+        for i in range(5):
+            q.enqueue(_make_event(EventType.CREATED, Path(f"f{i}.txt")))
+        # 5 enqueues on 2-slot queue → 3 drops.
+        assert q.dropped_count == 3
+        # Unbounded queue never records drops.
+        unbounded = EventQueue()
+        for i in range(50):
+            unbounded.enqueue(_make_event(EventType.CREATED, Path(f"u{i}.txt")))
+        assert unbounded.dropped_count == 0
+
+    def test_is_full_signals_backpressure(self) -> None:
+        q = EventQueue(max_size=2)
+        assert q.is_full is False
+        q.enqueue(_make_event(EventType.CREATED, Path("a.txt")))
+        assert q.is_full is False
+        q.enqueue(_make_event(EventType.CREATED, Path("b.txt")))
+        assert q.is_full is True
+        # Consuming makes room — backpressure released.
+        q.dequeue_batch(max_size=1)
+        assert q.is_full is False
+        # Unbounded is never full.
+        assert EventQueue().is_full is False
+
+    def test_max_size_exposes_capacity(self) -> None:
+        assert EventQueue(max_size=42).max_size == 42
+        assert EventQueue().max_size == 0
+
+    def test_overflow_emits_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Pre-F1 overflow was silent; post-F1 the first drop logs."""
+        q = EventQueue(max_size=1)
+        q.enqueue(_make_event(EventType.CREATED, Path("seed.txt")))
+        with caplog.at_level("WARNING", logger="watcher.queue"):
+            q.enqueue(_make_event(EventType.CREATED, Path("overflow.txt")))
+        assert any("overflow" in rec.message.lower() for rec in caplog.records)
+        assert q.dropped_count == 1
+
+
 class TestEventQueueBlocking:
     def test_dequeue_blocking_returns_immediately_if_events_present(self) -> None:
         q = EventQueue()

--- a/tests/watcher/test_queue.py
+++ b/tests/watcher/test_queue.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from watcher.queue import EventQueue, EventType, FileEvent
+from watcher.queue import _DROP_LOG_INTERVAL, EventQueue, EventType, FileEvent
 
 pytestmark = [pytest.mark.unit]
 # Note: EventQueue tests use threading.Thread, making them
@@ -404,8 +404,14 @@ class TestEventQueueEdgeCases:
 
 
 @pytest.mark.unit
+@pytest.mark.ci
 class TestEventQueueBackpressure:
     """F1 (hardening roadmap #159): overflow is no longer silent.
+
+    Marked ``ci`` so the PR-suite ``-m "ci"`` run exercises the new
+    ``dropped_count`` / ``is_full`` / ``max_size`` paths — otherwise
+    the diff-cover gate (80% of changed lines) fails on D6-style
+    unit-only coverage.
 
     Pre-F1 the queue used ``deque(maxlen=...)`` which silently dropped
     the oldest event. Consumers had no way to know overflow had
@@ -506,8 +512,6 @@ class TestEventQueueBackpressure:
     ) -> None:
         """Logging throttled to every _DROP_LOG_INTERVAL drops so a
         saturated queue doesn't spam the log."""
-        from watcher.queue import _DROP_LOG_INTERVAL
-
         queue = EventQueue(max_size=1)
         queue.enqueue(self._make_event(tmp_path, name="seed.txt"))
         with caplog.at_level("WARNING", logger="watcher.queue"):

--- a/tests/watcher/test_queue.py
+++ b/tests/watcher/test_queue.py
@@ -396,3 +396,126 @@ class TestEventQueueEdgeCases:
         assert str(EventType.CREATED) == "EventType.CREATED" or "created" in EventType.CREATED
         assert EventType.MODIFIED.value == "modified"
         assert isinstance(EventType.DELETED, str)
+
+
+# ---------------------------------------------------------------------------
+# F1 hardening — backpressure + dropped-event metric
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestEventQueueBackpressure:
+    """F1 (hardening roadmap #159): overflow is no longer silent.
+
+    Pre-F1 the queue used ``deque(maxlen=...)`` which silently dropped
+    the oldest event. Consumers had no way to know overflow had
+    happened. These tests pin the new surface:
+
+    - ``dropped_count`` is a non-decreasing counter observable by callers
+    - ``is_full`` lets producers apply their own backpressure
+    - ``max_size`` is exposed so callers can reason about capacity
+    - Overflow still drops the oldest event (policy preserved for
+      backward compat with ``test_max_size_capacity``)
+    - A warning is logged at throttled intervals on sustained overflow
+    """
+
+    def _make_event(self, tmp_path: Path, name: str = "test.txt") -> FileEvent:
+        return FileEvent(
+            event_type=EventType.CREATED,
+            path=tmp_path / name,
+            timestamp=datetime.now(UTC),
+        )
+
+    def test_dropped_count_starts_at_zero(self) -> None:
+        """A freshly constructed queue has recorded no drops."""
+        assert EventQueue(max_size=10).dropped_count == 0
+        assert EventQueue().dropped_count == 0  # unbounded also reports zero
+
+    def test_dropped_count_increments_on_overflow(self, tmp_path: Path) -> None:
+        """Each enqueue past capacity bumps the counter by exactly one."""
+        queue = EventQueue(max_size=2)
+        for i in range(5):
+            queue.enqueue(self._make_event(tmp_path, name=f"f{i}.txt"))
+        # 5 enqueues on a 2-slot queue → 3 drops.
+        assert queue.dropped_count == 3
+        assert queue.size == 2
+
+    def test_dropped_count_stays_stable_when_not_full(self, tmp_path: Path) -> None:
+        """Enqueuing below capacity does not increment the drop counter."""
+        queue = EventQueue(max_size=10)
+        for i in range(5):
+            queue.enqueue(self._make_event(tmp_path, name=f"f{i}.txt"))
+        assert queue.dropped_count == 0
+
+    def test_unbounded_queue_never_drops(self, tmp_path: Path) -> None:
+        """``max_size=0`` means unbounded; no overflow path ever fires."""
+        queue = EventQueue()  # unbounded default
+        for i in range(1000):
+            queue.enqueue(self._make_event(tmp_path, name=f"f{i}.txt"))
+        assert queue.dropped_count == 0
+        assert queue.size == 1000
+
+    def test_is_full_reflects_capacity(self, tmp_path: Path) -> None:
+        queue = EventQueue(max_size=2)
+        assert queue.is_full is False
+        queue.enqueue(self._make_event(tmp_path, name="a.txt"))
+        assert queue.is_full is False
+        queue.enqueue(self._make_event(tmp_path, name="b.txt"))
+        assert queue.is_full is True
+        # Drop-oldest keeps the queue at capacity — still full.
+        queue.enqueue(self._make_event(tmp_path, name="c.txt"))
+        assert queue.is_full is True
+        # Consuming one event leaves a slot free.
+        queue.dequeue_batch(max_size=1)
+        assert queue.is_full is False
+
+    def test_is_full_always_false_for_unbounded(self, tmp_path: Path) -> None:
+        queue = EventQueue()  # max_size=0
+        for i in range(100):
+            queue.enqueue(self._make_event(tmp_path, name=f"f{i}.txt"))
+        assert queue.is_full is False
+
+    def test_max_size_property_exposes_constructor_value(self) -> None:
+        assert EventQueue(max_size=42).max_size == 42
+        assert EventQueue(max_size=0).max_size == 0
+        assert EventQueue().max_size == 0
+
+    def test_overflow_drops_oldest_not_newest(self, tmp_path: Path) -> None:
+        """Behaviour preserved from pre-F1: the drop-oldest policy."""
+        queue = EventQueue(max_size=3)
+        for i in range(5):
+            queue.enqueue(self._make_event(tmp_path, name=f"f{i}.txt"))
+        batch = queue.dequeue_batch(max_size=10)
+        assert [e.path.name for e in batch] == ["f2.txt", "f3.txt", "f4.txt"]
+
+    def test_first_drop_emits_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The very first drop produces a warning (no silent overflow)."""
+        queue = EventQueue(max_size=1)
+        queue.enqueue(self._make_event(tmp_path, name="a.txt"))
+        with caplog.at_level("WARNING", logger="watcher.queue"):
+            queue.enqueue(self._make_event(tmp_path, name="b.txt"))
+        assert any(
+            "overflow" in rec.message.lower() and "total_dropped=1" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_sustained_drops_are_throttled(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Logging throttled to every _DROP_LOG_INTERVAL drops so a
+        saturated queue doesn't spam the log."""
+        from watcher.queue import _DROP_LOG_INTERVAL
+
+        queue = EventQueue(max_size=1)
+        queue.enqueue(self._make_event(tmp_path, name="seed.txt"))
+        with caplog.at_level("WARNING", logger="watcher.queue"):
+            # Cause exactly _DROP_LOG_INTERVAL drops after the seed.
+            for i in range(_DROP_LOG_INTERVAL):
+                queue.enqueue(self._make_event(tmp_path, name=f"f{i}.txt"))
+        # Expect exactly two warnings: the first-drop signal + the
+        # ``_DROP_LOG_INTERVAL``th drop.
+        overflow_warnings = [r for r in caplog.records if "overflow" in r.message.lower()]
+        assert len(overflow_warnings) == 2
+        assert queue.dropped_count == _DROP_LOG_INTERVAL


### PR DESCRIPTION
## Summary

Epic F.lifecycle F1 (hardening roadmap #159). Before F1, \`EventQueue\` used \`deque(maxlen=...)\` which silently dropped the oldest event on overflow. Consumers had no way to know overflow had happened, producers had no way to apply backpressure, and sustained saturation was invisible in logs.

## Changes

| Surface | Behaviour |
|---|---|
| \`dropped_count\` (new property) | Non-decreasing counter of events lost to overflow since construction. |
| \`is_full\` (new property) | Lets producers apply their own backpressure (coalesce, skip debouncing, etc.) before enqueue. \`False\` for unbounded queues. |
| \`max_size\` (new property) | Exposes the configured capacity. |
| Throttled overflow warning | First drop logs; subsequent drops log every \`_DROP_LOG_INTERVAL=100\`. Prevents spam while guaranteeing first-drop visibility. |
| Drop-oldest policy | **Preserved** for backward compat — \`test_max_size_capacity\` and all pre-F1 tests pass unchanged. |

## Tests

- **9 new unit tests** in \`tests/watcher/test_queue.py::TestEventQueueBackpressure\` covering counter behaviour, \`is_full\` semantics (bounded + unbounded), drop-oldest preservation, first-drop log emission, and throttled log spacing at \`_DROP_LOG_INTERVAL\`.
- **4 new integration tests** in \`tests/integration/test_watcher_components.py::TestEventQueueBackpressure\` exercising the same surface under the \`integration\` marker so the new code is inside the integration coverage envelope.

All 40 queue tests + 188 wider watcher tests pass. 7042 integration tests pass overall.

## Integration coverage (measured locally with the now-correct \`measure-integration-coverage.sh\`)

| Module | Before | After | Floor |
|---|---|---|---|
| \`src/watcher/queue.py\` | 100% | 100% | 99.5% |

(Pre-existing environmental drifts on \`memory_profiler\` / \`image_dedup\` are unchanged and pass on CI at 82%/88%.)

## Follow-ups (F2–F4, separate PRs)

- **F2** Daemon PID-reuse race — lock file or inode/ctime validation (\`src/daemon/pid.py:100-122\`)
- **F3** Debounce-dict TTL eviction to cap memory growth (\`src/watcher/handler.py:56-57,167-190\`)
- **F4** Signal-pipe overflow — log OSError, pre-drain in run loop (\`src/daemon/service.py:397-401\`)

## Test plan

- [x] \`pytest tests/watcher/\` — 188 pass (queue + handler + monitor)
- [x] \`bash .claude/scripts/measure-integration-coverage.sh\` — queue.py at 100%, floor gate clears
- [x] \`bash .claude/scripts/pre-commit-validation.sh\` — all gates pass (first F-epic PR to use branch-diff logic from #192)
- [x] ruff check + ruff format clean

⚠️ **Do not auto-merge.** Wait for reviewer signoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added queue saturation tracking through `is_full`, `dropped_count`, and `max_size` properties
  * Implemented throttled warning logs for dropped events

* **Bug Fixes**
  * Queue now explicitly tracks and logs dropped events instead of silent discarding

* **Tests**
  * Added comprehensive test coverage for queue overflow behavior and saturation handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->