### PR TITLE
fix(daemon/pid): reject non-finite create_time (NaN/Inf bypass F2)

### DIFF
--- a/src/daemon/pid.py
+++ b/src/daemon/pid.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import tempfile
 from dataclasses import dataclass
@@ -352,7 +353,24 @@ class PidFileManager:
                     raise TypeError(f"pid field must be int, got {type(raw_pid).__name__}")
                 pid = raw_pid
                 ct_raw = data.get("create_time")
-                create_time = float(ct_raw) if ct_raw is not None else None
+                if ct_raw is None:
+                    create_time: float | None = None
+                else:
+                    # Codex P2: reject non-finite ``create_time`` values
+                    # (NaN, +Inf, -Inf). ``float("nan")`` parses cleanly
+                    # from JSON strings like ``"nan"`` or from a
+                    # malformed numeric literal, but propagating NaN
+                    # into ``is_running`` silently defeats the F2
+                    # recycling check: ``abs(actual - NaN) > tolerance``
+                    # is ALWAYS False (any comparison with NaN is
+                    # False), so a recycled PID would be reported as
+                    # the original daemon. Inf makes the subtraction
+                    # overflow and the comparison either always True
+                    # (False-positive recycling mismatch) or NaN again.
+                    # Treat any non-finite value as corrupt.
+                    create_time = float(ct_raw)
+                    if not math.isfinite(create_time):
+                        raise ValueError(f"create_time must be finite, got {create_time!r}")
                 return PidRecord(pid=pid, create_time=create_time)
         except (json.JSONDecodeError, ValueError, TypeError) as exc:
             # Distinguish "valid JSON with malformed pid field" from

--- a/tests/daemon/test_pid.py
+++ b/tests/daemon/test_pid.py
@@ -270,6 +270,52 @@ class TestPidRecord:
         pid_file.write_text(json.dumps({"pid": "12345", "create_time": 1.0}))
         assert pid_manager.read_pid_record(pid_file) is None
 
+    def test_read_pid_record_rejects_nan_create_time(
+        self, pid_manager: PidFileManager, pid_file: Path
+    ) -> None:
+        """Codex P2: ``create_time = NaN`` silently defeats the F2
+        recycling check because ``abs(actual - NaN) > tolerance`` is
+        always False. Must be treated as corrupt.
+
+        JSON doesn't natively have NaN — some encoders emit the string
+        ``"nan"`` (e.g. numpy serializers, ad-hoc writers). We test by
+        writing the raw JSON fragment ``NaN`` (Python's json.loads
+        accepts it permissively by default).
+        """
+        # json.loads accepts ``NaN`` as a non-standard extension.
+        pid_file.write_text('{"pid": 12345, "create_time": NaN}')
+        assert pid_manager.read_pid_record(pid_file) is None
+
+    def test_read_pid_record_rejects_positive_infinity_create_time(
+        self, pid_manager: PidFileManager, pid_file: Path
+    ) -> None:
+        """Infinity is as corrupt as NaN for our purposes — arithmetic
+        with Inf gives Inf (comparison always True → False-positive
+        recycling) or NaN again. Reject."""
+        pid_file.write_text('{"pid": 12345, "create_time": Infinity}')
+        assert pid_manager.read_pid_record(pid_file) is None
+
+    def test_read_pid_record_rejects_negative_infinity_create_time(
+        self, pid_manager: PidFileManager, pid_file: Path
+    ) -> None:
+        """Negative infinity — same reasoning as +Inf."""
+        pid_file.write_text('{"pid": 12345, "create_time": -Infinity}')
+        assert pid_manager.read_pid_record(pid_file) is None
+
+    def test_is_running_nan_create_time_does_not_bypass_recycling_check(
+        self, pid_manager: PidFileManager, pid_file: Path
+    ) -> None:
+        """End-to-end proof of the bug codex flagged: a crafted PID
+        file with NaN create_time pointing at a live process (us) must
+        NOT be reported as running. Before the fix, ``is_running``
+        would return True because the NaN comparison always evaluates
+        False, masking the recycling check.
+        """
+        pid_file.write_text(f'{{"pid": {os.getpid()}, "create_time": NaN}}')
+        # read_pid_record returns None for NaN → is_running returns
+        # False (no record to validate).
+        assert pid_manager.is_running(pid_file) is False
+
     def test_is_running_detects_pid_recycling(
         self, pid_manager: PidFileManager, pid_file: Path
     ) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #195 — codex flagged a post-merge P2: `create_time = NaN` (and `±Inf`) silently bypasses the F2 PID-reuse recycling check.

## Root cause

`read_pid_record` accepted any `create_time` that `float()` could coerce. `float(\"nan\")` and `json.loads('NaN')` both succeed. The resulting NaN reached `is_running`:

\`\`\`python
if abs(actual_create_time - record.create_time) > _CREATE_TIME_TOLERANCE_S:
    return False
\`\`\`

Every comparison involving NaN evaluates False. So `abs(actual - NaN) > tolerance` is always False → the function returns True, reporting a recycled PID as the original daemon. Exactly the failure mode F2 was introduced to prevent.

## Fix

After `float(ct_raw)`, `math.isfinite(create_time)` — raise `ValueError` on non-finite values. The existing `except (json.JSONDecodeError, ValueError, TypeError)` catches it and returns None (corrupt), same path as malformed pid fields added in #195.

## Test plan

Four new tests in `TestPidRecord`:
- [x] `test_read_pid_record_rejects_nan_create_time` — `{\"pid\": 12345, \"create_time\": NaN}` → None
- [x] `test_read_pid_record_rejects_positive_infinity_create_time`
- [x] `test_read_pid_record_rejects_negative_infinity_create_time`
- [x] `test_is_running_nan_create_time_does_not_bypass_recycling_check` — end-to-end: crafted NaN record pointing at the current process (PID live) must report is_running=False (pre-fix it returned True)

Local `pytest tests/daemon/test_pid.py -q`: 40 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)