### PR TITLE
feat(intelligence): D5 — PreferenceStorage protocol + SQLite adapter

### DIFF
--- a/src/services/intelligence/__init__.py
+++ b/src/services/intelligence/__init__.py
@@ -25,6 +25,11 @@ from services.intelligence.pattern_extractor import (
     PatternElement,
 )
 from services.intelligence.pattern_learner import PatternLearner
+from services.intelligence.preference_storage import (
+    InMemoryPreferenceStorage,
+    PreferenceStorage,
+    SqlitePreferenceStorage,
+)
 from services.intelligence.preference_store import (
     DirectoryPreference,
     PreferenceStore,
@@ -65,6 +70,9 @@ __all__ = [
     "track_file_move",
     "track_file_rename",
     "track_category_change",
+    "PreferenceStorage",
+    "InMemoryPreferenceStorage",
+    "SqlitePreferenceStorage",
     "PreferenceStore",
     "DirectoryPreference",
     "SchemaVersion",

--- a/src/services/intelligence/preference_storage.py
+++ b/src/services/intelligence/preference_storage.py
@@ -1,0 +1,544 @@
+"""Storage backends for ``PreferenceTracker`` (Epic D / D5).
+
+Tracks: issue #157 (Hardening Epic D, item D5).
+
+Two implementations of the :class:`PreferenceStorage` Protocol:
+
+- :class:`InMemoryPreferenceStorage` — preserves the original
+  ``PreferenceTracker`` behavior (in-process dicts, thread-safe via RLock).
+  ``PreferenceTracker()`` with no args wires this up by default.
+- :class:`SqlitePreferenceStorage` — adapter around
+  :class:`PreferenceDatabaseManager` that translates the manager's
+  string-keyed dict rows into ``Preference`` / ``Correction`` dataclass
+  instances. Use this when corrections must persist across processes.
+
+The Protocol is intentionally narrow — only the storage primitives the
+tracker needs from a backend. Domain logic (correction → preference
+extraction, best-match selection by extension, etc.) stays in
+``PreferenceTracker``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from threading import RLock
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from .preference_database import PreferenceDatabaseManager
+from .preference_tracker import (
+    Correction,
+    CorrectionType,
+    Preference,
+    PreferenceMetadata,
+    PreferenceType,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class PreferenceStorage(Protocol):
+    """Storage backend protocol for :class:`PreferenceTracker`.
+
+    Designed to be narrow: the tracker keeps its domain logic (extracting
+    preferences from corrections, best-match selection by file extension,
+    etc.) and delegates only the storage primitives.
+    """
+
+    # Preference CRUD ------------------------------------------------------
+
+    def save_preference(self, preference: Preference) -> None:
+        """Insert or update ``preference`` (idempotent on type+key)."""
+
+    def find_preferences(
+        self,
+        preference_type: PreferenceType,
+        key: str | None = None,
+    ) -> list[Preference]:
+        """Return preferences of ``preference_type``, optionally filtered by ``key``."""
+
+    def update_preference_confidence(
+        self,
+        preference: Preference,
+        success: bool,
+    ) -> None:
+        """Adjust the preference's confidence: +0.05 cap 0.98 on success, -0.10 floor 0.10 on failure."""
+
+    def delete_preferences(
+        self,
+        preference_type: PreferenceType | None = None,
+    ) -> int:
+        """Delete preferences (all or by type). Returns number of rows deleted."""
+
+    # Correction history ---------------------------------------------------
+
+    def save_correction(self, correction: Correction) -> None:
+        """Append a correction to the history."""
+
+    def get_corrections_for_file(self, file_path: Path) -> list[Correction]:
+        """Return corrections whose source OR destination equals ``file_path``."""
+
+    def get_recent_corrections(self, limit: int = 10) -> list[Correction]:
+        """Return the most recent corrections, newest first, capped at ``limit``."""
+
+    # Statistics + bulk ----------------------------------------------------
+
+    def get_statistics(self) -> dict[str, Any]:
+        """Return aggregate counters: at minimum ``total_preferences``."""
+
+    def export_data(self) -> dict[str, Any]:
+        """Serialize all storage state to a JSON-friendly dict."""
+
+    def import_data(self, data: dict[str, Any]) -> None:
+        """Replace storage state with the contents of ``data`` (from :meth:`export_data`)."""
+
+
+# ---------------------------------------------------------------------------
+# InMemoryPreferenceStorage — in-process dicts (the original tracker model)
+# ---------------------------------------------------------------------------
+
+
+class InMemoryPreferenceStorage:
+    """In-process dict storage. Thread-safe via ``RLock``.
+
+    Behavior is bit-identical to the pre-D5 ``PreferenceTracker`` storage
+    layer: preferences are keyed by ``preference_type:key`` and stored
+    as a list of :class:`Preference` instances; corrections are an
+    append-only list.
+    """
+
+    def __init__(self) -> None:
+        """Initialize empty in-memory storage with a reentrant lock."""
+        self._lock = RLock()
+        self._preferences: dict[str, list[Preference]] = {}
+        self._corrections: list[Correction] = []
+        self._total_preferences = 0
+        self._successful_applications = 0
+        self._failed_applications = 0
+
+    @staticmethod
+    def _storage_key(preference_type: PreferenceType, key: str) -> str:
+        return f"{preference_type.value}:{key}"
+
+    def save_preference(self, preference: Preference) -> None:
+        """Upsert ``preference``; updates existing entry on (type, key) collision."""
+        with self._lock:
+            storage_key = self._storage_key(preference.preference_type, preference.key)
+            existing = self._preferences.get(storage_key, [])
+            for idx, existing_pref in enumerate(existing):
+                if existing_pref.key == preference.key:
+                    # Replace existing in place — preserves list ordering.
+                    existing[idx] = preference
+                    return
+            existing.append(preference)
+            self._preferences[storage_key] = existing
+            self._total_preferences += 1
+
+    def find_preferences(
+        self,
+        preference_type: PreferenceType,
+        key: str | None = None,
+    ) -> list[Preference]:
+        """Return preferences of ``preference_type``, optionally filtered by ``key``."""
+        with self._lock:
+            results: list[Preference] = []
+            for storage_key, prefs in self._preferences.items():
+                if not storage_key.startswith(f"{preference_type.value}:"):
+                    continue
+                for pref in prefs:
+                    if pref.preference_type != preference_type:
+                        continue
+                    if key is not None and pref.key != key:
+                        continue
+                    results.append(pref)
+            return results
+
+    def update_preference_confidence(
+        self,
+        preference: Preference,
+        success: bool,
+    ) -> None:
+        """Adjust confidence (+0.05 cap 0.98 on success / -0.10 floor 0.10 on failure)."""
+        with self._lock:
+            now = datetime.now(UTC)
+            if success:
+                preference.metadata.confidence = min(0.98, preference.metadata.confidence + 0.05)
+                preference.metadata.last_used = now
+                self._successful_applications += 1
+            else:
+                preference.metadata.confidence = max(0.1, preference.metadata.confidence - 0.1)
+                self._failed_applications += 1
+            preference.metadata.updated = now
+
+    def delete_preferences(
+        self,
+        preference_type: PreferenceType | None = None,
+    ) -> int:
+        """Delete preferences (all if ``None``, else only that type). Returns delete count."""
+        with self._lock:
+            if preference_type is None:
+                count = sum(len(prefs) for prefs in self._preferences.values())
+                self._preferences.clear()
+                self._corrections.clear()
+                self._total_preferences = 0
+                return count
+
+            count = 0
+            keys_to_remove: list[str] = []
+            for storage_key, prefs_list in self._preferences.items():
+                kept = [p for p in prefs_list if p.preference_type != preference_type]
+                count += len(prefs_list) - len(kept)
+                if not kept:
+                    keys_to_remove.append(storage_key)
+                else:
+                    self._preferences[storage_key] = kept
+            for k in keys_to_remove:
+                del self._preferences[k]
+            self._total_preferences -= count
+            return count
+
+    def save_correction(self, correction: Correction) -> None:
+        """Append a correction to the history."""
+        with self._lock:
+            self._corrections.append(correction)
+
+    def get_corrections_for_file(self, file_path: Path) -> list[Correction]:
+        """Return corrections matching ``file_path`` as either source or destination."""
+        with self._lock:
+            return [
+                c for c in self._corrections if c.source == file_path or c.destination == file_path
+            ]
+
+    def get_recent_corrections(self, limit: int = 10) -> list[Correction]:
+        """Return the most recent corrections (newest first), capped at ``limit``."""
+        with self._lock:
+            sorted_corrs = sorted(self._corrections, key=lambda c: c.timestamp, reverse=True)
+            return sorted_corrs[:limit]
+
+    def get_statistics(self) -> dict[str, Any]:
+        """Return aggregate stats: total_preferences, successful/failed applications, correction count."""
+        with self._lock:
+            all_prefs: list[Preference] = []
+            for prefs in self._preferences.values():
+                all_prefs.extend(prefs)
+            avg_confidence = (
+                sum(p.metadata.confidence for p in all_prefs) / len(all_prefs) if all_prefs else 0.0
+            )
+            return {
+                "total_preferences": len(all_prefs),
+                "unique_preferences": len(self._preferences),
+                # ``total_corrections`` is the running count of corrections
+                # ever passed to ``save_correction``; ``total_correction_history``
+                # is the current list length. They're always equal in this
+                # backend (we never delete corrections), but the original
+                # tracker exposed both keys, so we preserve both for
+                # backwards-compat with existing test assertions.
+                "total_corrections": len(self._corrections),
+                "total_correction_history": len(self._corrections),
+                "successful_applications": self._successful_applications,
+                "failed_applications": self._failed_applications,
+                "average_confidence": round(avg_confidence, 3),
+            }
+
+    def export_data(self) -> dict[str, Any]:
+        """Serialize all preferences + corrections + counters to a JSON-friendly dict."""
+        with self._lock:
+            return {
+                "preferences": {
+                    key: [p.to_dict() for p in prefs] for key, prefs in self._preferences.items()
+                },
+                "corrections": [c.to_dict() for c in self._corrections],
+                "statistics": {
+                    "total_preferences": self._total_preferences,
+                    "successful_applications": self._successful_applications,
+                    "failed_applications": self._failed_applications,
+                },
+                "exported_at": datetime.now(UTC).isoformat(),
+            }
+
+    def import_data(self, data: dict[str, Any]) -> None:
+        """Replace all storage state with ``data``'s contents."""
+        with self._lock:
+            self._preferences.clear()
+            self._corrections.clear()
+            for storage_key, prefs_list in data.get("preferences", {}).items():
+                self._preferences[storage_key] = [Preference.from_dict(p) for p in prefs_list]
+            for corr_data in data.get("corrections", []):
+                self._corrections.append(
+                    Correction(
+                        correction_type=CorrectionType(corr_data["correction_type"]),
+                        source=Path(corr_data["source"]),
+                        destination=Path(corr_data["destination"]),
+                        timestamp=datetime.fromisoformat(corr_data["timestamp"]),
+                        context=corr_data.get("context", {}),
+                    )
+                )
+            stats = data.get("statistics", {})
+            self._total_preferences = stats.get("total_preferences", 0)
+            self._successful_applications = stats.get("successful_applications", 0)
+            self._failed_applications = stats.get("failed_applications", 0)
+
+
+# ---------------------------------------------------------------------------
+# SqlitePreferenceStorage — adapter over PreferenceDatabaseManager
+# ---------------------------------------------------------------------------
+
+
+def _row_to_preference(row: dict[str, Any]) -> Preference:
+    """Translate a ``preferences`` table row (string-keyed dict) into a Preference."""
+    created = datetime.fromisoformat(row["created_at"].replace("Z", "+00:00"))
+    updated = datetime.fromisoformat(row["updated_at"].replace("Z", "+00:00"))
+    last_used_raw = row.get("last_used_at")
+    last_used = (
+        datetime.fromisoformat(last_used_raw.replace("Z", "+00:00")) if last_used_raw else None
+    )
+    context = row.get("context") or {}
+    if isinstance(context, str):
+        context = json.loads(context)
+    return Preference(
+        preference_type=PreferenceType(row["preference_type"]),
+        key=row["key"],
+        # Stored as text; if the original was a dict/list we round-trip via JSON.
+        value=_decode_pref_value(row["value"]),
+        metadata=PreferenceMetadata(
+            created=created,
+            updated=updated,
+            confidence=float(row["confidence"]),
+            frequency=int(row["frequency"]),
+            last_used=last_used,
+            source=row.get("source", "user_correction"),
+        ),
+        context=context,
+    )
+
+
+def _decode_pref_value(stored: str) -> Any:
+    """Restore a preference value from its stored form (JSON if it parses, else str)."""
+    if not stored:
+        return stored
+    if stored[0] in ("{", "[", '"') or stored in ("true", "false", "null"):
+        try:
+            return json.loads(stored)
+        except json.JSONDecodeError:
+            return stored
+    return stored
+
+
+def _encode_pref_value(value: Any) -> str:
+    """Encode a preference value for SQLite TEXT storage (JSON for complex types)."""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value)
+
+
+class SqlitePreferenceStorage:
+    """Adapter exposing :class:`PreferenceDatabaseManager` as :class:`PreferenceStorage`.
+
+    The manager handles the SQL; this class translates between the
+    string-keyed dicts the manager returns and the dataclass instances the
+    Protocol's callers expect.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        """Initialize SQLite storage at ``db_path`` (creates parent dir if needed)."""
+        self._db = PreferenceDatabaseManager(db_path)
+        self._db.initialize()
+        self._lock = RLock()
+
+    def close(self) -> None:
+        """Release the SQLite connection (idempotent)."""
+        self._db.close()
+
+    def save_preference(self, preference: Preference) -> None:
+        """Upsert ``preference`` via the database manager."""
+        with self._lock:
+            self._db.add_preference(
+                preference_type=preference.preference_type.value,
+                key=preference.key,
+                value=_encode_pref_value(preference.value),
+                confidence=preference.metadata.confidence,
+                frequency=preference.metadata.frequency,
+                source=preference.metadata.source,
+                context=preference.context if preference.context else None,
+            )
+
+    def find_preferences(
+        self,
+        preference_type: PreferenceType,
+        key: str | None = None,
+    ) -> list[Preference]:
+        """Look up preferences via the manager's by-type / by-key methods."""
+        with self._lock:
+            if key is not None:
+                row = self._db.get_preference(preference_type.value, key)
+                return [_row_to_preference(row)] if row else []
+            rows = self._db.get_preferences_by_type(preference_type.value)
+            return [_row_to_preference(r) for r in rows]
+
+    def update_preference_confidence(
+        self,
+        preference: Preference,
+        success: bool,
+    ) -> None:
+        """Apply confidence delta and mirror the new value to the live ``preference``."""
+        with self._lock:
+            # Apply the same delta the in-memory backend does, then update both
+            # the in-memory dataclass and the database row by (type, key).
+            now = datetime.now(UTC)
+            if success:
+                preference.metadata.confidence = min(0.98, preference.metadata.confidence + 0.05)
+                preference.metadata.last_used = now
+            else:
+                preference.metadata.confidence = max(0.1, preference.metadata.confidence - 0.1)
+            preference.metadata.updated = now
+
+            # Locate the row by (type, key) and update its confidence column.
+            row = self._db.get_preference(preference.preference_type.value, preference.key)
+            if row is not None:
+                self._db.update_preference_confidence(
+                    int(row["id"]), preference.metadata.confidence
+                )
+
+    def delete_preferences(
+        self,
+        preference_type: PreferenceType | None = None,
+    ) -> int:
+        """Delete preferences (all or by type) via the manager. Returns delete count."""
+        with self._lock:
+            conn = self._db.get_connection()
+            if preference_type is None:
+                cur = conn.execute("SELECT COUNT(*) FROM preferences")
+                count = int(cur.fetchone()[0])
+                conn.execute("DELETE FROM preferences")
+                conn.execute("DELETE FROM corrections")
+                return count
+            cur = conn.execute(
+                "SELECT COUNT(*) FROM preferences WHERE preference_type = ?",
+                (preference_type.value,),
+            )
+            count = int(cur.fetchone()[0])
+            conn.execute(
+                "DELETE FROM preferences WHERE preference_type = ?",
+                (preference_type.value,),
+            )
+            return count
+
+    def save_correction(self, correction: Correction) -> None:
+        """Append a correction via the manager."""
+        with self._lock:
+            metadata = dict(correction.context) if correction.context else None
+            self._db.add_correction(
+                correction_type=correction.correction_type.value,
+                source_path=str(correction.source),
+                destination_path=str(correction.destination),
+                category_old=(metadata or {}).get("old_category"),
+                category_new=(metadata or {}).get("new_category"),
+                metadata=metadata,
+            )
+
+    def get_corrections_for_file(self, file_path: Path) -> list[Correction]:
+        """Filter corrections by source OR destination matching ``file_path``."""
+        with self._lock:
+            conn = self._db.get_connection()
+            target = str(file_path)
+            cur = conn.execute(
+                """
+                SELECT * FROM corrections
+                WHERE source_path = ? OR destination_path = ?
+                ORDER BY timestamp DESC
+                """,
+                (target, target),
+            )
+            return [self._row_to_correction(dict(r)) for r in cur.fetchall()]
+
+    def get_recent_corrections(self, limit: int = 10) -> list[Correction]:
+        """Return up to ``limit`` most-recent corrections."""
+        with self._lock:
+            rows = self._db.get_corrections(limit=limit)
+            return [self._row_to_correction(r) for r in rows]
+
+    def get_statistics(self) -> dict[str, Any]:
+        """Return aggregate stats with the same keys as the in-memory backend."""
+        with self._lock:
+            stats = self._db.get_preference_stats()
+            conn = self._db.get_connection()
+            cur = conn.execute("SELECT COUNT(*) FROM corrections")
+            corrections_count = int(cur.fetchone()[0])
+            stats["total_correction_history"] = corrections_count
+            stats["total_corrections"] = corrections_count
+            return stats
+
+    def export_data(self) -> dict[str, Any]:
+        """Serialize SQLite contents to the same export shape as InMemoryPreferenceStorage."""
+        with self._lock:
+            conn = self._db.get_connection()
+            cur = conn.execute("SELECT * FROM preferences")
+            preferences: dict[str, list[dict[str, Any]]] = {}
+            for r in cur.fetchall():
+                row = dict(r)
+                pref = _row_to_preference(row)
+                storage_key = f"{pref.preference_type.value}:{pref.key}"
+                preferences.setdefault(storage_key, []).append(pref.to_dict())
+
+            cur = conn.execute("SELECT * FROM corrections ORDER BY timestamp ASC")
+            corrections = [self._row_to_correction(dict(r)).to_dict() for r in cur.fetchall()]
+
+            return {
+                "preferences": preferences,
+                "corrections": corrections,
+                "statistics": self._db.get_preference_stats(),
+                "exported_at": datetime.now(UTC).isoformat(),
+            }
+
+    def import_data(self, data: dict[str, Any]) -> None:
+        """Replace all stored preferences/corrections with ``data`` contents."""
+        with self._lock:
+            conn = self._db.get_connection()
+            conn.execute("DELETE FROM preferences")
+            conn.execute("DELETE FROM corrections")
+
+            for prefs_list in data.get("preferences", {}).values():
+                for pref_dict in prefs_list:
+                    pref = Preference.from_dict(pref_dict)
+                    self.save_preference(pref)
+
+            for corr_data in data.get("corrections", []):
+                self.save_correction(
+                    Correction(
+                        correction_type=CorrectionType(corr_data["correction_type"]),
+                        source=Path(corr_data["source"]),
+                        destination=Path(corr_data["destination"]),
+                        timestamp=datetime.fromisoformat(corr_data["timestamp"]),
+                        context=corr_data.get("context", {}),
+                    )
+                )
+
+    @staticmethod
+    def _row_to_correction(row: dict[str, Any]) -> Correction:
+        """Translate a ``corrections`` row into a Correction dataclass."""
+        timestamp = datetime.fromisoformat(row["timestamp"].replace("Z", "+00:00"))
+        metadata = row.get("metadata") or {}
+        if isinstance(metadata, str):
+            metadata = json.loads(metadata)
+        return Correction(
+            correction_type=CorrectionType(row["correction_type"]),
+            source=Path(row["source_path"]),
+            destination=Path(row.get("destination_path") or row["source_path"]),
+            timestamp=timestamp,
+            context=metadata,
+        )
+
+
+__all__ = [
+    "InMemoryPreferenceStorage",
+    "PreferenceStorage",
+    "SqlitePreferenceStorage",
+]

--- a/src/services/intelligence/preference_storage.py
+++ b/src/services/intelligence/preference_storage.py
@@ -25,7 +25,7 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 from threading import RLock
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from .preference_database import PreferenceDatabaseManager
 from .preference_tracker import (
@@ -36,8 +36,13 @@ from .preference_tracker import (
     PreferenceType,
 )
 
-if TYPE_CHECKING:
-    pass
+# Note on imports: ``preference_tracker`` defers ``from .preference_storage
+# import InMemoryPreferenceStorage`` into ``PreferenceTracker.__init__`` so
+# this module can import the dataclasses at top level. The cycle is broken
+# in one direction (tracker → storage uses a deferred import); module-level
+# dataclass imports here are safe and required for runtime use as method
+# parameter / return types. Extracting the dataclasses to a third module
+# would eliminate even the deferred import but is out of scope for D5.
 
 
 # ---------------------------------------------------------------------------
@@ -119,9 +124,12 @@ class InMemoryPreferenceStorage:
     def __init__(self) -> None:
         """Initialize empty in-memory storage with a reentrant lock."""
         self._lock = RLock()
+        # ``total_preferences`` was previously a separate counter that
+        # could drift from ``len(_preferences)`` on rewrite vs append
+        # (CodeRabbit finding on PR #207). It's now derived in
+        # ``get_statistics`` from ``sum(len(prefs) for ...)``.
         self._preferences: dict[str, list[Preference]] = {}
         self._corrections: list[Correction] = []
-        self._total_preferences = 0
         self._successful_applications = 0
         self._failed_applications = 0
 
@@ -141,7 +149,6 @@ class InMemoryPreferenceStorage:
                     return
             existing.append(preference)
             self._preferences[storage_key] = existing
-            self._total_preferences += 1
 
     def find_preferences(
         self,
@@ -189,7 +196,6 @@ class InMemoryPreferenceStorage:
                 count = sum(len(prefs) for prefs in self._preferences.values())
                 self._preferences.clear()
                 self._corrections.clear()
-                self._total_preferences = 0
                 return count
 
             count = 0
@@ -203,7 +209,6 @@ class InMemoryPreferenceStorage:
                     self._preferences[storage_key] = kept
             for k in keys_to_remove:
                 del self._preferences[k]
-            self._total_preferences -= count
             return count
 
     def save_correction(self, correction: Correction) -> None:
@@ -252,13 +257,14 @@ class InMemoryPreferenceStorage:
     def export_data(self) -> dict[str, Any]:
         """Serialize all preferences + corrections + counters to a JSON-friendly dict."""
         with self._lock:
+            total = sum(len(prefs) for prefs in self._preferences.values())
             return {
                 "preferences": {
                     key: [p.to_dict() for p in prefs] for key, prefs in self._preferences.items()
                 },
                 "corrections": [c.to_dict() for c in self._corrections],
                 "statistics": {
-                    "total_preferences": self._total_preferences,
+                    "total_preferences": total,
                     "successful_applications": self._successful_applications,
                     "failed_applications": self._failed_applications,
                 },
@@ -282,8 +288,10 @@ class InMemoryPreferenceStorage:
                         context=corr_data.get("context", {}),
                     )
                 )
+            # ``total_preferences`` in the imported statistics block is
+            # informational only — the live count is derived from
+            # ``len(self._preferences)`` in ``get_statistics``.
             stats = data.get("statistics", {})
-            self._total_preferences = stats.get("total_preferences", 0)
             self._successful_applications = stats.get("successful_applications", 0)
             self._failed_applications = stats.get("failed_applications", 0)
 
@@ -321,23 +329,38 @@ def _row_to_preference(row: dict[str, Any]) -> Preference:
     )
 
 
+def _encode_pref_value(value: Any) -> str:
+    """Encode a preference value for SQLite TEXT storage.
+
+    Always uses JSON so the encoding is fully reversible by
+    :func:`_decode_pref_value` — strings round-trip as quoted JSON,
+    numbers/bools/None as their JSON literals, dicts/lists as JSON
+    objects/arrays. Without this symmetry, ``42`` would store as
+    ``"42"`` and decode back as the string ``"42"`` (CodeRabbit /
+    Codex P2 finding on PR #207).
+    """
+    return json.dumps(value)
+
+
 def _decode_pref_value(stored: str) -> Any:
-    """Restore a preference value from its stored form (JSON if it parses, else str)."""
+    """Restore a preference value from its JSON-encoded text form.
+
+    Inverse of :func:`_encode_pref_value`. Falls back to the raw text
+    only if the column predates the always-JSON encoding (defensive —
+    no main-branch data exists in the legacy form yet, but the fallback
+    keeps the read path robust against manually-inserted rows).
+    """
     if not stored:
         return stored
-    if stored[0] in ("{", "[", '"') or stored in ("true", "false", "null"):
-        try:
-            return json.loads(stored)
-        except json.JSONDecodeError:
-            return stored
-    return stored
+    try:
+        return json.loads(stored)
+    except json.JSONDecodeError:
+        return stored
 
 
-def _encode_pref_value(value: Any) -> str:
-    """Encode a preference value for SQLite TEXT storage (JSON for complex types)."""
-    if isinstance(value, str):
-        return value
-    return json.dumps(value)
+def _iso_z(dt: datetime) -> str:
+    """Render ``dt`` as ISO-8601 with the 'Z' UTC suffix (matches DB column convention)."""
+    return dt.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
 class SqlitePreferenceStorage:
@@ -353,13 +376,39 @@ class SqlitePreferenceStorage:
         self._db = PreferenceDatabaseManager(db_path)
         self._db.initialize()
         self._lock = RLock()
+        # In-memory counters for stats keys the SQLite schema doesn't
+        # carry — the original tracker stored these as in-process
+        # counters that never persisted across restarts, so this matches
+        # pre-D5 behavior. (CodeRabbit / Copilot review on PR #207.)
+        self._successful_applications = 0
+        self._failed_applications = 0
 
     def close(self) -> None:
         """Release the SQLite connection (idempotent)."""
         self._db.close()
 
+    def __enter__(self) -> SqlitePreferenceStorage:
+        """Enable ``with SqlitePreferenceStorage(...) as storage:`` usage."""
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Always close the underlying connection on context exit."""
+        del exc_type, exc_val, exc_tb
+        self.close()
+
     def save_preference(self, preference: Preference) -> None:
-        """Upsert ``preference`` via the database manager."""
+        """Upsert ``preference`` honoring metadata timestamps and frequency.
+
+        The underlying ``PreferenceDatabaseManager.add_preference``
+        always stamps ``created_at`` / ``updated_at`` as "now" AND its
+        ``ON CONFLICT … DO UPDATE`` clause increments ``frequency`` on
+        every save (which would silently bump the dataclass's value on
+        re-save flows like ``get_preference`` writing back ``last_used``).
+        We follow up with a raw UPDATE that restores the timestamps AND
+        the dataclass's ``frequency`` so save_preference is idempotent
+        for the same ``preference`` instance. (Per Codex P2 + Copilot
+        findings on PR #207.)
+        """
         with self._lock:
             self._db.add_preference(
                 preference_type=preference.preference_type.value,
@@ -369,6 +418,27 @@ class SqlitePreferenceStorage:
                 frequency=preference.metadata.frequency,
                 source=preference.metadata.source,
                 context=preference.context if preference.context else None,
+            )
+            # Restore dataclass timestamps + frequency (manager wrote
+            # `now` and may have bumped frequency on the conflict path).
+            conn = self._db.get_connection()
+            conn.execute(
+                """
+                UPDATE preferences
+                SET created_at = ?, updated_at = ?, last_used_at = ?,
+                    frequency = ?
+                WHERE preference_type = ? AND key = ?
+                """,
+                (
+                    _iso_z(preference.metadata.created),
+                    _iso_z(preference.metadata.updated),
+                    _iso_z(preference.metadata.last_used)
+                    if preference.metadata.last_used
+                    else None,
+                    preference.metadata.frequency,
+                    preference.preference_type.value,
+                    preference.key,
+                ),
             )
 
     def find_preferences(
@@ -389,31 +459,66 @@ class SqlitePreferenceStorage:
         preference: Preference,
         success: bool,
     ) -> None:
-        """Apply confidence delta and mirror the new value to the live ``preference``."""
+        """Apply confidence delta and persist to SQLite (raises if pref absent).
+
+        Raises :class:`KeyError` when the preference has no row in the
+        database — silently no-op'ing here would diverge from the
+        in-memory backend, where the dataclass mutation always sticks.
+        Callers must :meth:`save_preference` before updating confidence.
+
+        Persists ``last_used_at`` on the success path (the manager's
+        ``update_preference_confidence`` only writes ``confidence``,
+        leaving ``last_used_at`` stale on the SQLite backend — Codex P2
+        finding on PR #207).
+        """
         with self._lock:
-            # Apply the same delta the in-memory backend does, then update both
-            # the in-memory dataclass and the database row by (type, key).
             now = datetime.now(UTC)
             if success:
                 preference.metadata.confidence = min(0.98, preference.metadata.confidence + 0.05)
                 preference.metadata.last_used = now
+                self._successful_applications += 1
             else:
                 preference.metadata.confidence = max(0.1, preference.metadata.confidence - 0.1)
+                self._failed_applications += 1
             preference.metadata.updated = now
 
-            # Locate the row by (type, key) and update its confidence column.
+            # Locate the row by (type, key) and update confidence + last_used_at + updated_at.
             row = self._db.get_preference(preference.preference_type.value, preference.key)
-            if row is not None:
-                self._db.update_preference_confidence(
-                    int(row["id"]), preference.metadata.confidence
+            if row is None:
+                raise KeyError(
+                    f"No persisted preference for ({preference.preference_type.value}, "
+                    f"{preference.key!r}); call save_preference first."
                 )
+            conn = self._db.get_connection()
+            conn.execute(
+                """
+                UPDATE preferences
+                SET confidence = ?, updated_at = ?, last_used_at = ?
+                WHERE id = ?
+                """,
+                (
+                    preference.metadata.confidence,
+                    _iso_z(preference.metadata.updated),
+                    _iso_z(preference.metadata.last_used)
+                    if preference.metadata.last_used
+                    else None,
+                    int(row["id"]),
+                ),
+            )
 
     def delete_preferences(
         self,
         preference_type: PreferenceType | None = None,
     ) -> int:
-        """Delete preferences (all or by type) via the manager. Returns delete count."""
-        with self._lock:
+        """Delete preferences (all or by type). Returns delete count.
+
+        Wrapped in :meth:`PreferenceDatabaseManager.transaction` so the
+        count + delete pair is atomic and rolls back on failure
+        (CodeRabbit on PR #207). When called with ``preference_type=None``,
+        also clears the ``corrections`` table to match the in-memory
+        backend's semantics.
+        """
+        with self._lock, self._db.transaction():
             conn = self._db.get_connection()
             if preference_type is None:
                 cur = conn.execute("SELECT COUNT(*) FROM preferences")
@@ -433,16 +538,27 @@ class SqlitePreferenceStorage:
             return count
 
     def save_correction(self, correction: Correction) -> None:
-        """Append a correction via the manager."""
+        """Append a correction honoring ``correction.timestamp``.
+
+        ``PreferenceDatabaseManager.add_correction`` always stamps
+        ``timestamp`` with "now"; we follow up with a raw UPDATE so
+        backfilled / imported corrections keep their original
+        chronology. (Codex P2 + CodeRabbit + Copilot on PR #207.)
+        """
         with self._lock:
             metadata = dict(correction.context) if correction.context else None
-            self._db.add_correction(
+            row_id = self._db.add_correction(
                 correction_type=correction.correction_type.value,
                 source_path=str(correction.source),
                 destination_path=str(correction.destination),
                 category_old=(metadata or {}).get("old_category"),
                 category_new=(metadata or {}).get("new_category"),
                 metadata=metadata,
+            )
+            conn = self._db.get_connection()
+            conn.execute(
+                "UPDATE corrections SET timestamp = ? WHERE id = ?",
+                (_iso_z(correction.timestamp), row_id),
             )
 
     def get_corrections_for_file(self, file_path: Path) -> list[Correction]:
@@ -467,15 +583,35 @@ class SqlitePreferenceStorage:
             return [self._row_to_correction(r) for r in rows]
 
     def get_statistics(self) -> dict[str, Any]:
-        """Return aggregate stats with the same keys as the in-memory backend."""
+        """Return aggregate stats with the same keys as the in-memory backend.
+
+        Includes ``successful_applications`` / ``failed_applications`` /
+        ``unique_preferences`` / ``average_confidence`` so callers and
+        tests don't need to special-case the SQLite backend. (Codex P2 +
+        Copilot finding on PR #207 — the original tracker exposed these
+        keys in-memory.)
+        """
         with self._lock:
-            stats = self._db.get_preference_stats()
+            db_stats = self._db.get_preference_stats()
             conn = self._db.get_connection()
             cur = conn.execute("SELECT COUNT(*) FROM corrections")
             corrections_count = int(cur.fetchone()[0])
-            stats["total_correction_history"] = corrections_count
-            stats["total_corrections"] = corrections_count
-            return stats
+            cur = conn.execute(
+                "SELECT COUNT(DISTINCT preference_type || ':' || key) FROM preferences"
+            )
+            unique_count = int(cur.fetchone()[0])
+            return {
+                "total_preferences": db_stats.get("total_preferences", 0),
+                "unique_preferences": unique_count,
+                "total_correction_history": corrections_count,
+                "total_corrections": corrections_count,
+                "successful_applications": self._successful_applications,
+                "failed_applications": self._failed_applications,
+                "average_confidence": round(db_stats.get("average_confidence", 0.0) or 0.0, 3),
+                # Preserve the manager's by_type breakdown so existing
+                # callers depending on it (if any) still see it.
+                "by_type": db_stats.get("by_type", {}),
+            }
 
     def export_data(self) -> dict[str, Any]:
         """Serialize SQLite contents to the same export shape as InMemoryPreferenceStorage."""
@@ -500,8 +636,14 @@ class SqlitePreferenceStorage:
             }
 
     def import_data(self, data: dict[str, Any]) -> None:
-        """Replace all stored preferences/corrections with ``data`` contents."""
-        with self._lock:
+        """Replace stored preferences/corrections with ``data`` contents atomically.
+
+        Wrapped in a single :meth:`PreferenceDatabaseManager.transaction`
+        so a mid-loop insert failure rolls everything back instead of
+        leaving the storage in a half-wiped state. (CodeRabbit finding
+        on PR #207.)
+        """
+        with self._lock, self._db.transaction():
             conn = self._db.get_connection()
             conn.execute("DELETE FROM preferences")
             conn.execute("DELETE FROM corrections")

--- a/src/services/intelligence/preference_storage.py
+++ b/src/services/intelligence/preference_storage.py
@@ -1,3 +1,4 @@
+# pyre-ignore-all-errors
 """Storage backends for ``PreferenceTracker`` (Epic D / D5).
 
 Tracks: issue #157 (Hardening Epic D, item D5).

--- a/src/services/intelligence/preference_storage.py
+++ b/src/services/intelligence/preference_storage.py
@@ -397,47 +397,60 @@ class SqlitePreferenceStorage:
         self.close()
 
     def save_preference(self, preference: Preference) -> None:
-        """Upsert ``preference`` honoring metadata timestamps and frequency.
+        """Upsert ``preference`` with full metadata fidelity.
 
-        The underlying ``PreferenceDatabaseManager.add_preference``
-        always stamps ``created_at`` / ``updated_at`` as "now" AND its
-        ``ON CONFLICT … DO UPDATE`` clause increments ``frequency`` on
-        every save (which would silently bump the dataclass's value on
-        re-save flows like ``get_preference`` writing back ``last_used``).
-        We follow up with a raw UPDATE that restores the timestamps AND
-        the dataclass's ``frequency`` so save_preference is idempotent
-        for the same ``preference`` instance. (Per Codex P2 + Copilot
-        findings on PR #207.)
+        Bypasses ``PreferenceDatabaseManager.add_preference``'s
+        ``ON CONFLICT … DO UPDATE SET frequency = frequency + 1`` clause
+        in favor of an explicit ``INSERT … ON CONFLICT … DO UPDATE``
+        that takes ALL field values from the dataclass. This gives the
+        caller full control:
+
+        - Frequency is set to ``preference.metadata.frequency`` exactly
+          (idempotent for re-saves like ``get_preference``'s ``last_used``
+          write-back, where the caller didn't intend to bump frequency).
+        - Multi-writer atomicity is the caller's responsibility (the
+          ``PreferenceTracker._tracker_lock`` makes single-process
+          writes atomic; cross-process concurrent writers can lose
+          increments — this matches the in-memory backend's behavior
+          and is documented as a known limitation for D5).
+        - All metadata timestamps round-trip without the manager
+          stamping ``now``.
+
+        Per Codex P1+P2 + CodeRabbit + Copilot findings on PR #207.
         """
         with self._lock:
-            self._db.add_preference(
-                preference_type=preference.preference_type.value,
-                key=preference.key,
-                value=_encode_pref_value(preference.value),
-                confidence=preference.metadata.confidence,
-                frequency=preference.metadata.frequency,
-                source=preference.metadata.source,
-                context=preference.context if preference.context else None,
-            )
-            # Restore dataclass timestamps + frequency (manager wrote
-            # `now` and may have bumped frequency on the conflict path).
             conn = self._db.get_connection()
+            context_json = json.dumps(preference.context) if preference.context else None
+            last_used_at = (
+                _iso_z(preference.metadata.last_used) if preference.metadata.last_used else None
+            )
             conn.execute(
                 """
-                UPDATE preferences
-                SET created_at = ?, updated_at = ?, last_used_at = ?,
-                    frequency = ?
-                WHERE preference_type = ? AND key = ?
+                INSERT INTO preferences (
+                    preference_type, key, value, confidence, frequency,
+                    created_at, updated_at, last_used_at, source, context
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(preference_type, key) DO UPDATE SET
+                    value = excluded.value,
+                    confidence = excluded.confidence,
+                    frequency = excluded.frequency,
+                    created_at = excluded.created_at,
+                    updated_at = excluded.updated_at,
+                    last_used_at = excluded.last_used_at,
+                    source = excluded.source,
+                    context = excluded.context
                 """,
                 (
-                    _iso_z(preference.metadata.created),
-                    _iso_z(preference.metadata.updated),
-                    _iso_z(preference.metadata.last_used)
-                    if preference.metadata.last_used
-                    else None,
-                    preference.metadata.frequency,
                     preference.preference_type.value,
                     preference.key,
+                    _encode_pref_value(preference.value),
+                    preference.metadata.confidence,
+                    preference.metadata.frequency,
+                    _iso_z(preference.metadata.created),
+                    _iso_z(preference.metadata.updated),
+                    last_used_at,
+                    preference.metadata.source,
+                    context_json,
                 ),
             )
 
@@ -642,6 +655,12 @@ class SqlitePreferenceStorage:
         so a mid-loop insert failure rolls everything back instead of
         leaving the storage in a half-wiped state. (CodeRabbit finding
         on PR #207.)
+
+        Also resets the in-process success/failure application counters
+        and hydrates them from ``data["statistics"]`` if present —
+        otherwise stale counts from the storage instance's pre-import
+        history would survive into the imported state and contaminate
+        ``get_statistics()`` output. (Codex P2 on PR #207.)
         """
         with self._lock, self._db.transaction():
             conn = self._db.get_connection()
@@ -663,6 +682,12 @@ class SqlitePreferenceStorage:
                         context=corr_data.get("context", {}),
                     )
                 )
+
+            # Reset application counters; re-hydrate from snapshot's
+            # statistics block if it provides them.
+            stats = data.get("statistics", {})
+            self._successful_applications = stats.get("successful_applications", 0)
+            self._failed_applications = stats.get("failed_applications", 0)
 
     @staticmethod
     def _row_to_correction(row: dict[str, Any]) -> Correction:

--- a/src/services/intelligence/preference_storage.py
+++ b/src/services/intelligence/preference_storage.py
@@ -485,6 +485,18 @@ class SqlitePreferenceStorage:
         finding on PR #207).
         """
         with self._lock:
+            # Persistence check FIRST — if the row is absent we raise
+            # without mutating the dataclass or bumping the application
+            # counters (Codex P2 on PR #207). Otherwise a failed call
+            # would still corrupt in-memory state and ``get_statistics``
+            # would report applications that never reached the DB.
+            row = self._db.get_preference(preference.preference_type.value, preference.key)
+            if row is None:
+                raise KeyError(
+                    f"No persisted preference for ({preference.preference_type.value}, "
+                    f"{preference.key!r}); call save_preference first."
+                )
+
             now = datetime.now(UTC)
             if success:
                 preference.metadata.confidence = min(0.98, preference.metadata.confidence + 0.05)
@@ -494,14 +506,6 @@ class SqlitePreferenceStorage:
                 preference.metadata.confidence = max(0.1, preference.metadata.confidence - 0.1)
                 self._failed_applications += 1
             preference.metadata.updated = now
-
-            # Locate the row by (type, key) and update confidence + last_used_at + updated_at.
-            row = self._db.get_preference(preference.preference_type.value, preference.key)
-            if row is None:
-                raise KeyError(
-                    f"No persisted preference for ({preference.preference_type.value}, "
-                    f"{preference.key!r}); call save_preference first."
-                )
             conn = self._db.get_connection()
             conn.execute(
                 """
@@ -627,7 +631,14 @@ class SqlitePreferenceStorage:
             }
 
     def export_data(self) -> dict[str, Any]:
-        """Serialize SQLite contents to the same export shape as InMemoryPreferenceStorage."""
+        """Serialize SQLite contents to the same export shape as InMemoryPreferenceStorage.
+
+        Includes the in-memory ``successful_applications`` /
+        ``failed_applications`` counters in the ``statistics`` block so
+        an export → import round-trip preserves them (Codex P2 on PR
+        #207 — the manager's ``get_preference_stats()`` only knows
+        about persisted DB columns).
+        """
         with self._lock:
             conn = self._db.get_connection()
             cur = conn.execute("SELECT * FROM preferences")
@@ -641,10 +652,14 @@ class SqlitePreferenceStorage:
             cur = conn.execute("SELECT * FROM corrections ORDER BY timestamp ASC")
             corrections = [self._row_to_correction(dict(r)).to_dict() for r in cur.fetchall()]
 
+            statistics = dict(self._db.get_preference_stats())
+            statistics["successful_applications"] = self._successful_applications
+            statistics["failed_applications"] = self._failed_applications
+
             return {
                 "preferences": preferences,
                 "corrections": corrections,
-                "statistics": self._db.get_preference_stats(),
+                "statistics": statistics,
                 "exported_at": datetime.now(UTC).isoformat(),
             }
 

--- a/src/services/intelligence/preference_tracker.py
+++ b/src/services/intelligence/preference_tracker.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
+from threading import RLock
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -178,6 +179,14 @@ class PreferenceTracker:
         self._storage: PreferenceStorage = (
             storage if storage is not None else InMemoryPreferenceStorage()
         )
+        # Tracker-level lock guards the read-then-write sequence in
+        # ``_extract_preferences_from_correction`` (F3 / Codex P1 on PR
+        # #207). The storage backend has its own RLock for individual
+        # ops, but its lock is released between ``find_preferences`` and
+        # ``save_preference`` — without this tracker-level guard, two
+        # concurrent ``track_correction`` calls for the same pattern can
+        # both see "no existing preference" and overwrite each other.
+        self._tracker_lock = RLock()
 
     def track_correction(
         self,
@@ -202,8 +211,13 @@ class PreferenceTracker:
             timestamp=now,
             context=context or {},
         )
-        self._storage.save_correction(correction)
-        self._extract_preferences_from_correction(correction)
+        # Tracker-level lock spans save_correction + extract → save_preference.
+        # Without it, two concurrent track_correction calls for the same
+        # pattern can both observe "no existing preference" and overwrite
+        # each other's frequency=1 record. (Codex P1 on PR #207.)
+        with self._tracker_lock:
+            self._storage.save_correction(correction)
+            self._extract_preferences_from_correction(correction)
 
     def _extract_preferences_from_correction(self, correction: Correction) -> None:
         """Extract / update a preference from ``correction`` via the storage backend.
@@ -294,7 +308,13 @@ class PreferenceTracker:
             if not matching:
                 return None
             best = max(matching, key=lambda p: p.metadata.confidence)
+            # Persist the last_used update through the storage layer; the
+            # in-memory backend would mutate-in-place anyway, but the SQLite
+            # backend reconstructs a fresh dataclass on every find_preferences
+            # so a bare attribute mutation here would be lost. (Per CodeRabbit
+            # / Copilot review on PR #207.)
             best.metadata.last_used = datetime.now(UTC)
+            self._storage.save_preference(best)
             return best
 
         prefix_map = {
@@ -315,7 +335,10 @@ class PreferenceTracker:
         if not prefs:
             return None
         best = max(prefs, key=lambda p: p.metadata.confidence)
+        # Persist last_used through storage so SQLite backend reflects the
+        # change (the in-memory backend would mutate-in-place anyway).
         best.metadata.last_used = datetime.now(UTC)
+        self._storage.save_preference(best)
         return best
 
     def get_all_preferences(

--- a/src/services/intelligence/preference_tracker.py
+++ b/src/services/intelligence/preference_tracker.py
@@ -4,10 +4,18 @@ This module implements the core preference tracking engine that learns from user
 corrections and changes. It tracks user behavior, stores preferences with metadata,
 and provides real-time preference updates with thread-safe operations.
 
+Storage backend (Epic D / D5, issue #157): the tracker delegates persistence to
+a :class:`~services.intelligence.preference_storage.PreferenceStorage` instance
+injected via the keyword-only ``storage`` argument. The default
+(``PreferenceTracker()``) wires up :class:`InMemoryPreferenceStorage`, preserving
+the original in-process behavior; ``PreferenceTracker(storage=
+SqlitePreferenceStorage(db_path))`` swaps in SQLite without changing any
+public method signature.
+
 Features:
 - Track file moves, renames, and category override corrections
-- In-memory preference management with metadata
-- Thread-safe operations using locks
+- Pluggable storage backend via the ``PreferenceStorage`` Protocol
+- Thread-safe operations using locks (storage backends own their own locking)
 - Preference confidence and frequency tracking
 - Real-time preference updates
 """
@@ -18,8 +26,10 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
-from threading import RLock
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .preference_storage import PreferenceStorage
 
 
 class PreferenceType(Enum):
@@ -143,22 +153,31 @@ class Correction:
 class PreferenceTracker:
     """Core preference tracking engine that learns from user corrections.
 
-    This class manages in-memory preferences with thread-safe operations,
-    tracks user corrections, and maintains preference metadata including
-    confidence scores and usage frequency.
+    Domain orchestrator over a :class:`PreferenceStorage` backend. The tracker
+    keeps the correction → preference extraction logic and the best-match
+    selection by file extension; the backend handles persistence (in-memory
+    or SQLite).
     """
 
-    def __init__(self) -> None:
-        """Initialize the preference tracker."""
-        self._lock = RLock()  # Reentrant lock for thread safety
-        self._preferences: dict[str, list[Preference]] = {}  # Key -> List of preferences
-        self._corrections: list[Correction] = []  # History of corrections
-        self._statistics: dict[str, Any] = {
-            "total_corrections": 0,
-            "total_preferences": 0,
-            "successful_applications": 0,
-            "failed_applications": 0,
-        }
+    def __init__(self, *, storage: PreferenceStorage | None = None) -> None:
+        """Initialize with an optional storage backend.
+
+        Args:
+            storage: Storage backend implementing :class:`PreferenceStorage`.
+                Keyword-only for consistency with ``TrashGC.__init__`` (F8.1)
+                and to make the dependency-injection intent self-documenting
+                at the call site. ``None`` (the default) constructs an
+                :class:`InMemoryPreferenceStorage`, preserving the original
+                in-process behavior.
+        """
+        # Local import: PreferenceStorage / InMemoryPreferenceStorage live in
+        # ``preference_storage`` which itself imports the dataclasses defined
+        # in this module. A top-level import would create a cycle.
+        from .preference_storage import InMemoryPreferenceStorage
+
+        self._storage: PreferenceStorage = (
+            storage if storage is not None else InMemoryPreferenceStorage()
+        )
 
     def track_correction(
         self,
@@ -175,92 +194,72 @@ class PreferenceTracker:
             correction_type: Type of correction made
             context: Additional context about the correction
         """
-        with self._lock:
-            now = datetime.now(UTC)
-
-            # Create correction record
-            correction = Correction(
-                correction_type=correction_type,
-                source=source,
-                destination=destination,
-                timestamp=now,
-                context=context or {},
-            )
-
-            self._corrections.append(correction)
-            self._statistics["total_corrections"] += 1
-
-            # Extract and update preferences based on correction type
-            self._extract_preferences_from_correction(correction)
+        now = datetime.now(UTC)
+        correction = Correction(
+            correction_type=correction_type,
+            source=source,
+            destination=destination,
+            timestamp=now,
+            context=context or {},
+        )
+        self._storage.save_correction(correction)
+        self._extract_preferences_from_correction(correction)
 
     def _extract_preferences_from_correction(self, correction: Correction) -> None:
-        """Extract and update preferences from a correction.
+        """Extract / update a preference from ``correction`` via the storage backend.
 
-        This method analyzes the correction and updates relevant preferences.
-        Must be called within a lock.
+        Domain logic — derives the preference type and value from the
+        correction shape and either creates a fresh preference or updates the
+        existing one (frequency + confidence boost capped at 0.95).
         """
         now = datetime.now(UTC)
         pattern_key = correction.get_pattern_key()
 
-        # Determine preference type based on correction type
         pref_value: Any
         if correction.correction_type == CorrectionType.FILE_MOVE:
             pref_type = PreferenceType.FOLDER_MAPPING
-            pref_key = pattern_key
             pref_value = str(correction.destination.parent)
-
         elif correction.correction_type == CorrectionType.FILE_RENAME:
             pref_type = PreferenceType.NAMING_PATTERN
-            pref_key = pattern_key
             pref_value = correction.destination.name
-
         elif correction.correction_type == CorrectionType.CATEGORY_CHANGE:
             pref_type = PreferenceType.CATEGORY_OVERRIDE
-            pref_key = pattern_key
             pref_value = correction.context.get("new_category", "unknown")
-
         else:
-            # For other types, create a custom preference
             pref_type = PreferenceType.CUSTOM
-            pref_key = pattern_key
             pref_value = {
                 "destination": str(correction.destination),
                 "source": str(correction.source),
             }
 
-        # Check if preference already exists
-        existing_pref = self._find_preference(pref_type, pref_key)
+        existing_list = self._storage.find_preferences(pref_type, key=pattern_key)
+        existing = existing_list[0] if existing_list else None
 
-        if existing_pref:
-            # Update existing preference
-            existing_pref.metadata.updated = now
-            existing_pref.metadata.frequency += 1
-            existing_pref.metadata.last_used = now
-
-            # Increase confidence based on frequency (cap at 0.95)
-            confidence_increase = min(0.05, (1.0 - existing_pref.metadata.confidence) * 0.1)
-            existing_pref.metadata.confidence = min(
-                0.95, existing_pref.metadata.confidence + confidence_increase
+        if existing is not None:
+            # Update existing preference in place — frequency + capped confidence boost.
+            existing.metadata.updated = now
+            existing.metadata.frequency += 1
+            existing.metadata.last_used = now
+            confidence_increase = min(0.05, (1.0 - existing.metadata.confidence) * 0.1)
+            existing.metadata.confidence = min(
+                0.95, existing.metadata.confidence + confidence_increase
             )
-
-            # Update value if it changed
-            if existing_pref.value != pref_value:
-                existing_pref.value = pref_value
-                existing_pref.context["value_changed"] = True
+            if existing.value != pref_value:
+                existing.value = pref_value
+                existing.context["value_changed"] = True
+            self._storage.save_preference(existing)
         else:
-            # Create new preference
             metadata = PreferenceMetadata(
                 created=now,
                 updated=now,
-                confidence=0.5,  # Start with medium confidence
+                confidence=0.5,
                 frequency=1,
                 last_used=now,
                 source="user_correction",
             )
-
             preference = Preference(
                 preference_type=pref_type,
-                key=pref_key,
+                key=pattern_key,
                 value=pref_value,
                 metadata=metadata,
                 context={
@@ -268,31 +267,7 @@ class PreferenceTracker:
                     "source_extension": correction.source.suffix.lower(),
                 },
             )
-
-            # Add to preferences
-            storage_key = self._get_storage_key(pref_type, pref_key)
-            if storage_key not in self._preferences:
-                self._preferences[storage_key] = []
-            self._preferences[storage_key].append(preference)
-            self._statistics["total_preferences"] += 1
-
-    def _find_preference(self, preference_type: PreferenceType, key: str) -> Preference | None:
-        """Find an existing preference by type and key.
-
-        Must be called within a lock.
-        """
-        storage_key = self._get_storage_key(preference_type, key)
-        prefs = self._preferences.get(storage_key, [])
-
-        for pref in prefs:
-            if pref.preference_type == preference_type and pref.key == key:
-                return pref
-
-        return None
-
-    def _get_storage_key(self, preference_type: PreferenceType, key: str) -> str:
-        """Generate a storage key for a preference."""
-        return f"{preference_type.value}:{key}"
+            self._storage.save_preference(preference)
 
     def get_preference(
         self,
@@ -305,240 +280,88 @@ class PreferenceTracker:
         Args:
             file_path: Path to the file
             preference_type: Type of preference to retrieve
-            context: Additional context for matching
+            context: Additional context for matching (currently unused;
+                retained for forward compatibility)
 
         Returns:
             The best matching preference or None
         """
-        with self._lock:
-            # For folder mapping preferences, match by extension and correction type
-            # Not by current parent directory, since we want to learn where to move files
-            if preference_type == PreferenceType.FOLDER_MAPPING:
-                extension = file_path.suffix.lower() if file_path.suffix else "no_ext"
-
-                # Find all folder mapping preferences for this extension
-                matching_prefs = []
-                for storage_key, prefs_list in self._preferences.items():
-                    if not storage_key.startswith("folder_mapping:"):
-                        continue
-                    for pref in prefs_list:
-                        if pref.preference_type == PreferenceType.FOLDER_MAPPING:
-                            # Check if this preference matches the extension
-                            if pref.context.get("source_extension") == extension:
-                                matching_prefs.append(pref)
-
-                if not matching_prefs:
-                    return None
-
-                # Return the preference with highest confidence
-                best_pref = max(matching_prefs, key=lambda p: p.metadata.confidence)
-                best_pref.metadata.last_used = datetime.now(UTC)
-                return best_pref
-
-            # Map preference type to correction type prefix for key matching
-            prefix_map = {
-                PreferenceType.FOLDER_MAPPING: CorrectionType.FILE_MOVE.value,
-                PreferenceType.NAMING_PATTERN: CorrectionType.FILE_RENAME.value,
-                PreferenceType.CATEGORY_OVERRIDE: CorrectionType.CATEGORY_CHANGE.value,
-                PreferenceType.CUSTOM: CorrectionType.MANUAL_OVERRIDE.value,
-            }
-            prefix = prefix_map.get(preference_type, preference_type.value)
-
-            # For other preference types, use exact pattern matching
-            pattern_parts = [
-                prefix,
-                file_path.suffix.lower() if file_path.suffix else "no_ext",
-                file_path.parent.name if file_path.parent else "root",
-            ]
-            pattern_key = "|".join(pattern_parts)
-
-            storage_key = self._get_storage_key(preference_type, pattern_key)
-            prefs = self._preferences.get(storage_key, [])
-
-            if not prefs:
+        del context  # reserved for future predicates
+        if preference_type == PreferenceType.FOLDER_MAPPING:
+            extension = file_path.suffix.lower() if file_path.suffix else "no_ext"
+            all_folder = self._storage.find_preferences(PreferenceType.FOLDER_MAPPING)
+            matching = [p for p in all_folder if p.context.get("source_extension") == extension]
+            if not matching:
                 return None
+            best = max(matching, key=lambda p: p.metadata.confidence)
+            best.metadata.last_used = datetime.now(UTC)
+            return best
 
-            # Return the preference with highest confidence
-            best_pref = max(prefs, key=lambda p: p.metadata.confidence)
+        prefix_map = {
+            PreferenceType.FOLDER_MAPPING: CorrectionType.FILE_MOVE.value,
+            PreferenceType.NAMING_PATTERN: CorrectionType.FILE_RENAME.value,
+            PreferenceType.CATEGORY_OVERRIDE: CorrectionType.CATEGORY_CHANGE.value,
+            PreferenceType.CUSTOM: CorrectionType.MANUAL_OVERRIDE.value,
+        }
+        prefix = prefix_map.get(preference_type, preference_type.value)
+        pattern_parts = [
+            prefix,
+            file_path.suffix.lower() if file_path.suffix else "no_ext",
+            file_path.parent.name if file_path.parent else "root",
+        ]
+        pattern_key = "|".join(pattern_parts)
 
-            # Update last used timestamp
-            best_pref.metadata.last_used = datetime.now(UTC)
-
-            return best_pref
+        prefs = self._storage.find_preferences(preference_type, key=pattern_key)
+        if not prefs:
+            return None
+        best = max(prefs, key=lambda p: p.metadata.confidence)
+        best.metadata.last_used = datetime.now(UTC)
+        return best
 
     def get_all_preferences(
         self, preference_type: PreferenceType | None = None
     ) -> list[Preference]:
-        """Get all preferences, optionally filtered by type.
-
-        Args:
-            preference_type: Optional type filter
-
-        Returns:
-            List of preferences
-        """
-        with self._lock:
-            all_prefs = []
-            for prefs_list in self._preferences.values():
-                all_prefs.extend(prefs_list)
-
-            if preference_type:
-                all_prefs = [p for p in all_prefs if p.preference_type == preference_type]
-
-            return all_prefs
+        """Return preferences, optionally filtered by type."""
+        if preference_type is not None:
+            return self._storage.find_preferences(preference_type)
+        # All types — concat across the enum.
+        results: list[Preference] = []
+        for pt in PreferenceType:
+            results.extend(self._storage.find_preferences(pt))
+        return results
 
     def update_preference_confidence(self, preference: Preference, success: bool) -> None:
-        """Update preference confidence based on application success.
+        """Adjust ``preference``'s confidence based on application success.
 
-        Args:
-            preference: The preference that was applied
-            success: Whether the application was successful
+        Delegates to the storage backend, which applies the same delta
+        (+0.05 cap 0.98 on success / -0.10 floor 0.10 on failure) for both
+        in-memory and SQLite implementations.
         """
-        with self._lock:
-            now = datetime.now(UTC)
-
-            if success:
-                # Increase confidence (cap at 0.98)
-                preference.metadata.confidence = min(0.98, preference.metadata.confidence + 0.05)
-                preference.metadata.last_used = now
-                self._statistics["successful_applications"] += 1
-            else:
-                # Decrease confidence (floor at 0.1)
-                preference.metadata.confidence = max(0.1, preference.metadata.confidence - 0.1)
-                self._statistics["failed_applications"] += 1
-
-            preference.metadata.updated = now
+        self._storage.update_preference_confidence(preference, success)
 
     def get_statistics(self) -> dict[str, Any]:
-        """Get statistics about tracked preferences.
-
-        Returns:
-            Dictionary with statistics
-        """
-        with self._lock:
-            stats = self._statistics.copy()
-            stats["unique_preferences"] = len(self._preferences)
-            stats["total_correction_history"] = len(self._corrections)
-
-            # Calculate average confidence
-            all_prefs = self.get_all_preferences()
-            if all_prefs:
-                avg_confidence = sum(p.metadata.confidence for p in all_prefs) / len(all_prefs)
-                stats["average_confidence"] = round(avg_confidence, 3)
-            else:
-                stats["average_confidence"] = 0.0
-
-            return stats
+        """Return aggregate statistics about tracked preferences."""
+        return self._storage.get_statistics()
 
     def clear_preferences(self, preference_type: PreferenceType | None = None) -> int:
-        """Clear preferences, optionally filtered by type.
-
-        Args:
-            preference_type: Optional type filter
-
-        Returns:
-            Number of preferences cleared
-        """
-        with self._lock:
-            if preference_type is None:
-                # Clear all preferences
-                count = sum(len(prefs) for prefs in self._preferences.values())
-                self._preferences.clear()
-                self._corrections.clear()
-                self._statistics["total_preferences"] = 0
-                return count
-            else:
-                # Clear only preferences of specific type
-                count = 0
-                keys_to_remove = []
-
-                for storage_key, prefs_list in self._preferences.items():
-                    filtered_prefs = [p for p in prefs_list if p.preference_type != preference_type]
-                    count += len(prefs_list) - len(filtered_prefs)
-
-                    if not filtered_prefs:
-                        keys_to_remove.append(storage_key)
-                    else:
-                        self._preferences[storage_key] = filtered_prefs
-
-                for key in keys_to_remove:
-                    del self._preferences[key]
-
-                self._statistics["total_preferences"] -= count
-                return count
+        """Clear preferences (all or by type). Returns the number cleared."""
+        return self._storage.delete_preferences(preference_type)
 
     def export_data(self) -> dict[str, Any]:
-        """Export all preference data for persistence.
-
-        Returns:
-            Dictionary with all preferences and metadata
-        """
-        with self._lock:
-            return {
-                "preferences": {
-                    key: [p.to_dict() for p in prefs] for key, prefs in self._preferences.items()
-                },
-                "corrections": [c.to_dict() for c in self._corrections],
-                "statistics": self._statistics.copy(),
-                "exported_at": datetime.now(UTC).isoformat(),
-            }
+        """Export all preference data for persistence."""
+        return self._storage.export_data()
 
     def import_data(self, data: dict[str, Any]) -> None:
-        """Import preference data from persistence.
-
-        Args:
-            data: Dictionary with preference data
-        """
-        with self._lock:
-            # Clear existing data
-            self._preferences.clear()
-            self._corrections.clear()
-
-            # Import preferences
-            for key, prefs_list in data.get("preferences", {}).items():
-                self._preferences[key] = [Preference.from_dict(p) for p in prefs_list]
-
-            # Import corrections
-            for corr_data in data.get("corrections", []):
-                correction = Correction(
-                    correction_type=CorrectionType(corr_data["correction_type"]),
-                    source=Path(corr_data["source"]),
-                    destination=Path(corr_data["destination"]),
-                    timestamp=datetime.fromisoformat(corr_data["timestamp"]),
-                    context=corr_data.get("context", {}),
-                )
-                self._corrections.append(correction)
-
-            # Import statistics
-            if "statistics" in data:
-                self._statistics.update(data["statistics"])
+        """Import preference data, replacing current state."""
+        self._storage.import_data(data)
 
     def get_corrections_for_file(self, file_path: Path) -> list[Correction]:
-        """Get all corrections related to a specific file.
-
-        Args:
-            file_path: Path to the file
-
-        Returns:
-            List of corrections
-        """
-        with self._lock:
-            return [
-                c for c in self._corrections if c.source == file_path or c.destination == file_path
-            ]
+        """Get all corrections related to a specific file."""
+        return self._storage.get_corrections_for_file(file_path)
 
     def get_recent_corrections(self, limit: int = 10) -> list[Correction]:
-        """Get the most recent corrections.
-
-        Args:
-            limit: Maximum number of corrections to return
-
-        Returns:
-            List of recent corrections
-        """
-        with self._lock:
-            sorted_corrections = sorted(self._corrections, key=lambda c: c.timestamp, reverse=True)
-            return sorted_corrections[:limit]
+        """Get the most recent corrections, newest first."""
+        return self._storage.get_recent_corrections(limit)
 
 
 # Convenience functions for common operations

--- a/tests/integration/test_intelligence_learning.py
+++ b/tests/integration/test_intelligence_learning.py
@@ -367,3 +367,46 @@ class TestPreferenceDBConnection:
 
     def test_close_does_not_raise(self, db: PreferenceDatabaseManager) -> None:
         db.close()
+
+
+# ---------------------------------------------------------------------------
+# D5: PreferenceTracker(storage=SqlitePreferenceStorage(...)) end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestTrackerWithSqliteStorage:
+    """Smoke test: tracker with the SQLite backend persists corrections + extracted preferences."""
+
+    def test_track_correction_round_trip_through_sqlite(self, tmp_path: Path) -> None:
+        from services.intelligence.preference_storage import SqlitePreferenceStorage
+        from services.intelligence.preference_tracker import (
+            CorrectionType,
+            PreferenceTracker,
+            PreferenceType,
+        )
+
+        db_path = tmp_path / "prefs.db"
+        storage = SqlitePreferenceStorage(db_path)
+        tracker = PreferenceTracker(storage=storage)
+
+        src = tmp_path / "report.pdf"
+        dst = tmp_path / "Documents" / "report.pdf"
+        tracker.track_correction(
+            source=src,
+            destination=dst,
+            correction_type=CorrectionType.FILE_MOVE,
+        )
+
+        # The correction landed in SQLite via the tracker's storage layer
+        recent = tracker.get_recent_corrections(limit=10)
+        assert len(recent) == 1
+        assert recent[0].source == src
+        assert recent[0].destination == dst
+        assert recent[0].correction_type == CorrectionType.FILE_MOVE
+
+        # The extracted FOLDER_MAPPING preference is also retrievable
+        prefs = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)
+        assert len(prefs) == 1
+        assert prefs[0].context.get("source_extension") == ".pdf"
+
+        storage.close()

--- a/tests/integration/test_intelligence_learning.py
+++ b/tests/integration/test_intelligence_learning.py
@@ -386,27 +386,33 @@ class TestTrackerWithSqliteStorage:
         )
 
         db_path = tmp_path / "prefs.db"
-        storage = SqlitePreferenceStorage(db_path)
-        tracker = PreferenceTracker(storage=storage)
+        # ``with`` ensures the SQLite connection closes even if any of
+        # the assertions below raise (CodeRabbit on PR #207 — was a
+        # storage.close() at the end of a happy-path-only block).
+        with SqlitePreferenceStorage(db_path) as storage:
+            tracker = PreferenceTracker(storage=storage)
 
-        src = tmp_path / "report.pdf"
-        dst = tmp_path / "Documents" / "report.pdf"
-        tracker.track_correction(
-            source=src,
-            destination=dst,
-            correction_type=CorrectionType.FILE_MOVE,
-        )
+            src = tmp_path / "report.pdf"
+            dst = tmp_path / "Documents" / "report.pdf"
+            # Pass non-empty context so save_correction's metadata
+            # branch is exercised (CodeRabbit on PR #207 — original
+            # smoke only hit the no-context happy path).
+            tracker.track_correction(
+                source=src,
+                destination=dst,
+                correction_type=CorrectionType.FILE_MOVE,
+                context={"trigger": "user_drag", "session": "smoke"},
+            )
 
-        # The correction landed in SQLite via the tracker's storage layer
-        recent = tracker.get_recent_corrections(limit=10)
-        assert len(recent) == 1
-        assert recent[0].source == src
-        assert recent[0].destination == dst
-        assert recent[0].correction_type == CorrectionType.FILE_MOVE
+            # The correction landed in SQLite with the supplied context
+            recent = tracker.get_recent_corrections(limit=10)
+            assert len(recent) == 1
+            assert recent[0].source == src
+            assert recent[0].destination == dst
+            assert recent[0].correction_type == CorrectionType.FILE_MOVE
+            assert recent[0].context == {"trigger": "user_drag", "session": "smoke"}
 
-        # The extracted FOLDER_MAPPING preference is also retrievable
-        prefs = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)
-        assert len(prefs) == 1
-        assert prefs[0].context.get("source_extension") == ".pdf"
-
-        storage.close()
+            # The extracted FOLDER_MAPPING preference is also retrievable
+            prefs = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)
+            assert len(prefs) == 1
+            assert prefs[0].context.get("source_extension") == ".pdf"

--- a/tests/integration/test_preference_tracker_branches.py
+++ b/tests/integration/test_preference_tracker_branches.py
@@ -750,7 +750,7 @@ class TestClearPreferences:
         assert remaining[0].preference_type == PreferenceType.NAMING_PATTERN
 
     def test_clear_by_type_when_storage_key_becomes_empty(self) -> None:
-        """When all prefs in a storage key are removed, the key is deleted."""
+        """When all prefs of a type are removed, querying returns an empty list."""
         from services.intelligence.preference_tracker import (
             CorrectionType,
             PreferenceType,
@@ -762,10 +762,13 @@ class TestClearPreferences:
             destination=Path("/docs/x.pdf"),
             correction_type=CorrectionType.FILE_MOVE,
         )
-        # Clear the only preference type → storage key should be removed
+        # Clear the only preference type → no preferences remain
+        # (Pre-D5 this asserted on tracker._preferences directly; with the
+        # PreferenceStorage Protocol the public ``get_all_preferences`` is
+        # the right surface — issue #157.)
         cleared = tracker.clear_preferences(PreferenceType.FOLDER_MAPPING)
         assert cleared == 1
-        assert len(tracker._preferences) == 0
+        assert tracker.get_all_preferences() == []
 
     def test_clear_returns_zero_when_nothing_to_clear(self) -> None:
         """Clearing a type with no preferences returns 0."""
@@ -890,23 +893,41 @@ class TestExportImportData:
         folder_prefs = tracker.get_all_preferences(PreferenceType.FOLDER_MAPPING)
         assert len(folder_prefs) == 1
 
-    def test_import_data_updates_statistics(self) -> None:
-        """import_data merges statistics from the payload."""
+    def test_import_data_restores_corrections_count(self) -> None:
+        """``import_data`` round-trips ``total_corrections`` via the corrections list.
+
+        After D5 (#157) the tracker derives ``total_corrections`` from the
+        actual corrections list rather than maintaining an independent
+        counter, so stats reflect the data even if the imported payload's
+        ``statistics`` block disagrees with the corrections array.
+        """
+        from datetime import UTC, datetime
+
         tracker = _tracker()
+        # Build a correction payload of length 3 — that's what stats should report
+        ts = datetime(2026, 1, 15, 10, 30, tzinfo=UTC).isoformat()
         tracker.import_data(
             {
                 "preferences": {},
-                "corrections": [],
+                "corrections": [
+                    {
+                        "correction_type": "file_move",
+                        "source": f"/a/{i}.txt",
+                        "destination": f"/b/{i}.txt",
+                        "timestamp": ts,
+                        "context": {},
+                    }
+                    for i in range(3)
+                ],
                 "statistics": {
-                    "total_corrections": 99,
-                    "total_preferences": 42,
+                    "total_preferences": 0,
                     "successful_applications": 10,
                     "failed_applications": 5,
                 },
             }
         )
         stats = tracker.get_statistics()
-        assert stats["total_corrections"] == 99
+        assert stats["total_corrections"] == 3
 
     def test_import_data_without_statistics_key(self) -> None:
         """import_data with no 'statistics' key in payload → no error."""

--- a/tests/services/intelligence/test_preference_storage.py
+++ b/tests/services/intelligence/test_preference_storage.py
@@ -687,3 +687,70 @@ class TestLastUsedPersistedThroughTracker:
             assert re_fetched[0].metadata.last_used >= t0
         finally:
             storage.close()
+
+
+# ---------------------------------------------------------------------------
+# Second-cycle review fixes (PR #207, Codex post-fix re-review)
+# ---------------------------------------------------------------------------
+
+
+class TestSavePreferenceIdempotentFrequency:
+    """``save_preference`` doesn't auto-bump frequency on re-save (Codex P1 follow-up)."""
+
+    def test_resave_preserves_frequency_in_sqlite(self, tmp_path: Path) -> None:
+        with SqlitePreferenceStorage(tmp_path / "p.db") as storage:
+            now = datetime(2026, 1, 15, 10, 30, tzinfo=UTC)
+            pref = Preference(
+                preference_type=PreferenceType.FOLDER_MAPPING,
+                key="file_move|.pdf|Documents",
+                value="Documents",
+                metadata=PreferenceMetadata(created=now, updated=now, confidence=0.5, frequency=11),
+                context={"source_extension": ".pdf"},
+            )
+            storage.save_preference(pref)
+
+            # Re-save without changing dataclass — e.g., what get_preference
+            # does after mutating last_used. Frequency must NOT bump.
+            storage.save_preference(pref)
+            storage.save_preference(pref)
+
+            recovered = storage.find_preferences(PreferenceType.FOLDER_MAPPING)
+            assert len(recovered) == 1
+            assert recovered[0].metadata.frequency == 11
+
+
+class TestImportDataResetsApplicationCounters:
+    """``import_data`` resets success/failure counters (Codex P2 follow-up)."""
+
+    def test_import_clears_stale_application_counts_for_sqlite(self, tmp_path: Path) -> None:
+        with SqlitePreferenceStorage(tmp_path / "p.db") as storage:
+            # Build up some pre-import application history
+            pref = _make_preference()
+            storage.save_preference(pref)
+            storage.update_preference_confidence(pref, success=True)
+            storage.update_preference_confidence(pref, success=False)
+            stats = storage.get_statistics()
+            assert stats["successful_applications"] == 1
+            assert stats["failed_applications"] == 1
+
+            # Import a snapshot with NO statistics block — counters must reset
+            storage.import_data({"preferences": {}, "corrections": []})
+            stats = storage.get_statistics()
+            assert stats["successful_applications"] == 0
+            assert stats["failed_applications"] == 0
+
+    def test_import_hydrates_application_counts_from_snapshot(self, tmp_path: Path) -> None:
+        with SqlitePreferenceStorage(tmp_path / "p.db") as storage:
+            storage.import_data(
+                {
+                    "preferences": {},
+                    "corrections": [],
+                    "statistics": {
+                        "successful_applications": 7,
+                        "failed_applications": 3,
+                    },
+                }
+            )
+            stats = storage.get_statistics()
+            assert stats["successful_applications"] == 7
+            assert stats["failed_applications"] == 3

--- a/tests/services/intelligence/test_preference_storage.py
+++ b/tests/services/intelligence/test_preference_storage.py
@@ -754,3 +754,72 @@ class TestImportDataResetsApplicationCounters:
             stats = storage.get_statistics()
             assert stats["successful_applications"] == 7
             assert stats["failed_applications"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Third-cycle review fixes (PR #207, Codex 20:07Z re-review)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateConfidenceErrorAtomicity:
+    """``update_preference_confidence`` is atomic w.r.t. side-effects on error.
+
+    A failed call (no backing row) must NOT mutate ``preference.metadata``
+    or bump ``_successful_applications`` / ``_failed_applications`` —
+    the persistence check now runs FIRST (Codex P2 on PR #207).
+    """
+
+    def test_update_on_unsaved_pref_does_not_mutate_dataclass(self, tmp_path: Path) -> None:
+        with SqlitePreferenceStorage(tmp_path / "p.db") as storage:
+            pref = _make_preference(confidence=0.5)
+            original_confidence = pref.metadata.confidence
+            original_last_used = pref.metadata.last_used
+
+            with pytest.raises(KeyError):
+                storage.update_preference_confidence(pref, success=True)
+
+            # Dataclass is unchanged — no mutation before the raise
+            assert pref.metadata.confidence == original_confidence
+            assert pref.metadata.last_used == original_last_used
+
+    def test_update_on_unsaved_pref_does_not_bump_counters(self, tmp_path: Path) -> None:
+        with SqlitePreferenceStorage(tmp_path / "p.db") as storage:
+            pref_unsaved = _make_preference(key="ghost")
+            pref_saved = _make_preference(key="real")
+            storage.save_preference(pref_saved)
+
+            # First do a real success so counter is at 1
+            storage.update_preference_confidence(pref_saved, success=True)
+            assert storage.get_statistics()["successful_applications"] == 1
+
+            # Now attempt update on the unsaved one — must not bump
+            with pytest.raises(KeyError):
+                storage.update_preference_confidence(pref_unsaved, success=True)
+
+            # Counter unchanged
+            assert storage.get_statistics()["successful_applications"] == 1
+
+
+class TestExportPreservesApplicationCounters:
+    """``export_data`` includes in-memory application counters (Codex P2 on PR #207)."""
+
+    def test_export_round_trip_preserves_application_counters_in_sqlite(
+        self, tmp_path: Path
+    ) -> None:
+        with SqlitePreferenceStorage(tmp_path / "p1.db") as src_storage:
+            pref = _make_preference()
+            src_storage.save_preference(pref)
+            src_storage.update_preference_confidence(pref, success=True)
+            src_storage.update_preference_confidence(pref, success=True)
+            src_storage.update_preference_confidence(pref, success=False)
+            assert src_storage.get_statistics()["successful_applications"] == 2
+            assert src_storage.get_statistics()["failed_applications"] == 1
+
+            snapshot = src_storage.export_data()
+
+        # Import into a fresh storage and verify counters survived
+        with SqlitePreferenceStorage(tmp_path / "p2.db") as dst_storage:
+            dst_storage.import_data(snapshot)
+            stats = dst_storage.get_statistics()
+            assert stats["successful_applications"] == 2
+            assert stats["failed_applications"] == 1

--- a/tests/services/intelligence/test_preference_storage.py
+++ b/tests/services/intelligence/test_preference_storage.py
@@ -38,7 +38,7 @@ from services.intelligence.preference_tracker import (
 if TYPE_CHECKING:
     pass
 
-pytestmark = [pytest.mark.unit, pytest.mark.ci]
+pytestmark = [pytest.mark.unit, pytest.mark.ci, pytest.mark.integration]
 
 
 # ---------------------------------------------------------------------------
@@ -49,7 +49,10 @@ pytestmark = [pytest.mark.unit, pytest.mark.ci]
 def _make_preference(
     preference_type: PreferenceType = PreferenceType.FOLDER_MAPPING,
     key: str = "file_move|.pdf|Documents",
-    value: str | dict[str, str] = "/home/user/Documents",
+    # Default ``value`` is a generic relative-string folder name (not ``/home/...``)
+    # so the G2 hardcoded-path rail (which scans test files for ``/home/`` /
+    # ``/tmp/`` / ``/Users/`` literals) stays clean.
+    value: str | dict[str, str] = "Documents",
     confidence: float = 0.5,
     frequency: int = 1,
 ) -> Preference:

--- a/tests/services/intelligence/test_preference_storage.py
+++ b/tests/services/intelligence/test_preference_storage.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
@@ -35,10 +34,13 @@ from services.intelligence.preference_tracker import (
     PreferenceType,
 )
 
-if TYPE_CHECKING:
-    pass
-
-pytestmark = [pytest.mark.unit, pytest.mark.ci, pytest.mark.integration]
+# Marker rationale (CodeRabbit on PR #207): the original triple
+# ``[unit, ci, integration]`` would let both the ``unit`` and
+# ``not integration`` lanes pull these in. Drop ``unit`` since these
+# tests exercise the SQLite backend end-to-end (real file I/O); keep
+# ``ci`` so they run in the PR CI lane and ``integration`` so they
+# count toward integration coverage of preference_storage.py.
+pytestmark = [pytest.mark.integration, pytest.mark.ci]
 
 
 # ---------------------------------------------------------------------------
@@ -93,13 +95,26 @@ def _make_correction(
 
 
 @pytest.fixture(params=["in_memory", "sqlite"])
-def storage(request: pytest.FixtureRequest, tmp_path: Path) -> PreferenceStorage:
-    """Yield each storage implementation under test."""
+def storage(request: pytest.FixtureRequest, tmp_path: Path):
+    """Yield each storage implementation under test, finalized with ``close()``.
+
+    SQLite cases hold an open connection; without the finalizer they
+    leak under xdist or on Windows where the file lock blocks reuse
+    (CodeRabbit on PR #207).
+    """
     if request.param == "in_memory":
-        return InMemoryPreferenceStorage()
-    if request.param == "sqlite":
-        return SqlitePreferenceStorage(tmp_path / "preferences.db")
-    raise ValueError(f"Unknown storage param: {request.param}")
+        s: PreferenceStorage = InMemoryPreferenceStorage()
+    elif request.param == "sqlite":
+        s = SqlitePreferenceStorage(tmp_path / "preferences.db")
+    else:
+        raise ValueError(f"Unknown storage param: {request.param}")
+    try:
+        yield s
+    finally:
+        # InMemoryPreferenceStorage doesn't define close(); only call
+        # it on backends that do (currently only SQLite).
+        if hasattr(s, "close"):
+            s.close()
 
 
 class TestPreferenceCRUD:
@@ -266,6 +281,57 @@ class TestCorrectionHistory:
         result = storage.get_corrections_for_file(tmp_path / "ghost.pdf")
         assert result == []
 
+    def test_save_correction_with_non_empty_context_round_trips(
+        self, storage: PreferenceStorage, tmp_path: Path
+    ) -> None:
+        """``correction.context`` (dict) must survive save→find round-trip.
+
+        CodeRabbit on PR #207 noted the contract suite only exercised
+        the ``context={}`` happy path, missing the metadata-binding
+        behavior in ``SqlitePreferenceStorage.save_correction``.
+        """
+        src = tmp_path / "doc.txt"
+        dst = tmp_path / "Documents" / "doc.txt"
+        correction = Correction(
+            correction_type=CorrectionType.CATEGORY_CHANGE,
+            source=src,
+            destination=dst,
+            timestamp=datetime(2026, 1, 15, 10, 30, tzinfo=UTC),
+            context={
+                "old_category": "general",
+                "new_category": "documents",
+                "note": "manual override",
+            },
+        )
+        storage.save_correction(correction)
+
+        results = storage.get_corrections_for_file(src)
+        assert len(results) == 1
+        assert results[0].context == {
+            "old_category": "general",
+            "new_category": "documents",
+            "note": "manual override",
+        }
+
+
+class TestDeleteByTypePreservesCorrections:
+    """``delete_preferences(type)`` MUST NOT clear corrections (CodeRabbit on PR #207)."""
+
+    def test_delete_by_type_leaves_corrections_intact(
+        self, storage: PreferenceStorage, tmp_path: Path
+    ) -> None:
+        a = _make_preference(key="a", preference_type=PreferenceType.FOLDER_MAPPING)
+        storage.save_preference(a)
+        storage.save_correction(_make_correction(tmp_path / "x.txt", tmp_path / "y.txt"))
+
+        deleted = storage.delete_preferences(PreferenceType.FOLDER_MAPPING)
+        assert deleted == 1
+
+        # Preferences gone, corrections preserved
+        assert storage.find_preferences(PreferenceType.FOLDER_MAPPING) == []
+        recent = storage.get_recent_corrections(limit=10)
+        assert len(recent) == 1
+
 
 class TestStatistics:
     def test_stats_includes_total_preferences(self, storage: PreferenceStorage) -> None:
@@ -287,27 +353,50 @@ class TestStatistics:
 
 
 class TestExportImportRoundTrip:
-    def test_export_then_import_recovers_preferences(
+    def test_export_then_import_recovers_preferences_and_corrections(
         self, storage: PreferenceStorage, tmp_path: Path
     ) -> None:
-        # Round-trip a preference + a correction through export/import.
+        """Round-trip a preference AND a correction through export/import.
+
+        Asserts both come back with full fidelity (CodeRabbit on PR
+        #207 — the original test only asserted the preference, missing
+        the SQLite-timestamp regression that this PR also fixes).
+        """
         pref = _make_preference()
+        ts = datetime(2026, 1, 15, 10, 30, tzinfo=UTC)
+        src_path = tmp_path / "a"
+        dst_path = tmp_path / "b"
+        correction = Correction(
+            correction_type=CorrectionType.FILE_MOVE,
+            source=src_path,
+            destination=dst_path,
+            timestamp=ts,
+            context={"note": "round-trip"},
+        )
         storage.save_preference(pref)
-        storage.save_correction(_make_correction(tmp_path / "a", tmp_path / "b"))
+        storage.save_correction(correction)
 
         snapshot = storage.export_data()
         assert isinstance(snapshot, dict)
 
-        # Wipe and restore
+        # Wipe both preferences and corrections, then restore from snapshot.
+        # ``delete_preferences()`` (no arg) clears corrections too.
         storage.delete_preferences()
-        # delete_preferences clears preferences but corrections are still
-        # in the spec's export/import scope. The import call restores both.
         storage.import_data(snapshot)
 
         recovered = storage.find_preferences(PreferenceType.FOLDER_MAPPING)
         assert len(recovered) == 1
         assert recovered[0].key == pref.key
         assert recovered[0].value == pref.value
+
+        # Correction is restored with intact source/destination/timestamp/type
+        recovered_corrs = storage.get_corrections_for_file(src_path)
+        assert len(recovered_corrs) == 1
+        rc = recovered_corrs[0]
+        assert rc.source == src_path
+        assert rc.destination == dst_path
+        assert rc.correction_type == CorrectionType.FILE_MOVE
+        assert rc.timestamp == ts
 
 
 # ---------------------------------------------------------------------------
@@ -319,10 +408,15 @@ class TestPreferenceTrackerInjection:
     """``PreferenceTracker(storage=...)`` delegates correctly to the backend."""
 
     def test_default_constructor_uses_in_memory(self) -> None:
-        tracker = PreferenceTracker()
         # No exception, no args needed — backwards-compat preserved.
-        # The default storage is InMemoryPreferenceStorage.
-        assert isinstance(tracker._storage, InMemoryPreferenceStorage)
+        # The default storage is InMemoryPreferenceStorage. We assert via
+        # observable behavior (no SQLite file, find returns [] cleanly)
+        # rather than poking ``tracker._storage`` (CodeRabbit on PR #207).
+        tracker = PreferenceTracker()
+        from services.intelligence.preference_tracker import PreferenceType as PT
+
+        # find round-trip works without any backing file or external setup
+        assert tracker.get_all_preferences(PT.FOLDER_MAPPING) == []
 
     def test_track_correction_routes_to_storage_save_correction(self, tmp_path: Path) -> None:
         mock_storage = MagicMock(spec=PreferenceStorage)
@@ -368,10 +462,20 @@ class TestPreferenceTrackerInjection:
         assert saved_pref.preference_type == PreferenceType.FOLDER_MAPPING
 
     def test_explicit_in_memory_storage(self) -> None:
-        # Constructing with an explicit InMemoryPreferenceStorage works.
+        """Constructing with an explicit storage instance routes calls to it.
+
+        Asserts via observable behavior (the same Preference saved
+        through the storage shows up via the tracker) rather than
+        poking ``tracker._storage`` (CodeRabbit on PR #207).
+        """
         storage = InMemoryPreferenceStorage()
         tracker = PreferenceTracker(storage=storage)
-        assert tracker._storage is storage
+        # Save through the injected storage, observe via the tracker
+        pref = _make_preference()
+        storage.save_preference(pref)
+        from services.intelligence.preference_tracker import PreferenceType as PT
+
+        assert len(tracker.get_all_preferences(PT.FOLDER_MAPPING)) == 1
 
 
 class TestSqliteStorageDirect:
@@ -379,28 +483,207 @@ class TestSqliteStorageDirect:
 
     def test_db_file_created_on_first_save(self, tmp_path: Path) -> None:
         db_path = tmp_path / "subdir" / "preferences.db"
-        # Parent directory will be created
-        storage = SqlitePreferenceStorage(db_path)
-
-        storage.save_preference(_make_preference())
-
-        # File now exists
-        assert db_path.exists()
-        assert db_path.stat().st_size > 0
+        # Parent directory will be created. ``with`` ensures the
+        # connection is closed on assertion failure too (CodeRabbit on
+        # PR #207 — leak prevention).
+        with SqlitePreferenceStorage(db_path) as storage:
+            storage.save_preference(_make_preference())
+            assert db_path.exists()
+            assert db_path.stat().st_size > 0
 
     def test_round_trip_survives_storage_recreation(self, tmp_path: Path) -> None:
         db_path = tmp_path / "preferences.db"
-
-        # First storage instance writes a preference
-        storage1 = SqlitePreferenceStorage(db_path)
         pref = _make_preference()
-        storage1.save_preference(pref)
-        # Close to release file handles
-        storage1.close()
 
-        # Second instance over the same file reads it back
-        storage2 = SqlitePreferenceStorage(db_path)
-        recovered = storage2.find_preferences(PreferenceType.FOLDER_MAPPING)
-        assert len(recovered) == 1
-        assert recovered[0].key == pref.key
-        storage2.close()
+        # First storage instance writes a preference; ``with`` ensures
+        # the connection closes even if the save raises (CodeRabbit on
+        # PR #207).
+        with SqlitePreferenceStorage(db_path) as storage1:
+            storage1.save_preference(pref)
+
+        # Second instance over the same file reads it back.
+        with SqlitePreferenceStorage(db_path) as storage2:
+            recovered = storage2.find_preferences(PreferenceType.FOLDER_MAPPING)
+            assert len(recovered) == 1
+            assert recovered[0].key == pref.key
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for PR #207 review fixes
+# ---------------------------------------------------------------------------
+
+
+class TestPreviouslyMissingFidelity:
+    """SQLite-only fixes that the in-memory backend never exhibited."""
+
+    def test_sqlite_save_preference_honors_metadata_timestamps(self, tmp_path: Path) -> None:
+        """``SqlitePreferenceStorage.save_preference`` must round-trip metadata timestamps."""
+        storage = SqlitePreferenceStorage(tmp_path / "p.db")
+        try:
+            old_created = datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
+            old_updated = datetime(2024, 6, 1, 12, 0, tzinfo=UTC)
+            old_last_used = datetime(2024, 9, 1, 12, 0, tzinfo=UTC)
+            pref = Preference(
+                preference_type=PreferenceType.FOLDER_MAPPING,
+                key="file_move|.pdf|Documents",
+                value="Documents",
+                metadata=PreferenceMetadata(
+                    created=old_created,
+                    updated=old_updated,
+                    confidence=0.5,
+                    frequency=1,
+                    last_used=old_last_used,
+                    source="user_correction",
+                ),
+                context={"source_extension": ".pdf"},
+            )
+            storage.save_preference(pref)
+
+            recovered = storage.find_preferences(PreferenceType.FOLDER_MAPPING)
+            assert len(recovered) == 1
+            assert recovered[0].metadata.created == old_created
+            assert recovered[0].metadata.updated == old_updated
+            assert recovered[0].metadata.last_used == old_last_used
+        finally:
+            storage.close()
+
+    def test_sqlite_save_correction_honors_timestamp(self, tmp_path: Path) -> None:
+        """``SqlitePreferenceStorage.save_correction`` must persist the supplied timestamp."""
+        storage = SqlitePreferenceStorage(tmp_path / "p.db")
+        try:
+            backfill_ts = datetime(2024, 3, 14, 9, 0, tzinfo=UTC)
+            correction = Correction(
+                correction_type=CorrectionType.FILE_MOVE,
+                source=tmp_path / "x.pdf",
+                destination=tmp_path / "Docs" / "x.pdf",
+                timestamp=backfill_ts,
+                context={},
+            )
+            storage.save_correction(correction)
+
+            recent = storage.get_recent_corrections(limit=10)
+            assert len(recent) == 1
+            assert recent[0].timestamp == backfill_ts
+        finally:
+            storage.close()
+
+    def test_sqlite_update_preference_confidence_raises_when_pref_absent(
+        self, tmp_path: Path
+    ) -> None:
+        """Updating confidence on a never-saved preference must raise (not silently no-op)."""
+        storage = SqlitePreferenceStorage(tmp_path / "p.db")
+        try:
+            pref = _make_preference()
+            # No save_preference call → row doesn't exist
+            with pytest.raises(KeyError, match="No persisted preference"):
+                storage.update_preference_confidence(pref, success=True)
+        finally:
+            storage.close()
+
+    def test_sqlite_int_value_round_trips_as_int(self, tmp_path: Path) -> None:
+        """``_encode_pref_value`` / ``_decode_pref_value`` must preserve numeric types."""
+        storage = SqlitePreferenceStorage(tmp_path / "p.db")
+        try:
+            now = datetime(2026, 1, 15, 10, 30, tzinfo=UTC)
+            pref = Preference(
+                preference_type=PreferenceType.CUSTOM,
+                key="numeric",
+                value=42,  # int (not str)
+                metadata=PreferenceMetadata(created=now, updated=now),
+                context={},
+            )
+            storage.save_preference(pref)
+            recovered = storage.find_preferences(PreferenceType.CUSTOM)
+            assert len(recovered) == 1
+            assert recovered[0].value == 42
+            assert isinstance(recovered[0].value, int)
+        finally:
+            storage.close()
+
+
+class TestStatsKeysParity:
+    """``get_statistics`` exposes the same keys for both backends."""
+
+    def test_sqlite_statistics_has_legacy_keys(self, tmp_path: Path) -> None:
+        storage = SqlitePreferenceStorage(tmp_path / "p.db")
+        try:
+            stats = storage.get_statistics()
+            for key in (
+                "total_preferences",
+                "unique_preferences",
+                "total_corrections",
+                "successful_applications",
+                "failed_applications",
+                "average_confidence",
+            ):
+                assert key in stats, f"missing legacy stats key: {key}"
+        finally:
+            storage.close()
+
+
+class TestImportDataAtomic:
+    """``import_data`` must be transactional (CodeRabbit on PR #207)."""
+
+    def test_import_data_failure_rolls_back(self, tmp_path: Path) -> None:
+        """If a save mid-import raises, the previous data must be preserved."""
+        storage = SqlitePreferenceStorage(tmp_path / "p.db")
+        try:
+            # Seed: one preference + one correction
+            pref = _make_preference(key="file_move|.pdf|Documents")
+            storage.save_preference(pref)
+            storage.save_correction(_make_correction(tmp_path / "a.pdf", tmp_path / "b.pdf"))
+            assert len(storage.find_preferences(PreferenceType.FOLDER_MAPPING)) == 1
+
+            # Construct a snapshot whose corrections list has a bad row
+            # (missing required ``timestamp`` key) so save_correction
+            # raises mid-import.
+            bad_snapshot = {
+                "preferences": {
+                    "folder_mapping:new_key": [_make_preference(key="new_key").to_dict()]
+                },
+                "corrections": [
+                    {
+                        "correction_type": "file_move",
+                        "source": "/x",
+                        "destination": "/y",
+                        # Missing 'timestamp' → datetime.fromisoformat raises
+                        "context": {},
+                    }
+                ],
+            }
+            with pytest.raises((KeyError, TypeError, ValueError)):
+                storage.import_data(bad_snapshot)
+
+            # Original data should be preserved (transaction rolled back).
+            preserved = storage.find_preferences(PreferenceType.FOLDER_MAPPING)
+            assert len(preserved) == 1
+            assert preserved[0].key == "file_move|.pdf|Documents"
+        finally:
+            storage.close()
+
+
+class TestLastUsedPersistedThroughTracker:
+    """``PreferenceTracker.get_preference`` must persist ``last_used`` (CodeRabbit)."""
+
+    def test_get_preference_persists_last_used_in_sqlite_backend(self, tmp_path: Path) -> None:
+        storage = SqlitePreferenceStorage(tmp_path / "p.db")
+        try:
+            tracker = PreferenceTracker(storage=storage)
+            tracker.track_correction(
+                source=tmp_path / "doc.pdf",
+                destination=tmp_path / "Documents" / "doc.pdf",
+                correction_type=CorrectionType.FILE_MOVE,
+            )
+
+            t0 = datetime.now(UTC)
+            best = tracker.get_preference(tmp_path / "another.pdf", PreferenceType.FOLDER_MAPPING)
+            assert best is not None
+
+            # Re-fetch via storage (NEW dataclass instance) and check that
+            # ``last_used`` got written through to the DB.
+            re_fetched = storage.find_preferences(PreferenceType.FOLDER_MAPPING)
+            assert len(re_fetched) == 1
+            assert re_fetched[0].metadata.last_used is not None
+            assert re_fetched[0].metadata.last_used >= t0
+        finally:
+            storage.close()

--- a/tests/services/intelligence/test_preference_storage.py
+++ b/tests/services/intelligence/test_preference_storage.py
@@ -1,0 +1,403 @@
+"""Protocol-contract tests for ``preference_storage`` (Epic D / D5).
+
+Tracks: issue #157 (Hardening Epic D, item D5).
+
+Test contract (from ``docs/internal/D-storage-design.md`` §3.6):
+- One parametrized class runs against both ``InMemoryPreferenceStorage()``
+  and ``SqlitePreferenceStorage(tmp_path / "test.db")``.
+- Each test asserts the published shape of the Protocol — never reaches
+  into private dicts, never assumes a specific implementation.
+- ``PreferenceTracker(storage=mock_storage)`` test asserts ``track_correction``
+  delegates to ``save_preference`` / ``save_correction`` with the right payload
+  (mock-call-args, not just call_count — per anti-pattern T3).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.intelligence.preference_storage import (
+    InMemoryPreferenceStorage,
+    PreferenceStorage,
+    SqlitePreferenceStorage,
+)
+from services.intelligence.preference_tracker import (
+    Correction,
+    CorrectionType,
+    Preference,
+    PreferenceMetadata,
+    PreferenceTracker,
+    PreferenceType,
+)
+
+if TYPE_CHECKING:
+    pass
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_preference(
+    preference_type: PreferenceType = PreferenceType.FOLDER_MAPPING,
+    key: str = "file_move|.pdf|Documents",
+    value: str | dict[str, str] = "/home/user/Documents",
+    confidence: float = 0.5,
+    frequency: int = 1,
+) -> Preference:
+    now = datetime(2026, 1, 15, 10, 30, tzinfo=UTC)
+    return Preference(
+        preference_type=preference_type,
+        key=key,
+        value=value,
+        metadata=PreferenceMetadata(
+            created=now,
+            updated=now,
+            confidence=confidence,
+            frequency=frequency,
+            last_used=now,
+            source="user_correction",
+        ),
+        context={"source_extension": ".pdf"},
+    )
+
+
+def _make_correction(
+    source: Path,
+    destination: Path,
+    correction_type: CorrectionType = CorrectionType.FILE_MOVE,
+) -> Correction:
+    return Correction(
+        correction_type=correction_type,
+        source=source,
+        destination=destination,
+        timestamp=datetime(2026, 1, 15, 10, 30, tzinfo=UTC),
+        context={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Protocol-contract tests (parametrized over both implementations)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(params=["in_memory", "sqlite"])
+def storage(request: pytest.FixtureRequest, tmp_path: Path) -> PreferenceStorage:
+    """Yield each storage implementation under test."""
+    if request.param == "in_memory":
+        return InMemoryPreferenceStorage()
+    if request.param == "sqlite":
+        return SqlitePreferenceStorage(tmp_path / "preferences.db")
+    raise ValueError(f"Unknown storage param: {request.param}")
+
+
+class TestPreferenceCRUD:
+    """The four preference-CRUD methods round-trip through both backends."""
+
+    def test_save_then_find_by_type_returns_dataclass(self, storage: PreferenceStorage) -> None:
+        pref = _make_preference()
+        storage.save_preference(pref)
+
+        found = storage.find_preferences(PreferenceType.FOLDER_MAPPING)
+        assert len(found) == 1
+        retrieved = found[0]
+        assert isinstance(retrieved, Preference)
+        assert retrieved.preference_type == PreferenceType.FOLDER_MAPPING
+        assert retrieved.key == pref.key
+        assert retrieved.value == pref.value
+        assert retrieved.metadata.confidence == 0.5
+        assert retrieved.metadata.frequency == 1
+
+    def test_find_filters_by_key_when_provided(self, storage: PreferenceStorage) -> None:
+        a = _make_preference(key="file_move|.pdf|Documents")
+        b = _make_preference(key="file_move|.txt|Notes")
+        storage.save_preference(a)
+        storage.save_preference(b)
+
+        only_pdf = storage.find_preferences(
+            PreferenceType.FOLDER_MAPPING, key="file_move|.pdf|Documents"
+        )
+        assert len(only_pdf) == 1
+        assert only_pdf[0].key == "file_move|.pdf|Documents"
+
+    def test_find_returns_empty_for_unknown_type(self, storage: PreferenceStorage) -> None:
+        result = storage.find_preferences(PreferenceType.NAMING_PATTERN)
+        assert result == []
+
+    def test_save_is_idempotent_for_same_type_and_key(self, storage: PreferenceStorage) -> None:
+        # Saving the same (type, key) twice must NOT create two rows; the
+        # second save updates the existing entry.
+        first = _make_preference(value="/path/v1", confidence=0.5)
+        storage.save_preference(first)
+
+        second = _make_preference(value="/path/v2", confidence=0.7)
+        storage.save_preference(second)
+
+        all_prefs = storage.find_preferences(PreferenceType.FOLDER_MAPPING)
+        assert len(all_prefs) == 1
+        assert all_prefs[0].value == "/path/v2"
+
+    def test_update_confidence_success_increases_confidence(
+        self, storage: PreferenceStorage
+    ) -> None:
+        pref = _make_preference(confidence=0.5)
+        storage.save_preference(pref)
+
+        storage.update_preference_confidence(pref, success=True)
+
+        found = storage.find_preferences(PreferenceType.FOLDER_MAPPING)
+        assert len(found) == 1
+        # Confidence increased by exactly 0.05 per the tracker rule
+        assert found[0].metadata.confidence == pytest.approx(0.55, abs=0.001)
+
+    def test_update_confidence_failure_decreases_confidence(
+        self, storage: PreferenceStorage
+    ) -> None:
+        pref = _make_preference(confidence=0.5)
+        storage.save_preference(pref)
+
+        storage.update_preference_confidence(pref, success=False)
+
+        found = storage.find_preferences(PreferenceType.FOLDER_MAPPING)
+        assert len(found) == 1
+        assert found[0].metadata.confidence == pytest.approx(0.4, abs=0.001)
+
+    def test_update_confidence_caps_at_floor(self, storage: PreferenceStorage) -> None:
+        pref = _make_preference(confidence=0.1)
+        storage.save_preference(pref)
+
+        # Multiple failures should not push below the 0.1 floor
+        storage.update_preference_confidence(pref, success=False)
+        storage.update_preference_confidence(pref, success=False)
+
+        found = storage.find_preferences(PreferenceType.FOLDER_MAPPING)
+        assert found[0].metadata.confidence >= 0.1
+
+    def test_update_confidence_caps_at_ceiling(self, storage: PreferenceStorage) -> None:
+        pref = _make_preference(confidence=0.97)
+        storage.save_preference(pref)
+
+        storage.update_preference_confidence(pref, success=True)
+
+        found = storage.find_preferences(PreferenceType.FOLDER_MAPPING)
+        # Successful update caps at 0.98
+        assert found[0].metadata.confidence <= 0.98
+
+    def test_delete_all_clears_storage(self, storage: PreferenceStorage) -> None:
+        a = _make_preference(key="a", preference_type=PreferenceType.FOLDER_MAPPING)
+        b = _make_preference(key="b", preference_type=PreferenceType.NAMING_PATTERN)
+        storage.save_preference(a)
+        storage.save_preference(b)
+
+        deleted = storage.delete_preferences()
+
+        assert deleted == 2
+        assert storage.find_preferences(PreferenceType.FOLDER_MAPPING) == []
+        assert storage.find_preferences(PreferenceType.NAMING_PATTERN) == []
+
+    def test_delete_by_type_only_clears_that_type(self, storage: PreferenceStorage) -> None:
+        folder = _make_preference(key="a", preference_type=PreferenceType.FOLDER_MAPPING)
+        naming = _make_preference(key="b", preference_type=PreferenceType.NAMING_PATTERN)
+        storage.save_preference(folder)
+        storage.save_preference(naming)
+
+        deleted = storage.delete_preferences(PreferenceType.FOLDER_MAPPING)
+
+        assert deleted == 1
+        assert storage.find_preferences(PreferenceType.FOLDER_MAPPING) == []
+        # The other type is untouched
+        remaining = storage.find_preferences(PreferenceType.NAMING_PATTERN)
+        assert len(remaining) == 1
+        assert remaining[0].key == "b"
+
+
+class TestCorrectionHistory:
+    def test_save_correction_appears_in_get_corrections_for_file(
+        self, storage: PreferenceStorage, tmp_path: Path
+    ) -> None:
+        src = tmp_path / "src.pdf"
+        dst = tmp_path / "Documents" / "src.pdf"
+        correction = _make_correction(src, dst)
+        storage.save_correction(correction)
+
+        results = storage.get_corrections_for_file(src)
+        assert len(results) == 1
+        assert results[0].source == src
+        assert results[0].destination == dst
+        assert results[0].correction_type == CorrectionType.FILE_MOVE
+
+    def test_get_corrections_for_file_matches_destination_too(
+        self, storage: PreferenceStorage, tmp_path: Path
+    ) -> None:
+        src = tmp_path / "old.pdf"
+        dst = tmp_path / "new.pdf"
+        storage.save_correction(_make_correction(src, dst))
+
+        # Querying by destination should also find it
+        by_destination = storage.get_corrections_for_file(dst)
+        assert len(by_destination) == 1
+        assert by_destination[0].destination == dst
+
+    def test_get_recent_corrections_respects_limit(
+        self, storage: PreferenceStorage, tmp_path: Path
+    ) -> None:
+        for i in range(5):
+            storage.save_correction(
+                _make_correction(tmp_path / f"f{i}.pdf", tmp_path / f"d{i}.pdf")
+            )
+
+        recent = storage.get_recent_corrections(limit=3)
+        assert len(recent) == 3
+
+    def test_get_corrections_for_file_returns_empty_when_unmatched(
+        self, storage: PreferenceStorage, tmp_path: Path
+    ) -> None:
+        result = storage.get_corrections_for_file(tmp_path / "ghost.pdf")
+        assert result == []
+
+
+class TestStatistics:
+    def test_stats_includes_total_preferences(self, storage: PreferenceStorage) -> None:
+        a = _make_preference(key="a", preference_type=PreferenceType.FOLDER_MAPPING)
+        b = _make_preference(key="b", preference_type=PreferenceType.NAMING_PATTERN)
+        storage.save_preference(a)
+        storage.save_preference(b)
+
+        stats = storage.get_statistics()
+
+        # Both implementations expose total_preferences in some form
+        # (key name normalized in the Protocol).
+        assert "total_preferences" in stats
+        assert stats["total_preferences"] == 2
+
+    def test_stats_handles_empty_storage(self, storage: PreferenceStorage) -> None:
+        stats = storage.get_statistics()
+        assert stats["total_preferences"] == 0
+
+
+class TestExportImportRoundTrip:
+    def test_export_then_import_recovers_preferences(
+        self, storage: PreferenceStorage, tmp_path: Path
+    ) -> None:
+        # Round-trip a preference + a correction through export/import.
+        pref = _make_preference()
+        storage.save_preference(pref)
+        storage.save_correction(_make_correction(tmp_path / "a", tmp_path / "b"))
+
+        snapshot = storage.export_data()
+        assert isinstance(snapshot, dict)
+
+        # Wipe and restore
+        storage.delete_preferences()
+        # delete_preferences clears preferences but corrections are still
+        # in the spec's export/import scope. The import call restores both.
+        storage.import_data(snapshot)
+
+        recovered = storage.find_preferences(PreferenceType.FOLDER_MAPPING)
+        assert len(recovered) == 1
+        assert recovered[0].key == pref.key
+        assert recovered[0].value == pref.value
+
+
+# ---------------------------------------------------------------------------
+# PreferenceTracker injection tests (no parametrize: tracker uses storage)
+# ---------------------------------------------------------------------------
+
+
+class TestPreferenceTrackerInjection:
+    """``PreferenceTracker(storage=...)`` delegates correctly to the backend."""
+
+    def test_default_constructor_uses_in_memory(self) -> None:
+        tracker = PreferenceTracker()
+        # No exception, no args needed — backwards-compat preserved.
+        # The default storage is InMemoryPreferenceStorage.
+        assert isinstance(tracker._storage, InMemoryPreferenceStorage)
+
+    def test_track_correction_routes_to_storage_save_correction(self, tmp_path: Path) -> None:
+        mock_storage = MagicMock(spec=PreferenceStorage)
+        # find_preferences returns [] so tracker takes the new-pref code path
+        mock_storage.find_preferences.return_value = []
+
+        tracker = PreferenceTracker(storage=mock_storage)
+        src = tmp_path / "report.pdf"
+        dst = tmp_path / "Documents" / "report.pdf"
+        tracker.track_correction(
+            source=src,
+            destination=dst,
+            correction_type=CorrectionType.FILE_MOVE,
+        )
+
+        # Mock-call-args verification (T3): the correction passed to storage
+        # must carry the exact path/type the caller provided.
+        mock_storage.save_correction.assert_called_once()
+        saved = mock_storage.save_correction.call_args.args[0]
+        assert isinstance(saved, Correction)
+        assert saved.source == src
+        assert saved.destination == dst
+        assert saved.correction_type == CorrectionType.FILE_MOVE
+
+    def test_track_correction_routes_to_storage_save_preference(self, tmp_path: Path) -> None:
+        mock_storage = MagicMock(spec=PreferenceStorage)
+        mock_storage.find_preferences.return_value = []
+
+        tracker = PreferenceTracker(storage=mock_storage)
+        src = tmp_path / "doc.pdf"
+        dst = tmp_path / "Archive" / "doc.pdf"
+        tracker.track_correction(
+            source=src,
+            destination=dst,
+            correction_type=CorrectionType.FILE_MOVE,
+        )
+
+        # The new preference is saved to storage (one call only — first time
+        # this pattern is seen, so tracker's "extract" code path runs).
+        mock_storage.save_preference.assert_called_once()
+        saved_pref = mock_storage.save_preference.call_args.args[0]
+        assert isinstance(saved_pref, Preference)
+        assert saved_pref.preference_type == PreferenceType.FOLDER_MAPPING
+
+    def test_explicit_in_memory_storage(self) -> None:
+        # Constructing with an explicit InMemoryPreferenceStorage works.
+        storage = InMemoryPreferenceStorage()
+        tracker = PreferenceTracker(storage=storage)
+        assert tracker._storage is storage
+
+
+class TestSqliteStorageDirect:
+    """SQLite-specific concerns that don't fit the Protocol contract tests."""
+
+    def test_db_file_created_on_first_save(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "subdir" / "preferences.db"
+        # Parent directory will be created
+        storage = SqlitePreferenceStorage(db_path)
+
+        storage.save_preference(_make_preference())
+
+        # File now exists
+        assert db_path.exists()
+        assert db_path.stat().st_size > 0
+
+    def test_round_trip_survives_storage_recreation(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "preferences.db"
+
+        # First storage instance writes a preference
+        storage1 = SqlitePreferenceStorage(db_path)
+        pref = _make_preference()
+        storage1.save_preference(pref)
+        # Close to release file handles
+        storage1.close()
+
+        # Second instance over the same file reads it back
+        storage2 = SqlitePreferenceStorage(db_path)
+        recovered = storage2.find_preferences(PreferenceType.FOLDER_MAPPING)
+        assert len(recovered) == 1
+        assert recovered[0].key == pref.key
+        storage2.close()


### PR DESCRIPTION
## Summary

Implements D5 of Epic D (issue #157). Lifts `PreferenceTracker`'s in-process dicts behind a `PreferenceStorage` Protocol and adds a SQLite-backed adapter so callers can swap persistence without rewriting the tracker.

`PreferenceTracker()` (no args) keeps its current in-memory behavior — fully backwards-compat. `PreferenceTracker(storage=SqlitePreferenceStorage(db_path))` opts into persistence end-to-end.

Closes the D5 portion of Epic D (#157). With #205 (cleanup), #206 (D4 Renderer), and this PR, Epic D is done; closing Epic D closes the meta-tracker #161.

## Surface

```python
@runtime_checkable
class PreferenceStorage(Protocol):
    # Preference CRUD
    def save_preference(self, preference: Preference) -> None: ...
    def find_preferences(
        self, preference_type: PreferenceType, key: str | None = None
    ) -> list[Preference]: ...
    def update_preference_confidence(
        self, preference: Preference, success: bool
    ) -> None: ...
    def delete_preferences(
        self, preference_type: PreferenceType | None = None
    ) -> int: ...

    # Correction history
    def save_correction(self, correction: Correction) -> None: ...
    def get_corrections_for_file(self, file_path: Path) -> list[Correction]: ...
    def get_recent_corrections(self, limit: int = 10) -> list[Correction]: ...

    # Statistics + bulk
    def get_statistics(self) -> dict[str, Any]: ...
    def export_data(self) -> dict[str, Any]: ...
    def import_data(self, data: dict[str, Any]) -> None: ...
```

The tracker's complex `get_preference()` (best-match selection by extension) stays in the tracker — that's domain logic, not storage.

## Test plan

- [x] 40 parametrized contract tests run twice (once for `InMemoryPreferenceStorage`, once for `SqlitePreferenceStorage`).
- [x] Existing `tests/services/intelligence/test_preference_tracker.py` (28 tests) passes unchanged via the in-memory default.
- [x] New `TestTrackerWithSqliteStorage` integration smoke proves `tracker.track_correction → SQLite → tracker.get_recent_corrections` round-trip.
- [x] 71 D5 tests + 1235 broader intelligence regression: all pass locally.
- [x] mypy clean on `preference_storage.py` + `preference_tracker.py`.
- [x] ruff format / check: clean.
- [x] Pre-commit validation: clean.
- [ ] CI green on PR.

## Out of scope (per design spec §5)

- `PreferenceStore` (directory-rule preferences) consolidation — different domain.
- Switching the production default to SQLite — requires opt-out config flag and migration path.

## Commit

3703c8e — feat(intelligence): D5 — extract PreferenceStorage protocol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable preference storage with in-memory and SQLite backends, export/import of preferences and corrections, and persisted statistics.
  * Preference tracking now delegates to storage (supports persisted corrections, confidence updates, deletion and recent-corrections queries).
  * Storage classes exposed via the public intelligence API.

* **Tests**
  * Added integration and contract tests exercising tracker behavior across both storage backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->