### PR TITLE
F7.1: durable_move journal protocol — v2 schema + recovery operator visibility

### DIFF
--- a/docs/internal/F7-1-journal-protocol-design.md
+++ b/docs/internal/F7-1-journal-protocol-design.md
@@ -1,0 +1,767 @@
+# F7.1 Journal Protocol — Design Spec
+
+Tracks: issue #201 (follow-up to PR #197).
+Supersedes: `docs/internal/F7-8-crash-recovery-model.md` §6 non-goals.
+
+## 1. Goal
+
+Lift the durable-move journal from "ad-hoc file the helper happens to write" to a
+first-class protocol surface. Close the five gaps PR #197 review exposed:
+
+1. Collapse-key conflation — mixed-op same-path entries mask each other.
+2. Parse-time AttributeError on non-object JSON values.
+3. Live-journal rewrite (sweep truncate+write) loses retained entries on crash.
+4. STARTED state is ambiguous without content comparison (PR #197 retained-forever workaround).
+5. Dir-move is coordination-only with no operator-visible recovery path.
+
+Non-goals from #201:
+
+- Trash GC deletion API (owned by #202).
+- Non-undo `shutil.move` sites in roadmap inventory.
+- DB / config changes except shared test helpers.
+
+---
+
+## 2. Journal schema — v2
+
+Superset of v1 (op=move/dir_move, src, dst, state). Additions marked `NEW`.
+
+| Field | Type | Required | v1 | Purpose |
+|---|---|---|---|---|
+| `schema` | `int` | yes (v2) | NEW | Journal-record schema version. `2` for this spec; readers accept `1` and up-convert. |
+| `op` | `str` | yes | ✓ | Operation type — `move`, `dir_move`; future ops share the journal. |
+| `op_id` | `str \| None` | optional | NEW | Unique per-operation UUID (v2 writers). v1 records have `None` here; see §3.1 collapse rules. |
+| `src` | `str` | yes | ✓ | Absolute normalized source path. |
+| `dst` | `str` | yes | ✓ | Absolute normalized destination path. |
+| `state` | `str` | yes | ✓ | One of `started`, `copied`, `done`. (`copied` only used by `op=move`.) |
+| `tmp_path` | `str` | yes for `op=move` EXDEV started; else no | NEW | Absolute path of the tmp file/symlink used by the EXDEV path — required to exist on disk from before the started-write until consumed by `os.replace`. Letters sweep disambiguate STARTED via `lexists(tmp_path)`. |
+| `ts` | `float` | no | NEW | Epoch seconds of the write. Operator diagnostics only. |
+| `host_pid` | `int` | no | NEW | Writer process PID. **Diagnostic only — never use for liveness checks** (PID reuse makes that unreliable per F2). |
+| `_raw` | (internal) | — | — | Python-side only (not serialized). Unknown-op entries retain their full raw JSON line here so compaction can re-serialize them verbatim — a future binary's handler receives all fields a v1/v2 binary might drop. |
+
+### Back-compat
+
+Readers MUST accept v1 records (missing `schema` field implies v1). `op_id` is
+**optional** — v1 records lack it, and the collapse-key reducer handles both
+cases (§3.1). v1 `op=move started` records lack `tmp_path` and so cannot be
+disambiguated by the new protocol; they retain PR #197 behavior: operator-
+visible retain with warning (see §5.1 "v1 `started`" row).
+
+Writers in this branch produce v2 exclusively. Compaction re-serializes v1
+retained records as v1 (no synthetic `op_id` injection) so their identity stays
+stable across sweeps. Unknown-op entries (any `op` not in `_KNOWN_OPS`) are
+re-serialized verbatim from their captured `_raw` line so forward-compat metadata
+is preserved.
+
+---
+
+## 3. Operation identity and collapse keying
+
+### 3.1 Collapse key
+
+All latest-state reducers (sweep `_reconcile_entries`, `is_path_in_flight`)
+collapse by an operation identity derived from the entry. The rules, in order:
+
+1. **v2 known-op record WITH `op_id`**: identity is `("v2", op, op_id)`.
+   Uniquely identifies one invocation; different retries of the same move do
+   not collapse.
+2. **v1 known-op record** (`schema` absent): identity is `("v1", op, src, dst)`.
+   Path-keyed fallback matching PR #197 behavior.
+3. **v2 known-op record WITHOUT `op_id`**: **malformed.** Parse-time rejection
+   per §4.1 — logged at WARNING and dropped. v2 writers in this branch always
+   emit `op_id`; a known-op v2 record missing it is either corrupt or came from
+   a misconfigured external writer, and treating it as v1 identity would
+   silently collapse invocations that should stay distinct. Safer to drop.
+4. **Unknown-op record** (op not in `_KNOWN_OPS`): identity is
+   `("unknown", op, _hash16(_raw))` where `_hash16` is the first 16 hex chars
+   of `sha256(_raw.encode()).hexdigest()` — derived from the full raw line. Rationale: a future op's correctness may
+   depend on fields our parser doesn't know about. Collapsing two unknown-op
+   records by `(op, src, dst)` alone could conflate invocations that a future
+   binary's handler would distinguish via its own fields. Hashing the raw line
+   guarantees different serialized payloads stay distinct; compaction
+   re-serializes them verbatim from `_raw` (§4.2).
+
+```python
+def _identity(entry: _JournalEntry) -> tuple:
+    if entry.op in _KNOWN_OPS:
+        if entry.schema == 2:
+            # v2 writers ALWAYS emit op_id; see parse rule §4.1 rejection #8.
+            assert entry.op_id is not None, "invariant: v2 known-op has op_id"
+            return ("v2", entry.op, entry.op_id)
+        # v1: path-keyed fallback for PR #197 back-compat.
+        return ("v1", entry.op, entry.src, entry.dst)
+    # Unknown op: raw-line hash so different payloads never collapse.
+    assert entry._raw is not None, "invariant: unknown-op records retain _raw"
+    return ("unknown", entry.op, _hash16(entry._raw))
+```
+
+This closes codex `iy4u` (same-path different-op masking) AND adds
+retry-identity for v2 records AND prevents future unknown ops from silently
+collapsing with each other via a v2 parser that doesn't understand their
+additional fields.
+
+### 3.2 Progression rule
+
+Within a single `op_id`, states progress monotonically: `started` → `copied`
+(op=move only) → `done`. `_reconcile_entries` uses the last state per identity. A
+later `done` supersedes an earlier `started`/`copied` of the same op_id.
+
+### 3.3 Mixed-op example
+
+Journal:
+
+```jsonl
+{"schema": 2, "op": "move",     "op_id": "A", "src": "/a", "dst": "/b", "state": "started"}
+{"schema": 2, "op": "dir_move", "op_id": "B", "src": "/a", "dst": "/b", "state": "started"}
+{"schema": 2, "op": "dir_move", "op_id": "B", "src": "/a", "dst": "/b", "state": "done"}
+```
+
+Post-reconcile: two identities — `(move, A, /a, /b)` retained for sweep, `(dir_move,
+B, /a, /b)` dropped. Pre-fix (PR #197), the second and third rows would have
+overwritten the first, dropping the `move` recovery metadata.
+
+---
+
+## 4. Parse contract
+
+`_parse_journal_text` and `_read_journal` MUST accept one JSONL line per record and
+for each line produce exactly one of: valid entry, logged-and-skipped malformed
+entry. No input (inside a total journal size cap — see §6.5) may cause the parser
+to raise.
+
+### 4.1 Rejection cases (logged + skipped)
+
+1. JSON parse error (v1 + v2).
+2. `json.loads` returns non-object (`null`, `[]`, scalars, strings). **codex iy4w**
+3. Missing required field (op, src, dst, state).
+4. Non-string value in a required-string field.
+5. `op` not in `_KNOWN_OPS` AND `schema` is v1 — v1 records are expected to be
+   `op=move`; anything else on a v1 record is garbage. v2 unknown ops are NOT
+   rejected; they're retained with raw-payload preservation (§4.2, §5.1).
+6. `schema` present but not a positive int.
+7. Line > 64 KiB (prevents pathological payload abuse).
+8. **v2 known-op record WITHOUT `op_id`.** v2 writers in this branch always
+   emit `op_id` per §3.1. A known-op v2 record missing it is either corrupt
+   or came from a misconfigured external writer; treating it as v1 identity
+   would silently collapse invocations that should stay distinct. Rejection
+   keeps the identity rule honest.
+9. **v2 `op=move` `state=started` record WITHOUT `tmp_path`.** The tmp-exists
+   invariant (§7.1) requires `tmp_path` on every v2 `move started` record —
+   without it sweep cannot safely disambiguate pre-replace vs post-replace
+   crashes. Writers emit `tmp_path` unconditionally for this combination;
+   rejection prevents a corrupt/external record from tricking sweep into
+   unlink-src data loss.
+
+Rejected lines are logged at WARNING with the offending line truncated to 200
+chars. Sweep continues to the next line.
+
+### 4.2 Unknown future fields
+
+For **known ops** (`move`, `dir_move`): extra JSON fields are ignored — the
+parser returns a `_JournalEntry` populated from the known-v2 attribute set only.
+Those ops have stable schemas defined here; extras are genuinely unknown noise.
+
+For **unknown ops** (anything not in `_KNOWN_OPS`): the parser preserves the full
+raw JSON line on the `_JournalEntry._raw` attribute. Compaction writes these
+entries back verbatim using `_raw`, so a future binary with a handler for the
+op receives ALL fields the v1/v2 writer persisted — NOT just the
+`(op, src, dst, state)` core that v2's parser happens to recognize. This fixes
+a scope creep the original spec missed: dropping extras would silently destroy
+metadata the future handler may need.
+
+---
+
+## 5. Sweep / reconciliation
+
+### 5.1 Recovery state table (v2)
+
+`lexists_*` columns are `src`, `dst`, `tmp` file-system presence. `—` means
+irrelevant to the action.
+
+**Invariant underpinning the disambiguation** (see §7): for every v2 `op=move`
+`started` record, `tmp_path` is created on disk **before** the started entry is
+written, and no code path removes `tmp_path` on failure — only `os.replace` or
+sweep touches it afterward. Therefore `lexists(tmp_path) == False` for a v2
+`move started` record is a **positive signal** that `os.replace` ran and
+consumed the tmp. Without this invariant the table's "tmp absent → post-replace"
+rows would be unsafe (the blocking concern raised in review).
+
+| op | state | schema | lexists(tmp) | lexists(dst) | lexists(src) | Action | Rationale |
+|---|---|---|---|---|---|---|---|
+| `move` | `started` | v2 | true | — | — | Delete tmp → drop entry | tmp still present ⇒ pre-`os.replace` crash; dst untouched by our txn. |
+| `move` | `started` | v2 | false | true | true | Unlink src → fsync(src.parent) → drop | tmp consumed by `os.replace` + pre-`copied`-log crash; finish as copied. |
+| `move` | `started` | v2 | false | true | false | Drop | Post-unlink pre-`done` crash; already consistent. |
+| `move` | `started` | v2 | false | false | true | Retain + warn | Unusual — `os.replace` ran but dst has since been removed out-of-band. Operator inspection: unlink src would destroy the only remaining copy. |
+| `move` | `started` | v2 | false | false | false | Drop + warn | Catastrophic (dst consumed + out-of-band deleted + src gone). No safe action. |
+| `move` | `started` | v1 | — | — | — | Retain + warn | v1 records lack `tmp_path`; cannot disambiguate. Matches PR #197 behavior. |
+| `move` | `copied` | any | — | true | true | Unlink src → fsync → drop | Existing PR #197 behavior. |
+| `move` | `copied` | any | — | true | false | Drop | Existing PR #197 behavior. |
+| `move` | `copied` | any | — | false | — | Retain + warn | Existing codex hGWW guard. |
+| `move` | `done` | any | — | — | — | Drop | Already reconciled. |
+| `move` | unknown state | any | — | — | — | Retain + warn | Known op but unrecognized state value — preserve for a future binary that may understand it. |
+| `dir_move` | `done` | any | — | — | — | Drop | Coordination complete. |
+| `dir_move` | `started` | any | — | — | — | Drop + warn | shutil.move crash; operator must inspect on-disk state. |
+| `dir_move` | unknown state | any | — | — | — | Retain + warn | Same reasoning as `move` unknown state. |
+| unknown `op` | any | any | — | — | — | Retain + warn | codex hdFb — future binary's handler will process. Entry re-serialized verbatim from `_raw` on compaction (§4.2). |
+
+**Key win**: rows 1–5 replace PR #197's unconditional "retain STARTED as ambiguous"
+with deterministic recovery in 4 of the 5 concrete sub-cases, provided the §7
+writer protocol holds tmp_path existence as an invariant. Only the unusual
+dst-absent+src-present case remains retain-only, flagged with an operator-actionable
+warning.
+
+**Safety fallback**: if `tmp_path` is missing from a v2 `move started` record for
+any reason (bug, corruption), sweep treats it as a v1 record (retain + warn)
+rather than applying the "tmp absent → post-replace" inference. The disambiguation
+rule is gated on *both* `schema == 2` AND `tmp_path is not None`.
+
+### 5.2 Tmp cleanup
+
+When row 1 applies (tmp exists), sweep unlinks tmp AFTER determining recovery
+action but BEFORE dropping the entry. Unlink failures are logged + entry retained
+(same pattern as existing copied-state OSError-retain).
+
+### 5.3 Dir_move semantics (decision)
+
+**Decision: keep `dir_move` coordination-only.** True durable directory recovery
+is out of F7.1 scope — it would require a staged copy + atomic swap of arbitrary
+directory trees, which is a substantially larger design. The issue body lists this
+as an explicit decision point; this spec makes the call.
+
+Consequence: `dir_move started` entries on sweep are dropped with an operator
+warning (§5.1 row 11). Operator visibility (§8) surfaces the warning history so
+partially-moved directories are discoverable.
+
+### 5.4 Unknown-op retention
+
+Preserves codex hdFb behavior. Future binaries that know the op resolve the
+entry when their sweep runs. No change from PR #197.
+
+---
+
+## 6. Atomic journal compaction + lock-file coordination
+
+Two blocking correctness issues flagged in the round-1 design review:
+
+1. PR #197 sweep uses `fh.truncate()` + `fh.write(...)` on the LIVE journal while
+   holding `LOCK_EX`. A crash between truncate and write-complete leaves the
+   journal truncated to zero, destroying all retained entries (CodeRabbit round-10).
+2. If the journal itself is the lock subject AND compaction `os.replace`s it with
+   a new inode, a concurrent appender that opened the OLD inode before the
+   replace blocks on the old inode's lock, then after sweep releases, appends to
+   the UNLINKED old inode. **Lost append.** (Round-1 review, blocking.)
+
+The fix for both: **separate lock file + atomic journal compaction**.
+
+### 6.1 Lock file
+
+A sibling `<journal>.lock` is the coordination subject for all protocol
+operations. It is:
+
+- Created (if absent) by any reader or writer on first access.
+- **Never replaced or unlinked** during normal operation — stays at a stable inode
+  for the lifetime of the state directory.
+- Empty (zero bytes); the file itself carries no data. Only its inode exists as
+  a `fcntl.flock` target.
+- Located alongside the journal (same directory) so one lock covers both the
+  journal file and any compaction tmp.
+
+All `fcntl.flock` calls (append, sweep, `is_path_in_flight`) take locks on
+`<journal>.lock` — not on `<journal>`. `os.replace` on the journal therefore
+cannot invalidate a held lock.
+
+### 6.2 Compaction algorithm
+
+1. Open `<journal>.lock` (creating if absent) → acquire `LOCK_EX` on its fd.
+2. Open `<journal>` for reading; parse + reconcile → `retained: list[_JournalEntry]`.
+3. If `retained == []` and the on-disk journal is already empty: release lock,
+   return (no write needed).
+4. Write retained entries to `<journal>.<pid>.compact.tmp` in the same directory,
+   via `open("x")` (fail if it already exists).
+5. `write + flush + fsync(tmp_fd)`.
+6. `fsync_directory(<journal>.parent)` — make the tmp's dir entry durable.
+7. `os.replace(tmp, <journal>)` — atomic inode swap for the journal file.
+8. `fsync_directory(<journal>.parent)` — make the replace durable.
+9. Release `LOCK_EX` (close lock fd's flock, leave the lock file on disk).
+
+Because `<journal>.lock` is never replaced, step 7's inode swap doesn't
+invalidate any flock held by appenders waiting on the same lock file.
+
+### 6.3 Crash window analysis
+
+| Crash at step | On-disk state | Recovery |
+|---|---|---|
+| 1–3 | Journal unchanged | Next sweep re-reconciles; idempotent. |
+| 4 mid-write | Stale compact tmp; journal intact | Next sweep's step 4 sees `FileExistsError` via `open("x")` → stale-tmp handler (§6.4) removes + retries once. |
+| 5 mid-fsync | Stale compact tmp; journal intact | Same recovery as 4. |
+| 6 before replace | Stale compact tmp; journal intact | Same recovery as 4. |
+| 7 mid-replace | Atomic: either journal = old content, or = tmp content | Either state is consistent; next sweep re-reconciles from whichever version landed. |
+| 8 before fsync_directory | Replace landed in page cache but not directory entry | On reboot, journal may revert to old; next sweep re-reconciles (idempotent). |
+| After 8 | Compacted | Done. |
+
+No state leaves the journal as `zero-bytes + retained-entries-pending`. No
+window allows an appender to write to an unlinked inode.
+
+### 6.4 Stale compact-tmp cleanup
+
+Step 4's `open("x", ...)` raises `FileExistsError` if a prior crashed sweep
+left a tmp. Handler: log warning, unlink the stale tmp, retry step 4 **once**.
+Not a loop — two `FileExistsError`s in a row indicates a pathology (e.g.
+permissions) that sweep shouldn't paper over.
+
+### 6.5 Lock invariants
+
+- All protocol operations acquire their lock on `<journal>.lock`, NOT on
+  `<journal>`. The journal file may be replaced; the lock file is stable.
+- `_append_journal` (POSIX) takes `LOCK_EX` on `<journal>.lock` for each append.
+- Sweep / compaction takes `LOCK_EX` for steps 1–9.
+- `is_path_in_flight` takes `LOCK_SH` on `<journal>.lock` — which blocks any
+  `LOCK_EX` holder (writer or compaction) from progressing, AND blocks the
+  reader while any `LOCK_EX` is held. This is the intended F8 semantics: readers
+  never observe a journal state mid-append or mid-compaction.
+
+POSIX flock semantics confirm this: `LOCK_SH` is granted only when no `LOCK_EX`
+is held, and `LOCK_EX` requires no other lock (shared or exclusive) to be held.
+So shared readers and exclusive writers cannot be simultaneously active on the
+same lock file. Corrects the §6.4 wording in the v1 draft ("reads block during
+compaction but not during appends" was wrong — reads also block during appends,
+which is desirable).
+
+### 6.6 Size cap
+
+Journals >16 MiB trigger a WARNING log and compaction skips to avoid unbounded
+memory + write amplification. The size cap is belt-and-suspenders: steady state,
+the journal is bounded by the number of concurrently in-flight moves (currently
+≤1 per CLI invocation).
+
+---
+
+## 7. STARTED disambiguation via `tmp_path`
+
+PR #197's retain-as-ambiguous behavior for `move started` is the direct consequence
+of sweep not knowing whether `os.replace` had completed. v2 adds `tmp_path` to
+`started` records; sweep then distinguishes:
+
+- `lexists(tmp_path) == True` — pre-replace crash (tmp is orphan).
+- `lexists(tmp_path) == False` — post-replace crash (replace has run, tmp consumed).
+
+**This disambiguation is only safe if tmp is guaranteed to exist on disk between
+the started journal write and the `os.replace` consumption.** Otherwise a crash
+window where tmp hasn't been created yet (but the journal has been written)
+would be misread as post-replace and sweep would unlink src incorrectly. Round-1
+review flagged this as a blocking issue.
+
+### 7.1 The tmp-exists invariant
+
+For every v2 `op=move` `started` journal record, the following invariant MUST
+hold:
+
+> From the moment the `started` record is durable on disk, `tmp_path` exists on
+> disk **and its directory entry is durable**, and remains that way until
+> either `os.replace` atomically consumes it (swap to dst) OR sweep deletes it
+> during recovery.
+
+The durability qualifier is critical. If `tmp_path` exists only in the page
+cache but its directory entry hasn't been flushed, a power-loss crash on the
+write path ("create tmp → journal append+fsync → crash before dir fsync")
+leaves the journal record on disk while the tmp file vanishes on reboot. Sweep
+would then observe `lexists(tmp_path) == False` and misread as "post-replace
+completed" → unlink src → data loss.
+
+Three rules enforce the invariant:
+
+1. **tmp is created BEFORE the `started` journal write.** For both regular
+   files (`NamedTemporaryFile(delete=False)` creates + closes an empty file)
+   and symlinks (`os.symlink(target, tmp)` is a single atomic syscall), the
+   writer calls the tmp-creating operation first, then journals `started`.
+   A crash between the two leaves an orphan tmp with no journal entry — that's
+   operator debris, not a sweep concern.
+2. **`fsync_directory(<dst.parent>)` runs between tmp creation and the
+   `started` journal write.** Makes the tmp's directory entry durable so a
+   later reboot cannot lose tmp while retaining the started record. Without
+   this fsync the §5.1 "tmp absent → post-replace inference" is unsafe under
+   power loss — the blocking concern raised in round-2 review.
+3. **No code path removes tmp on exception.** Specifically, the current
+   `_durable_cross_device_move` `except BaseException: tmp_path.unlink()`
+   handler is **removed**. Exceptions propagate unchanged; tmp persists for
+   sweep to handle. Callers that retry get a new `tmp_path` (uniquely
+   suffixed); the orphan tmp from the failed attempt is cleaned by the next
+   sweep.
+
+### 7.2 Updated writer sequence (EXDEV, regular file)
+
+1. Allocate + **create** empty tmp via `NamedTemporaryFile(delete=False)`.
+2. **`fsync_directory(<dst.parent>)`** — make the tmp file's directory entry
+   durable before the journal can claim tmp exists. (Round-2 blocking fix.)
+3. `_append_journal(started, op_id=<uuid>, tmp_path=<abs>)`.
+4. `shutil.copyfile(src, tmp_path)` + `shutil.copystat(src, tmp_path)`.
+5. `fsync(tmp_fd)` + `fsync_directory(<dst.parent>)`.
+6. `os.replace(tmp_path, dst)` — tmp is consumed atomically into dst.
+7. `fsync_directory(<dst.parent>)`.
+8. `_append_journal(copied, op_id=<same>)`.
+9. `os.unlink(src)`.
+10. `fsync_directory(<src.parent>)`.
+11. `_append_journal(done, op_id=<same>)`.
+
+### 7.3 Updated writer sequence (EXDEV, symlink)
+
+1. Compute `target = os.readlink(src)`.
+2. Generate `tmp_path` (PID + random suffix).
+3. `os.symlink(target, tmp_path)` — atomic, creates the symlink as tmp.
+4. **`fsync_directory(<dst.parent>)`** — make the tmp symlink's directory
+   entry durable before the journal can claim tmp exists. (Round-2 blocking
+   fix.)
+5. `_append_journal(started, op_id=<uuid>, tmp_path=<abs>)`.
+6. `os.replace(tmp_path, dst)`.
+7. `fsync_directory(<dst.parent>)`.
+8. `_append_journal(copied, op_id=<same>)`.
+9. `os.unlink(src)`.
+10. `fsync_directory(<src.parent>)`.
+11. `_append_journal(done, op_id=<same>)`.
+
+A crash between the tmp-creating syscall and the pre-started `fsync_directory`
+(steps 1–3 regular, 1–4 symlink) leaves an orphan tmp with no journal entry —
+operator debris, not sweep-visible. A crash anywhere from the `started` append
+onward leaves a v2 record where `tmp_path` exists **durably** on disk and
+sweep can disambiguate correctly.
+
+### 7.4 Exception-cleanup removal
+
+The current `except BaseException: tmp_path.unlink()` block in
+`_durable_cross_device_move` is **deleted**. Rationale: cleaning tmp on
+exception breaks the §7.1 invariant (tmp would be absent between the journal
+started write and a later sweep, indistinguishable from "post-replace
+completed"). Retries get fresh tmp paths (random suffix in regular-file case;
+PID+random in symlink case) so accumulated orphans are bounded, and sweep
+always deletes matching orphan tmps on the next run.
+
+### 7.5 Crash-point catalog
+
+Mechanically derivable from §7.2 and §7.3. The §5.1 recovery state table covers
+all boundaries.
+
+---
+
+## 8. Operator visibility
+
+Scoped down per round-1 review: this PR adds only `fo undo recover`. `fo doctor`
+integration (the command exists at `src/cli/doctor.py`) is a reasonable
+follow-up but kept out of this PR to minimize scope.
+
+### 8.1 `plan_recovery_actions` — shared pure planner
+
+Round-2 review flagged: a "report-only mode" on the sweep function risks
+accidental sharing of mutating code paths. Fix: extract a pure planner that
+both sweep and `fo undo recover` call.
+
+Signature:
+
+```python
+from dataclasses import dataclass
+from typing import Literal
+
+@dataclass(frozen=True)
+class _PlannedAction:
+    identity: tuple              # §3.1 collapse key
+    entry: _JournalEntry         # the reconciled entry
+    verb: Literal[               # sweep decision from §5.1
+        "drop",
+        "retain",
+        "drop_tmp_then_drop",    # row 1: unlink tmp, drop entry
+        "unlink_src_then_drop",  # rows 2, 7: unlink src + fsync, drop entry
+    ]
+    reason: str                  # human-readable for logs / CLI rendering
+    needs_warning: bool          # log a WARNING on retain/drop-warn rows
+
+def plan_recovery_actions(
+    entries: list[_JournalEntry],
+    fs_observer: Callable[[str], bool] = os.path.lexists,
+) -> list[_PlannedAction]: ...
+```
+
+**Pure:** no file-system mutation. `fs_observer` defaults to `os.path.lexists`
+(reads on-disk state to drive §5.1 disambiguation) but can be stubbed in tests
+to exercise every row deterministically.
+
+**Both call sites use the same function:**
+
+- `sweep()` calls `plan_recovery_actions(entries)`, then a separate
+  `_apply_planned_actions(plan, journal)` executes each action's verb under
+  `LOCK_EX`.
+- `fo undo recover` calls `plan_recovery_actions(entries)`, then renders the
+  plan as a table (no execution).
+
+Regression test runs both call sites on the same input and asserts the CLI's
+rendered plan matches the executor's observed actions row-for-row.
+
+### 8.2 `fo undo recover`
+
+CLI subcommand that:
+
+1. Reads the journal under `LOCK_SH` (on `<journal>.lock` per §6.1).
+2. Calls `plan_recovery_actions(entries)` (§8.1) — pure, no mutation.
+3. Prints a table of retained / actionable entries with `op`, `state`, `age`,
+   `src`, `dst`, and the planned verb + reason.
+4. For v2 `move started` entries the rendered reason includes the
+   disambiguation tier (pre-replace / post-replace / post-unlink / ambiguous).
+5. Exits `0` if the plan is empty, `1` if any action is planned (so scripts
+   can detect "needs cleanup").
+
+Use case: after a crash, an operator runs `fo undo recover` to see what the
+next sweep would do — no mystery WARNINGS in logs.
+
+### 8.3 Structured log fields
+
+All journal warnings/errors log with consistent keyword fields: `op`, `op_id`,
+`state`, `src`, `dst`, `tmp_path` (when applicable). Enables grep-based
+post-mortem across a crash / retry cycle.
+
+---
+
+## 9. Test plan
+
+### 9.1 Schema + parse
+
+- v1 record without `schema` field accepted.
+- v2 record round-trips through parse → entry → serialize.
+- Malformed JSON logged + skipped.
+- Non-object JSON (`null`, `[]`, `"str"`, `42`) logged + skipped — **codex iy4w**.
+- Missing required field logged + skipped.
+- Oversized line (>64 KiB) logged + skipped.
+- Unknown future field ignored.
+
+### 9.2 Collapse key
+
+- Same-path different-op records don't mask each other — **codex iy4u**.
+- Same-path same-op different op_id records treated as distinct identities.
+- Same op_id progression: started → copied → done collapses to done.
+
+### 9.3 STARTED disambiguation
+
+Tests the §5.1 table rows 1–6:
+
+- `started` with `lexists(tmp_path) = true` → tmp unlinked, entry dropped, src
+  + dst preserved (row 1).
+- `started` with `lexists(tmp_path) = false` + `lexists(dst) = true` +
+  `lexists(src) = true` → src unlinked, fsync(src.parent), entry dropped (row 2).
+- `started` with `lexists(tmp_path) = false` + `lexists(dst) = true` +
+  `lexists(src) = false` → drop (row 3).
+- `started` with `lexists(tmp_path) = false` + `lexists(dst) = false` +
+  `lexists(src) = true` → retain + operator warning (row 4).
+- `started` with all paths absent → drop + warn (row 5).
+- v1 `started` (no `tmp_path` field) → retain (PR #197 compat; row 6).
+
+**Invariant tests** (critical — these protect the round-1 + round-2 review
+fixes):
+
+- Writer creates tmp BEFORE journal started: inspect journal between start of
+  `durable_move` and first fsync — at any observation where journal contains a
+  v2 `started` record, `tmp_path` MUST exist on disk.
+- **Parent-dir fsync before started** (round-2 blocking fix): instrument the
+  writer's syscall sequence (monkeypatch `fsync_directory` + `_append_journal`
+  to append to a trace list). Assert that for the EXDEV regular-file and
+  symlink paths, the trace contains `fsync_directory(dst.parent)` at least
+  once BEFORE the `_append_journal(started, ...)` call. Without this
+  ordering the tmp-exists invariant is not crash-durable.
+- Exception-cleanup removal: monkeypatch `shutil.copyfile` to raise after
+  journal started. Assert tmp still on disk after the exception propagates.
+  Sweep then disambiguates correctly (row 1).
+- Symlink variant: same invariant test using `os.symlink`-backed tmp.
+- Safety fallback: if a v2 `started` record is written WITHOUT `tmp_path`
+  (bug/corruption), the parser rejects it per §4.1 rule 8. Direct unit test on
+  `_parse_journal_text` with a hand-crafted v2 record missing `op_id` OR
+  `tmp_path` (where required).
+
+### 9.4 Atomic compaction + lock file
+
+- Compaction replaces via compact-tmp + `os.replace`, NOT live truncate.
+- Stale compact-tmp from prior crashed sweep handled (log + retry once).
+- Crash simulation (monkeypatch `os.replace` to raise after compact-tmp write)
+  → journal retains original content, next sweep completes successfully.
+- All locks are on `<journal>.lock` (stable inode), never on `<journal>`
+  (which gets replaced). Regression test: hold `LOCK_EX` on lock file in main
+  thread, start compaction in worker, `os.replace` the journal underneath →
+  worker's lock is still valid, subsequent append lands in the new journal,
+  NOT an unlinked inode. This directly covers the round-1 review blocking case.
+- `<journal>.lock` is never unlinked during normal operation.
+- `LOCK_EX` held throughout compaction; concurrent `_append_journal` AND
+  `is_path_in_flight` both block.
+- `is_path_in_flight` with `LOCK_SH` blocks on any `LOCK_EX` (appender OR
+  compaction) — verifies the corrected §6.5 wording.
+- Journal >16 MiB triggers size-cap warning + skips compaction.
+
+### 9.5 Dir_move
+
+- `dir_move started` dropped with warning on sweep.
+- `dir_move done` dropped silently.
+- Existing directory-restore path still works end-to-end.
+
+### 9.6 Operator visibility
+
+- `fo undo recover` with empty journal → exits 0, prints "no retained entries".
+- `fo undo recover` with retained entries → exits 1, prints formatted table.
+- `fo undo recover` per-row hint matches the §5.1 disambiguation tier for the
+  on-disk observation (tmp present / tmp absent + src present / etc.).
+- `plan_recovery_actions(entries) -> list[_PlannedAction]` is pure: given
+  identical inputs it returns identical output with no file-system mutation.
+  Sweep's mutation path calls `plan_recovery_actions` then executes each
+  returned action; `fo undo recover` calls `plan_recovery_actions` and renders
+  without executing. Regression test runs both call sites on the same input
+  and asserts the CLI's rendered plan matches the planner's return value
+  verbatim — guarantees there's no "report-only mode" branch that could drift
+  from sweep's behavior.
+
+---
+
+## 10. Non-goals reiterated
+
+- Trash GC deletion API → #202.
+- True durable directory recovery → deferred; documented §5.3.
+- Non-undo shutil.move sites → separate issues per roadmap.
+
+---
+
+## 11. Implementation order (TDD)
+
+1. **Schema v2 parser + `_raw` preservation for unknown ops** + round-trip tests
+   (§4, §9.1). Closes codex `iy4w` (dict-type validation).
+2. **`plan_recovery_actions` pure planner** (§8.1). Introduced BEFORE the
+   collapse-key and writer-protocol changes so each subsequent step adds rows
+   to its coverage rather than touching sweep's mutation path. Sweep refactors
+   to call the planner + a new `_apply_planned_actions` executor; behavior
+   identical to PR #197 at this step.
+3. **Collapse-key refactor** inside the planner + tests (§3, §9.2). Closes
+   codex `iy4u`.
+4. **Lock-file extraction** (§6.1): all flock operations move from `<journal>`
+   to `<journal>.lock`. Regression test covers the round-1 review blocking
+   case (replace-under-held-lock).
+5. **Atomic compaction** via compact-tmp + `os.replace` (§6.2–6.4) + crash-window
+   tests (§9.4).
+6. **`tmp_path` field + writer-protocol change** (§7): tmp created before
+   started, `fsync_directory(<dst.parent>)` before the started journal write,
+   no exception cleanup. STARTED disambiguation tests (§9.3) including the
+   tmp-durability and invariant tests.
+7. **Dir_move decision locked in** (§5.3) + existing tests adjusted (§9.5).
+8. **`fo undo recover` CLI** + structured log fields (§8) + tests (§9.6).
+
+Each step is a self-contained commit + CI green before the next. The
+`tmp_path` / writer-protocol change (step 6) is the highest-risk step and
+goes last among protocol changes so the earlier refactors (planner, collapse-
+key, lock file, atomic compaction) land against PR #197's writer and don't
+couple refactor risk with behavior-shift risk.
+
+---
+
+## 12. Self-review (per writing-plans skill)
+
+**Spec coverage:** every item in #201's acceptance criteria is bound to a §:
+  - Protocol spec/table → §2, §5.1
+  - Op-separated recovery → §3, §9.2
+  - Malformed-line tolerance → §4
+  - Crash-safe compaction → §6
+  - Automated STARTED recovery → §7
+  - Test matrix → §9
+  - Operator visibility → §8
+
+**Placeholder scan:** no TBD/TODO; all references cite concrete helpers or commit
+SHAs.
+
+**Type consistency:** `_JournalEntry` gains `schema: int`, `op_id: str`,
+`tmp_path: str | None`, `ts: float | None`, `host_pid: int | None`. Every reducer
+and reader referenced uses these types consistently.
+
+**Ambiguity check:** §5.1 row 4 (move started with dst-absent + src-present) is
+the only residual retain case. Documented as operator-inspection with a specific
+warning message — not a hand-wave.
+
+---
+
+**Tracks:** issue #201.
+**Supersedes:** PR #197 `docs/internal/F7-F8-crash-recovery-model.md` §6 non-goals
+items (tmp_path metadata, atomic compaction, directory semantics decision).
+**Last Updated:** 2026-04-24.
+
+---
+
+## Revision history
+
+### Round 1 (initial draft) → Round 2 (current)
+
+Round-1 review flagged two blocking correctness issues and four tightening
+items. All addressed in the current revision:
+
+**Blocking fixes:**
+
+1. **Lock file** (§6.1, §6.5): all flock operations now acquire on
+   `<journal>.lock` (stable inode, never replaced). Prior draft locked
+   `<journal>` directly, which became unsafe when compaction `os.replace`'d the
+   journal — a concurrent appender that opened the old inode before replace
+   would block on the old inode's lock, then append to an unlinked file after
+   sweep released. Lost journal record.
+2. **tmp-always-exists invariant** (§7.1, §7.4): tmp is created BEFORE the
+   started journal write, and no code path removes tmp on exception. Prior
+   draft allowed "bare name" tmp allocation for symlinks and a pre-replace
+   exception cleanup, either of which could produce "tmp absent + journal says
+   started" in a pre-replace crash — sweep would then misread as post-replace
+   and unlink src (data loss).
+
+**Tightening fixes:**
+
+3. **Unknown-op raw payload preservation** (§2 schema, §4.2): unknown-op
+   entries retain the full raw JSON line via `_raw`, re-serialized verbatim on
+   compaction. Prior draft dropped extras on parse, silently destroying metadata
+   a future handler might need.
+4. **v1 compat / `op_id` optionality** (§2 schema, §3.1): `op_id` is `str | None`;
+   v1 records carry `None` and collapse-key falls back to `("v1", op, src, dst)`.
+   v1 retained records re-serialized as v1 (no synthetic op_id injection).
+   Prior draft required `op_id` which contradicted v1 back-compat.
+5. **Known-op unknown-state row** (§5.1): explicit row in the recovery state
+   table for `op ∈ _KNOWN_OPS` with an unrecognized `state` value (retain + warn).
+6. **LOCK_SH-vs-appender wording** (§6.5): corrected the prior draft's wrong
+   claim that shared-lock reads don't block during appends. POSIX flock
+   semantics block shared readers during any exclusive holder — which is the
+   intended F8 behavior anyway.
+
+**Scope adjustment:**
+
+7. **`fo doctor` integration deferred** (§8): scoped down to just `fo undo recover`.
+   The `fo doctor` command exists but integrating a journal section there is
+   kept out of this PR to minimize scope. Follow-up-ready (low risk, read-only).
+
+### Round 2 → Round 3 (current)
+
+Round-2 review flagged one new blocking correctness issue and three tightening
+items. All addressed:
+
+**Blocking fix:**
+
+8. **Parent-dir fsync before `started` journal write** (§7.1, §7.2 step 2,
+   §7.3 step 4): the tmp-exists invariant required the tmp *file* to exist
+   before journal started, but the tmp's *directory entry* was not fsynced. A
+   crash window "create tmp → journal append+fsync → crash before dir fsync"
+   could leave the durable journal while tmp vanishes on reboot, making sweep
+   misinfer post-replace and unlink src (data loss). Fix: `fsync_directory(<dst.parent>)`
+   between tmp creation and the started append, for both regular-file and
+   symlink writers. Regression test instruments the writer's syscall sequence
+   and asserts the dir-fsync-before-started ordering (§9.3 "parent-dir fsync
+   before started").
+
+**Tightening fixes:**
+
+9. **Stale `fo doctor` test removed from §9.6**: the round-2 scope adjustment
+   dropped `fo doctor` integration but left a regression test referencing it.
+   Replaced with coverage of the shared planner (§8.1) ensuring the CLI's
+   rendered plan matches sweep's executed actions row-for-row.
+10. **Sharper v2 `op_id` rules** (§3.1, §4.1 rule 8): v2 known-op records
+    missing `op_id` are now parse-time malformed (dropped with warning), not
+    silently treated as v1 identity. Unknown-op records without `op_id` use
+    raw-line hash identity (first 16 hex of `sha256(_raw)`) so compaction cannot collapse
+    semantically-distinct future records that a v2 parser doesn't understand.
+    Parse also rejects v2 `move started` records missing `tmp_path` (§4.1 rule 9)
+    so the tmp-exists invariant can't be bypassed by corrupt/external input.
+11. **Pure `plan_recovery_actions` planner** (§8.1): both sweep and
+    `fo undo recover` call the same pure planner, then either execute the plan
+    (sweep) or render it (CLI). Replaces the round-2 "report-only mode" which
+    risked a mutating-code-path drift between the two call sites. Regression
+    test asserts CLI rendering and sweep execution agree on the action plan
+    given the same input.

--- a/docs/internal/F7-1-journal-protocol-design.md
+++ b/docs/internal/F7-1-journal-protocol-design.md
@@ -444,7 +444,7 @@ all boundaries.
 
 ## 8. Operator visibility
 
-Scoped down per round-1 review: this PR adds only `fo undo recover`. `fo doctor`
+Scoped down per round-1 review: this PR adds only `fo recover`. `fo doctor`
 integration (the command exists at `src/cli/doctor.py`) is a reasonable
 follow-up but kept out of this PR to minimize scope.
 
@@ -452,7 +452,7 @@ follow-up but kept out of this PR to minimize scope.
 
 Round-2 review flagged: a "report-only mode" on the sweep function risks
 accidental sharing of mutating code paths. Fix: extract a pure planner that
-both sweep and `fo undo recover` call.
+both sweep and `fo recover` call.
 
 Signature:
 
@@ -488,27 +488,29 @@ to exercise every row deterministically.
 - `sweep()` calls `plan_recovery_actions(entries)`, then a separate
   `_apply_planned_actions(plan, journal)` executes each action's verb under
   `LOCK_EX`.
-- `fo undo recover` calls `plan_recovery_actions(entries)`, then renders the
+- `fo recover` calls `plan_recovery_actions(entries)`, then renders the
   plan as a table (no execution).
 
 Regression test runs both call sites on the same input and asserts the CLI's
 rendered plan matches the executor's observed actions row-for-row.
 
-### 8.2 `fo undo recover`
+### 8.2 `fo recover`
 
-CLI subcommand that:
+CLI command (top-level, not nested under `fo undo`, to avoid restructuring the
+existing flat `fo undo` command) that:
 
 1. Reads the journal under `LOCK_SH` (on `<journal>.lock` per §6.1).
 2. Calls `plan_recovery_actions(entries)` (§8.1) — pure, no mutation.
-3. Prints a table of retained / actionable entries with `op`, `state`, `age`,
-   `src`, `dst`, and the planned verb + reason.
+3. Prints a table of retained / actionable entries with `op`, `state`, `src`,
+   `dst`, `tmp_path` (when present), and the planned verb + reason.
 4. For v2 `move started` entries the rendered reason includes the
-   disambiguation tier (pre-replace / post-replace / post-unlink / ambiguous).
-5. Exits `0` if the plan is empty, `1` if any action is planned (so scripts
-   can detect "needs cleanup").
+   disambiguation tier (`[pre-replace]` / `[post-replace]` / `[v1-ambiguous]`).
+5. Exits `0` if the plan has no actionable entries (empty OR all-`drop`),
+   `1` if any non-`drop` action would be taken (so scripts can detect
+   "needs cleanup").
 
-Use case: after a crash, an operator runs `fo undo recover` to see what the
-next sweep would do — no mystery WARNINGS in logs.
+Use case: after a crash, an operator runs `fo recover` to see what the next
+sweep would do — no mystery WARNINGS in logs.
 
 ### 8.3 Structured log fields
 
@@ -598,14 +600,14 @@ fixes):
 
 ### 9.6 Operator visibility
 
-- `fo undo recover` with empty journal → exits 0, prints "no retained entries".
-- `fo undo recover` with retained entries → exits 1, prints formatted table.
-- `fo undo recover` per-row hint matches the §5.1 disambiguation tier for the
+- `fo recover` with empty journal → exits 0, prints "no retained entries".
+- `fo recover` with retained entries → exits 1, prints formatted table.
+- `fo recover` per-row hint matches the §5.1 disambiguation tier for the
   on-disk observation (tmp present / tmp absent + src present / etc.).
 - `plan_recovery_actions(entries) -> list[_PlannedAction]` is pure: given
   identical inputs it returns identical output with no file-system mutation.
   Sweep's mutation path calls `plan_recovery_actions` then executes each
-  returned action; `fo undo recover` calls `plan_recovery_actions` and renders
+  returned action; `fo recover` calls `plan_recovery_actions` and renders
   without executing. Regression test runs both call sites on the same input
   and asserts the CLI's rendered plan matches the planner's return value
   verbatim — guarantees there's no "report-only mode" branch that could drift
@@ -642,7 +644,7 @@ fixes):
    no exception cleanup. STARTED disambiguation tests (§9.3) including the
    tmp-durability and invariant tests.
 7. **Dir_move decision locked in** (§5.3) + existing tests adjusted (§9.5).
-8. **`fo undo recover` CLI** + structured log fields (§8) + tests (§9.6).
+8. **`fo recover` CLI** + structured log fields (§8) + tests (§9.6).
 
 Each step is a self-contained commit + CI green before the next. The
 `tmp_path` / writer-protocol change (step 6) is the highest-risk step and
@@ -724,7 +726,7 @@ items. All addressed in the current revision:
 
 **Scope adjustment:**
 
-7. **`fo doctor` integration deferred** (§8): scoped down to just `fo undo recover`.
+7. **`fo doctor` integration deferred** (§8): scoped down to just `fo recover`.
    The `fo doctor` command exists but integrating a journal section there is
    kept out of this PR to minimize scope. Follow-up-ready (low risk, read-only).
 
@@ -760,7 +762,7 @@ items. All addressed:
     Parse also rejects v2 `move started` records missing `tmp_path` (§4.1 rule 9)
     so the tmp-exists invariant can't be bypassed by corrupt/external input.
 11. **Pure `plan_recovery_actions` planner** (§8.1): both sweep and
-    `fo undo recover` call the same pure planner, then either execute the plan
+    `fo recover` call the same pure planner, then either execute the plan
     (sweep) or render it (CLI). Replaces the round-2 "report-only mode" which
     risked a mutating-code-path drift between the two call sites. Regression
     test asserts CLI rendering and sweep execution agree on the action plan

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -251,6 +251,28 @@ def history(
 
 
 @app.command()
+def recover(  # noqa: G3 (--journal is a read-only path; defaults to system state dir)
+    journal: Path | None = typer.Option(
+        None,
+        help="Override path to durable_move.journal (defaults to the user state dir).",
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output."),
+) -> None:
+    """Preview pending durable_move recovery actions without executing them.
+
+    F7.1 §8.2: reads the journal under ``LOCK_SH``, calls the pure
+    :func:`plan_recovery_actions` planner, and prints the planned
+    sweep verbs + reasons. Exits 0 if nothing actionable, 1 if any
+    recovery work would be performed (so scripts can detect a stuck
+    journal without invoking sweep itself).
+    """
+    from cli.undo_recover import recover_command as _recover
+
+    code = _recover(journal=journal, verbose=verbose or _get_state().verbose)
+    raise typer.Exit(code=code)
+
+
+@app.command()
 def analytics(
     directory: Path | None = typer.Argument(None, help="Directory to analyze."),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output."),

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -103,23 +103,31 @@ def main_callback(
     # the on-disk state is coherent before the user's intent executes.
     # Failures here are logged + swallowed — a sweep error is never
     # worth crashing the CLI over; the next run will retry.
-    try:
-        _durable_move_sweep(_default_journal_path())
-    except Exception:
-        # Coderabbit PRRT_kwDOR_Rkws59fzVf: log at WARNING, not DEBUG.
-        # Most users don't run with debug verbosity, so a permanently
-        # unreadable journal (permission denied, corrupted JSONL) would
-        # silently accumulate unrecovered entries across every
-        # invocation with zero operator signal. WARNING surfaces the
-        # problem without impacting normal runs (the journal is
-        # missing/empty on the common path and ``sweep`` fast-exits
-        # before hitting any of these error paths).
-        logging.getLogger(__name__).warning(
-            "durable_move sweep at CLI startup failed; "
-            "interrupted-move recovery may be stuck. Inspect %s",
-            _default_journal_path(),
-            exc_info=True,
-        )
+    #
+    # F7.1 / codex lCbV / coderabbit lDDy: SKIP the startup sweep when
+    # the user is invoking ``fo recover``. ``recover`` is the read-only
+    # preview of what sweep would do; running sweep first would mutate
+    # state (unlink, compact) before the preview ran and then report
+    # "no retained entries" — breaking the read-only contract and
+    # making the preview unreliable.
+    if ctx.invoked_subcommand != "recover":
+        try:
+            _durable_move_sweep(_default_journal_path())
+        except Exception:
+            # Coderabbit PRRT_kwDOR_Rkws59fzVf: log at WARNING, not DEBUG.
+            # Most users don't run with debug verbosity, so a permanently
+            # unreadable journal (permission denied, corrupted JSONL) would
+            # silently accumulate unrecovered entries across every
+            # invocation with zero operator signal. WARNING surfaces the
+            # problem without impacting normal runs (the journal is
+            # missing/empty on the common path and ``sweep`` fast-exits
+            # before hitting any of these error paths).
+            logging.getLogger(__name__).warning(
+                "durable_move sweep at CLI startup failed; "
+                "interrupted-move recovery may be stuck. Inspect %s",
+                _default_journal_path(),
+                exc_info=True,
+            )
 
     set_flags(yes=yes, no_interactive=no_interactive)
 

--- a/src/cli/undo_recover.py
+++ b/src/cli/undo_recover.py
@@ -1,0 +1,132 @@
+"""F7.1 step 8 / §8.2: ``fo recover`` — preview pending durable_move recovery.
+
+The command reads the durable_move journal under ``LOCK_SH`` (per §6.5),
+calls the pure :func:`plan_recovery_actions` planner (§8.1), and renders
+the planned recovery actions as a table for operator visibility.
+
+Critical: this command is read-only. It calls only the planner — never
+the executor. The next CLI start (which runs ``sweep``) is what actually
+performs the planned actions.
+
+Exit-code contract:
+
+- ``0`` if the plan contains no retained / actionable entries (i.e. all
+  verbs are ``drop``).
+- ``1`` if any non-``drop`` action would be taken so scripts can detect
+  "needs cleanup".
+
+The §5.1 STARTED disambiguation tier (pre-replace / post-replace /
+v1-ambiguous) appears in the rendered reason for v2 ``move started``
+rows so operators can correlate sweep's planned action with on-disk
+state without re-reading the journal.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from undo import _journal
+from undo.durable_move import (
+    _PlannedAction,
+    plan_recovery_actions,
+    read_journal_under_shared_lock,
+)
+
+logger = logging.getLogger(__name__)
+
+# Verbs that represent actionable work (anything sweep would do beyond
+# trivially dropping a finished entry). ``drop`` alone is finished
+# bookkeeping — no recovery needed.
+_ACTIONABLE_VERBS = frozenset({"retain", "unlink_src_then_drop", "drop_tmp_then_drop"})
+
+
+def recover_command(
+    journal: Path | None = None,
+    verbose: bool = False,
+) -> int:
+    """Entry point for ``fo recover``.
+
+    Args:
+        journal: Override the default ``durable_move.journal`` path.
+            ``None`` (default) → :func:`undo._journal.default_journal_path`.
+        verbose: Enable DEBUG-level logging for troubleshooting.
+
+    Returns:
+        Exit code per §8.2: ``0`` if no actionable entries, ``1`` if any.
+    """
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG)
+
+    journal_path = journal if journal is not None else _journal.default_journal_path()
+
+    entries = read_journal_under_shared_lock(journal_path)
+    if not entries:
+        print(f"no retained entries in {journal_path}")
+        return 0
+
+    plan = plan_recovery_actions(entries)
+    actionable = [a for a in plan if a.verb in _ACTIONABLE_VERBS]
+
+    if not actionable:
+        print(f"no retained entries in {journal_path} ({len(plan)} dropped — already finished)")
+        return 0
+
+    _render_plan_table(journal_path, plan, actionable)
+    return 1
+
+
+def _render_plan_table(
+    journal_path: Path,
+    plan: list[_PlannedAction],
+    actionable: list[_PlannedAction],
+) -> None:
+    """Print a human-readable table of the planned actions.
+
+    Renders only ``actionable`` rows (so finished ``drop`` entries
+    don't add noise) but reports the full plan size in the header
+    so operators can see how much was already settled.
+    """
+    print(f"recovery plan for {journal_path}")
+    print(
+        f"  {len(actionable)} actionable entr{'y' if len(actionable) == 1 else 'ies'} "
+        f"(of {len(plan)} total)"
+    )
+    print()
+    # Column header — fixed widths for readability without pulling in
+    # rich (which would inflate startup time for what's a debugging
+    # one-shot command).
+    header = f"{'OP':<10} {'STATE':<10} {'VERB':<22} REASON"
+    print(header)
+    print("-" * len(header))
+    for action in actionable:
+        e = action.entry
+        op = e.op
+        state = e.state
+        verb = action.verb
+        reason = _decorate_reason(action)
+        print(f"{op:<10} {state:<10} {verb:<22} {reason}")
+        print(f"           src: {e.src}")
+        print(f"           dst: {e.dst}")
+        if e.tmp_path is not None:
+            print(f"           tmp: {e.tmp_path}")
+
+
+def _decorate_reason(action: _PlannedAction) -> str:
+    """Annotate the planner's reason with the §5.1 disambiguation tier
+    for v2 ``move started`` rows so operators see WHY sweep would take
+    the chosen verb (pre-replace tmp orphan vs. post-replace src-only
+    cleanup).
+    """
+    e = action.entry
+    if e.op != "move" or e.state != "started":
+        return action.reason
+    if e.schema == 2 and e.tmp_path is not None:
+        if action.verb == "drop_tmp_then_drop":
+            tier = "pre-replace"
+        elif action.verb == "unlink_src_then_drop":
+            tier = "post-replace"
+        else:
+            return action.reason
+        return f"[{tier}] {action.reason}"
+    return f"[v1-ambiguous] {action.reason}"

--- a/src/cli/undo_recover.py
+++ b/src/cli/undo_recover.py
@@ -6,13 +6,18 @@ the planned recovery actions as a table for operator visibility.
 
 Critical: this command is read-only. It calls only the planner — never
 the executor. The next CLI start (which runs ``sweep``) is what actually
-performs the planned actions.
+performs the planned actions. ``main_callback`` skips the startup sweep
+when ``recover`` is the invoked subcommand to preserve this contract
+(codex lCbV / coderabbit lDDy).
 
 Exit-code contract:
 
-- ``0`` if the plan contains no retained / actionable entries (i.e. all
-  verbs are ``drop``).
-- ``1`` if any non-``drop`` action would be taken so scripts can detect
+- ``0`` if no actionable entries (no ``retain`` / ``unlink_src_then_drop``
+  / ``drop_tmp_then_drop`` rows). Operator-visible WARNING-level drops
+  (e.g. stranded ``dir_move started`` per §5.3) DO appear in the
+  rendered table but don't bump the exit code — sweep would just drop
+  them, no recovery action runs.
+- ``1`` if any actionable verb is planned, so scripts can detect
   "needs cleanup".
 
 The §5.1 STARTED disambiguation tier (pre-replace / post-replace /
@@ -53,7 +58,10 @@ def recover_command(
         verbose: Enable DEBUG-level logging for troubleshooting.
 
     Returns:
-        Exit code per §8.2: ``0`` if no actionable entries, ``1`` if any.
+        Exit code per §8.2: ``1`` if any actionable verb is planned
+        (``retain`` / ``unlink_src_then_drop`` / ``drop_tmp_then_drop``),
+        ``0`` otherwise — including when the only visible rows are
+        WARNING-level ``drop``s like stranded ``dir_move started``.
     """
     if verbose:
         logging.basicConfig(level=logging.DEBUG)
@@ -67,13 +75,20 @@ def recover_command(
 
     plan = plan_recovery_actions(entries)
     actionable = [a for a in plan if a.verb in _ACTIONABLE_VERBS]
+    # CodeRabbit lDD3: also surface ``drop`` rows the planner flagged at
+    # WARNING level (e.g. stranded ``dir_move started`` per §5.3 — the
+    # entry IS dropped because sweep can't safely retry, but the operator
+    # needs to know on-disk state may need inspection). Exit code stays
+    # 0 for these because there's no recovery action sweep would take —
+    # they're operator-visibility rows, not "needs cleanup" rows.
+    visible = [a for a in plan if a.verb in _ACTIONABLE_VERBS or a.log_level >= logging.WARNING]
 
-    if not actionable:
+    if not visible:
         print(f"no retained entries in {journal_path} ({len(plan)} dropped — already finished)")
         return 0
 
-    _render_plan_table(journal_path, plan, actionable)
-    return 1
+    _render_plan_table(journal_path, plan, visible)
+    return 1 if actionable else 0
 
 
 def _render_plan_table(
@@ -113,10 +128,12 @@ def _render_plan_table(
 
 
 def _decorate_reason(action: _PlannedAction) -> str:
-    """Annotate the planner's reason with the §5.1 disambiguation tier
-    for v2 ``move started`` rows so operators see WHY sweep would take
-    the chosen verb (pre-replace tmp orphan vs. post-replace src-only
-    cleanup).
+    """Annotate the planner's reason with the §5.1 disambiguation tier.
+
+    For v2 ``move started`` rows the prefix tells operators WHY sweep
+    would take the chosen verb (pre-replace tmp orphan vs. post-replace
+    src-only cleanup). v1 records get a ``[v1-ambiguous]`` prefix.
+    Any other op/state pair returns the planner's reason unchanged.
     """
     e = action.entry
     if e.op != "move" or e.state != "started":

--- a/src/undo/durable_move.py
+++ b/src/undo/durable_move.py
@@ -51,6 +51,7 @@ steady-state size is bounded.
 from __future__ import annotations
 
 import errno
+import hashlib
 import json
 import logging
 import os
@@ -83,14 +84,58 @@ OP_DIR_MOVE = "dir_move"
 _KNOWN_OPS = frozenset({OP_MOVE, OP_DIR_MOVE})
 
 
+_MAX_JOURNAL_LINE_BYTES = 64 * 1024
+"""§4.1 rule 7: cap on a single journal line in bytes. Lines above this are
+rejected at parse time to prevent pathological payload-size attacks. 64 KiB
+leaves ample headroom above realistic path lengths plus the v2 envelope."""
+
+
+def _hash16(raw: str) -> str:
+    """Return the first 16 hex chars of ``sha256(raw)``.
+
+    §3.1 rule 4: used for unknown-op collapse-key identity so semantically-
+    distinct future records don't silently conflate when collapsed by this
+    binary's v2 parser (which doesn't understand their additional fields).
+    16 hex = 64 bits of identity — ample for the per-journal record counts
+    the protocol expects (≤ dozens).
+    """
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
 @dataclass(frozen=True)
 class _JournalEntry:
-    """A parsed journal row."""
+    """A parsed journal row.
+
+    F7.1 schema v2 (see ``docs/internal/F7-1-journal-protocol-design.md`` §2):
+
+    - ``schema``: 1 for legacy PR #197 records (no ``schema`` field on disk),
+      2 for records this binary writes. Writers always emit 2; parsers accept
+      both for back-compat.
+    - ``op_id``: unique per-invocation UUID (v2 only). ``None`` on v1 records.
+      v2 known-op records MUST carry ``op_id`` — parse-time rejected otherwise
+      per §4.1 rule 8.
+    - ``tmp_path``: absolute path of the EXDEV copy's tmp file/symlink. Only
+      populated on v2 ``op=move state=started`` records; ``None`` elsewhere.
+      The §7.1 tmp-exists invariant requires it on every such record —
+      parse-time rejected otherwise per §4.1 rule 9.
+    - ``ts``/``host_pid``: diagnostic metadata written by v2 writers, never
+      consulted by the protocol itself (PID reuse makes ``host_pid`` unsafe
+      for liveness checks per F2).
+    - ``_raw``: for unknown-op records ONLY — the full JSON line as read,
+      preserved so compaction re-serializes verbatim (§4.2). Known-op entries
+      keep ``_raw = None``; the serializer reconstructs from fields.
+    """
 
     op: str
     src: str
     dst: str
     state: str
+    schema: int = 1
+    op_id: str | None = None
+    tmp_path: str | None = None
+    ts: float | None = None
+    host_pid: int | None = None
+    _raw: str | None = None
 
 
 def _normalized_path_str(path: Path) -> str:
@@ -492,40 +537,222 @@ def _reconcile_entries(entries: list[_JournalEntry]) -> list[_JournalEntry]:
 
 
 def _serialize_entry(e: _JournalEntry) -> str:
-    """JSON-serialize a journal entry for write-back."""
-    return json.dumps({"op": e.op, "src": e.src, "dst": e.dst, "state": e.state})
+    """JSON-serialize a journal entry for write-back.
+
+    F7.1 §4.2: unknown-op entries are re-serialized VERBATIM from ``_raw``
+    so a future binary with a handler for the op receives every field the
+    writer persisted — NOT just the v2 parser's known core. Known-op entries
+    reconstruct from fields.
+
+    v2 entries (``schema == 2``) emit the extended v2 envelope; v1 entries
+    (``schema == 1``, PR #197 back-compat) emit the legacy 4-field form so
+    round-trip identity holds across a compaction.
+    """
+    # Unknown op: verbatim round-trip via the captured raw line.
+    if e._raw is not None:
+        return e._raw
+    if e.schema == 1:
+        return json.dumps({"op": e.op, "src": e.src, "dst": e.dst, "state": e.state})
+    # v2 envelope. Omit diagnostic fields when None so we don't bloat the
+    # journal; the parser treats missing diagnostic fields as None on read.
+    payload: dict[str, object] = {
+        "schema": e.schema,
+        "op": e.op,
+        "op_id": e.op_id,
+        "src": e.src,
+        "dst": e.dst,
+        "state": e.state,
+    }
+    if e.tmp_path is not None:
+        payload["tmp_path"] = e.tmp_path
+    if e.ts is not None:
+        payload["ts"] = e.ts
+    if e.host_pid is not None:
+        payload["host_pid"] = e.host_pid
+    return json.dumps(payload)
 
 
 def _parse_journal_text(text: str) -> list[_JournalEntry]:
     """Parse JSONL journal text into typed entries.
 
-    Mirrors :func:`_read_journal` but works on an already-read string
-    so ``_sweep_locked_body`` can use the locked fd's read.
+    Applies the §4.1 rejection rules — every malformed line is logged +
+    skipped; no input can cause the parser to raise. v1 records
+    (``schema`` absent) and v2 records (``schema == 2``) both accepted.
+    Unknown-op entries retain their full raw JSON line on ``_raw`` per
+    §4.2 for verbatim forward-compat.
     """
     entries: list[_JournalEntry] = []
     for raw_line in text.splitlines():
         line = raw_line.strip()
         if not line:
             continue
-        try:
-            data = json.loads(line)
-        except json.JSONDecodeError:
-            logger.warning("sweep: dropping unparsable journal line: %r", line)
-            continue
-        op = data.get("op")
-        src = data.get("src")
-        dst = data.get("dst")
-        state = data.get("state")
-        if not (
-            isinstance(op, str)
-            and isinstance(src, str)
-            and isinstance(dst, str)
-            and isinstance(state, str)
-        ):
-            logger.warning("sweep: dropping malformed journal entry: %r", data)
-            continue
-        entries.append(_JournalEntry(op=op, src=src, dst=dst, state=state))
+        entry = _parse_one_journal_line(line)
+        if entry is not None:
+            entries.append(entry)
     return entries
+
+
+class _ParseReject(Exception):
+    """Internal sentinel: a field validator rejected the line.
+
+    Validators raise this with the line already logged so the top-level
+    parser can ``except _ParseReject: return None`` without nested
+    logging concerns. Not exposed outside the module.
+    """
+
+
+def _reject(msg: str, *args: object, line: str) -> _ParseReject:
+    """Log a rejection reason + truncated line and return a sentinel exception.
+
+    Keeps every rejection site one-liner-ish so
+    :func:`_parse_one_journal_line` stays within the cyclomatic budget. The
+    caller raises the returned value so control flow stays explicit.
+    """
+    logger.warning(msg + ": %r", *args, line[:200])
+    return _ParseReject()
+
+
+def _validate_core_fields(data: dict, line: str) -> tuple[str, str, str, str]:
+    """§4.1 rules 3 + 4: op/src/dst/state present and string-typed."""
+    op = data.get("op")
+    src = data.get("src")
+    dst = data.get("dst")
+    state = data.get("state")
+    if not (
+        isinstance(op, str)
+        and isinstance(src, str)
+        and isinstance(dst, str)
+        and isinstance(state, str)
+    ):
+        raise _reject("sweep: dropping malformed journal entry", line=line)
+    return op, src, dst, state
+
+
+def _validate_schema(data: dict, line: str) -> int:
+    """§4.1 rule 6: schema is absent (→ 1) or a positive int."""
+    schema_raw = data.get("schema")
+    if schema_raw is None:
+        return 1
+    if isinstance(schema_raw, bool) or not isinstance(schema_raw, int) or schema_raw < 1:
+        raise _reject("sweep: dropping entry with invalid schema %r", schema_raw, line=line)
+    return schema_raw
+
+
+def _validate_op_id(data: dict, line: str) -> str | None:
+    """Parse ``op_id``. None if absent, string if typed, rejection otherwise."""
+    raw = data.get("op_id")
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        return raw
+    raise _reject("sweep: dropping entry with non-string op_id %r", raw, line=line)
+
+
+def _validate_tmp_path(data: dict, line: str) -> str | None:
+    """Parse ``tmp_path``. None if absent, string if typed, rejection otherwise."""
+    raw = data.get("tmp_path")
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        return raw
+    raise _reject("sweep: dropping entry with non-string tmp_path %r", raw, line=line)
+
+
+def _validate_ts(data: dict, line: str) -> float | None:
+    """Parse diagnostic ``ts``. None/float; reject bool (bool is int subclass)."""
+    raw = data.get("ts")
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        raise _reject("sweep: dropping entry with bool ts", line=line)
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    raise _reject("sweep: dropping entry with non-numeric ts %r", raw, line=line)
+
+
+def _validate_host_pid(data: dict, line: str) -> int | None:
+    """Parse diagnostic ``host_pid``. None/int; reject bool."""
+    raw = data.get("host_pid")
+    if raw is None:
+        return None
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise _reject("sweep: dropping entry with non-int host_pid %r", raw, line=line)
+    return raw
+
+
+def _parse_one_journal_line(line: str) -> _JournalEntry | None:
+    """Parse a single stripped journal line per §4.1 rejection rules.
+
+    Returns ``None`` (and logs WARNING) on any rejection case. Returns a
+    typed :class:`_JournalEntry` on success. Rejection sites delegate
+    to per-field ``_validate_*`` helpers to keep this function within
+    the project's cyclomatic complexity budget.
+    """
+    # §4.1 rule 7: oversized line cap (measured in bytes so UTF-8 payloads
+    # can't slip past via multi-byte characters).
+    encoded = line.encode("utf-8")
+    if len(encoded) > _MAX_JOURNAL_LINE_BYTES:
+        logger.warning(
+            "sweep: dropping oversized journal line (%d bytes > %d cap): %r",
+            len(encoded),
+            _MAX_JOURNAL_LINE_BYTES,
+            line[:200],
+        )
+        return None
+    # §4.1 rule 1: JSON parse error.
+    try:
+        data = json.loads(line)
+    except json.JSONDecodeError:
+        logger.warning("sweep: dropping unparsable journal line: %r", line[:200])
+        return None
+    # §4.1 rule 2 (codex iy4w): valid JSON but not an object.
+    if not isinstance(data, dict):
+        logger.warning(
+            "sweep: dropping non-object journal line (got %s): %r",
+            type(data).__name__,
+            line[:200],
+        )
+        return None
+    # Per-field validation via helpers — each raises _ParseReject with the
+    # line already logged.
+    try:
+        op, src, dst, state = _validate_core_fields(data, line)
+        schema = _validate_schema(data, line)
+        if schema == 1 and op not in _KNOWN_OPS:
+            raise _reject(
+                "sweep: dropping v1 entry with unknown op %r (v1 records must be in %s)",
+                op,
+                sorted(_KNOWN_OPS),
+                line=line,
+            )
+        op_id = _validate_op_id(data, line)
+        if schema == 2 and op in _KNOWN_OPS and op_id is None:
+            raise _reject("sweep: dropping v2 known-op entry missing op_id", line=line)
+        tmp_path = _validate_tmp_path(data, line)
+        if schema == 2 and op == OP_MOVE and state == STATE_STARTED and tmp_path is None:
+            raise _reject(
+                "sweep: dropping v2 move-started entry missing tmp_path (§7.1 invariant)",
+                line=line,
+            )
+        ts = _validate_ts(data, line)
+        host_pid = _validate_host_pid(data, line)
+    except _ParseReject:
+        return None
+    # §4.2: unknown ops retain the raw line verbatim for forward-compat.
+    # Known ops drop extra fields silently.
+    raw_for_unknown_op = line if op not in _KNOWN_OPS else None
+    return _JournalEntry(
+        op=op,
+        src=src,
+        dst=dst,
+        state=state,
+        schema=schema,
+        op_id=op_id,
+        tmp_path=tmp_path,
+        ts=ts,
+        host_pid=host_pid,
+        _raw=raw_for_unknown_op,
+    )
 
 
 def _complete_or_rollback(entry: _JournalEntry) -> bool:
@@ -802,32 +1029,15 @@ def _append_journal(journal: Path, payload: Mapping[str, object]) -> None:
 
 
 def _read_journal(journal: Path) -> list[_JournalEntry]:
-    """Parse the JSONL journal into typed entries. Missing/empty → []."""
+    """Parse the JSONL journal into typed entries. Missing/empty → [].
+
+    F7.1 consolidation: previously duplicated the parse body from
+    :func:`_parse_journal_text`, which caused the round-8 ``isinstance(data,
+    dict)`` fix to be applied to only one of the two parsers (codex iy4w
+    flagged this in the #201 body — "the same pattern appears in
+    ``_read_journal``"). Now a thin wrapper over the shared parser so the
+    §4.1 rejection rules cover both call sites.
+    """
     if not journal.exists():
         return []
-    entries: list[_JournalEntry] = []
-    for line in journal.read_text().splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            data = json.loads(line)
-        except json.JSONDecodeError:
-            logger.warning("sweep: dropping unparsable journal line: %r", line)
-            continue
-        # Only ``op: "move"`` entries are produced today; future ops
-        # can land in the same journal without disturbing callers.
-        op = data.get("op")
-        src = data.get("src")
-        dst = data.get("dst")
-        state = data.get("state")
-        if not (
-            isinstance(op, str)
-            and isinstance(src, str)
-            and isinstance(dst, str)
-            and isinstance(state, str)
-        ):
-            logger.warning("sweep: dropping malformed journal entry: %r", data)
-            continue
-        entries.append(_JournalEntry(op=op, src=src, dst=dst, state=state))
-    return entries
+    return _parse_journal_text(journal.read_text())

--- a/src/undo/durable_move.py
+++ b/src/undo/durable_move.py
@@ -58,6 +58,8 @@ import logging
 import os
 import shutil
 import tempfile
+import time
+import uuid
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -292,141 +294,135 @@ def durable_move(src: Path, dst: Path, *, journal: Path) -> None:
 
 
 def _durable_cross_device_move(src: Path, dst: Path, *, journal: Path) -> None:
-    """EXDEV branch: copy + fsync + os.replace + unlink, with journal.
+    """EXDEV branch: copy + fsync + os.replace + unlink, with v2 journal.
 
-    Sequence is carefully ordered so a crash at any point leaves
-    recoverable state:
+    Step 6 / §7.2 (regular file) + §7.3 (symlink) sequence:
 
-    1. Append ``started`` entry. Crash here = no copy yet; sweep
-       deletes (never-created or partial) destination.
-    2. Copy ``src`` → ``<dst>.tmp`` inside ``dst.parent`` (same-fs
-       as ``dst``). Copy errors propagate — the journal has an
-       unresolved ``started`` entry that sweep cleans up.
-    3. Fsync the temp file and its directory. Without the directory
-       fsync, a power loss after ``os.replace`` could leave the
-       directory entry pointing at an inode whose pages haven't hit
-       disk — a classic atomic-write footgun.
-    4. ``os.replace(tmp, dst)``. Atomic because tmp + dst are on the
-       same filesystem (dst.parent).
-    5. Append ``copied`` entry. Crash here = destination complete,
-       source still exists; sweep unlinks the source.
-    6. Unlink source. Crash here = destination complete, source
-       gone; state is effectively ``done`` but no ``done`` entry is
-       logged yet. Sweep would redundantly try to unlink a
-       nonexistent source, which is a no-op.
-    7. Append ``done`` entry for audit/observability.
+    1. Allocate ``op_id``, build the v2 payload base (``schema=2``,
+       ``op_id``, ``ts``, ``host_pid``).
+    2. Create tmp BEFORE the started journal write (regular: empty
+       ``NamedTemporaryFile(delete=False)``; symlink: ``os.symlink``).
+    3. ``fsync_directory(dst.parent)`` — round-2 blocking fix: makes
+       the tmp's directory entry durable before the started entry can
+       claim ``tmp_path`` exists. Without this, a crash window where
+       tmp lives only in the page cache breaks the §7.1 tmp-exists
+       invariant and sweep would misread tmp-absent as post-replace.
+    4. Append ``started`` with ``tmp_path`` populated.
+    5. Copy + fsync (regular only — symlink target lives in the inode).
+    6. ``os.replace(tmp, dst)`` — consumes tmp atomically into dst.
+    7. ``fsync_directory(dst.parent)`` so the new directory entry is
+       durable before we log ``copied`` (codex P1 fwMG).
+    8. Append ``copied`` with the same ``op_id``.
+    9. ``os.unlink(src)`` + ``fsync_directory(src.parent)`` (codex P2
+       gnah: unlink durability before the ``done`` write).
+    10. Append ``done`` with the same ``op_id``.
+
+    §7.4: this function does NOT remove tmp on exception. If anything
+    after step 2 raises, tmp persists on disk and sweep observes
+    ``lexists(tmp_path)`` to disambiguate pre-replace (tmp present) from
+    post-replace (tmp absent) crashes. The tmp-cleanup that PR #197 had
+    here would have broken that invariant.
     """
     # Resolve to absolute paths before journaling. ``is_path_in_flight``
     # will match on ``str()`` of the resolved form, so callers passing
     # unresolved / relative / symlinked paths still get the right
     # match (coderabbit PRRT_kwDOR_Rkws59fzVv).
-    payload = {
-        "op": "move",
+    op_id = uuid.uuid4().hex
+    base_payload: dict[str, Any] = {
+        "schema": 2,
+        "op": OP_MOVE,
+        "op_id": op_id,
         "src": _normalized_path_str(src),
         "dst": _normalized_path_str(dst),
-        "state": STATE_STARTED,
+        "ts": time.time(),
+        "host_pid": os.getpid(),
     }
-    _append_journal(journal, payload)
 
-    tmp_path: Path | None = None
-    try:
-        if src.is_symlink():
-            # Codex P1 PRRT_kwDOR_Rkws59gnab: preserve symlink identity
-            # on EXDEV moves. ``shutil.copyfile`` follows symlinks and
-            # would replace ``dst`` with a regular file containing the
-            # target's bytes — breaking rollback fidelity for symlink
-            # trash entries and destroying dangling symlinks entirely
-            # (shutil.copyfile on a dangling symlink raises
-            # ``FileNotFoundError``). Replicates ``shutil.move``'s
-            # pre-F7 symlink handling: readlink → create new symlink
-            # at a tmp path → os.replace → unlink the original.
-            # ``readlink`` preserves absolute-vs-relative target form.
-            target = os.readlink(src)
-            tmp_path = dst.parent / f".{dst.name}.{os.getpid()}.symlink.tmp"
-            # Clean any stale tmp from a prior crashed attempt at the
-            # exact same path. The PID suffix makes collisions between
-            # concurrent processes impossible; the only realistic way
-            # the tmp exists is that a prior invocation with the same
-            # PID crashed mid-symlink (before the ``os.replace``).
-            # An ``OSError`` here surfaces to the outer handler which
-            # logs + leaves the journal's ``started`` entry for sweep.
-            if os.path.lexists(tmp_path):
-                tmp_path.unlink()
-            os.symlink(target, tmp_path)
-            # No file data to fsync for a symlink — the target string
-            # lives in the inode itself on most filesystems — but the
-            # directory entry DOES need to be fsynced before the
-            # rename (parity with the regular-file branch below).
-            fsync_directory(dst)
-            os.replace(tmp_path, dst)
-            fsync_directory(dst)
-            tmp_path = None
-        else:
-            # Copy into a temp in dst's parent so the final rename is
-            # same-filesystem. ``NamedTemporaryFile(delete=False)`` keeps
-            # the file on disk for the os.replace step.
-            with tempfile.NamedTemporaryFile(
-                dir=str(dst.parent),
-                prefix=f".{dst.name}.",
-                suffix=".tmp",
-                delete=False,
-            ) as tmp:
-                tmp_path = Path(tmp.name)
-            shutil.copyfile(src, tmp_path)
-            # Preserve mode bits so daemons that rely on chmod survive
-            # the copy (matches pre-F7 ``shutil.move`` behavior on
-            # cross-device moves, which uses copy2 internally).
-            try:
-                shutil.copystat(src, tmp_path)
-            except OSError:
-                # copystat failures are non-fatal — better to complete
-                # the move with default mode than fail.
-                logger.debug(
-                    "copystat failed for %s → %s; proceeding with default mode",
-                    src,
-                    tmp_path,
-                    exc_info=True,
-                )
-            # fsync file + parent dir before the rename so a power loss
-            # after ``os.replace`` can't leave the new directory entry
-            # pointing at an inode with unflushed pages.
-            fd = os.open(tmp_path, os.O_RDONLY)
-            try:
-                os.fsync(fd)
-            finally:
-                os.close(fd)
-            # ``fsync_directory(dst)`` fsyncs ``dst.parent`` — see
-            # ``utils.atomic_io.fsync_directory`` docstring. Same effect
-            # as an explicit ``_fsync_directory(dst.parent)`` but reuses
-            # the shared helper.
-            fsync_directory(dst)
-            os.replace(tmp_path, dst)
-            # Codex P1 PRRT_kwDOR_Rkws59fwMG: fsync ``dst.parent`` AGAIN
-            # after the rename so the new directory entry is durable
-            # before we log ``copied`` and unlink the source. Without
-            # this second fsync, a crash between ``os.replace`` and the
-            # next journal append could leave the journal claiming
-            # ``copied`` while the rename itself hadn't reached disk —
-            # sweep would then unlink the (recoverable) source while
-            # the destination directory entry had rolled back.
-            fsync_directory(dst)
-            tmp_path = None  # successfully moved into place
-    except BaseException:
-        # Leave the ``started`` journal entry and clean up stray tmp
-        # so operators don't accumulate .tmp debris. Use ``lexists``
-        # so a dangling-symlink tmp (target doesn't exist) still gets
-        # removed — ``Path.exists()`` would return False for those.
-        if tmp_path is not None and os.path.lexists(tmp_path):
-            try:
-                tmp_path.unlink()
-            except OSError:
-                logger.debug("Failed to clean up stray temp file %s", tmp_path, exc_info=True)
-        raise
+    # §7.2 step 1 / §7.3 steps 1-3: create tmp BEFORE the started entry.
+    # An exception during tmp creation propagates with NO journal entry
+    # written — that's operator debris (orphan tmp + no record), not a
+    # sweep concern (§7.2 commentary on "crash between syscall and
+    # pre-started fsync_directory").
+    if src.is_symlink():
+        # Codex P1 PRRT_kwDOR_Rkws59gnab: preserve symlink identity on
+        # EXDEV moves. ``readlink`` keeps absolute-vs-relative form.
+        target = os.readlink(src)
+        tmp_path = dst.parent / f".{dst.name}.{os.getpid()}.symlink.tmp"
+        # Clean any stale tmp from a prior crashed attempt at the exact
+        # same path. The PID suffix makes collisions between concurrent
+        # processes impossible; the only realistic way the tmp exists is
+        # that a prior invocation with the same PID crashed mid-symlink
+        # (before the ``os.replace``).
+        if os.path.lexists(tmp_path):
+            tmp_path.unlink()
+        os.symlink(target, tmp_path)
+    else:
+        # Copy target lives in dst's parent so the final rename is
+        # same-filesystem. ``NamedTemporaryFile(delete=False)`` creates
+        # + closes an empty file — fits the §7.2 step 1 contract.
+        with tempfile.NamedTemporaryFile(
+            dir=str(dst.parent),
+            prefix=f".{dst.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            tmp_path = Path(tmp.name)
 
-    # Destination is complete. Log the copied state BEFORE unlinking
-    # the source so a crash between these two steps is recoverable
-    # by sweep (it sees ``copied`` and unlinks the source).
-    _append_journal(journal, {**payload, "state": STATE_COPIED})
+    # §7.1 rule 2 / round-2 blocking fix: fsync_directory(dst.parent)
+    # BEFORE the started journal append makes the tmp's directory entry
+    # durable. Without this ordering, the tmp-exists invariant is not
+    # crash-durable and sweep's tmp-absent ⇒ post-replace inference is
+    # unsafe under power loss.
+    fsync_directory(dst)
+
+    # §7.2 step 3 / §7.3 step 5: started entry now carries tmp_path so
+    # sweep can disambiguate.
+    _append_journal(
+        journal,
+        {**base_payload, "state": STATE_STARTED, "tmp_path": str(tmp_path)},
+    )
+
+    if src.is_symlink():
+        # No file data to fsync for a symlink — the target string lives
+        # in the inode itself on most filesystems. The dst.parent fsync
+        # before the started write already covered the tmp's dir entry.
+        os.replace(tmp_path, dst)
+        fsync_directory(dst)
+    else:
+        shutil.copyfile(src, tmp_path)
+        # Preserve mode bits so daemons that rely on chmod survive the
+        # copy (matches pre-F7 ``shutil.move`` behavior on cross-device
+        # moves, which uses copy2 internally).
+        try:
+            shutil.copystat(src, tmp_path)
+        except OSError:
+            # copystat failures are non-fatal — better to complete the
+            # move with default mode than fail.
+            logger.debug(
+                "copystat failed for %s → %s; proceeding with default mode",
+                src,
+                tmp_path,
+                exc_info=True,
+            )
+        # fsync file + parent dir before the rename so a power loss
+        # after ``os.replace`` can't leave the new directory entry
+        # pointing at an inode with unflushed pages.
+        fd = os.open(tmp_path, os.O_RDONLY)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        fsync_directory(dst)
+        os.replace(tmp_path, dst)
+        # Codex P1 PRRT_kwDOR_Rkws59fwMG: fsync ``dst.parent`` AGAIN
+        # after the rename so the new directory entry is durable before
+        # we log ``copied`` and unlink the source.
+        fsync_directory(dst)
+
+    # Destination is complete. Log copied BEFORE unlinking src so a
+    # crash here is recoverable by sweep (it sees ``copied`` and
+    # finishes by unlinking src). Same op_id as started.
+    _append_journal(journal, {**base_payload, "state": STATE_COPIED})
 
     try:
         os.unlink(src)
@@ -434,16 +430,11 @@ def _durable_cross_device_move(src: Path, dst: Path, *, journal: Path) -> None:
         # Source already gone — treat as done.
         pass
 
-    # Codex P2 PRRT_kwDOR_Rkws59gnah: fsync ``src.parent`` so the
-    # unlink itself is crash-durable before we log ``done``. On POSIX
-    # an ``os.unlink`` is not persisted until the containing directory
-    # is fsynced; without this call, a power loss here could let ``src``
-    # reappear on reboot while the journal already records ``done``.
-    # ``sweep()`` would then drop the entry and never reconcile the
-    # resurrected file, leaving a phantom copy on disk.
+    # Codex P2 PRRT_kwDOR_Rkws59gnah: fsync ``src.parent`` so the unlink
+    # itself is crash-durable before we log ``done``.
     fsync_directory(src)
 
-    _append_journal(journal, {**payload, "state": STATE_DONE})
+    _append_journal(journal, {**base_payload, "state": STATE_DONE})
 
 
 def directory_move(src: Path, dst: Path, *, journal: Path) -> None:
@@ -673,9 +664,14 @@ _PlannedVerb = Literal[
     "drop",
     "retain",
     "unlink_src_then_drop",
+    "drop_tmp_then_drop",
 ]
-"""Step 2: closed verb set per §5.1 PR #197 subset. Step 6 will add
-``drop_tmp_then_drop`` for the v2 STARTED-with-tmp_path-present row."""
+"""Closed verb set per §5.1.
+
+- ``drop`` / ``retain`` / ``unlink_src_then_drop`` — PR #197 subset (step 2).
+- ``drop_tmp_then_drop`` — step 6, v2 ``move started`` + ``lexists(tmp_path)``
+  pre-replace row: unlink the orphan tmp, then drop the entry.
+"""
 
 
 @dataclass(frozen=True)
@@ -817,14 +813,44 @@ def _plan_one(
         )
     # entry.op == OP_MOVE — the F7 atomic/durable single-file path.
     if entry.state == STATE_STARTED:
-        # PR #197 step-2 behavior: ambiguous, retain. Step 6 will
-        # disambiguate via fs_observer(entry.tmp_path).
+        # §7.1 disambiguation (step 6): v2 records carry ``tmp_path`` and
+        # uphold the tmp-exists invariant, so observing ``lexists(tmp_path)``
+        # tells sweep which side of the ``os.replace`` boundary the crash
+        # landed on. v1 records (no schema, no tmp_path) lack the metadata
+        # and preserve PR #197 retain-as-ambiguous behavior.
+        if entry.schema == 2 and entry.tmp_path is not None:
+            if fs_observer(entry.tmp_path):
+                # Pre-replace crash: tmp orphan, replace never ran. src is
+                # still the canonical copy. Unlink tmp; drop entry.
+                return _PlannedAction(
+                    identity=identity,
+                    entry=entry,
+                    verb="drop_tmp_then_drop",
+                    reason=(
+                        f"started entry {entry.src} -> {entry.dst} (tmp "
+                        f"{entry.tmp_path} present) — pre-replace crash; "
+                        "unlinking orphan tmp, src remains canonical"
+                    ),
+                )
+            # Post-replace crash: tmp consumed by ``os.replace``; dst is
+            # complete. Same finishing step as the COPIED row — unlink src.
+            return _PlannedAction(
+                identity=identity,
+                entry=entry,
+                verb="unlink_src_then_drop",
+                reason=(
+                    f"started entry {entry.src} -> {entry.dst} (tmp "
+                    f"{entry.tmp_path} absent) — post-replace crash; "
+                    "finishing by unlinking src"
+                ),
+            )
+        # v1 fallback: no tmp_path metadata to disambiguate.
         return _PlannedAction(
             identity=identity,
             entry=entry,
             verb="retain",
             reason=(
-                f"started entry {entry.src} -> {entry.dst} is ambiguous "
+                f"v1 started entry {entry.src} -> {entry.dst} is ambiguous "
                 "(crash in copy→replace window); cannot reconcile without "
                 "content comparison — operator or retry must resolve"
             ),
@@ -884,9 +910,9 @@ def _apply_planned_actions(plan: list[_PlannedAction]) -> list[_JournalEntry]:
       ``FileNotFoundError`` on unlink is swallowed (already gone). Other
       ``OSError`` falls back to retain — the next sweep retries
       (codex fwMK + PR #197 round-5).
-
-    Step 6 will add ``drop_tmp_then_drop`` for the v2 STARTED-tmp-present
-    row.
+    - ``drop_tmp_then_drop`` (step 6, §7.1 pre-replace row): unlink the
+      v2 ``tmp_path`` orphan, then drop the entry. Same OSError-retains
+      semantics as ``unlink_src_then_drop``.
     """
     retained: list[_JournalEntry] = []
     for action in plan:
@@ -899,6 +925,10 @@ def _apply_planned_actions(plan: list[_PlannedAction]) -> list[_JournalEntry]:
             continue
         if action.verb == "unlink_src_then_drop":
             if not _execute_unlink_src(action.entry):
+                retained.append(action.entry)
+            continue
+        if action.verb == "drop_tmp_then_drop":
+            if not _execute_unlink_tmp(action.entry):
                 retained.append(action.entry)
             continue
         # Defensive: an unknown verb is a programming error, not an
@@ -942,6 +972,50 @@ def _execute_unlink_src(entry: _JournalEntry) -> bool:
     except OSError as exc:
         logger.debug(
             "sweep: fsync of src.parent after unlink failed: %s",
+            exc,
+            exc_info=True,
+        )
+    return True
+
+
+def _execute_unlink_tmp(entry: _JournalEntry) -> bool:
+    """Unlink ``entry.tmp_path`` (v2 STARTED orphan) and fsync its parent.
+
+    Returns True on success (entry should drop), False on transient
+    ``OSError`` (entry should retain — same retry semantics as
+    :func:`_execute_unlink_src`). ``FileNotFoundError`` is success:
+    if an operator already cleaned the orphan, sweep is idempotent.
+
+    Defensive: ``entry.tmp_path is None`` shouldn't reach here (the
+    planner only emits ``drop_tmp_then_drop`` for v2 records with
+    ``tmp_path``), but if it does, log + retain.
+    """
+    if entry.tmp_path is None:  # pragma: no cover - planner invariant
+        logger.error(
+            "sweep: drop_tmp_then_drop on entry without tmp_path %r; retaining",
+            entry,
+        )
+        return False
+    tmp = Path(entry.tmp_path)
+    try:
+        tmp.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.warning(
+            "sweep: failed to unlink tmp orphan %s after pre-replace crash: %s",
+            tmp,
+            exc,
+            exc_info=True,
+        )
+        return False
+    # Match _execute_unlink_src: fsync the parent so the unlink is
+    # crash-durable before sweep compacts this entry out of the journal.
+    try:
+        fsync_directory(tmp)
+    except OSError as exc:
+        logger.debug(
+            "sweep: fsync of tmp.parent after unlink failed: %s",
             exc,
             exc_info=True,
         )

--- a/src/undo/durable_move.py
+++ b/src/undo/durable_move.py
@@ -832,16 +832,36 @@ def _plan_one(
                         "unlinking orphan tmp, src remains canonical"
                     ),
                 )
-            # Post-replace crash: tmp consumed by ``os.replace``; dst is
-            # complete. Same finishing step as the COPIED row — unlink src.
+            # Tmp absent — usually post-replace, but only safe to unlink
+            # src if dst actually exists. Codex P1 lCbU: tmp-absent is
+            # NOT proof that ``os.replace`` ran; tmp could also have been
+            # cleaned out-of-band by an operator. If dst is also missing,
+            # src is the canonical copy and unlinking it is data loss.
+            # Mirror the codex hGWW guard from the COPIED row.
+            if not fs_observer(entry.dst):
+                return _PlannedAction(
+                    identity=identity,
+                    entry=entry,
+                    verb="retain",
+                    reason=(
+                        f"started entry {entry.src} -> {entry.dst} (tmp "
+                        f"{entry.tmp_path} absent, dst absent) — cannot prove "
+                        "post-replace; unlinking src would destroy the last "
+                        "remaining copy. Retaining for operator inspection."
+                    ),
+                    log_level=logging.WARNING,
+                )
+            # Post-replace crash confirmed: tmp absent + dst present means
+            # ``os.replace`` consumed tmp into dst. Same finishing step as
+            # the COPIED row — unlink src.
             return _PlannedAction(
                 identity=identity,
                 entry=entry,
                 verb="unlink_src_then_drop",
                 reason=(
                     f"started entry {entry.src} -> {entry.dst} (tmp "
-                    f"{entry.tmp_path} absent) — post-replace crash; "
-                    "finishing by unlinking src"
+                    f"{entry.tmp_path} absent, dst present) — post-replace "
+                    "crash; finishing by unlinking src"
                 ),
             )
         # v1 fallback: no tmp_path metadata to disambiguate.
@@ -884,12 +904,21 @@ def _plan_one(
             verb="drop",
             reason=f"done entry {entry.src} -> {entry.dst}; nothing to do",
         )
-    # Known op with unrecognized state — drop with warning. Same as PR #197.
+    # §5.1 "known-op unknown state": retain + warn. Codex / coderabbit
+    # PRRT_kwDOR_Rkws59lDD8: dropping the entry would lose the recovery
+    # record AND let ``is_path_in_flight()`` stop protecting the path —
+    # even though a newer binary that knows the new state may still need
+    # it. Retaining is the safe default; the operator inspects the
+    # warning and either upgrades the binary or hand-resolves the entry.
     return _PlannedAction(
         identity=identity,
         entry=entry,
-        verb="drop",
-        reason=f"unknown state {entry.state!r} for op {entry.op!r}; dropping",
+        verb="retain",
+        reason=(
+            f"unknown state {entry.state!r} for op {entry.op!r}; retaining "
+            "so a newer binary can resolve and is_path_in_flight() keeps "
+            "protecting the path"
+        ),
         log_level=logging.WARNING,
     )
 

--- a/src/undo/durable_move.py
+++ b/src/undo/durable_move.py
@@ -1252,6 +1252,35 @@ def _parse_one_journal_line(line: str) -> _JournalEntry | None:
     )
 
 
+def read_journal_under_shared_lock(journal: Path) -> list[_JournalEntry]:
+    """Public reader for ``fo recover`` and other read-only consumers (§8.2).
+
+    Acquires ``LOCK_SH`` on ``<journal>.lock`` (per §6.5) so the read
+    blocks while any writer or compaction holds ``LOCK_EX``, and
+    returns parsed entries. Missing or empty journal → empty list
+    (no-op — the caller treats it as "nothing to recover").
+
+    Distinct from :func:`is_path_in_flight` which collapses to the
+    latest state per identity for membership queries; this returns
+    raw entries so callers can pass them straight to
+    :func:`plan_recovery_actions`.
+
+    On non-POSIX (Windows, no ``fcntl``), falls back to an unlocked
+    read consistent with the module docstring's single-CLI-invocation
+    invariant.
+    """
+    journal = Path(journal)
+    if not journal.exists():
+        return []
+    if _HAS_FCNTL:
+        try:
+            with _locked(journal, fcntl.LOCK_SH), open(journal, encoding="utf-8") as fh:
+                return _parse_journal_text(fh.read())
+        except FileNotFoundError:  # pragma: no cover - exists()→open() race
+            return []
+    return _read_journal(journal)  # pragma: no cover - Windows-only path
+
+
 def is_path_in_flight(path: Path, *, journal: Path) -> bool:
     """Return True iff *path* is the src or dst of an uncompleted move.
 

--- a/src/undo/durable_move.py
+++ b/src/undo/durable_move.py
@@ -61,7 +61,7 @@ import tempfile
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from utils.atomic_io import fsync_directory
 from utils.atomic_write import append_durable
@@ -79,6 +79,11 @@ except ImportError:  # pragma: no cover - Windows
     _HAS_FCNTL = False
 
 logger = logging.getLogger(__name__)
+
+# Heterogeneous collapse-identity tuple. Three shapes per §3.1:
+# ``("v2", op, op_id)`` / ``("v1", op, src, dst)`` / ``("unknown", op, _hash16)``.
+# ``tuple[object, ...]`` captures the variability without losing strictness.
+_OpIdentity = tuple[object, ...]
 
 
 # Journal state constants. Exposed so callers (and tests) can assert
@@ -524,42 +529,127 @@ def sweep(journal: Path) -> None:
     # and the unlocked sweep body runs (single-CLI-invocation invariant
     # per the module docstring).
     if _HAS_FCNTL:
-        try:
-            with _locked(journal, fcntl.LOCK_EX), open(journal, "r+") as fh:
+        with _locked(journal, fcntl.LOCK_EX):
+            try:
+                fh = open(journal, "r+")
+            except FileNotFoundError:
+                # Journal disappeared between ``exists()`` and ``open()`` —
+                # nothing to sweep. Narrow scope: don't swallow OSError
+                # raised by the body (e.g. ``os.replace`` failures during
+                # compaction must propagate so callers can react).
+                return
+            try:
                 _sweep_locked_body(journal, fh)
-            return
-        except OSError:
-            # ``OSError`` on open can happen if the journal disappeared
-            # between ``exists()`` and ``open()`` — fall through to the
-            # unlocked path which handles the missing-file case.
-            pass
+            finally:
+                fh.close()
+        return
     _sweep_unlocked_body(journal)
 
 
+_MAX_JOURNAL_SIZE_BYTES = 16 * 1024 * 1024
+"""§6.6 size cap. Journals above this are skipped during compaction with
+a WARNING. Steady-state journals are bounded by the in-flight count
+(currently ≤1 per CLI invocation), so this is belt-and-suspenders against
+pathological growth (a misconfigured retry loop, an external writer,
+etc.). 16 MiB is well above the realistic ceiling."""
+
+
 def _sweep_locked_body(journal: Path, fh) -> None:  # type: ignore[no-untyped-def]
-    """Sweep body executed while holding an exclusive flock on ``fh``.
+    """Sweep body executed while holding an exclusive flock on the lock file.
+
+    Coderabbit round-10 / step-5 atomic compaction (§6.2): retained
+    entries are written to ``<journal>.<pid>.compact.tmp`` then
+    ``os.replace``'d into the journal path. A crash mid-compaction
+    leaves either the OLD journal intact (if the replace hadn't
+    happened) or the NEW journal complete (if it had). No
+    truncated-with-pending-entries window.
 
     The ``journal`` path is carried through for diagnostic logging
-    (coderabbit PRRT_kwDOR_Rkws59hgCS) — it parallels the
-    ``_sweep_unlocked_body(journal)`` signature and gives debug log
-    lines the journal location when the sweep retains entries.
+    (coderabbit PRRT_kwDOR_Rkws59hgCS) and now also for the compact-
+    tmp file path; ``fh`` is the journal-file fd opened by the caller
+    for the read step. Writes go through the compact-tmp + replace
+    path, NOT through ``fh``.
     """
     fh.seek(0)
-    entries = _parse_journal_text(fh.read())
+    journal_text = fh.read()
+    # §6.6 size cap — skip compaction with a WARNING.
+    if len(journal_text.encode("utf-8")) > _MAX_JOURNAL_SIZE_BYTES:
+        logger.warning(
+            "sweep: skipping compaction — journal %s exceeds size cap (%d bytes > %d). "
+            "Steady-state journals should be bounded by in-flight count; "
+            "investigate runaway append behavior.",
+            journal,
+            len(journal_text.encode("utf-8")),
+            _MAX_JOURNAL_SIZE_BYTES,
+        )
+        return
+    entries = _parse_journal_text(journal_text)
     if not entries:
         return
     retained = _reconcile_entries(entries)
-    fh.seek(0)
-    fh.truncate()
-    if retained:
-        fh.write("\n".join(_serialize_entry(e) for e in retained) + "\n")
-        logger.debug(
-            "sweep: retained %d unreconciled entries in %s",
-            len(retained),
-            journal,
-        )
-    fh.flush()
-    os.fsync(fh.fileno())
+    if not retained and not journal_text.strip():
+        # Already empty + nothing to write.
+        return
+    _atomic_compact_journal(journal, retained)
+
+
+def _atomic_compact_journal(journal: Path, retained: list[_JournalEntry]) -> None:
+    """Replace *journal* atomically with the serialized *retained* entries.
+
+    §6.2 algorithm:
+
+    1. Write to ``<journal>.<pid>.compact.tmp`` via ``open("x")`` so a
+       stale tmp from a prior crashed sweep is detected.
+    2. ``write + flush + fsync(tmp_fd)``.
+    3. ``fsync_directory(journal.parent)`` — durable tmp dir entry.
+    4. ``os.replace(tmp, journal)`` — atomic.
+    5. ``fsync_directory(journal.parent)`` — durable replace.
+
+    On stale-tmp ``FileExistsError`` (§6.4), unlinks the stale and
+    retries once. Two failures in a row indicates a permissions
+    pathology that sweep shouldn't paper over — re-raise.
+
+    Caller must hold the ``<journal>.lock`` ``LOCK_EX`` (i.e. only
+    invoke from inside ``_sweep_locked_body`` or another locked
+    context).
+    """
+    tmp = journal.with_name(f"{journal.name}.{os.getpid()}.compact.tmp")
+    payload = "\n".join(_serialize_entry(e) for e in retained)
+    if payload:
+        payload += "\n"
+    try:
+        _write_compact_tmp(tmp, payload)
+    except FileExistsError:
+        # §6.4: stale tmp from prior crashed sweep — unlink + retry once.
+        logger.warning("sweep: removing stale compact-tmp %s and retrying once", tmp)
+        with contextlib.suppress(FileNotFoundError):
+            tmp.unlink()
+        _write_compact_tmp(tmp, payload)
+    fsync_directory(journal)
+    os.replace(tmp, journal)
+    fsync_directory(journal)
+    logger.debug(
+        "sweep: compacted %s — %d retained entr%s",
+        journal,
+        len(retained),
+        "y" if len(retained) == 1 else "ies",
+    )
+
+
+def _write_compact_tmp(tmp: Path, payload: str) -> None:
+    """Open ``tmp`` exclusively (``open("x")``), write *payload*, fsync, close.
+
+    Extracted for reuse by the §6.4 stale-tmp retry. Raises
+    ``FileExistsError`` if the tmp already exists — caller decides
+    whether to clean and retry.
+    """
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+    try:
+        if payload:
+            os.write(fd, payload.encode("utf-8"))
+        os.fsync(fd)
+    finally:
+        os.close(fd)
 
 
 def _sweep_unlocked_body(journal: Path) -> None:
@@ -599,14 +689,14 @@ class _PlannedAction:
     planner and executes. No "report-only mode" branch can drift.
     """
 
-    identity: tuple
+    identity: _OpIdentity
     entry: _JournalEntry
     verb: _PlannedVerb
     reason: str
     log_level: int = logging.DEBUG
 
 
-def _identity(entry: _JournalEntry) -> tuple:
+def _identity(entry: _JournalEntry) -> _OpIdentity:
     """Operation identity for collapse-key reduction (§3.1).
 
     Three rules in order:
@@ -670,7 +760,7 @@ def plan_recovery_actions(
         recovery state table covers the full row matrix that step 6 +
         future steps will fill in.
     """
-    latest: dict[tuple, _JournalEntry] = {}
+    latest: dict[_OpIdentity, _JournalEntry] = {}
     for entry in entries:
         latest[_identity(entry)] = entry
     plan: list[_PlannedAction] = []
@@ -680,7 +770,7 @@ def plan_recovery_actions(
 
 
 def _plan_one(
-    identity: tuple,
+    identity: _OpIdentity,
     entry: _JournalEntry,
     fs_observer: Callable[[str], bool],
 ) -> _PlannedAction:
@@ -945,7 +1035,7 @@ def _reject(msg: str, *args: object, line: str) -> _ParseReject:
     return _ParseReject()
 
 
-def _validate_core_fields(data: dict, line: str) -> tuple[str, str, str, str]:
+def _validate_core_fields(data: dict[str, Any], line: str) -> tuple[str, str, str, str]:
     """§4.1 rules 3 + 4: op/src/dst/state present and string-typed."""
     op = data.get("op")
     src = data.get("src")
@@ -961,17 +1051,17 @@ def _validate_core_fields(data: dict, line: str) -> tuple[str, str, str, str]:
     return op, src, dst, state
 
 
-def _validate_schema(data: dict, line: str) -> int:
+def _validate_schema(data: dict[str, Any], line: str) -> int:
     """§4.1 rule 6: schema is absent (→ 1) or a positive int."""
     schema_raw = data.get("schema")
     if schema_raw is None:
         return 1
     if isinstance(schema_raw, bool) or not isinstance(schema_raw, int) or schema_raw < 1:
         raise _reject("sweep: dropping entry with invalid schema %r", schema_raw, line=line)
-    return schema_raw
+    return int(schema_raw)
 
 
-def _validate_op_id(data: dict, line: str) -> str | None:
+def _validate_op_id(data: dict[str, Any], line: str) -> str | None:
     """Parse ``op_id``. None if absent, string if typed, rejection otherwise."""
     raw = data.get("op_id")
     if raw is None:
@@ -981,7 +1071,7 @@ def _validate_op_id(data: dict, line: str) -> str | None:
     raise _reject("sweep: dropping entry with non-string op_id %r", raw, line=line)
 
 
-def _validate_tmp_path(data: dict, line: str) -> str | None:
+def _validate_tmp_path(data: dict[str, Any], line: str) -> str | None:
     """Parse ``tmp_path``. None if absent, string if typed, rejection otherwise."""
     raw = data.get("tmp_path")
     if raw is None:
@@ -991,7 +1081,7 @@ def _validate_tmp_path(data: dict, line: str) -> str | None:
     raise _reject("sweep: dropping entry with non-string tmp_path %r", raw, line=line)
 
 
-def _validate_ts(data: dict, line: str) -> float | None:
+def _validate_ts(data: dict[str, Any], line: str) -> float | None:
     """Parse diagnostic ``ts``. None/float; reject bool (bool is int subclass)."""
     raw = data.get("ts")
     if raw is None:
@@ -1003,14 +1093,14 @@ def _validate_ts(data: dict, line: str) -> float | None:
     raise _reject("sweep: dropping entry with non-numeric ts %r", raw, line=line)
 
 
-def _validate_host_pid(data: dict, line: str) -> int | None:
+def _validate_host_pid(data: dict[str, Any], line: str) -> int | None:
     """Parse diagnostic ``host_pid``. None/int; reject bool."""
     raw = data.get("host_pid")
     if raw is None:
         return None
     if isinstance(raw, bool) or not isinstance(raw, int):
         raise _reject("sweep: dropping entry with non-int host_pid %r", raw, line=line)
-    return raw
+    return int(raw)
 
 
 def _parse_one_journal_line(line: str) -> _JournalEntry | None:

--- a/src/undo/durable_move.py
+++ b/src/undo/durable_move.py
@@ -50,6 +50,7 @@ steady-state size is bounded.
 
 from __future__ import annotations
 
+import contextlib
 import errno
 import hashlib
 import json
@@ -57,13 +58,25 @@ import logging
 import os
 import shutil
 import tempfile
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
 from utils.atomic_io import fsync_directory
 from utils.atomic_write import append_durable
+
+# F9 top-level optional import: ``fcntl`` is POSIX-only. Wrapped in a
+# try/except so the module imports cleanly on Windows; functions that
+# actually need flock check ``_HAS_FCNTL`` and fall back to the unlocked
+# path with the single-CLI-invocation invariant from the module docstring.
+try:
+    import fcntl
+
+    _HAS_FCNTL = True
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+    _HAS_FCNTL = False
 
 logger = logging.getLogger(__name__)
 
@@ -163,6 +176,61 @@ def _normalized_path_str(path: Path) -> str:
     Windows case) compare as equal in :func:`is_path_in_flight`.
     """
     return os.path.normcase(os.path.abspath(os.fspath(path)))
+
+
+_LOCK_SUFFIX = ".lock"
+
+
+def _lock_path(journal: Path) -> Path:
+    """Return the sibling lock-file path for *journal* (§6.1).
+
+    All ``fcntl.flock`` operations in the protocol acquire on this
+    file rather than on ``journal`` directly. The lock file:
+
+    - Is created on first need by :func:`_locked` (zero-byte).
+    - Is **never replaced or unlinked** during normal protocol ops, so
+      its inode is stable across compactions that ``os.replace`` the
+      journal.
+    - Carries no data — only its inode exists as a flock target.
+
+    This is the round-1 review blocking fix: locking the journal
+    directly meant a compaction's ``os.replace`` could leave a
+    concurrent appender holding a lock on the now-unlinked old inode,
+    causing its append to land in an unreachable file.
+    """
+    return journal.with_name(journal.name + _LOCK_SUFFIX)
+
+
+@contextlib.contextmanager
+def _locked(journal: Path, mode: int) -> Iterator[object | None]:
+    """Acquire ``fcntl.flock(mode)`` on the journal's lock file.
+
+    POSIX-only. On Windows or when ``fcntl`` is unavailable, yields
+    ``None`` and runs the body unlocked — relies on the
+    single-CLI-invocation invariant per the module docstring.
+
+    Ensures ``<journal>.parent`` exists and creates the lock file
+    (zero-byte) if absent. The lock file's directory entry is durable
+    immediately because flock acquisition won't proceed past the OS
+    page cache; in practice the lock's role is purely coordination
+    so durability isn't a correctness concern.
+    """
+    if not _HAS_FCNTL:  # pragma: no cover - Windows
+        yield None
+        return
+    journal.parent.mkdir(parents=True, exist_ok=True)
+    lock = _lock_path(journal)
+    # ``open(..., "a")`` creates the file if absent without truncating
+    # it — keeps a stable inode across all callers.
+    fh = open(lock, "a", encoding="utf-8")
+    try:
+        fcntl.flock(fh.fileno(), mode)
+        try:
+            yield fh
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    finally:
+        fh.close()
 
 
 def durable_move(src: Path, dst: Path, *, journal: Path) -> None:
@@ -448,31 +516,22 @@ def sweep(journal: Path) -> None:
     if not journal.exists():
         return
 
-    # Coderabbit PRRT_kwDOR_Rkws59fzVp: hold an exclusive
-    # ``fcntl.flock`` on the journal for the whole read-modify-write.
-    # Without it, a concurrent ``fo`` invocation that appends a
-    # ``started`` entry between the read and the rewrite would have
-    # its entry silently wiped by the truncate. ``fcntl.flock`` is
-    # POSIX-only; on Windows we fall back to the pre-lock read-modify-
-    # write path and rely on the "single CLI invocation" invariant
-    # documented at the module level.
-    if os.name != "nt":
+    # Coordinate via ``<journal>.lock`` (§6.1, step 4): the lock subject
+    # is a stable-inode sibling file, NEVER replaced by sweep. Locking
+    # the journal directly would let a future compaction's ``os.replace``
+    # invalidate concurrent appenders' locks. ``fcntl.flock`` is
+    # POSIX-only; on Windows ``_locked`` yields without coordinating
+    # and the unlocked sweep body runs (single-CLI-invocation invariant
+    # per the module docstring).
+    if _HAS_FCNTL:
         try:
-            import fcntl
-
-            with open(journal, "r+") as fh:
-                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-                try:
-                    _sweep_locked_body(journal, fh)
-                finally:
-                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+            with _locked(journal, fcntl.LOCK_EX), open(journal, "r+") as fh:
+                _sweep_locked_body(journal, fh)
             return
-        except (ImportError, OSError):
-            # ``ImportError``: fcntl unavailable (shouldn't happen on
-            # POSIX but defensive). ``OSError`` on open can happen if
-            # the journal disappeared between ``exists`` and
-            # ``open`` — fall through to the unlocked path which
-            # handles the missing-file case.
+        except OSError:
+            # ``OSError`` on open can happen if the journal disappeared
+            # between ``exists()`` and ``open()`` — fall through to the
+            # unlocked path which handles the missing-file case.
             pass
     _sweep_unlocked_body(journal)
 
@@ -1066,26 +1125,21 @@ def is_path_in_flight(path: Path, *, journal: Path) -> bool:
     if not journal.exists():
         return False
 
+    # Coordinate via ``<journal>.lock`` (§6.1, step 4) — same lock as
+    # writers. ``LOCK_SH`` blocks while any ``LOCK_EX`` is held by an
+    # appender or compaction, so the reader never observes a journal
+    # state mid-write (the F8 GC race protection).
     entries: list[_JournalEntry] = []
-    if os.name != "nt":
+    if _HAS_FCNTL:
         try:
-            import fcntl
-        except ImportError:  # pragma: no cover - POSIX ships fcntl
-            fcntl = None  # type: ignore[assignment]
-        if fcntl is not None:
-            try:
-                with open(journal, encoding="utf-8") as fh:
-                    fcntl.flock(fh.fileno(), fcntl.LOCK_SH)
-                    try:
-                        entries = _parse_journal_text(fh.read())
-                    finally:
-                        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
-            except FileNotFoundError:  # pragma: no cover - exists()→open() race
-                # Journal disappeared between exists() and open() —
-                # treat the same as missing-journal. No coordination
-                # needed since no writer can touch a deleted file.
-                return False
-    if not entries and os.name == "nt":  # pragma: no cover - Windows-only
+            with _locked(journal, fcntl.LOCK_SH), open(journal, encoding="utf-8") as fh:
+                entries = _parse_journal_text(fh.read())
+        except FileNotFoundError:  # pragma: no cover - exists()→open() race
+            # Journal disappeared between exists() and open() — treat
+            # the same as missing-journal. No coordination needed since
+            # no writer can touch a deleted file.
+            return False
+    else:  # pragma: no cover - Windows-only
         # Windows: fall back to unlocked read; relies on the single-
         # CLI-invocation invariant per the module docstring.
         entries = _read_journal(journal)
@@ -1130,23 +1184,19 @@ def _append_journal(journal: Path, payload: Mapping[str, object]) -> None:
     invocation" invariant; Windows sweep uses the unlocked body too.
     """
     journal.parent.mkdir(parents=True, exist_ok=True)
-    if os.name != "nt":
-        try:
-            import fcntl
-        except ImportError:  # pragma: no cover - POSIX ships fcntl
-            fcntl = None  # type: ignore[assignment]
-        if fcntl is not None:
-            line = json.dumps(payload) + "\n"
-            with open(journal, "a", encoding="utf-8") as fh:
-                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-                try:
-                    fh.write(line)
-                    fh.flush()
-                    os.fsync(fh.fileno())
-                finally:
-                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
-            fsync_directory(journal)
-            return
+    # Coordinate via ``<journal>.lock`` (§6.1, step 4): same lock as
+    # sweep + readers. The journal file itself may be replaced by a
+    # future compaction (step 5); the lock file's stable inode means
+    # this appender's lock acquisition coordinates with that
+    # compaction without depending on the journal inode.
+    if _HAS_FCNTL:
+        line = json.dumps(payload) + "\n"
+        with _locked(journal, fcntl.LOCK_EX), open(journal, "a", encoding="utf-8") as fh:
+            fh.write(line)
+            fh.flush()
+            os.fsync(fh.fileno())
+        fsync_directory(journal)
+        return
     append_durable(journal, json.dumps(payload))
 
 

--- a/src/undo/durable_move.py
+++ b/src/undo/durable_move.py
@@ -57,9 +57,10 @@ import logging
 import os
 import shutil
 import tempfile
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from utils.atomic_io import fsync_directory
 from utils.atomic_write import append_durable
@@ -519,21 +520,274 @@ def _sweep_unlocked_body(journal: Path) -> None:
         journal.write_text("")
 
 
-def _reconcile_entries(entries: list[_JournalEntry]) -> list[_JournalEntry]:
-    """Collapse entries to latest state per (src, dst) and reconcile.
+_PlannedVerb = Literal[
+    "drop",
+    "retain",
+    "unlink_src_then_drop",
+]
+"""Step 2: closed verb set per §5.1 PR #197 subset. Step 6 will add
+``drop_tmp_then_drop`` for the v2 STARTED-with-tmp_path-present row."""
 
-    Returns the subset of entries that still need retry after
-    ``_complete_or_rollback`` — i.e. the ones whose cleanup raised
-    a transient ``OSError``.
+
+@dataclass(frozen=True)
+class _PlannedAction:
+    """A single sweep decision + the entry it applies to.
+
+    Produced by :func:`plan_recovery_actions` (pure, no mutation), executed
+    by :func:`_apply_planned_actions`. Round-3 spec §8.1: keeping these
+    separate means ``fo undo recover`` and sweep agree on what would
+    happen — the CLI calls the planner and renders; sweep calls the
+    planner and executes. No "report-only mode" branch can drift.
     """
-    latest: dict[tuple[str, str], _JournalEntry] = {}
+
+    identity: tuple
+    entry: _JournalEntry
+    verb: _PlannedVerb
+    reason: str
+    log_level: int = logging.DEBUG
+
+
+def _identity_pr197(entry: _JournalEntry) -> tuple:
+    """PR #197 collapse key — placeholder pending the step-3 swap.
+
+    Returns ``(src, dst)`` so same paths in different ops overwrite each
+    other (the codex iy4u bug); step 3 replaces this with the op_id-aware
+    §3.1 identity rule. Kept as a named function so the swap is a
+    one-line change at the call site.
+    """
+    return (entry.src, entry.dst)
+
+
+def plan_recovery_actions(
+    entries: list[_JournalEntry],
+    fs_observer: Callable[[str], bool] = os.path.lexists,
+) -> list[_PlannedAction]:
+    """Pure planner: decide what sweep would do for each retained entry.
+
+    Round-3 design §8.1: this function performs ZERO disk mutation. It
+    collapses ``entries`` by the §3.1 identity (step 2 uses PR #197's
+    ``(src, dst)``; step 3 will swap in op_id-aware identity), observes
+    on-disk state via ``fs_observer`` (defaults to ``os.path.lexists``;
+    tests stub for deterministic table coverage), and returns a list of
+    :class:`_PlannedAction` that :func:`_apply_planned_actions` then
+    executes.
+
+    Both sweep and ``fo undo recover`` (step 8) call this function with
+    the same inputs — sweep proceeds to the executor, the CLI just
+    renders. That keeps "what sweep would do" and "what the CLI shows"
+    bit-identical.
+
+    Args:
+        entries: parsed journal entries (from
+            :func:`_parse_journal_text` or :func:`_read_journal`).
+        fs_observer: callable taking a path string and returning whether
+            the path exists. Defaults to ``os.path.lexists`` so dangling
+            symlinks count as "present" (matches PR #197 round-6 codex
+            hGWW guard).
+
+    Returns:
+        One :class:`_PlannedAction` per collapsed identity, in iteration
+        order. Verb selection mirrors PR #197 step-2 behavior; the §5.1
+        recovery state table covers the full row matrix that step 6 +
+        future steps will fill in.
+    """
+    latest: dict[tuple, _JournalEntry] = {}
     for entry in entries:
-        latest[(entry.src, entry.dst)] = entry
+        latest[_identity_pr197(entry)] = entry
+    plan: list[_PlannedAction] = []
+    for identity, entry in latest.items():
+        plan.append(_plan_one(identity, entry, fs_observer))
+    return plan
+
+
+def _plan_one(
+    identity: tuple,
+    entry: _JournalEntry,
+    fs_observer: Callable[[str], bool],
+) -> _PlannedAction:
+    """Decision matrix for a single collapsed entry.
+
+    PR #197 step-2 subset of §5.1. Step 6 will extend the ``move started``
+    row to consult ``fs_observer(entry.tmp_path)`` for disambiguation.
+    """
+    # Unknown op: future binary's handler owns it; preserve raw payload
+    # via _raw (already captured by the parser per §4.2).
+    if entry.op not in _KNOWN_OPS:
+        return _PlannedAction(
+            identity=identity,
+            entry=entry,
+            verb="retain",
+            reason=(
+                f"unknown op {entry.op!r} (state={entry.state!r}); waiting for "
+                f"a binary that knows this op. Known ops: {sorted(_KNOWN_OPS)}"
+            ),
+            log_level=logging.WARNING,
+        )
+    # dir_move: coordination-only (round-10). Sweep can't safely retry
+    # shutil.move; drop in any state. WARN if state != done so operator
+    # knows on-disk state may need inspection.
+    if entry.op == OP_DIR_MOVE:
+        if entry.state == STATE_DONE:
+            return _PlannedAction(
+                identity=identity,
+                entry=entry,
+                verb="drop",
+                reason="dir_move done — coordination complete",
+            )
+        return _PlannedAction(
+            identity=identity,
+            entry=entry,
+            verb="drop",
+            reason=(
+                f"dir_move entry {entry.src} -> {entry.dst} in state "
+                f"{entry.state!r} — directory moves are non-atomic; "
+                f"on-disk state needs operator inspection. Dropping "
+                f"entry to release the in-flight marker."
+            ),
+            log_level=logging.WARNING,
+        )
+    # entry.op == OP_MOVE — the F7 atomic/durable single-file path.
+    if entry.state == STATE_STARTED:
+        # PR #197 step-2 behavior: ambiguous, retain. Step 6 will
+        # disambiguate via fs_observer(entry.tmp_path).
+        return _PlannedAction(
+            identity=identity,
+            entry=entry,
+            verb="retain",
+            reason=(
+                f"started entry {entry.src} -> {entry.dst} is ambiguous "
+                "(crash in copy→replace window); cannot reconcile without "
+                "content comparison — operator or retry must resolve"
+            ),
+            log_level=logging.WARNING,
+        )
+    if entry.state == STATE_COPIED:
+        # Codex hGWW: dst-presence guard. Missing dst means out-of-band
+        # cleanup happened between the journal write and now; unlinking
+        # src would destroy the last copy.
+        if not fs_observer(entry.dst):
+            return _PlannedAction(
+                identity=identity,
+                entry=entry,
+                verb="retain",
+                reason=(
+                    f"copied entry {entry.src} -> {entry.dst} — dst is missing; "
+                    "unlinking src would destroy the last remaining copy"
+                ),
+                log_level=logging.WARNING,
+            )
+        return _PlannedAction(
+            identity=identity,
+            entry=entry,
+            verb="unlink_src_then_drop",
+            reason=f"copied entry {entry.src} -> {entry.dst}; finishing by unlinking src",
+        )
+    if entry.state == STATE_DONE:
+        return _PlannedAction(
+            identity=identity,
+            entry=entry,
+            verb="drop",
+            reason=f"done entry {entry.src} -> {entry.dst}; nothing to do",
+        )
+    # Known op with unrecognized state — drop with warning. Same as PR #197.
+    return _PlannedAction(
+        identity=identity,
+        entry=entry,
+        verb="drop",
+        reason=f"unknown state {entry.state!r} for op {entry.op!r}; dropping",
+        log_level=logging.WARNING,
+    )
+
+
+def _apply_planned_actions(plan: list[_PlannedAction]) -> list[_JournalEntry]:
+    """Execute each :class:`_PlannedAction`, returning the retained entries.
+
+    Round-3 §8.1: companion to :func:`plan_recovery_actions`. The planner
+    decided WHAT to do; this function does it. Mutations are confined
+    here so the planner stays pure and the CLI/sweep parity contract
+    holds.
+
+    Verbs:
+
+    - ``drop``: log at the planner-chosen level, drop the entry.
+    - ``retain``: log at the planner-chosen level, keep the entry.
+    - ``unlink_src_then_drop``: unlink src + fsync(src.parent), then drop.
+      ``FileNotFoundError`` on unlink is swallowed (already gone). Other
+      ``OSError`` falls back to retain — the next sweep retries
+      (codex fwMK + PR #197 round-5).
+
+    Step 6 will add ``drop_tmp_then_drop`` for the v2 STARTED-tmp-present
+    row.
+    """
     retained: list[_JournalEntry] = []
-    for entry in latest.values():
-        if not _complete_or_rollback(entry):
-            retained.append(entry)
+    for action in plan:
+        if action.log_level >= logging.WARNING or action.log_level >= logging.INFO:
+            logger.log(action.log_level, "sweep: %s", action.reason)
+        if action.verb == "retain":
+            retained.append(action.entry)
+            continue
+        if action.verb == "drop":
+            continue
+        if action.verb == "unlink_src_then_drop":
+            if not _execute_unlink_src(action.entry):
+                retained.append(action.entry)
+            continue
+        # Defensive: an unknown verb is a programming error, not an
+        # input concern — log and retain so we don't silently swallow it.
+        logger.error(
+            "sweep: unknown planned verb %r on entry %r; retaining defensively",
+            action.verb,
+            action.entry,
+        )
+        retained.append(action.entry)
     return retained
+
+
+def _execute_unlink_src(entry: _JournalEntry) -> bool:
+    """Unlink ``entry.src`` and fsync ``src.parent``.
+
+    Returns True on success (entry should drop), False on transient
+    ``OSError`` (entry should retain). Extracted from
+    :func:`_apply_planned_actions` for testability and to keep the
+    executor's main loop within the cyclomatic budget.
+    """
+    src = Path(entry.src)
+    try:
+        src.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.warning(
+            "sweep: failed to unlink source after copied state %s: %s",
+            src,
+            exc,
+            exc_info=True,
+        )
+        return False
+    # Codex P2 PRRT_kwDOR_Rkws59hT9b: fsync src.parent so the unlink
+    # is crash-durable BEFORE sweep truncates this entry out of the
+    # journal. fsync OSError on unusual FS is non-fatal — the unlink
+    # already succeeded.
+    try:
+        fsync_directory(src)
+    except OSError as exc:
+        logger.debug(
+            "sweep: fsync of src.parent after unlink failed: %s",
+            exc,
+            exc_info=True,
+        )
+    return True
+
+
+def _reconcile_entries(entries: list[_JournalEntry]) -> list[_JournalEntry]:
+    """Plan + execute reconciliation in one call.
+
+    Thin wrapper preserving the existing sweep call site. The work is
+    split between :func:`plan_recovery_actions` (pure decision) and
+    :func:`_apply_planned_actions` (mutation). Step 8's ``fo undo
+    recover`` calls just the planner.
+    """
+    return _apply_planned_actions(plan_recovery_actions(entries))
 
 
 def _serialize_entry(e: _JournalEntry) -> str:
@@ -753,158 +1007,6 @@ def _parse_one_journal_line(line: str) -> _JournalEntry | None:
         host_pid=host_pid,
         _raw=raw_for_unknown_op,
     )
-
-
-def _complete_or_rollback(entry: _JournalEntry) -> bool:
-    """Act on a single journal entry based on its state.
-
-    Returns:
-        ``True`` if the entry was successfully reconciled (or was
-        already ``done``) and can be dropped from the journal.
-        ``False`` if a transient error (usually ``OSError``) left the
-        state unresolved — caller must retain the entry so the next
-        sweep can retry.
-    """
-    # Codex P2 PRRT_kwDOR_Rkws59hdFb: the journal is shared across
-    # operation types — the module docstring reserves ``op`` for
-    # future ``"copy"``, ``"symlink"``, etc. Sweep only knows how to
-    # reconcile the ops in ``_KNOWN_OPS``; for anything else, acting
-    # on ``entry.state`` with move semantics (e.g. ``src.unlink()``
-    # in the ``copied`` branch) would cause data loss on a downgrade
-    # from a binary that wrote the newer op. Retain the entry so a
-    # future binary with the right handler can process it.
-    if entry.op not in _KNOWN_OPS:
-        logger.warning(
-            "sweep: retaining journal entry with unknown op %r (state=%r); "
-            "this sweep binary only knows %s, will leave for a handler "
-            "that understands the op.",
-            entry.op,
-            entry.state,
-            sorted(_KNOWN_OPS),
-        )
-        return False
-
-    src = Path(entry.src)
-    dst = Path(entry.dst)
-
-    # ``dir_move`` (round-10): coordination-only entries. Sweep cannot
-    # safely retry shutil.move (non-atomic, non-idempotent), so any
-    # state other than ``done`` indicates a crashed move that needs
-    # operator inspection. Drop the entry either way — keeping it
-    # around would just keep the path marked in-flight forever and
-    # block GC.
-    if entry.op == OP_DIR_MOVE:
-        if entry.state != STATE_DONE:
-            logger.warning(
-                "sweep: dir_move entry %s -> %s in state %r — directory "
-                "moves are non-atomic; on-disk state needs operator "
-                "inspection. Dropping entry to release the in-flight marker.",
-                src,
-                dst,
-                entry.state,
-            )
-        return True  # drop
-
-    # entry.op == OP_MOVE — the F7 atomic/durable single-file path.
-    if entry.state == STATE_STARTED:
-        # Codex P1 PRRT_kwDOR_Rkws59gbdD + PRRT_kwDOR_Rkws59g2Ex:
-        # ``started`` is an AMBIGUOUS state, not a "move never
-        # committed" state. The EXDEV path logs ``started`` before
-        # the copy and does NOT log ``copied`` until AFTER
-        # ``os.replace``, so a crash anywhere in this window leaves
-        # a ``started`` record with one of three possible on-disk
-        # realities:
-        #
-        #   (a) crash before os.replace: src intact, dst pristine
-        #       (pre-existing file OR absent). Retry is safe.
-        #   (b) crash during or after os.replace but before the
-        #       ``copied`` log fsyncs: dst has the NEW content, src
-        #       still exists. A naive retry would double-copy; the
-        #       correct recovery is "unlink src" (i.e. complete the
-        #       ``copied`` semantics).
-        #   (c) same as (b) but os.replace was atomic and the tmp
-        #       already got cleaned — indistinguishable from (b)
-        #       without content comparison.
-        #
-        # We cannot safely disambiguate (a) from (b) without
-        # introducing a new journal state or storing tmp_path in the
-        # record (future F7.1). For now the SAFE reconciliation is:
-        # do NOT unlink dst (which would destroy a legitimate
-        # pre-existing file in case (a)) and do NOT unlink src
-        # (which would cause data loss in case (a) where dst was
-        # never replaced), and RETAIN the entry so the next sweep /
-        # operator sees it. Dropping the entry would lose all retry
-        # metadata and potentially leave both src+dst on disk forever.
-        logger.warning(
-            "sweep: retaining ambiguous started entry %s -> %s "
-            "(crash occurred in the copy→replace window; cannot safely "
-            "reconcile without content comparison — operator or retry "
-            "must resolve)",
-            src,
-            dst,
-        )
-        return False  # retain for next sweep / manual reconciliation
-    elif entry.state == STATE_COPIED:
-        # Codex P1 PRRT_kwDOR_Rkws59hGWW: verify dst still exists
-        # before unlinking src. A crash-and-recovery window can leave
-        # the journal with a ``copied`` record while an out-of-band
-        # actor (operator cleanup, another process, backup restore)
-        # removed dst between the journal write and this sweep. Blind
-        # ``src.unlink()`` in that state destroys the last remaining
-        # copy — a data-loss path. ``os.path.lexists`` is used
-        # (instead of ``dst.exists()``) so a dangling-symlink dst
-        # still counts as "present" — the symlink itself is a first-
-        # class file-system entity we committed to on os.replace.
-        if not os.path.lexists(dst):
-            logger.warning(
-                "sweep: retaining copied entry %s -> %s — dst is missing; "
-                "unlinking src would destroy the last remaining copy. "
-                "Operator or retry must reconcile.",
-                src,
-                dst,
-            )
-            return False
-        try:
-            src.unlink()
-        except FileNotFoundError:
-            pass
-        except OSError as exc:
-            logger.warning(
-                "sweep: failed to unlink source after copied state %s: %s",
-                src,
-                exc,
-                exc_info=True,
-            )
-            return False
-        # Codex P2 PRRT_kwDOR_Rkws59hT9b: fsync ``src.parent`` so the
-        # unlink is crash-durable BEFORE sweep truncates this entry
-        # out of the journal. Parallel to the in-line post-unlink
-        # fsync in ``_durable_cross_device_move`` (gnah). Without
-        # this, a power loss between the unlink and the journal
-        # truncate could let ``src`` reappear on reboot while sweep
-        # has already dropped the record — no retry metadata, no way
-        # to know there's a phantom file to clean up.
-        try:
-            fsync_directory(src)
-        except OSError as exc:
-            # fsync itself can raise on unusual filesystems. Log but
-            # don't fail the reconciliation — the unlink itself
-            # succeeded and sweep's next pass would notice if the
-            # dir entry wasn't persisted.
-            logger.debug(
-                "sweep: fsync of src.parent after unlink failed: %s",
-                exc,
-                exc_info=True,
-            )
-    elif entry.state == STATE_DONE:
-        # Nothing to do — operation completed before the crash (or
-        # before the last journal flush).
-        pass
-    else:
-        logger.warning("sweep: unknown journal state %r for entry %r", entry.state, entry)
-        # Unknown states are dropped rather than retained — retrying
-        # an unrecognized entry won't change anything.
-    return True
 
 
 def is_path_in_flight(path: Path, *, journal: Path) -> bool:

--- a/src/undo/durable_move.py
+++ b/src/undo/durable_move.py
@@ -547,15 +547,35 @@ class _PlannedAction:
     log_level: int = logging.DEBUG
 
 
-def _identity_pr197(entry: _JournalEntry) -> tuple:
-    """PR #197 collapse key — placeholder pending the step-3 swap.
+def _identity(entry: _JournalEntry) -> tuple:
+    """Operation identity for collapse-key reduction (§3.1).
 
-    Returns ``(src, dst)`` so same paths in different ops overwrite each
-    other (the codex iy4u bug); step 3 replaces this with the op_id-aware
-    §3.1 identity rule. Kept as a named function so the swap is a
-    one-line change at the call site.
+    Three rules in order:
+
+    1. v2 known-op record (``schema == 2``, op ∈ ``_KNOWN_OPS``,
+       ``op_id`` present): identity is ``("v2", op, op_id)`` — a single
+       invocation; different retries of the same move stay distinct.
+       The parser enforces ``op_id`` presence (§4.1 rule 8) so a v2
+       known-op entry without ``op_id`` never reaches this point.
+    2. v1 known-op record (no ``schema`` field on disk): identity is
+       ``("v1", op, src, dst)`` — path-keyed fallback matching PR #197
+       behavior. The ``"v1"`` discriminator means a v1 record cannot
+       collapse with a v2 record sharing the same ``(op, src, dst)``,
+       so v2's stronger identity is never silently downgraded.
+    3. Unknown op: identity is ``("unknown", op, _hash16(_raw))`` —
+       hashed from the full raw line so semantically-distinct future
+       records (with fields our parser doesn't understand) don't
+       conflate. The parser captures ``_raw`` for unknown ops via
+       §4.2; a defensive ``or ""`` covers the ``_raw is None`` case
+       a hand-constructed test entry might create.
+
+    Closes codex iy4u (same-path different-op masking) per #201.
     """
-    return (entry.src, entry.dst)
+    if entry.op in _KNOWN_OPS:
+        if entry.schema == 2 and entry.op_id is not None:
+            return ("v2", entry.op, entry.op_id)
+        return ("v1", entry.op, entry.src, entry.dst)
+    return ("unknown", entry.op, _hash16(entry._raw or ""))
 
 
 def plan_recovery_actions(
@@ -593,7 +613,7 @@ def plan_recovery_actions(
     """
     latest: dict[tuple, _JournalEntry] = {}
     for entry in entries:
-        latest[_identity_pr197(entry)] = entry
+        latest[_identity(entry)] = entry
     plan: list[_PlannedAction] = []
     for identity, entry in latest.items():
         plan.append(_plan_one(identity, entry, fs_observer))

--- a/src/undo/durable_move.py
+++ b/src/undo/durable_move.py
@@ -1341,11 +1341,16 @@ def is_path_in_flight(path: Path, *, journal: Path) -> bool:
     # Normalize the query path the same way writers do so the compare
     # works on equivalent paths (coderabbit PRRT_kwDOR_Rkws59fzVv).
     path_str = _normalized_path_str(path)
-    # Collapse to the latest state per (src, dst) — an entry may
-    # have been updated across crash-recovery attempts.
-    latest: dict[tuple[str, str], _JournalEntry] = {}
+    # §3.1: collapse by the operation identity ("v2"/op/op_id, "v1"/op/src/dst,
+    # or "unknown"/op/_hash16) — same key the planner uses. Path-keyed collapse
+    # would re-introduce the codex iy4u masking bug for F8 trash-GC: e.g. a
+    # ``move /a /b started`` followed by an unrelated ``dir_move /a /b done``
+    # would let the dir_move done supersede the move started under
+    # ``(src, dst)`` reduction, and ``is_path_in_flight(/a)`` would falsely
+    # return False during the move's copy → replace window.
+    latest: dict[_OpIdentity, _JournalEntry] = {}
     for entry in entries:
-        latest[(entry.src, entry.dst)] = entry
+        latest[_identity(entry)] = entry
     for entry in latest.values():
         if entry.state == STATE_DONE:
             continue

--- a/tests/cli/test_undo_recover.py
+++ b/tests/cli/test_undo_recover.py
@@ -1,0 +1,305 @@
+"""Tests for the ``fo recover`` CLI command (F7.1 step 8 / §8.2).
+
+The command reads the durable_move journal under ``LOCK_SH`` (per §6.5),
+calls the pure ``plan_recovery_actions`` planner, and renders the plan
+as a table for operator visibility — no disk mutation.
+
+Exit-code contract:
+
+- ``0`` if the plan is empty (no actionable retained entries).
+- ``1`` if any action would be taken (so scripts can detect "needs cleanup").
+
+Per §9.6 test plan items:
+
+- empty / missing journal → exit 0, "no retained entries" rendered.
+- retained entries → exit 1, formatted table with op/state/src/dst/verb/reason.
+- v2 ``move started`` rows include the §5.1 disambiguation tier in the reason.
+- planner is pure: invoking the CLI MUST NOT mutate any file on disk.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Per-test Typer runner for explicitness."""
+    return CliRunner()
+
+
+def _write_journal_lines(journal: Path, entries: list[dict]) -> None:
+    """Write JSONL entries directly (bypassing the writer's lock — fine
+    in tests since we control the only writer)."""
+    journal.parent.mkdir(parents=True, exist_ok=True)
+    journal.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Public reader contract
+# ---------------------------------------------------------------------------
+
+
+class TestReadJournalUnderSharedLock:
+    """``read_journal_under_shared_lock`` is the public reader the CLI
+    uses — acquires ``LOCK_SH`` on ``<journal>.lock`` (per §6.1) and
+    returns parsed entries. Missing journal → empty list (no-op)."""
+
+    def test_missing_journal_returns_empty(self, tmp_path: Path) -> None:
+        from undo.durable_move import read_journal_under_shared_lock
+
+        journal = tmp_path / "absent.journal"
+        assert read_journal_under_shared_lock(journal) == []
+
+    def test_empty_journal_returns_empty(self, tmp_path: Path) -> None:
+        from undo.durable_move import read_journal_under_shared_lock
+
+        journal = tmp_path / "empty.journal"
+        journal.write_text("")
+        assert read_journal_under_shared_lock(journal) == []
+
+    def test_returns_parsed_entries(self, tmp_path: Path) -> None:
+        from undo.durable_move import read_journal_under_shared_lock
+
+        journal = tmp_path / "move.journal"
+        _write_journal_lines(
+            journal,
+            [
+                {"op": "move", "src": "/a", "dst": "/b", "state": "started"},
+                {"op": "move", "src": "/a", "dst": "/b", "state": "copied"},
+            ],
+        )
+        entries = read_journal_under_shared_lock(journal)
+        assert len(entries) == 2
+        assert entries[0].state == "started"
+        assert entries[1].state == "copied"
+
+
+# ---------------------------------------------------------------------------
+# CLI command
+# ---------------------------------------------------------------------------
+
+
+class TestRecoverCommand:
+    """``fo recover`` end-to-end: invoke through the Typer app, assert
+    on exit code + rendered output."""
+
+    def test_recover_missing_journal_exits_zero(
+        self, tmp_path: Path, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No journal on disk → no retained entries → exit 0."""
+        from cli.main import app
+
+        monkeypatch.setattr(
+            "undo._journal.default_journal_path", lambda: tmp_path / "absent.journal"
+        )
+
+        result = runner.invoke(app, ["recover"])
+        assert result.exit_code == 0, result.output
+        assert "no retained entries" in result.output.lower(), result.output
+
+    def test_recover_empty_journal_exits_zero(
+        self, tmp_path: Path, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Journal exists but is empty → no retained entries → exit 0."""
+        from cli.main import app
+
+        journal = tmp_path / "empty.journal"
+        journal.write_text("")
+        monkeypatch.setattr("undo._journal.default_journal_path", lambda: journal)
+
+        result = runner.invoke(app, ["recover"])
+        assert result.exit_code == 0, result.output
+
+    def test_recover_done_only_exits_zero(
+        self, tmp_path: Path, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Journal with only ``done`` entries → planner emits ``drop``
+        verbs; no retained actions → exit 0."""
+        from cli.main import app
+
+        journal = tmp_path / "move.journal"
+        _write_journal_lines(journal, [{"op": "move", "src": "/x", "dst": "/y", "state": "done"}])
+        monkeypatch.setattr("undo._journal.default_journal_path", lambda: journal)
+
+        result = runner.invoke(app, ["recover"])
+        assert result.exit_code == 0, result.output
+
+    def test_recover_copied_with_dst_present_exits_one(
+        self, tmp_path: Path, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``copied`` with dst present → planner emits
+        ``unlink_src_then_drop`` → actionable → exit 1.
+
+        Critical: invoking ``recover`` MUST NOT execute the unlink
+        (planner is pure). src remains on disk after the command."""
+        from cli.main import app
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("must survive recover")
+        dst.write_text("complete dst")
+        journal = tmp_path / "move.journal"
+        _write_journal_lines(
+            journal,
+            [{"op": "move", "src": str(src), "dst": str(dst), "state": "copied"}],
+        )
+        monkeypatch.setattr("undo._journal.default_journal_path", lambda: journal)
+
+        result = runner.invoke(app, ["recover"])
+        assert result.exit_code == 1, result.output
+        # Output names the verb the executor would run.
+        assert "unlink_src_then_drop" in result.output, result.output
+        # CLI is read-only.
+        assert src.read_text() == "must survive recover"
+        assert dst.read_text() == "complete dst"
+
+    def test_recover_copied_with_dst_missing_exits_one(
+        self, tmp_path: Path, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``copied`` with dst absent → planner emits ``retain``
+        (codex hGWW guard: dst missing means tmp/dst was cleaned out
+        of band; unlinking src would destroy the last copy) → exit 1."""
+        from cli.main import app
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "missing.txt"
+        src.write_text("only copy")
+        journal = tmp_path / "move.journal"
+        _write_journal_lines(
+            journal,
+            [{"op": "move", "src": str(src), "dst": str(dst), "state": "copied"}],
+        )
+        monkeypatch.setattr("undo._journal.default_journal_path", lambda: journal)
+
+        result = runner.invoke(app, ["recover"])
+        assert result.exit_code == 1, result.output
+        assert "retain" in result.output, result.output
+        # src still present.
+        assert src.read_text() == "only copy"
+
+    def test_recover_v2_started_tmp_present_renders_pre_replace_tier(
+        self, tmp_path: Path, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """v2 ``move started`` with ``tmp_path`` present → planner
+        emits ``drop_tmp_then_drop``, and the rendered reason indicates
+        the §5.1 pre-replace disambiguation tier so operators
+        understand WHY sweep would unlink tmp instead of src."""
+        from cli.main import app
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        tmp = tmp_path / ".dst.txt.42.tmp"
+        src.write_text("canonical")
+        tmp.write_text("orphan tmp from pre-replace crash")
+        journal = tmp_path / "move.journal"
+        _write_journal_lines(
+            journal,
+            [
+                {
+                    "schema": 2,
+                    "op": "move",
+                    "op_id": "op-pre",
+                    "src": str(src),
+                    "dst": str(dst),
+                    "tmp_path": str(tmp),
+                    "state": "started",
+                }
+            ],
+        )
+        monkeypatch.setattr("undo._journal.default_journal_path", lambda: journal)
+
+        result = runner.invoke(app, ["recover"])
+        assert result.exit_code == 1, result.output
+        assert "drop_tmp_then_drop" in result.output, result.output
+        # Reason includes the §5.1 disambiguation tier hint.
+        assert "pre-replace" in result.output.lower(), result.output
+        # Read-only: tmp still on disk after the CLI runs.
+        assert tmp.exists()
+        assert src.read_text() == "canonical"
+
+    def test_recover_v2_started_tmp_absent_renders_post_replace_tier(
+        self, tmp_path: Path, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """v2 ``move started`` with ``tmp_path`` absent → planner
+        emits ``unlink_src_then_drop``, reason indicates post-replace
+        tier so operators understand the rationale."""
+        from cli.main import app
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        # tmp absent (post-replace crash: replace consumed it).
+        src.write_text("post-replace src")
+        journal = tmp_path / "move.journal"
+        _write_journal_lines(
+            journal,
+            [
+                {
+                    "schema": 2,
+                    "op": "move",
+                    "op_id": "op-post",
+                    "src": str(src),
+                    "dst": str(dst),
+                    "tmp_path": str(tmp_path / ".dst.txt.42.tmp"),
+                    "state": "started",
+                }
+            ],
+        )
+        monkeypatch.setattr("undo._journal.default_journal_path", lambda: journal)
+
+        result = runner.invoke(app, ["recover"])
+        assert result.exit_code == 1, result.output
+        assert "unlink_src_then_drop" in result.output, result.output
+        assert "post-replace" in result.output.lower(), result.output
+
+    def test_recover_does_not_mutate_disk(
+        self,
+        tmp_path: Path,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The CLI MUST be read-only — it calls only the planner, never
+        the executor. Instrumented unlink + fsync_directory: zero calls
+        from undo.durable_move during the recover command."""
+        from cli.main import app
+        from undo import durable_move as dm_mod
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("x")
+        dst.write_text("y")
+        journal = tmp_path / "move.journal"
+        _write_journal_lines(
+            journal,
+            [{"op": "move", "src": str(src), "dst": str(dst), "state": "copied"}],
+        )
+        monkeypatch.setattr("undo._journal.default_journal_path", lambda: journal)
+
+        mutations: list[str] = []
+
+        real_unlink = Path.unlink
+
+        def tracking_unlink(self: Path, *a: object, **k: object) -> None:
+            mutations.append(f"unlink:{self}")
+            return real_unlink(self, *a, **k)
+
+        def tracking_fsync(p: Path) -> None:
+            mutations.append(f"fsync:{p}")
+
+        monkeypatch.setattr(Path, "unlink", tracking_unlink)
+        monkeypatch.setattr(dm_mod, "fsync_directory", tracking_fsync)
+
+        result = runner.invoke(app, ["recover"])
+        assert result.exit_code == 1, result.output
+        assert mutations == [], f"CLI must be read-only; observed mutations: {mutations}"

--- a/tests/cli/test_undo_recover.py
+++ b/tests/cli/test_undo_recover.py
@@ -25,7 +25,7 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
-pytestmark = [pytest.mark.unit, pytest.mark.ci]
+pytestmark = [pytest.mark.unit, pytest.mark.ci, pytest.mark.integration]
 
 
 # ---------------------------------------------------------------------------
@@ -232,15 +232,22 @@ class TestRecoverCommand:
     def test_recover_v2_started_tmp_absent_renders_post_replace_tier(
         self, tmp_path: Path, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """v2 ``move started`` with ``tmp_path`` absent → planner
-        emits ``unlink_src_then_drop``, reason indicates post-replace
-        tier so operators understand the rationale."""
+        """v2 ``move started`` with ``tmp_path`` absent + dst PRESENT
+        → planner emits ``unlink_src_then_drop`` (post-replace
+        confirmed by dst's presence), reason indicates post-replace
+        tier so operators understand the rationale.
+
+        Codex lCbU dst-presence guard: tmp absent alone is not proof
+        of post-replace. dst present is what makes the
+        unlink_src_then_drop verb safe.
+        """
         from cli.main import app
 
         src = tmp_path / "src.txt"
         dst = tmp_path / "dst.txt"
-        # tmp absent (post-replace crash: replace consumed it).
         src.write_text("post-replace src")
+        # dst present — proof that os.replace consumed tmp into dst.
+        dst.write_text("post-replace dst (replace consumed tmp)")
         journal = tmp_path / "move.journal"
         _write_journal_lines(
             journal,
@@ -262,6 +269,83 @@ class TestRecoverCommand:
         assert result.exit_code == 1, result.output
         assert "unlink_src_then_drop" in result.output, result.output
         assert "post-replace" in result.output.lower(), result.output
+
+    def test_recover_skips_startup_sweep(
+        self, tmp_path: Path, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Codex P1 lCbV / coderabbit lDDy: ``main_callback`` runs
+        startup sweep before any command. ``fo recover`` is the
+        read-only preview of what sweep would do — running sweep
+        FIRST would mutate state (unlink, compact) and then the
+        preview would report "no retained entries". The startup sweep
+        MUST be skipped for the recover subcommand.
+        """
+        from cli.main import app
+
+        # Pre-populate a journal that sweep would compact (a done entry).
+        journal = tmp_path / "move.journal"
+        _write_journal_lines(journal, [{"op": "move", "src": "/x", "dst": "/y", "state": "done"}])
+        monkeypatch.setattr("undo._journal.default_journal_path", lambda: journal)
+
+        # Instrument sweep so we can prove it's NOT called by the
+        # recover invocation. The startup sweep targets the default
+        # journal path — also patched above — so we'd see the call here
+        # if it fired.
+        sweep_calls: list[Path] = []
+        from undo import durable_move as dm_mod
+
+        real_sweep = dm_mod.sweep
+
+        def tracking_sweep(j: Path) -> None:
+            sweep_calls.append(j)
+            real_sweep(j)
+
+        monkeypatch.setattr("cli.main._durable_move_sweep", tracking_sweep)
+
+        result = runner.invoke(app, ["recover"])
+        assert result.exit_code == 0, result.output
+        assert sweep_calls == [], (
+            f"recover MUST skip startup sweep (read-only contract); "
+            f"observed sweep calls: {sweep_calls}"
+        )
+
+    def test_recover_surfaces_warning_drops(
+        self, tmp_path: Path, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CodeRabbit lDD3: ``dir_move started`` entries are dropped
+        (sweep can't safely retry shutil.move) but flagged WARNING
+        because operators need to inspect on-disk state. The recover
+        preview MUST show these rows even though their verb is
+        ``drop`` — otherwise the command this PR adds for operator
+        visibility doesn't surface the case it most needs to.
+
+        Exit code stays 0 because there's no recovery action sweep
+        will take — these are operator-visibility rows, not
+        "needs cleanup" rows.
+        """
+        from cli.main import app
+
+        journal = tmp_path / "move.journal"
+        _write_journal_lines(
+            journal,
+            [
+                {
+                    "op": "dir_move",
+                    "src": str(tmp_path / "src_dir"),
+                    "dst": str(tmp_path / "dst_dir"),
+                    "state": "started",
+                }
+            ],
+        )
+        monkeypatch.setattr("undo._journal.default_journal_path", lambda: journal)
+
+        result = runner.invoke(app, ["recover"])
+        # Stranded dir_move is operator-visible but not actionable —
+        # exit 0 (no sweep verb would actually run).
+        assert result.exit_code == 0, result.output
+        # The row must still appear in the rendered preview.
+        assert "dir_move" in result.output, result.output
+        assert "drop" in result.output, result.output
 
     def test_recover_does_not_mutate_disk(
         self,

--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -1661,6 +1661,279 @@ class TestIsPathInFlightSharedLock:
 
 
 # ---------------------------------------------------------------------------
+# F7.1 journal schema v2 — parser + rejection-rule coverage
+# (tracks #201, docs/internal/F7-1-journal-protocol-design.md §4, §9.1)
+# ---------------------------------------------------------------------------
+
+
+class TestJournalSchemaV2Parser:
+    """F7.1 step 1: parser accepts v1 and v2 records, preserves unknown-op
+    raw lines, and rejects each §4.1 malformed case with a WARNING log.
+    """
+
+    def test_v1_record_no_schema_field_accepted(self, tmp_path: Path) -> None:
+        """A v1 record (no ``schema`` field) must still parse — PR #197
+        back-compat. The resulting entry has ``schema == 1``, ``op_id is
+        None``, ``tmp_path is None``."""
+        from undo.durable_move import _parse_journal_text
+
+        line = json.dumps({"op": "move", "src": "/a", "dst": "/b", "state": "done"})
+        entries = _parse_journal_text(line + "\n")
+
+        assert len(entries) == 1
+        e = entries[0]
+        assert e.op == "move"
+        assert e.src == "/a"
+        assert e.dst == "/b"
+        assert e.state == "done"
+        assert e.schema == 1
+        assert e.op_id is None
+        assert e.tmp_path is None
+
+    def test_v2_known_op_record_round_trips(self, tmp_path: Path) -> None:
+        """v2 record with all known-op fields round-trips through parse →
+        serialize → parse and preserves every field."""
+        from undo.durable_move import _parse_journal_text, _serialize_entry
+
+        src = str(tmp_path / "source.txt")
+        dst = str(tmp_path / "dest.txt")
+        tmp = str(tmp_path / "tmp-file.tmp")
+        src_line = json.dumps(
+            {
+                "schema": 2,
+                "op": "move",
+                "op_id": "abc123",
+                "src": src,
+                "dst": dst,
+                "state": "started",
+                "tmp_path": tmp,
+                "ts": 1714000000.5,
+                "host_pid": 12345,
+            }
+        )
+        parsed = _parse_journal_text(src_line + "\n")
+        assert len(parsed) == 1
+        e = parsed[0]
+        assert e.schema == 2
+        assert e.op_id == "abc123"
+        assert e.tmp_path == tmp
+        assert e.ts == 1714000000.5
+        assert e.host_pid == 12345
+
+        # Re-parse the serialized form — must produce an identical entry.
+        reparsed = _parse_journal_text(_serialize_entry(e) + "\n")
+        assert len(reparsed) == 1
+        assert reparsed[0] == e
+
+    def test_non_object_json_rejected(self, tmp_path: Path) -> None:
+        """§4.1 rule 2 (codex iy4w): JSON that parses but isn't an object
+        (null, list, scalar, string) is logged + skipped, not AttributeError.
+        Covers BOTH ``_parse_journal_text`` AND ``_read_journal`` — the
+        round-8 fix missed ``_read_journal`` per the #201 body."""
+        from undo.durable_move import _parse_journal_text, _read_journal
+
+        corrupt = "\n".join(
+            [
+                "null",
+                "[]",
+                '"bare string"',
+                "42",
+                json.dumps({"op": "move", "src": "/a", "dst": "/b", "state": "done"}),
+            ]
+        )
+        journal = tmp_path / "corrupt.journal"
+        journal.write_text(corrupt + "\n")
+
+        # Parser via text: 4 rejects + 1 accept.
+        via_text = _parse_journal_text(corrupt)
+        assert len(via_text) == 1
+        assert via_text[0].op == "move"
+
+        # Parser via file: same contract, no AttributeError from the
+        # pre-F7.1 _read_journal missing-dict-guard bug.
+        via_file = _read_journal(journal)
+        assert len(via_file) == 1
+        assert via_file[0].op == "move"
+
+    def test_missing_required_field_rejected(self) -> None:
+        """§4.1 rule 3: missing op/src/dst/state logged + skipped."""
+        from undo.durable_move import _parse_journal_text
+
+        corrupt = "\n".join(
+            [
+                json.dumps({"op": "move"}),  # missing src, dst, state
+                json.dumps({"src": "/a", "dst": "/b", "state": "done"}),  # missing op
+                json.dumps({"op": "move", "src": "/a"}),  # missing dst, state
+                json.dumps({"op": "move", "src": "/a", "dst": "/b", "state": "done"}),  # ok
+            ]
+        )
+        entries = _parse_journal_text(corrupt + "\n")
+        assert len(entries) == 1
+        assert entries[0].op == "move"
+
+    def test_oversized_line_rejected(self) -> None:
+        """§4.1 rule 7: line >64 KiB rejected to prevent pathological payloads."""
+        from undo.durable_move import _parse_journal_text
+
+        good = json.dumps({"op": "move", "src": "/a", "dst": "/b", "state": "done"})
+        huge = json.dumps(
+            {
+                "op": "move",
+                "src": "/a",
+                "dst": "/b",
+                "state": "done",
+                "_padding": "x" * (65 * 1024),
+            }
+        )
+        entries = _parse_journal_text(huge + "\n" + good + "\n")
+        assert len(entries) == 1
+        assert entries[0].src == "/a"
+
+    def test_v2_known_op_missing_op_id_rejected(self) -> None:
+        """§4.1 rule 8: v2 writer always emits op_id; a known-op v2 record
+        missing it is corrupt/external input and MUST be rejected (not
+        silently collapsed with v1 identity)."""
+        from undo.durable_move import _parse_journal_text
+
+        corrupt = json.dumps(
+            {
+                "schema": 2,
+                "op": "move",
+                # op_id missing — parse-time reject
+                "src": "/a",
+                "dst": "/b",
+                "state": "done",
+            }
+        )
+        ok = json.dumps(
+            {
+                "schema": 2,
+                "op": "move",
+                "op_id": "legit",
+                "src": "/c",
+                "dst": "/d",
+                "state": "done",
+            }
+        )
+        entries = _parse_journal_text(corrupt + "\n" + ok + "\n")
+        assert len(entries) == 1
+        assert entries[0].op_id == "legit"
+
+    def test_v2_move_started_missing_tmp_path_rejected(self) -> None:
+        """§4.1 rule 9: v2 ``move started`` without ``tmp_path`` is
+        rejected — the tmp-exists invariant (§7.1) depends on every
+        such record carrying the field. Without it sweep could
+        misinfer post-replace and unlink src (data loss)."""
+        from undo.durable_move import _parse_journal_text
+
+        corrupt = json.dumps(
+            {
+                "schema": 2,
+                "op": "move",
+                "op_id": "abc",
+                "src": "/a",
+                "dst": "/b",
+                "state": "started",
+                # tmp_path missing — parse-time reject for v2 move started
+            }
+        )
+        # Same record but copied/done — no tmp_path required.
+        ok_copied = json.dumps(
+            {
+                "schema": 2,
+                "op": "move",
+                "op_id": "def",
+                "src": "/c",
+                "dst": "/d",
+                "state": "copied",
+            }
+        )
+        entries = _parse_journal_text(corrupt + "\n" + ok_copied + "\n")
+        assert len(entries) == 1
+        assert entries[0].state == "copied"
+
+    def test_unknown_op_preserves_raw_line(self) -> None:
+        """§4.2: unknown-op records preserve the FULL raw JSON line on
+        ``_raw`` so compaction re-serializes them verbatim. A future
+        binary with a handler for the op receives all fields the writer
+        persisted, NOT just the v2 parser's known core."""
+        from undo.durable_move import _parse_journal_text, _serialize_entry
+
+        future_record = {
+            "schema": 3,
+            "op": "future_copy",
+            "op_id": "xyz",
+            "src": "/a",
+            "dst": "/b",
+            "state": "started",
+            "future_field_1": "content-hash-abc",
+            "future_field_2": {"nested": [1, 2, 3]},
+        }
+        raw_line = json.dumps(future_record)
+        entries = _parse_journal_text(raw_line + "\n")
+
+        assert len(entries) == 1
+        e = entries[0]
+        assert e.op == "future_copy"
+        assert e._raw == raw_line
+
+        # Compaction writes the entry back — must equal the original
+        # raw line, NOT a v2-projected subset.
+        serialized = _serialize_entry(e)
+        # Allow for whitespace/key-ordering differences via re-parse.
+        assert json.loads(serialized) == future_record
+
+    def test_known_op_unknown_future_field_ignored(self) -> None:
+        """§4.2: for KNOWN ops, extra JSON fields are ignored (no _raw).
+        Those ops have a stable schema we control; extras are noise."""
+        from undo.durable_move import _parse_journal_text
+
+        line = json.dumps(
+            {
+                "schema": 2,
+                "op": "move",
+                "op_id": "abc",
+                "src": "/a",
+                "dst": "/b",
+                "state": "done",
+                "experimental_field": "should-be-dropped",
+            }
+        )
+        entries = _parse_journal_text(line + "\n")
+        assert len(entries) == 1
+        # Known-op entries don't retain _raw — field is a clean None.
+        assert entries[0]._raw is None
+
+    def test_malformed_json_still_rejected(self) -> None:
+        """§4.1 rule 1: JSON parse errors logged + skipped (pre-F7.1
+        behavior preserved)."""
+        from undo.durable_move import _parse_journal_text
+
+        corrupt = "\n".join(
+            [
+                "not json at all",
+                "{broken",
+                json.dumps({"op": "move", "src": "/a", "dst": "/b", "state": "done"}),
+            ]
+        )
+        entries = _parse_journal_text(corrupt + "\n")
+        assert len(entries) == 1
+
+    def test_hash16_is_stable(self) -> None:
+        """``_hash16`` (§3.1 rule 4) is stable: same input → same output.
+        Used for unknown-op collapse-key identity so future ops don't
+        silently conflate."""
+        from undo.durable_move import _hash16
+
+        raw = '{"op":"future","op_id":"x","src":"/a","dst":"/b","state":"done"}'
+        h = _hash16(raw)
+        assert len(h) == 16
+        assert _hash16(raw) == h  # deterministic
+        # Different content → different hash.
+        assert _hash16(raw.replace('"done"', '"started"')) != h
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -2066,11 +2066,13 @@ class TestPlanRecoveryActions:
                 f"expected verb={expected}, got {plan[0].verb}"
             )
 
-    def test_planner_collapses_entries_preserves_pr197_behavior(self) -> None:
-        """Step 2 preserves PR #197's ``(src, dst)`` collapse key — same
-        paths in different ops DO still mask each other (bug codex iy4u).
-        Step 3 will fix this by keying on op+op_id as well. This test
-        documents that step 2 is a refactor, not a behavior change."""
+    def test_planner_collapse_key_separates_ops(self) -> None:
+        """Step 3 / codex iy4u: collapse key includes ``op`` so same paths
+        in different ops cannot mask each other. The pre-fix behavior
+        (PR #197 step 2) was: ``dir_move done`` would overwrite ``move
+        started``, dropping the move's recovery metadata. Now both
+        identities survive the collapse and produce independent plans.
+        """
         from undo.durable_move import _JournalEntry, plan_recovery_actions
 
         entries = [
@@ -2079,11 +2081,138 @@ class TestPlanRecoveryActions:
             _JournalEntry(op="dir_move", src="/a", dst="/b", state="done"),
         ]
         plan = plan_recovery_actions(entries, fs_observer=lambda _p: False)
-        # Step 2 uses PR #197's path-only key, so the latest entry wins —
-        # which is the dir_move done. Move's started record is masked.
+        # Two identities now: move (retained as ambiguous) + dir_move
+        # (collapses to done, dropped).
+        assert len(plan) == 2
+        verb_by_op = {a.entry.op: a.verb for a in plan}
+        assert verb_by_op["move"] == "retain"
+        assert verb_by_op["dir_move"] == "drop"
+
+    def test_planner_collapse_key_separates_v2_op_ids(self) -> None:
+        """§3.1 rule 1: v2 ``(op, op_id)`` identity. Two retries of the
+        same move with different op_ids stay distinct so a superseding
+        retry's ``done`` cannot erase an older retained ``started``."""
+        from undo.durable_move import _JournalEntry, plan_recovery_actions
+
+        # Same paths, same op, different op_id → distinct identities.
+        entries = [
+            _JournalEntry(
+                op="move",
+                src="/a",
+                dst="/b",
+                state="started",
+                schema=2,
+                op_id="attempt-1",
+                tmp_path="/a.tmp",
+            ),
+            _JournalEntry(
+                op="move",
+                src="/a",
+                dst="/b",
+                state="done",
+                schema=2,
+                op_id="attempt-2",
+            ),
+        ]
+        plan = plan_recovery_actions(entries, fs_observer=lambda _p: False)
+        assert len(plan) == 2
+        # Both identities present; attempt-1's recovery metadata survives.
+        op_ids = {a.entry.op_id for a in plan}
+        assert op_ids == {"attempt-1", "attempt-2"}
+
+    def test_planner_collapse_key_v2_progression_collapses_same_op_id(self) -> None:
+        """§3.2: within a single op_id, states progress and collapse —
+        a later ``done`` for the SAME op_id supersedes earlier
+        started/copied entries (the legitimate collapse case)."""
+        from undo.durable_move import _JournalEntry, plan_recovery_actions
+
+        entries = [
+            _JournalEntry(
+                op="move",
+                src="/a",
+                dst="/b",
+                state="started",
+                schema=2,
+                op_id="single",
+                tmp_path="/a.tmp",
+            ),
+            _JournalEntry(
+                op="move",
+                src="/a",
+                dst="/b",
+                state="copied",
+                schema=2,
+                op_id="single",
+            ),
+            _JournalEntry(
+                op="move",
+                src="/a",
+                dst="/b",
+                state="done",
+                schema=2,
+                op_id="single",
+            ),
+        ]
+        plan = plan_recovery_actions(entries, fs_observer=lambda _p: True)
+        # Single identity collapses to the latest state: done → drop.
         assert len(plan) == 1
-        assert plan[0].entry.op == "dir_move"
         assert plan[0].entry.state == "done"
+        assert plan[0].verb == "drop"
+
+    def test_planner_collapse_key_v1_v2_never_collide(self) -> None:
+        """§3.1 ``v1`` / ``v2`` discriminator: a v1 record and a v2
+        record with the same ``(op, src, dst)`` get distinct identities,
+        so v2 cannot mask v1 retain metadata or vice-versa."""
+        from undo.durable_move import _JournalEntry, plan_recovery_actions
+
+        entries = [
+            # v1 record — no op_id, no schema.
+            _JournalEntry(op="move", src="/a", dst="/b", state="copied"),
+            # v2 record — explicit op_id.
+            _JournalEntry(
+                op="move",
+                src="/a",
+                dst="/b",
+                state="copied",
+                schema=2,
+                op_id="abc",
+            ),
+        ]
+        plan = plan_recovery_actions(entries, fs_observer=lambda _p: True)
+        assert len(plan) == 2
+
+    def test_planner_collapse_key_unknown_op_uses_raw_hash(self) -> None:
+        """§3.1 rule 4: unknown-op identity uses ``_hash16(_raw)`` so
+        future ops with semantically-distinct payloads don't conflate.
+        Two unknown-op entries with the same paths but different raw
+        lines produce distinct identities and BOTH retain."""
+        from undo.durable_move import _JournalEntry, plan_recovery_actions
+
+        entries = [
+            _JournalEntry(
+                op="future_copy",
+                src="/a",
+                dst="/b",
+                state="started",
+                schema=3,
+                _raw='{"schema":3,"op":"future_copy","src":"/a","dst":"/b","state":"started","content_hash":"aaa"}',
+            ),
+            _JournalEntry(
+                op="future_copy",
+                src="/a",
+                dst="/b",
+                state="started",
+                schema=3,
+                _raw='{"schema":3,"op":"future_copy","src":"/a","dst":"/b","state":"started","content_hash":"bbb"}',
+            ),
+        ]
+        plan = plan_recovery_actions(entries, fs_observer=lambda _p: False)
+        # Both records survive — _hash16 differs per raw payload, so the
+        # collapse key separates them. A future binary's handler decides
+        # via its own field semantics.
+        assert len(plan) == 2
+        for action in plan:
+            assert action.verb == "retain"
 
     def test_executor_applies_unlink_src_then_drop(self, tmp_path: Path) -> None:
         """Executor's ``unlink_src_then_drop`` verb: unlinks src, fsyncs

--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -1934,6 +1934,257 @@ class TestJournalSchemaV2Parser:
 
 
 # ---------------------------------------------------------------------------
+# F7.1 step 2: pure planner `plan_recovery_actions`
+# (tracks #201, docs/internal/F7-1-journal-protocol-design.md §8.1, §9)
+# ---------------------------------------------------------------------------
+
+
+class TestPlanRecoveryActions:
+    """Planner is pure: computes a list of :class:`_PlannedAction` from a
+    list of :class:`_JournalEntry` + an optional ``fs_observer``, with zero
+    disk mutation. Sweep's ``_apply_planned_actions`` executor performs the
+    mutations. Step 2 preserves PR #197 behavior; step 3 changes the collapse
+    key; step 6 adds tmp_path disambiguation.
+    """
+
+    def test_planner_is_pure_no_disk_mutation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Planning on a journal containing a COPIED entry with dst present
+        on disk MUST NOT unlink src during the plan step. The planner is
+        pure; mutations happen only in the executor."""
+        from undo.durable_move import _JournalEntry, plan_recovery_actions
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("must not be unlinked by planner")
+        dst.write_text("complete destination")
+
+        # Instrument Path.unlink and fsync_directory — if the planner
+        # touches either, the test fails.
+        calls: list[tuple[str, object]] = []
+        real_unlink = Path.unlink
+
+        def tracking_unlink(self: Path, *a: object, **k: object) -> None:
+            calls.append(("unlink", self))
+            return real_unlink(self, *a, **k)
+
+        monkeypatch.setattr(Path, "unlink", tracking_unlink)
+        monkeypatch.setattr(
+            "undo.durable_move.fsync_directory",
+            lambda p: calls.append(("fsync", p)),
+        )
+
+        entries = [
+            _JournalEntry(op="move", src=str(src), dst=str(dst), state="copied"),
+        ]
+        plan = plan_recovery_actions(entries)
+
+        assert calls == [], (
+            f"planner must not mutate disk (§8.1 pure-planner contract); observed: {calls}"
+        )
+        assert len(plan) == 1
+        # Planner decided "unlink src, drop entry" based on the real
+        # lexists(dst) observation — but DIDN'T execute yet.
+        assert plan[0].verb == "unlink_src_then_drop"
+        # src is still on disk — executor hasn't run.
+        assert src.read_text() == "must not be unlinked by planner"
+
+    def test_planner_deterministic(self, tmp_path: Path) -> None:
+        """Given the same inputs + fs_observer, planner returns the same plan
+        twice. Required by the §8.1 CLI/sweep parity contract."""
+        from undo.durable_move import _JournalEntry, plan_recovery_actions
+
+        src = tmp_path / "s.txt"
+        dst = tmp_path / "d.txt"
+        src.write_text("x")
+        dst.write_text("y")
+        entries = [
+            _JournalEntry(op="move", src=str(src), dst=str(dst), state="copied"),
+            _JournalEntry(
+                op="dir_move",
+                src=str(tmp_path / "dir_a"),
+                dst=str(tmp_path / "dir_b"),
+                state="started",
+            ),
+            _JournalEntry(op="move", src="/x", dst="/y", state="done"),
+        ]
+        plan1 = plan_recovery_actions(entries)
+        plan2 = plan_recovery_actions(entries)
+        assert plan1 == plan2
+
+    def test_planner_fs_observer_stub(self) -> None:
+        """Planner accepts a custom ``fs_observer`` so tests can exercise
+        the §5.1 recovery-state-table rows without setting up real files.
+        This is also what ``fo undo recover`` uses for the "what WOULD
+        sweep do" preview."""
+        from undo.durable_move import _JournalEntry, plan_recovery_actions
+
+        entries = [
+            _JournalEntry(op="move", src="/a", dst="/b", state="copied"),
+        ]
+        # fs_observer says dst does NOT exist → §5.1 COPIED+dst-missing row → retain.
+        plan = plan_recovery_actions(entries, fs_observer=lambda _p: False)
+        assert len(plan) == 1
+        assert plan[0].verb == "retain"
+
+        # Same entry but fs_observer says dst exists → unlink_src_then_drop.
+        plan_present = plan_recovery_actions(entries, fs_observer=lambda _p: True)
+        assert plan_present[0].verb == "unlink_src_then_drop"
+
+    def test_planner_verb_matrix(self) -> None:
+        """PR #197 behavior at step 2: each (op, state, dst-present)
+        combination produces the expected verb. Table mirrors the
+        pre-step-6 subset of §5.1."""
+        from undo.durable_move import _JournalEntry, plan_recovery_actions
+
+        # (op, state, dst_present) -> expected verb
+        cases: list[tuple[str, str, bool, str]] = [
+            ("move", "started", True, "retain"),
+            ("move", "started", False, "retain"),
+            ("move", "copied", True, "unlink_src_then_drop"),
+            ("move", "copied", False, "retain"),
+            ("move", "done", True, "drop"),
+            ("move", "done", False, "drop"),
+            ("move", "unknown_state", True, "drop"),
+            ("dir_move", "started", True, "drop"),
+            ("dir_move", "done", True, "drop"),
+            ("dir_move", "unknown_state", True, "drop"),
+            ("future_op", "started", True, "retain"),  # unknown op retain
+            ("future_op", "done", True, "retain"),  # unknown op retain
+        ]
+        for op, state, dst_present, expected in cases:
+            entries = [_JournalEntry(op=op, src="/s", dst="/d", state=state)]
+            # Bind dst_present at lambda-creation time so each iteration
+            # captures its own value (B023).
+            plan = plan_recovery_actions(
+                entries, fs_observer=lambda _p, present=dst_present: present
+            )
+            assert len(plan) == 1
+            assert plan[0].verb == expected, (
+                f"op={op} state={state} dst_present={dst_present}: "
+                f"expected verb={expected}, got {plan[0].verb}"
+            )
+
+    def test_planner_collapses_entries_preserves_pr197_behavior(self) -> None:
+        """Step 2 preserves PR #197's ``(src, dst)`` collapse key — same
+        paths in different ops DO still mask each other (bug codex iy4u).
+        Step 3 will fix this by keying on op+op_id as well. This test
+        documents that step 2 is a refactor, not a behavior change."""
+        from undo.durable_move import _JournalEntry, plan_recovery_actions
+
+        entries = [
+            _JournalEntry(op="move", src="/a", dst="/b", state="started"),
+            _JournalEntry(op="dir_move", src="/a", dst="/b", state="started"),
+            _JournalEntry(op="dir_move", src="/a", dst="/b", state="done"),
+        ]
+        plan = plan_recovery_actions(entries, fs_observer=lambda _p: False)
+        # Step 2 uses PR #197's path-only key, so the latest entry wins —
+        # which is the dir_move done. Move's started record is masked.
+        assert len(plan) == 1
+        assert plan[0].entry.op == "dir_move"
+        assert plan[0].entry.state == "done"
+
+    def test_executor_applies_unlink_src_then_drop(self, tmp_path: Path) -> None:
+        """Executor's ``unlink_src_then_drop`` verb: unlinks src, fsyncs
+        src.parent, returns empty retained list."""
+        from undo.durable_move import (
+            _apply_planned_actions,
+            _JournalEntry,
+            plan_recovery_actions,
+        )
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("leftover")
+        dst.write_text("complete")
+        entries = [_JournalEntry(op="move", src=str(src), dst=str(dst), state="copied")]
+        plan = plan_recovery_actions(entries)
+        retained = _apply_planned_actions(plan)
+
+        assert retained == []  # dropped
+        assert not src.exists()  # unlinked
+        assert dst.read_text() == "complete"  # untouched
+
+    def test_executor_retain_does_not_mutate(self, tmp_path: Path) -> None:
+        """Executor's ``retain`` verb: no disk mutation, entry returned
+        in retained list."""
+        from undo.durable_move import (
+            _apply_planned_actions,
+            _JournalEntry,
+            plan_recovery_actions,
+        )
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"  # deliberately absent → COPIED retains
+        src.write_text("must survive")
+        entry = _JournalEntry(op="move", src=str(src), dst=str(dst), state="copied")
+        plan = plan_recovery_actions([entry])
+        retained = _apply_planned_actions(plan)
+
+        assert retained == [entry]
+        assert src.read_text() == "must survive"
+        assert not dst.exists()
+
+    def test_executor_drop_does_not_mutate(self, tmp_path: Path) -> None:
+        """Executor's ``drop`` verb: no disk mutation, entry dropped."""
+        from undo.durable_move import (
+            _apply_planned_actions,
+            _JournalEntry,
+            plan_recovery_actions,
+        )
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("untouched")
+        dst.write_text("untouched")
+        entry = _JournalEntry(op="move", src=str(src), dst=str(dst), state="done")
+        plan = plan_recovery_actions([entry])
+        retained = _apply_planned_actions(plan)
+
+        assert retained == []
+        assert src.read_text() == "untouched"
+        assert dst.read_text() == "untouched"
+
+    def test_executor_os_error_on_unlink_retains(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Preserves PR #197 round-5 behavior: OSError during unlink_src
+        retains the entry (transient permission / lock is retry-eligible).
+        The PLANNER produces ``unlink_src_then_drop`` optimistically; the
+        EXECUTOR downgrades to retain when the unlink raises."""
+        from undo.durable_move import (
+            _apply_planned_actions,
+            _JournalEntry,
+            plan_recovery_actions,
+        )
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("x")
+        dst.write_text("y")
+        entry = _JournalEntry(op="move", src=str(src), dst=str(dst), state="copied")
+        plan = plan_recovery_actions([entry])
+        assert plan[0].verb == "unlink_src_then_drop"
+
+        real_unlink = Path.unlink
+
+        def failing_unlink(self: Path, *a: object, **k: object) -> None:
+            if str(self) == str(src):
+                raise OSError(13, "simulated permission denied")
+            return real_unlink(self, *a, **k)
+
+        monkeypatch.setattr(Path, "unlink", failing_unlink)
+
+        retained = _apply_planned_actions(plan)
+        assert retained == [entry], (
+            "transient OSError on unlink must fall back to retain so the "
+            "next sweep can retry (codex fwMK, PR #197 round-5)"
+        )
+        assert src.exists()  # unlink raised → src survives
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -1949,6 +1949,184 @@ class TestJournalSchemaV2Parser:
 
 
 # ---------------------------------------------------------------------------
+# F7.1 step 5: atomic journal compaction
+# (tracks #201, docs/internal/F7-1-journal-protocol-design.md §6.2–6.6)
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicCompaction:
+    """Step 5 / coderabbit round-10 major: sweep no longer truncates the
+    live journal. Instead it writes retained entries to a compact-tmp,
+    fsyncs, then ``os.replace``s the journal — atomic on POSIX. A
+    crash mid-compaction leaves either the OLD journal intact OR the
+    NEW journal complete; never a zero-bytes-with-pending-entries state.
+    """
+
+    def test_compaction_replaces_journal_via_tmp_not_truncate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Sweep with retained entries must use ``os.replace`` (the
+        compact-tmp path), not ``fh.truncate`` on the live journal."""
+        from undo.durable_move import _append_journal, sweep
+
+        journal = tmp_path / "move.journal"
+        # Two entries: one will be retained (copied + dst missing), one will be
+        # dropped (done).
+        src_keep = tmp_path / "kept-src.txt"
+        src_keep.write_text("x")
+        dst_missing = tmp_path / "missing-dst.txt"  # deliberately absent
+        _append_journal(
+            journal,
+            {"op": "move", "src": str(src_keep), "dst": str(dst_missing), "state": "copied"},
+        )
+        _append_journal(journal, {"op": "move", "src": "/a", "dst": "/b", "state": "done"})
+
+        # Track os.replace calls — must be invoked at least once with
+        # the compact-tmp → journal swap.
+        replace_calls: list[tuple[str, str]] = []
+        real_replace = os.replace
+
+        def tracking_replace(src, dst):  # type: ignore[no-untyped-def]
+            replace_calls.append((str(src), str(dst)))
+            return real_replace(src, dst)
+
+        monkeypatch.setattr("undo.durable_move.os.replace", tracking_replace)
+
+        # Inode change is the observable proof of replace (vs in-place
+        # truncate, which would preserve inode).
+        journal_inode_before = journal.stat().st_ino
+
+        sweep(journal)
+
+        replace_targets = [dst for _src, dst in replace_calls]
+        assert str(journal) in replace_targets, (
+            f"sweep must os.replace the journal as part of compaction; "
+            f"replace calls were: {replace_calls}"
+        )
+        assert journal.stat().st_ino != journal_inode_before, (
+            "journal inode must change post-compaction (proof of os.replace, not in-place truncate)"
+        )
+        from undo.durable_move import _read_journal
+
+        entries = _read_journal(journal)
+        assert len(entries) == 1
+        assert entries[0].src == str(src_keep)
+
+    def test_compaction_crash_mid_replace_preserves_journal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Step 5 crash safety: if ``os.replace`` raises (simulated
+        mid-compaction crash), the original journal content survives
+        intact — no zero-bytes-with-pending-entries window."""
+        from undo.durable_move import _append_journal, sweep
+
+        journal = tmp_path / "move.journal"
+        src_keep = tmp_path / "src.txt"
+        src_keep.write_text("x")
+        dst_missing = tmp_path / "missing.txt"
+        _append_journal(
+            journal,
+            {"op": "move", "src": str(src_keep), "dst": str(dst_missing), "state": "copied"},
+        )
+        _append_journal(journal, {"op": "move", "src": "/a", "dst": "/b", "state": "done"})
+        original_content = journal.read_text()
+        original_lines = [line for line in original_content.splitlines() if line]
+        assert len(original_lines) == 2
+
+        # Simulate crash: os.replace raises mid-compaction.
+        def failing_replace(src, dst):  # type: ignore[no-untyped-def]
+            raise OSError(28, "simulated disk full mid-replace")
+
+        monkeypatch.setattr("undo.durable_move.os.replace", failing_replace)
+
+        with pytest.raises(OSError, match="simulated"):
+            sweep(journal)
+
+        # Journal content unchanged — both original entries survive.
+        post_crash = journal.read_text()
+        assert post_crash == original_content, (
+            "crash mid-replace must preserve the journal exactly; "
+            "the compact-tmp + os.replace pattern guarantees no "
+            "zero-bytes-with-pending-entries window"
+        )
+
+    def test_compaction_stale_tmp_from_prior_crashed_sweep(self, tmp_path: Path) -> None:
+        """§6.4: if a prior crashed sweep left a compact-tmp on disk,
+        the next sweep removes it once and retries."""
+        from undo.durable_move import _append_journal, sweep
+
+        journal = tmp_path / "move.journal"
+        src_keep = tmp_path / "kept.txt"
+        src_keep.write_text("x")
+        dst_missing = tmp_path / "missing.txt"
+        _append_journal(
+            journal,
+            {"op": "move", "src": str(src_keep), "dst": str(dst_missing), "state": "copied"},
+        )
+
+        # Simulate stale tmp from a prior crashed sweep — same path the
+        # current sweep would generate.
+        stale_tmp = tmp_path / f"move.journal.{os.getpid()}.compact.tmp"
+        stale_tmp.write_text("garbage from a prior crash\n")
+        assert stale_tmp.exists()
+
+        # Sweep must succeed despite the stale tmp.
+        sweep(journal)
+        assert not stale_tmp.exists(), "sweep must clean up stale compact-tmp"
+
+    def test_compaction_size_cap_skips_oversized_journal(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """§6.6: journals >16 MiB trigger a WARNING and skip
+        compaction (belt-and-suspenders; steady-state journals are
+        bounded by in-flight count). Sweep returns early without
+        rewriting."""
+        from undo.durable_move import sweep
+
+        journal = tmp_path / "move.journal"
+        # Build a journal whose total size exceeds the 16 MiB cap.
+        entry_template = json.dumps(
+            {
+                "op": "move",
+                "src": "/a",
+                "dst": "/b",
+                "state": "done",
+                "_padding": "x" * 4096,
+            }
+        )
+        # Each entry ~4 KiB; 4500 entries ~18 MiB.
+        with open(journal, "w") as fh:
+            for _ in range(4500):
+                fh.write(entry_template + "\n")
+        size_before = journal.stat().st_size
+        assert size_before > 16 * 1024 * 1024
+
+        with caplog.at_level("WARNING", logger="undo.durable_move"):
+            sweep(journal)
+
+        # Journal still oversized (sweep skipped compaction).
+        assert journal.stat().st_size == size_before
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("size cap" in m.lower() for m in msgs), f"expected size-cap WARNING; got {msgs}"
+
+    def test_compaction_empty_retained_clears_journal(self, tmp_path: Path) -> None:
+        """When sweep reconciles every entry to drop, the journal is
+        cleared (truncated to empty via the compact-tmp + replace path,
+        not in-place truncation)."""
+        from undo.durable_move import _append_journal, sweep
+
+        journal = tmp_path / "move.journal"
+        _append_journal(journal, {"op": "move", "src": "/a", "dst": "/b", "state": "done"})
+        _append_journal(journal, {"op": "move", "src": "/c", "dst": "/d", "state": "done"})
+
+        sweep(journal)
+
+        # Journal exists but is empty.
+        assert journal.exists()
+        assert journal.read_text().strip() == ""
+
+
+# ---------------------------------------------------------------------------
 # F7.1 step 4: lock-file extraction
 # (tracks #201, docs/internal/F7-1-journal-protocol-design.md §6.1, §6.5)
 # ---------------------------------------------------------------------------

--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -1306,22 +1306,31 @@ class TestAppendJournalFlockCoordination:
 
     def test_append_journal_blocks_while_sweep_holds_flock(self, tmp_path: Path) -> None:
         """Core invariant: an ``_append_journal`` call issued while
-        sweep (or any other holder) has ``LOCK_EX`` on the journal
-        blocks until the lock is released. Proves the appender
+        sweep (or any other holder) has ``LOCK_EX`` on the journal's
+        lock file blocks until the lock is released. Proves the appender
         respects the same advisory lock sweep uses.
+
+        Step 4 update: lock subject is ``<journal>.lock`` (stable
+        inode), not ``<journal>`` itself. Pre-step-4 this test held
+        ``LOCK_EX`` on the journal file directly.
         """
         fcntl = pytest.importorskip("fcntl")
         import threading
         import time
 
-        from undo.durable_move import _append_journal
+        from undo.durable_move import _append_journal, _lock_path
 
         journal = tmp_path / "move.journal"
-        journal.write_text("")  # create so the held-open fd has an inode
+        # Pre-create empty journal + empty lock file. Journal stays
+        # empty so the downstream "exactly 1 appended line" assertion
+        # holds; lock file gets the held LOCK_EX below.
+        journal.write_text("")
+        lock = _lock_path(journal)
+        lock.touch()
 
-        # Acquire LOCK_EX in the main thread — mimics sweep holding
-        # the journal during its read-modify-truncate cycle.
-        holder = open(journal, "r+", encoding="utf-8")
+        # Acquire LOCK_EX on the LOCK FILE in the main thread — mimics
+        # sweep holding the lock during its read-modify-write cycle.
+        holder = open(lock, "r+", encoding="utf-8")
         fcntl.flock(holder.fileno(), fcntl.LOCK_EX)
 
         # ``appender_entered`` is set IMMEDIATELY before the
@@ -1611,21 +1620,27 @@ class TestIsPathInFlightSharedLock:
     """
 
     def test_is_path_in_flight_blocks_while_writer_holds_lock_ex(self, tmp_path: Path) -> None:
-        """Hold ``LOCK_EX`` from main thread; the reader thread's
-        ``is_path_in_flight`` call must block until the lock is
-        released."""
+        """Hold ``LOCK_EX`` on the LOCK FILE from main thread; the
+        reader thread's ``is_path_in_flight`` call must block until
+        the lock is released.
+
+        Step 4 update: lock subject is ``<journal>.lock`` (stable
+        inode), not ``<journal>`` itself. Pre-step-4 this test held
+        ``LOCK_EX`` on the journal file directly — that no longer
+        coordinates with readers/writers under the new protocol.
+        """
         fcntl = pytest.importorskip("fcntl")
         import threading
 
-        from undo.durable_move import _append_journal, is_path_in_flight
+        from undo.durable_move import _append_journal, _lock_path, is_path_in_flight
 
         journal = tmp_path / "move.journal"
-        # Pre-populate so the file exists for the reader's open().
+        # Pre-populate so the lock file exists for the holder's open().
         _append_journal(journal, {"op": "move", "src": "/a", "dst": "/b", "state": "done"})
 
-        # Hold LOCK_EX from the main thread (simulates an active
-        # _append_journal mid-write).
-        holder = open(journal, "a", encoding="utf-8")
+        # Hold LOCK_EX on the LOCK FILE from the main thread (simulates
+        # an active _append_journal mid-write).
+        holder = open(_lock_path(journal), "a", encoding="utf-8")
         fcntl.flock(holder.fileno(), fcntl.LOCK_EX)
 
         reader_entered = threading.Event()
@@ -1931,6 +1946,189 @@ class TestJournalSchemaV2Parser:
         assert _hash16(raw) == h  # deterministic
         # Different content → different hash.
         assert _hash16(raw.replace('"done"', '"started"')) != h
+
+
+# ---------------------------------------------------------------------------
+# F7.1 step 4: lock-file extraction
+# (tracks #201, docs/internal/F7-1-journal-protocol-design.md §6.1, §6.5)
+# ---------------------------------------------------------------------------
+
+
+class TestJournalLockFile:
+    """Step 4 / round-1 review blocking fix: all flock operations acquire
+    on a sibling ``<journal>.lock`` file with a stable inode, NOT on
+    ``<journal>`` directly. Required for step 5's atomic compaction —
+    ``os.replace`` on the journal must not invalidate locks held by
+    concurrent appenders.
+    """
+
+    def test_lock_path_alongside_journal(self, tmp_path: Path) -> None:
+        """The lock subject is ``<journal>.lock`` in the same directory."""
+        from undo.durable_move import _lock_path
+
+        journal = tmp_path / "move.journal"
+        assert _lock_path(journal) == tmp_path / "move.journal.lock"
+
+    def test_append_creates_lock_file_at_stable_path(self, tmp_path: Path) -> None:
+        """First append creates both the journal AND the lock file. The
+        lock file is then NEVER unlinked or replaced by normal protocol
+        operations."""
+        pytest.importorskip("fcntl")
+        from undo.durable_move import _append_journal, _lock_path
+
+        journal = tmp_path / "move.journal"
+        lock = _lock_path(journal)
+
+        _append_journal(journal, {"op": "move", "src": "/a", "dst": "/b", "state": "done"})
+
+        assert journal.exists()
+        assert lock.exists()
+        # Capture the lock file's inode — subsequent operations must
+        # preserve it (the round-1 review blocking concern).
+        lock_inode_before = lock.stat().st_ino
+
+        # Several more appends + a sweep — lock inode must not change.
+        _append_journal(journal, {"op": "move", "src": "/c", "dst": "/d", "state": "done"})
+        from undo.durable_move import sweep
+
+        sweep(journal)
+
+        assert lock.exists(), "lock file must persist across protocol ops"
+        assert lock.stat().st_ino == lock_inode_before, (
+            "lock file inode must be stable across appends + sweep — "
+            "if it changes, concurrent flock holders lose coordination "
+            "(round-1 review blocking concern)"
+        )
+
+    def test_append_blocks_while_lock_ex_held_on_lock_file(self, tmp_path: Path) -> None:
+        """Acquiring ``LOCK_EX`` on ``<journal>.lock`` (NOT on
+        ``<journal>``) blocks ``_append_journal``. Proves the appender
+        coordinates on the new lock file."""
+        fcntl = pytest.importorskip("fcntl")
+        import threading
+
+        from undo.durable_move import _append_journal, _lock_path
+
+        journal = tmp_path / "move.journal"
+        # Pre-populate so the lock file exists.
+        _append_journal(journal, {"op": "move", "src": "/a", "dst": "/b", "state": "done"})
+        lock = _lock_path(journal)
+
+        # Hold LOCK_EX on the lock file from the main thread.
+        holder = open(lock, "r+", encoding="utf-8")
+        fcntl.flock(holder.fileno(), fcntl.LOCK_EX)
+
+        appender_entered = threading.Event()
+        append_done = threading.Event()
+
+        def _appender() -> None:
+            appender_entered.set()
+            try:
+                _append_journal(journal, {"op": "move", "src": "/x", "dst": "/y", "state": "done"})
+            finally:
+                append_done.set()
+
+        t = threading.Thread(target=_appender, daemon=True)
+        t.start()
+
+        assert appender_entered.wait(timeout=5.0), "appender never scheduled"
+        # Appender must block on the lock file's LOCK_EX.
+        assert not append_done.wait(timeout=0.5), (
+            "_append_journal must block while LOCK_EX is held on the lock "
+            "file (step-4 lock-file extraction)"
+        )
+
+        # Release; appender completes.
+        fcntl.flock(holder.fileno(), fcntl.LOCK_UN)
+        holder.close()
+        assert append_done.wait(timeout=5.0)
+        t.join(timeout=2)
+
+    def test_is_path_in_flight_blocks_on_lock_file_lock_ex(self, tmp_path: Path) -> None:
+        """Reader takes ``LOCK_SH`` on the lock file; LOCK_EX held on
+        the lock file blocks the reader. Same plumbing as step 4 for
+        the appender."""
+        fcntl = pytest.importorskip("fcntl")
+        import threading
+
+        from undo.durable_move import _append_journal, _lock_path, is_path_in_flight
+
+        journal = tmp_path / "move.journal"
+        _append_journal(journal, {"op": "move", "src": "/a", "dst": "/b", "state": "done"})
+        lock = _lock_path(journal)
+
+        holder = open(lock, "r+", encoding="utf-8")
+        fcntl.flock(holder.fileno(), fcntl.LOCK_EX)
+
+        reader_done = threading.Event()
+        result: list[bool | None] = [None]
+
+        def _reader() -> None:
+            try:
+                result[0] = is_path_in_flight(Path("/x"), journal=journal)
+            finally:
+                reader_done.set()
+
+        t = threading.Thread(target=_reader, daemon=True)
+        t.start()
+
+        assert not reader_done.wait(timeout=0.5), (
+            "is_path_in_flight must block while LOCK_EX held on lock file"
+        )
+        fcntl.flock(holder.fileno(), fcntl.LOCK_UN)
+        holder.close()
+        assert reader_done.wait(timeout=5.0)
+        t.join(timeout=2)
+        assert result[0] is False
+
+    def test_replace_journal_under_held_lock_does_not_break_appender(self, tmp_path: Path) -> None:
+        """Round-1 review blocking case: a sweep that would
+        ``os.replace`` the journal underneath a held lock MUST NOT
+        invalidate concurrent appenders' coordination. With the lock
+        on a separate ``<journal>.lock`` file (whose inode never
+        changes), an appender that holds LOCK_EX on the lock file is
+        unaffected by an inode swap on the journal itself.
+
+        This test simulates the dangerous sequence:
+            1. Appender T1 acquires LOCK_EX on the lock file (mid-write).
+            2. Compaction (T2) `os.replace`s the journal with a new inode.
+            3. T1 writes to its (still-open) journal fd — but if step 4
+               had been done correctly, T1's append should land in the
+               *new* journal because the appender opens via the journal
+               path on each call (subsequent appender T3 is the proxy).
+            4. T3 (a fresh appender) appends after the swap — must land
+               in the new journal.
+
+        Step 4 only proves the lock subject is independent of the
+        journal inode. Step 5's atomic compaction will exercise the
+        full os.replace path.
+        """
+        pytest.importorskip("fcntl")
+        from undo.durable_move import _append_journal, _lock_path, _read_journal
+
+        journal = tmp_path / "move.journal"
+        _append_journal(journal, {"op": "move", "src": "/a", "dst": "/b", "state": "done"})
+        lock = _lock_path(journal)
+        original_lock_inode = lock.stat().st_ino
+
+        # Simulate compaction: write a new file, os.replace the journal.
+        new_journal_content = (
+            json.dumps({"op": "move", "src": "/c", "dst": "/d", "state": "done"}) + "\n"
+        )
+        new_tmp = tmp_path / "move.journal.compact.tmp"
+        new_tmp.write_text(new_journal_content)
+        os.replace(new_tmp, journal)
+
+        # Lock file's inode must not have changed — it's a separate file.
+        assert lock.stat().st_ino == original_lock_inode
+
+        # New appender works against the new journal inode + same lock file.
+        _append_journal(journal, {"op": "move", "src": "/e", "dst": "/f", "state": "done"})
+
+        # Journal contains the post-replace content + the new append.
+        entries = _read_journal(journal)
+        srcs = {e.src for e in entries}
+        assert "/c" in srcs and "/e" in srcs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -1584,6 +1584,43 @@ class TestSweepDirMoveHandling:
             f"{[r.getMessage() for r in caplog.records]}"
         )
 
+    def test_sweep_drops_dir_move_done_silently(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """§5.3 / §9.5 lock-in: ``dir_move done`` is dropped silently
+        (no WARNING). Started entries warn so operators investigate
+        the on-disk state; done entries are routine coordination
+        completion and don't need operator attention."""
+        from undo.durable_move import sweep
+
+        src = tmp_path / "src_dir"
+        src.mkdir()
+        dst = tmp_path / "dst_dir"
+        journal = tmp_path / "move.journal"
+        _write_journal(
+            journal,
+            [{"op": "dir_move", "src": str(src), "dst": str(dst), "state": "done"}],
+        )
+
+        with caplog.at_level("WARNING", logger="undo.durable_move"):
+            sweep(journal)
+
+        assert _read_journal(journal) == []
+        # No WARNING-level records about dir_move from sweep — only
+        # filter for sweep messages mentioning dir_move so other
+        # subsystem warnings (if any) don't cause spurious failures.
+        sweep_warnings = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING"
+            and "dir_move" in r.getMessage()
+            and r.name == "undo.durable_move"
+        ]
+        assert sweep_warnings == [], (
+            "dir_move done must drop SILENTLY (§5.3); WARNING is reserved "
+            f"for non-done states. Observed: {[r.getMessage() for r in sweep_warnings]}"
+        )
+
     def test_sweep_does_not_apply_move_semantics_to_dir_move(self, tmp_path: Path) -> None:
         """A ``dir_move`` entry in a ``copied`` state must NOT trigger
         ``src.unlink`` (move-semantics for op=move). Belt-and-

--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -2689,6 +2689,478 @@ class TestPlanRecoveryActions:
         assert src.exists()  # unlink raised → src survives
 
 
+class TestStartedTmpPathDisambiguation:
+    """Step 6 / §7.1: v2 ``move started`` records carry ``tmp_path``;
+    sweep observes ``lexists(tmp_path)`` to disambiguate pre-replace
+    (tmp present) from post-replace (tmp absent) crashes.
+
+    The tmp-exists invariant (§7.1) is what makes tmp-absent ⇒
+    post-replace inference safe. Step 6 enforces that invariant on the
+    write path and consumes it in the planner.
+    """
+
+    def test_planner_v2_started_tmp_present_drops_tmp(self) -> None:
+        """§5.1 row: v2 ``move started`` + ``lexists(tmp_path) == True``
+        ⇒ pre-replace crash. ``os.replace`` never ran; tmp is an orphan
+        copy. Verb: ``drop_tmp_then_drop`` (executor unlinks tmp, drops
+        the entry; src remains untouched as the canonical copy)."""
+        from undo.durable_move import _JournalEntry, plan_recovery_actions
+
+        entry = _JournalEntry(
+            op="move",
+            src="/a",
+            dst="/b",
+            state="started",
+            schema=2,
+            op_id="op-pre",
+            tmp_path="/path/to/.b.42.tmp",
+        )
+        # fs_observer reports tmp present.
+        plan = plan_recovery_actions([entry], fs_observer=lambda p: p == "/path/to/.b.42.tmp")
+        assert len(plan) == 1
+        assert plan[0].verb == "drop_tmp_then_drop"
+
+    def test_planner_v2_started_tmp_absent_unlinks_src(self) -> None:
+        """§5.1 row: v2 ``move started`` + ``lexists(tmp_path) == False``
+        ⇒ post-replace crash. ``os.replace`` consumed tmp into dst;
+        the only thing left is to unlink src. Verb:
+        ``unlink_src_then_drop`` (same as the COPIED row — sweep
+        finishes by removing the now-redundant source)."""
+        from undo.durable_move import _JournalEntry, plan_recovery_actions
+
+        entry = _JournalEntry(
+            op="move",
+            src="/a",
+            dst="/b",
+            state="started",
+            schema=2,
+            op_id="op-post",
+            tmp_path="/path/to/.b.42.tmp",
+        )
+        # fs_observer reports tmp absent (replace consumed it).
+        plan = plan_recovery_actions([entry], fs_observer=lambda _p: False)
+        assert len(plan) == 1
+        assert plan[0].verb == "unlink_src_then_drop"
+
+    def test_planner_v1_started_remains_retain(self) -> None:
+        """v1 records (no ``schema``, no ``tmp_path``) preserve PR #197
+        retain-as-ambiguous behavior. The disambiguation is a v2-only
+        capability; v1 records lack the metadata to safely choose a
+        verb."""
+        from undo.durable_move import _JournalEntry, plan_recovery_actions
+
+        entry = _JournalEntry(op="move", src="/a", dst="/b", state="started")
+        plan = plan_recovery_actions([entry], fs_observer=lambda _p: True)
+        assert len(plan) == 1
+        assert plan[0].verb == "retain"
+
+    def test_executor_drop_tmp_then_drop_unlinks_tmp(self, tmp_path: Path) -> None:
+        """Executor's ``drop_tmp_then_drop`` verb: unlinks the tmp file,
+        drops the entry, leaves src + dst untouched (src is canonical
+        because the replace never ran)."""
+        from undo.durable_move import (
+            _apply_planned_actions,
+            _JournalEntry,
+            plan_recovery_actions,
+        )
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        tmp = tmp_path / ".dst.txt.42.tmp"
+        src.write_text("canonical source")
+        tmp.write_text("orphan tmp from pre-replace crash")
+        # dst absent — pre-replace crash means dst was never written.
+        entry = _JournalEntry(
+            op="move",
+            src=str(src),
+            dst=str(dst),
+            state="started",
+            schema=2,
+            op_id="op-1",
+            tmp_path=str(tmp),
+        )
+        plan = plan_recovery_actions([entry])
+        assert plan[0].verb == "drop_tmp_then_drop"
+
+        retained = _apply_planned_actions(plan)
+        assert retained == [], "drop_tmp_then_drop must drop the entry"
+        assert not tmp.exists(), "tmp must be unlinked"
+        assert src.read_text() == "canonical source", "src must be preserved"
+        assert not dst.exists(), "dst must remain absent"
+
+    def test_executor_drop_tmp_then_drop_handles_already_gone(self, tmp_path: Path) -> None:
+        """If ``tmp_path`` is already absent (e.g. operator cleaned it
+        before sweep ran), ``drop_tmp_then_drop`` swallows
+        ``FileNotFoundError`` and still drops the entry — same pattern
+        as ``unlink_src_then_drop``."""
+        from undo.durable_move import (
+            _apply_planned_actions,
+            _JournalEntry,
+        )
+
+        # Build a plan manually so the planner's fs_observer doesn't
+        # flip the verb to unlink_src_then_drop.
+        entry = _JournalEntry(
+            op="move",
+            src=str(tmp_path / "src.txt"),
+            dst=str(tmp_path / "dst.txt"),
+            state="started",
+            schema=2,
+            op_id="op-1",
+            tmp_path=str(tmp_path / "absent.tmp"),
+        )
+        from undo.durable_move import _PlannedAction
+
+        plan = [
+            _PlannedAction(
+                identity=("v2", "move", "op-1"),
+                entry=entry,
+                verb="drop_tmp_then_drop",
+                reason="test: tmp gone before sweep",
+            )
+        ]
+        retained = _apply_planned_actions(plan)
+        assert retained == [], "missing tmp must still drop entry (idempotent)"
+
+    def test_executor_drop_tmp_os_error_retains(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Transient ``OSError`` (other than ``FileNotFoundError``) on
+        tmp unlink retains the entry so the next sweep retries. Mirrors
+        the ``unlink_src_then_drop`` behavior (PR #197 round-5 / codex
+        fwMK)."""
+        from undo.durable_move import (
+            _apply_planned_actions,
+            _JournalEntry,
+            _PlannedAction,
+        )
+
+        tmp = tmp_path / ".dst.42.tmp"
+        tmp.write_text("orphan")
+        entry = _JournalEntry(
+            op="move",
+            src="/src",
+            dst="/dst",
+            state="started",
+            schema=2,
+            op_id="op-1",
+            tmp_path=str(tmp),
+        )
+        plan = [
+            _PlannedAction(
+                identity=("v2", "move", "op-1"),
+                entry=entry,
+                verb="drop_tmp_then_drop",
+                reason="test",
+            )
+        ]
+
+        real_unlink = Path.unlink
+
+        def failing_unlink(self: Path, *a: object, **k: object) -> None:
+            if str(self) == str(tmp):
+                raise OSError(13, "simulated permission denied")
+            return real_unlink(self, *a, **k)
+
+        monkeypatch.setattr(Path, "unlink", failing_unlink)
+
+        retained = _apply_planned_actions(plan)
+        assert retained == [entry], (
+            "transient OSError on tmp unlink must fall back to retain "
+            "(matches unlink_src_then_drop semantics)"
+        )
+        assert tmp.exists(), "unlink raised → tmp survives for next sweep"
+
+
+class TestWriterProtocolV2:
+    """Step 6 / §7.2 + §7.3: writer-side changes to satisfy the §7.1
+    tmp-exists invariant.
+
+    Concretely:
+
+    1. v2 envelope on every journal append: ``schema=2``, ``op_id``
+       (uuid stable across started/copied/done), ``tmp_path`` on
+       started.
+    2. ``fsync_directory(<dst.parent>)`` runs between tmp creation and
+       the started journal append (the round-2 blocking fix).
+    3. ``except BaseException: tmp_path.unlink()`` is removed (§7.4):
+       tmp persists if an exception fires after creation, so sweep
+       can disambiguate.
+    """
+
+    def _force_exdev(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Make ``os.replace`` raise EXDEV once, then pass through."""
+        real_replace = os.replace
+        triggered = {"v": False}
+
+        def exdev_once(src: object, dst: object) -> object:
+            if not triggered["v"]:
+                triggered["v"] = True
+                raise OSError(errno.EXDEV, "Cross-device link", str(src))
+            return real_replace(src, dst)
+
+        monkeypatch.setattr("undo.durable_move.os.replace", exdev_once)
+
+    def test_writer_started_record_carries_v2_envelope(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A successful EXDEV move emits a ``started`` entry with
+        ``schema=2``, a populated ``op_id``, and ``tmp_path`` pointing
+        at the actual tmp file path used during the copy."""
+        from undo.durable_move import durable_move
+
+        self._force_exdev(monkeypatch)
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("payload")
+        journal = tmp_path / "move.journal"
+
+        durable_move(src, dst, journal=journal)
+
+        entries = _read_journal(journal)
+        started = [e for e in entries if e["state"] == "started"]
+        assert len(started) == 1, f"expected one started entry; got {entries!r}"
+        rec = started[0]
+        assert rec["schema"] == 2, "writer must emit schema=2 envelope (§7.2)"
+        assert isinstance(rec.get("op_id"), str) and rec["op_id"], (
+            "v2 started must carry a non-empty op_id (§4.1 rule 8)"
+        )
+        assert isinstance(rec.get("tmp_path"), str) and rec["tmp_path"], (
+            "v2 move started must carry tmp_path for §7.1 disambiguation"
+        )
+        # tmp_path lives in dst.parent so the os.replace is same-fs.
+        assert Path(rec["tmp_path"]).parent == dst.parent
+
+    def test_writer_op_id_stable_across_started_copied_done(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All three state records for a single move share the SAME
+        ``op_id``, so §3.1 rule 1 collapse-key collapses them into a
+        single identity."""
+        from undo.durable_move import durable_move
+
+        self._force_exdev(monkeypatch)
+        src = tmp_path / "s.txt"
+        dst = tmp_path / "d.txt"
+        src.write_text("x")
+        journal = tmp_path / "move.journal"
+
+        durable_move(src, dst, journal=journal)
+
+        entries = _read_journal(journal)
+        op_ids = {e.get("op_id") for e in entries if e["op"] == "move"}
+        assert len(op_ids) == 1, (
+            f"all states for a single move must share one op_id; got {op_ids!r}"
+        )
+        assert next(iter(op_ids)), "op_id must be non-empty"
+
+    def test_writer_fsyncs_dst_parent_before_started_journal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Round-2 blocking fix (§7.1 rule 2): writer must call
+        ``fsync_directory(dst.parent)`` BEFORE the started journal
+        append. Without this ordering the tmp's directory entry can
+        be lost on power-loss, breaking the §5.1 tmp-absent ⇒
+        post-replace inference."""
+        from undo import durable_move as dm_mod
+
+        self._force_exdev(monkeypatch)
+        src = tmp_path / "s.txt"
+        dst = tmp_path / "d.txt"
+        src.write_text("payload")
+        journal = tmp_path / "move.journal"
+
+        # Record every fsync_directory call and every journal write
+        # (started state only). Step ordering: fsync(dst.parent) MUST
+        # appear before the first started-state journal write event.
+        events: list[tuple[str, str]] = []
+
+        real_fsync = dm_mod.fsync_directory
+
+        def tracking_fsync(p: Path) -> None:
+            events.append(("fsync", str(p.parent if p.is_file() else p)))
+            real_fsync(p)
+
+        real_append = dm_mod._append_journal
+
+        def tracking_append(j: Path, payload):  # type: ignore[no-untyped-def]
+            if payload.get("state") == "started":
+                events.append(("journal_started", str(j)))
+            real_append(j, payload)
+
+        monkeypatch.setattr("undo.durable_move.fsync_directory", tracking_fsync)
+        monkeypatch.setattr("undo.durable_move._append_journal", tracking_append)
+
+        dm_mod.durable_move(src, dst, journal=journal)
+
+        # Find first journal_started and confirm at least one fsync
+        # event preceded it.
+        first_started_idx = next(
+            (i for i, ev in enumerate(events) if ev[0] == "journal_started"),
+            None,
+        )
+        assert first_started_idx is not None, (
+            f"no started-state journal write recorded; events={events!r}"
+        )
+        prior_fsyncs = [ev for ev in events[:first_started_idx] if ev[0] == "fsync"]
+        assert prior_fsyncs, (
+            "§7.1 rule 2 requires fsync_directory(dst.parent) BEFORE the "
+            f"started journal append; events={events!r}"
+        )
+
+    def test_writer_no_exception_cleanup_of_tmp(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """§7.4: ``except BaseException: tmp_path.unlink()`` is removed.
+        Exceptions after tmp creation MUST leave tmp on disk so sweep
+        can observe ``lexists(tmp_path) == True`` and disambiguate as
+        pre-replace.
+
+        This test forces ``os.replace`` to raise inside the EXDEV body
+        AFTER the tmp has been created, then asserts the tmp is still
+        on disk.
+        """
+        from undo.durable_move import durable_move
+
+        # Force EXDEV on the FIRST replace (regular code path), then
+        # raise OSError on the second replace (tmp -> dst rename) so
+        # the body propagates an exception while tmp exists.
+        state = {"call": 0}
+
+        def replace_fail_at_tmp_to_dst(src_arg, dst_arg):  # type: ignore[no-untyped-def]
+            state["call"] += 1
+            if state["call"] == 1:
+                # Simulate cross-device on the same-device fast path so
+                # we fall into the EXDEV branch.
+                raise OSError(errno.EXDEV, "simulated cross-device")
+            # Subsequent call IS the tmp → dst rename inside the EXDEV
+            # branch — fail it.
+            raise OSError(28, "simulated disk full at replace")
+
+        monkeypatch.setattr("undo.durable_move.os.replace", replace_fail_at_tmp_to_dst)
+
+        src = tmp_path / "s.txt"
+        dst = tmp_path / "d.txt"
+        src.write_text("payload")
+        journal = tmp_path / "move.journal"
+
+        with pytest.raises(OSError, match="simulated"):
+            durable_move(src, dst, journal=journal)
+
+        # Inspect tmp_path from the started journal record.
+        entries = _read_journal(journal)
+        started = [e for e in entries if e["state"] == "started"]
+        assert len(started) == 1
+        tmp_path_str = started[0].get("tmp_path")
+        assert tmp_path_str, "started entry must record tmp_path for sweep"
+        assert Path(tmp_path_str).exists(), (
+            "§7.4: tmp must persist after exception so sweep can "
+            "observe lexists(tmp_path) == True and unlink it as orphan"
+        )
+
+    def test_writer_no_exception_cleanup_symlink(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same as above but for the symlink branch — tmp symlink
+        persists across exceptions."""
+        if os.name == "nt":
+            pytest.skip("POSIX symlinks")
+        from undo.durable_move import durable_move
+
+        # First replace = simulate cross-device on the same-device fast
+        # path. Second replace (the EXDEV branch's tmp→dst symlink
+        # rename) raises so the symlink tmp survives.
+        state = {"call": 0}
+
+        def replace_fail_at_tmp_to_dst(src_arg, dst_arg):  # type: ignore[no-untyped-def]
+            state["call"] += 1
+            if state["call"] == 1:
+                raise OSError(errno.EXDEV, "simulated cross-device")
+            raise OSError(28, "simulated disk full at symlink replace")
+
+        monkeypatch.setattr("undo.durable_move.os.replace", replace_fail_at_tmp_to_dst)
+
+        target = tmp_path / "target.txt"
+        target.write_text("data")
+        src = tmp_path / "link"
+        src.symlink_to(target)
+        dst = tmp_path / "moved-link"
+        journal = tmp_path / "move.journal"
+
+        with pytest.raises(OSError, match="simulated"):
+            durable_move(src, dst, journal=journal)
+
+        entries = _read_journal(journal)
+        started = [e for e in entries if e["state"] == "started"]
+        assert started, "started journal entry must exist for symlink branch"
+        tmp_path_str = started[0].get("tmp_path")
+        assert tmp_path_str, "v2 started must carry tmp_path"
+        # lexists handles the dangling-link case (target may have moved).
+        assert os.path.lexists(tmp_path_str), (
+            "§7.4: symlink tmp must persist on exception so sweep can see and unlink it"
+        )
+
+
+class TestSweepEndToEndV2Started:
+    """Step 6 integration: a real EXDEV move that crashes inside the
+    body, followed by a real ``sweep`` call. Validates the round-trip
+    through the v2 envelope, the §7.1 invariant, and the planner's
+    disambiguation rows."""
+
+    def test_sweep_recovers_pre_replace_crash_unlinks_tmp(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End-to-end pre-replace crash:
+
+        1. EXDEV branch creates tmp, fsyncs, writes started journal.
+        2. ``os.replace`` raises (simulated crash before tmp consumed).
+        3. ``sweep`` reads journal, observes ``lexists(tmp_path)==True``
+           on the orphan tmp, executes ``drop_tmp_then_drop``: unlinks
+           tmp, drops entry, leaves src as the canonical copy.
+        """
+        from undo.durable_move import durable_move, sweep
+
+        state = {"call": 0}
+
+        def fail_after_exdev(src_arg, dst_arg):  # type: ignore[no-untyped-def]
+            state["call"] += 1
+            if state["call"] == 1:
+                raise OSError(errno.EXDEV, "simulated cross-device")
+            raise OSError(28, "simulated crash mid-replace")
+
+        monkeypatch.setattr("undo.durable_move.os.replace", fail_after_exdev)
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("canonical")
+        journal = tmp_path / "move.journal"
+
+        with pytest.raises(OSError, match="simulated crash"):
+            durable_move(src, dst, journal=journal)
+
+        # Sanity: tmp orphan exists on disk; src + journal intact.
+        entries = _read_journal(journal)
+        tmp_path_str = entries[0]["tmp_path"]
+        assert Path(tmp_path_str).exists()
+        assert src.read_text() == "canonical"
+
+        # Restore os.replace so sweep's compaction can rewrite the journal.
+        monkeypatch.undo()
+
+        sweep(journal)
+
+        # Post-sweep: tmp gone, src preserved, journal compacted to empty.
+        assert not Path(tmp_path_str).exists(), (
+            "sweep must unlink the orphan tmp (drop_tmp_then_drop)"
+        )
+        assert src.read_text() == "canonical", (
+            "sweep MUST NOT touch src when tmp is present (pre-replace)"
+        )
+        assert not dst.exists(), "dst should still be absent"
+        # Journal compacted: started entry resolved, no surviving lines.
+        assert _read_journal(journal) == []
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -2726,6 +2726,82 @@ class TestPlanRecoveryActions:
         assert src.exists()  # unlink raised → src survives
 
 
+class TestIsPathInFlightCollapseIdentity:
+    """§3.1 / step 3 codex iy4u: ``is_path_in_flight`` MUST collapse by
+    the operation identity, not by ``(src, dst)`` alone. Path-keyed
+    collapse re-introduces the iy4u masking bug for the F8 trash-GC
+    coordination path.
+
+    Concrete failure mode without identity-keyed collapse: a
+    ``move /a /b started`` followed by a ``dir_move /a /b done`` for
+    the same paths would let the dir_move done supersede the move
+    started under ``(src, dst)`` reduction. ``is_path_in_flight(/a)``
+    would then return ``False`` during the move's copy → replace
+    window, and trash GC could delete /a out from under it. The
+    identity-keyed collapse keeps both records distinct.
+    """
+
+    def test_separate_ops_on_same_paths_dont_mask(self, tmp_path: Path) -> None:
+        """``move started`` + ``dir_move done`` on identical paths:
+        ``is_path_in_flight`` must still see the move's STARTED entry
+        and return True."""
+        from undo.durable_move import _append_journal, is_path_in_flight
+
+        journal = tmp_path / "move.journal"
+        # NB: writer-side dir_move uses v1 envelope; move uses v2.
+        # Different ops → different §3.1 identities even with same
+        # (src, dst), so the dir_move done can NOT mask the move started.
+        _append_journal(
+            journal,
+            {"op": "move", "src": "/a", "dst": "/b", "state": "started"},
+        )
+        _append_journal(
+            journal,
+            {"op": "dir_move", "src": "/a", "dst": "/b", "state": "done"},
+        )
+        # Without identity-keyed collapse, the dir_move done would
+        # overwrite the move started under (src, dst) and this would
+        # falsely return False.
+        assert is_path_in_flight(Path("/a"), journal=journal) is True
+        assert is_path_in_flight(Path("/b"), journal=journal) is True
+
+    def test_v2_op_id_distinct_attempts_dont_mask(self, tmp_path: Path) -> None:
+        """Two v2 ``move`` retries on the same paths but different
+        op_ids stay distinct under identity collapse — a later
+        attempt's done can NOT mask an earlier attempt's started."""
+        from undo.durable_move import _append_journal, is_path_in_flight
+
+        journal = tmp_path / "move.journal"
+        # Attempt 1: still in flight (started).
+        _append_journal(
+            journal,
+            {
+                "schema": 2,
+                "op": "move",
+                "op_id": "attempt-1",
+                "src": "/a",
+                "dst": "/b",
+                "tmp_path": "/a.tmp",
+                "state": "started",
+            },
+        )
+        # Attempt 2: completed.
+        _append_journal(
+            journal,
+            {
+                "schema": 2,
+                "op": "move",
+                "op_id": "attempt-2",
+                "src": "/a",
+                "dst": "/b",
+                "state": "done",
+            },
+        )
+        # Attempt 1's started must still be visible — its op_id keeps
+        # it distinct from attempt 2's done under §3.1 collapse.
+        assert is_path_in_flight(Path("/a"), journal=journal) is True
+
+
 class TestStartedTmpPathDisambiguation:
     """Step 6 / §7.1: v2 ``move started`` records carry ``tmp_path``;
     sweep observes ``lexists(tmp_path)`` to disambiguate pre-replace

--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -2459,9 +2459,17 @@ class TestPlanRecoveryActions:
             ("move", "copied", False, "retain"),
             ("move", "done", True, "drop"),
             ("move", "done", False, "drop"),
-            ("move", "unknown_state", True, "drop"),
+            # §5.1 row "known-op unknown state" applies to ``move``: retain
+            # + warn so a future binary that knows the new state can still
+            # resolve the entry, and is_path_in_flight() keeps protecting
+            # the path. CodeRabbit PRRT_kwDOR_Rkws59lDD8.
+            ("move", "unknown_state", True, "retain"),
             ("dir_move", "started", True, "drop"),
             ("dir_move", "done", True, "drop"),
+            # dir_move overrides the generic unknown-state retain because
+            # §5.3 makes dir_move coordination-only — sweep can't safely
+            # retry shutil.move regardless of state, so dropping releases
+            # the in-flight marker.
             ("dir_move", "unknown_state", True, "drop"),
             ("future_op", "started", True, "retain"),  # unknown op retain
             ("future_op", "done", True, "retain"),  # unknown op retain
@@ -2835,10 +2843,16 @@ class TestStartedTmpPathDisambiguation:
 
     def test_planner_v2_started_tmp_absent_unlinks_src(self) -> None:
         """§5.1 row: v2 ``move started`` + ``lexists(tmp_path) == False``
-        ⇒ post-replace crash. ``os.replace`` consumed tmp into dst;
-        the only thing left is to unlink src. Verb:
-        ``unlink_src_then_drop`` (same as the COPIED row — sweep
-        finishes by removing the now-redundant source)."""
+        + ``lexists(dst) == True`` ⇒ post-replace crash confirmed.
+        ``os.replace`` consumed tmp into dst; the only thing left is to
+        unlink src. Verb: ``unlink_src_then_drop`` (same as the COPIED
+        row — sweep finishes by removing the now-redundant source).
+
+        The dst-present check is the codex lCbU data-loss guard: tmp
+        absent alone is NOT proof that replace ran. See
+        ``test_planner_v2_started_tmp_absent_dst_absent_retains`` for
+        the negative case.
+        """
         from undo.durable_move import _JournalEntry, plan_recovery_actions
 
         entry = _JournalEntry(
@@ -2850,8 +2864,68 @@ class TestStartedTmpPathDisambiguation:
             op_id="op-post",
             tmp_path="/path/to/.b.42.tmp",
         )
-        # fs_observer reports tmp absent (replace consumed it).
+
+        # fs_observer: tmp absent, dst PRESENT (the proof of post-replace).
+        def fs(p: str) -> bool:
+            return p == "/b"
+
+        plan = plan_recovery_actions([entry], fs_observer=fs)
+        assert len(plan) == 1
+        assert plan[0].verb == "unlink_src_then_drop"
+
+    def test_planner_v2_started_tmp_absent_dst_absent_retains(self) -> None:
+        """Codex P1 PRRT_kwDOR_Rkws59lCbU: when v2 STARTED has tmp absent
+        AND dst also absent, sweep MUST NOT plan ``unlink_src_then_drop``
+        — that would destroy the last remaining copy on disk if dst was
+        cleaned out-of-band after a crash. Mirrors the codex hGWW
+        dst-presence guard on the COPIED row.
+
+        Rationale: tmp absent is NOT proof that ``os.replace`` ran. Tmp
+        could also be absent if an operator manually cleaned it. If dst
+        is then also absent, src is the canonical copy — unlinking it
+        is data loss. Retain instead so the next sweep / operator can
+        resolve.
+        """
+        from undo.durable_move import _JournalEntry, plan_recovery_actions
+
+        entry = _JournalEntry(
+            op="move",
+            src="/a",
+            dst="/b",
+            state="started",
+            schema=2,
+            op_id="op-x",
+            tmp_path="/path/to/.b.42.tmp",
+        )
+        # fs_observer: BOTH tmp and dst absent.
         plan = plan_recovery_actions([entry], fs_observer=lambda _p: False)
+        assert len(plan) == 1
+        assert plan[0].verb == "retain", (
+            f"v2 STARTED + tmp absent + dst absent must retain (data-loss guard); "
+            f"got {plan[0].verb}"
+        )
+
+    def test_planner_v2_started_tmp_absent_dst_present_unlinks_src(self) -> None:
+        """The post-replace branch only fires when dst is actually
+        present — that's the proof ``os.replace`` consumed tmp. With
+        tmp absent + dst present, ``unlink_src_then_drop`` is safe."""
+        from undo.durable_move import _JournalEntry, plan_recovery_actions
+
+        entry = _JournalEntry(
+            op="move",
+            src="/a",
+            dst="/b",
+            state="started",
+            schema=2,
+            op_id="op-x",
+            tmp_path="/path/to/.b.42.tmp",
+        )
+
+        # fs_observer: tmp absent, dst present.
+        def fs(p: str) -> bool:
+            return p == "/b"
+
+        plan = plan_recovery_actions([entry], fs_observer=fs)
         assert len(plan) == 1
         assert plan[0].verb == "unlink_src_then_drop"
 


### PR DESCRIPTION
## Summary

Implements **F7.1 (issue #201)** — promotes the durable_move journal from "ad-hoc file the helper writes" to a first-class crash-recovery protocol. Closes the five gaps PR #197 review exposed:

1. **Collapse-key conflation** — same `(src, dst)` across different ops masked each other (codex `iy4u`).
2. **Parse-time AttributeError** on non-object JSON values (codex `iy4w`).
3. **Live-journal rewrite** — sweep used in-place truncate+write, losing retained entries on a mid-rewrite crash.
4. **STARTED ambiguous** — PR #197 retained `started` entries forever; sweep couldn't tell pre-replace from post-replace.
5. **Dir_move is coordination-only** with no operator-visible recovery path.

Spec: `docs/internal/F7-1-journal-protocol-design.md` (3 review rounds; round-3 approved).

Branch is **9 commits**, each a self-contained step from the §11 implementation order, plus the code-reviewer fix.

## Highlights

- **v2 journal envelope**: `schema=2`, `op_id` (uuid stable across started→copied→done), `tmp_path` on `move started`, `ts`/`host_pid` diagnostics, plus `_raw` preservation for unknown-op entries (forward-compat).
- **3-tier collapse identity** (§3.1): `("v2", op, op_id)` / `("v1", op, src, dst)` / `("unknown", op, _hash16(_raw))`. Closes codex `iy4u` for both `_reconcile_entries` and `is_path_in_flight`.
- **Parse contract** (§4.1): 9 explicit rejection rules; oversized lines, malformed JSON, missing fields, schema mismatches all logged + skipped (never raised).
- **Lock file** (§6.1): `<journal>.lock` (stable inode) is the flock subject for all reader/writer/compaction operations. Closes the round-1 blocking case where `os.replace`-on-the-journal would invalidate concurrent appenders' locks.
- **Atomic compaction** (§6.2): compact-tmp + `os.replace` + parent-dir fsync. Crash mid-replace leaves either old journal intact or new journal complete — never zero-bytes-with-pending-entries. §6.4 stale-tmp single-retry, §6.6 16 MiB size cap.
- **Pure planner + executor** (§8.1): `plan_recovery_actions` is mutation-free; `_apply_planned_actions` is the only mutation site. Both sweep and `fo recover` call the planner — no "report-only mode" branch can drift.
- **STARTED disambiguation via `tmp_path`** (§7): tmp created BEFORE journal started write, `fsync_directory(dst.parent)` BEFORE journal started write (round-2 blocking fix), no exception cleanup of tmp (round-1 blocking fix). Sweep observes `lexists(tmp_path)` to choose `drop_tmp_then_drop` (pre-replace) vs `unlink_src_then_drop` (post-replace). v1 records preserve PR #197 retain-as-ambiguous.
- **`fo recover` CLI** (§8.2): read-only operator visibility — reads journal under LOCK_SH, calls planner, renders verb + reason table with disambiguation tier annotation. Exits 0 if nothing actionable, 1 otherwise.

## Commits (each self-contained, CI green)

| # | SHA | Step |
|---|-----|------|
| 1 | b10b7de2 | v2 journal schema + parse-time rejection rules |
| 2 | ac159dd9 | extract pure plan_recovery_actions planner |
| 3 | d59fad45 | op_id-aware collapse identity (closes codex iy4u) |
| 4 | fe83cbf8 | extract flock to `<journal>.lock` sibling |
| 5 | a7d6cf4c | atomic journal compaction via compact-tmp + os.replace |
| 6 | 8ee537c4 | v2 writer protocol + STARTED tmp_path disambiguation |
| 7 | f2b7f222 | lock in §5.3 dir_move decision with explicit silent-drop test |
| 8 | d13599bd | fo recover CLI for read-only journal preview |
| 9 | f2bb2129 | is_path_in_flight uses §3.1 collapse identity (code-review fix) |

## Test plan

- [x] Unit + ci suite (`tests/undo/`, `tests/cli/test_undo_recover.py`, `tests/integration/test_rollback_executor.py`, `tests/integration/test_state_recovery.py`, `tests/ci/`): **764 passed** locally.
- [x] Full integration suite locally (`bash .claude/scripts/measure-integration-coverage.sh`): **7210 passed, 90% coverage** (floor: 71.9%).
- [x] Pre-commit validation: pass (G3 rail, mypy strict, ruff format, lint, deptry, pymarkdown).
- [x] `/code-reviewer` agent: 1 important finding (is_path_in_flight collapse drift) — fixed in commit f2bb2129 with regression test.
- [x] Tests for crash safety:
  - `TestAtomicCompaction::test_compaction_crash_mid_replace_preserves_journal` — simulates `os.replace` raising mid-compaction; journal content unchanged.
  - `TestWriterProtocolV2::test_writer_no_exception_cleanup_of_tmp` (+ symlink variant) — exception after tmp creation leaves tmp on disk per §7.4.
  - `TestSweepEndToEndV2Started::test_sweep_recovers_pre_replace_crash_unlinks_tmp` — full round trip: real EXDEV move crashes, sweep recovers correctly.
  - `TestIsPathInFlightCollapseIdentity` (new): mixed-op + retry-attempt masking cases.
- [x] Local sanity check: `fo recover` on an absent journal exits 0; on a real `copied`-with-dst-present entry exits 1 and renders `unlink_src_then_drop`.

## Out of scope (per design §1 non-goals)

- F8 trash GC deletion API → tracked in **#202** (depends on this PR landing first).
- `fo doctor` integration → deferred per round-1 review scope-down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `fo recover` command previews pending recovery actions with exit codes for operational scripting.
  * Journal compaction now uses atomic file operations for safer concurrent access.
  * Improved crash recovery with deterministic reconciliation state handling.

* **Documentation**
  * Added Journal Protocol v2 design specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->