### PR TITLE
fix: main CI green after #205+#206+#207 merge

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -349,6 +349,34 @@ fo history --stats
 
 ---
 
+### `recover`
+
+Preview pending `durable_move` recovery actions without executing them.
+
+Reads the F7.1 durable-move journal under a shared file lock, runs the pure
+recovery planner, and prints the planned sweep verbs and reasons. Exits 0 if
+nothing actionable; exits 1 if any recovery work would be performed (so shell
+scripts can detect a stuck journal without invoking the sweep itself).
+
+**Usage:**
+
+```bash
+fo recover [OPTIONS]
+```
+
+**Options:**
+- `--journal PATH` — Override path to `durable_move.journal` (defaults to the user state dir)
+- `--verbose, -v` — Verbose output
+
+**Examples:**
+
+```bash
+fo recover
+fo recover --journal /tmp/journal.bin --verbose
+```
+
+---
+
 ### `analytics`
 
 Display storage analytics dashboard.

--- a/tests/test_cli_dedupe_v2.py
+++ b/tests/test_cli_dedupe_v2.py
@@ -157,9 +157,7 @@ class TestDedupeReport:
             return_value=mock_detector,
         ):
             # PR #206: ``--json`` was replaced by ``--format json``.
-            result = runner.invoke(
-                dedupe_app, ["report", str(tmp_path), "--format", "json"]
-            )
+            result = runner.invoke(dedupe_app, ["report", str(tmp_path), "--format", "json"])
         assert result.exit_code == 0
 
 

--- a/tests/test_cli_dedupe_v2.py
+++ b/tests/test_cli_dedupe_v2.py
@@ -98,9 +98,10 @@ class TestDedupeScan:
             "cli.dedupe_v2._get_detector",
             return_value=mock_detector_with_groups,
         ):
-            result = runner.invoke(dedupe_app, ["scan", str(tmp_path), "--json"])
+            # PR #206: ``--json`` was replaced by ``--format json`` (Renderer
+            # protocol extraction). Output is now a v1 envelope.
+            result = runner.invoke(dedupe_app, ["scan", str(tmp_path), "--format", "json"])
         assert result.exit_code == 0
-        # Should be valid JSON (somewhere in the output)
         assert "abc123" in result.output
 
 
@@ -155,25 +156,15 @@ class TestDedupeReport:
             "cli.dedupe_v2._get_detector",
             return_value=mock_detector,
         ):
-            result = runner.invoke(dedupe_app, ["report", str(tmp_path), "--json"])
+            # PR #206: ``--json`` was replaced by ``--format json``.
+            result = runner.invoke(
+                dedupe_app, ["report", str(tmp_path), "--format", "json"]
+            )
         assert result.exit_code == 0
 
 
-@pytest.mark.unit
-class TestFormatSize:
-    """Test _format_size helper."""
-
-    def test_bytes(self) -> None:
-        from cli.dedupe_v2 import _format_size
-
-        assert _format_size(100) == "100 B"
-
-    def test_kilobytes(self) -> None:
-        from cli.dedupe_v2 import _format_size
-
-        assert "KB" in _format_size(2048)
-
-    def test_zero(self) -> None:
-        from cli.dedupe_v2 import _format_size
-
-        assert _format_size(0) == "0 B"
+# ``TestFormatSize`` removed in PR #206: ``_format_size`` was extracted into
+# ``cli.dedupe_renderer`` as a private helper of the Renderer Protocol.
+# Direct unit tests for size formatting now live in
+# ``tests/cli/test_dedupe_renderer.py`` (the rendered Rich/JSON/Plain output
+# asserts ``"KB"``, ``"MB"``, etc. via the renderer surface).


### PR DESCRIPTION
## Summary

Hotfix for `main` CI failures after the D-storage epic landed (#205+#206+#207). PR CI runs the `-m ci` subset only, so two regressions slipped through to main:

1. **`tests/test_cli_dedupe_v2.py`** — a third dedupe-v2 test file I missed when updating others under `tests/cli/` and `tests/integration/`. Still imported the removed `cli.dedupe_v2._format_size` (now in `cli.dedupe_renderer`) and used the deleted `--json` flag.

2. **`tests/docs/test_cli_docs_accuracy.py::test_commands_exist`** — the `recover` command added in #204 (F8.1 trash GC) was never documented in `docs/cli-reference.md`.

## What's changed

- `tests/test_cli_dedupe_v2.py`:
  - `--json` → `--format json` (2 invocations)
  - Removed `TestFormatSize` class (size formatting is now exercised by the renderer's unit tests in `tests/cli/test_dedupe_renderer.py`)
- `docs/cli-reference.md`: added `### recover` section between `analytics` and the sub-commands header

## Test plan

- [x] `pytest tests/test_cli_dedupe_v2.py tests/docs/test_cli_docs_accuracy.py` — 13 passed, 1 xfailed (pre-existing)
- [x] Pre-commit validation passes
- [ ] Main CI green after merge