### PR TITLE
fix(docs): repair main CI + clarify pyre triage doc (PR #210 follow-up)

### DIFF
--- a/docs/internal/pyre-violations-triage-2026-04-25.md
+++ b/docs/internal/pyre-violations-triage-2026-04-25.md
@@ -6,6 +6,16 @@
 
 ## Summary
 
+> **Reading note**: the bucket totals below reflect the *original* triage
+> (`APPLY=8 + SUPPRESS=39 + DEFER=2 + DISMISS=3 = 52`). This PR collapses the 8
+> APPLY items into in-code suppressions (`try/except` + `# pyre-ignore[21]` on
+> the optional `numpy` / `rank_bm25` imports — see commit `697d6d61`) rather
+> than shipping them as separate APPLY commits, and the 3 DISMISS items are
+> handled externally in the GitHub Code Scanning UI. The PR description
+> therefore summarises the *applied* actions as `SUPPRESS=50, DEFER=2,
+> APPLY/DISMISS=0` — not a contradiction with the table, just the post-decision
+> view.
+
 | Bucket | Count | Notes |
 |--------|------:|-------|
 | **Total findings** | 52 | All `level: error` in SARIF |
@@ -163,7 +173,7 @@ The exact alert numbers depend on whatever GitHub Code Scanning shows after the 
 ## Verification
 
 1. **SARIF parses cleanly**: `jq '.runs[0].results | length' /tmp/pyre-sarif.json` → `52`. ✅
-2. **Bucket totals reconcile**: 8 + 39 + 2 + 3 (DISMISS not in the local 52) = within current 52 = 49; the 3 DISMISS items are external (GitHub UI), not in the local SARIF. The 49 local breakdown reconciles. ✅
+2. **Bucket totals reconcile**: local SARIF holds 49 findings (8 APPLY + 39 SUPPRESS + 2 DEFER); the 3 DISMISS items are external (GitHub Code Scanning UI) and not present in the local SARIF, giving 49 + 3 = 52 total. ✅
 3. **APPLY entries reproducible**: `grep -nE '^import numpy|^from numpy' src/services/{deduplication,search}/*.py` confirms the 4 files have unguarded module-level numpy imports. ✅
 4. **SUPPRESS [35] sites are inside @dataclass / ClassVar**: verified by reading each cited file. ✅
 5. **SUPPRESS [21] on redis is genuinely guarded**: lines 16–19 of `src/events/stream.py` show `try / except ImportError`. ✅

--- a/docs/internal/pyre-violations-triage-2026-04-25.md
+++ b/docs/internal/pyre-violations-triage-2026-04-25.md
@@ -49,15 +49,15 @@ All 8 are missing `try/except ImportError` guards on optional-dep imports. Per `
 - **Why it matters**: `numpy` ships with the `dedup-text` extra. A user on a base install hitting this module gets `ModuleNotFoundError: numpy` with no install hint. Cascading `PYRE-ERROR-11` on `NDArray` annotation (line 69) is a downstream effect of the same gap.
 - **Proposed fix** (same pattern as `src/services/search/bm25_index.py` after issue #49):
 
-  ```python
-  try:
-      import numpy as np
-      from numpy.typing import NDArray
-  except ImportError as exc:  # pragma: no cover
-      raise ImportError(
-          "Install with: pip install 'fo-core[dedup-text]'"
-      ) from exc
-  ```
+```python
+try:
+    import numpy as np
+    from numpy.typing import NDArray
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "Install with: pip install 'fo-core[dedup-text]'"
+    ) from exc
+```
 
 ### A2 — `src/services/deduplication/semantic.py:12-13`
 
@@ -154,15 +154,17 @@ GitHub Code Scanning likely retains alerts for files under the old pre-flatten l
 
 > Note: the literal pre-flatten namespace token is intentionally omitted from this
 > document — `tests/ci/test_flattened_identity_guardrail.py` enforces that the legacy
-> token does not reappear in any tracked text file. Refer to it as the
-> "old namespace prefix" or `src/<old-namespace>/...` instead.
+> token does not reappear in any tracked text file, and
+> `tests/docs/test_doc_file_paths.py` rejects backtick-wrapped placeholder paths.
+> Refer to the prefix as the "old namespace prefix" in prose; substitute it
+> mentally where the suffix shows the post-flatten location.
 
-**Likely stale alerts** (paths to verify in the Security tab — substitute the old
-namespace prefix where indicated):
+**Likely stale alerts** (suffixes to verify in the Security tab — prefix each with
+the old namespace path that was removed during the flatten refactor):
 
-- `src/<old-namespace>/services/audio/transcriber.py` — file no longer exists at this path
-- `src/<old-namespace>/services/deduplication/embedder.py` — moved to `src/services/deduplication/embedder.py`
-- `src/<old-namespace>/services/search/bm25_index.py` — moved to `src/services/search/bm25_index.py`
+- `services/audio/transcriber.py` — file no longer exists at this path
+- `services/deduplication/embedder.py` — moved to `src/services/deduplication/embedder.py`
+- `services/search/bm25_index.py` — moved to `src/services/search/bm25_index.py`
 
 **Proposed action** (owner-only — requires Code Scanning UI access): dismiss with reason **"Won't fix"** and comment **"File path moved during epic/flatten-src refactor — superseded by current run on flattened layout"**.
 

--- a/docs/internal/pyre-violations-triage-2026-04-25.md
+++ b/docs/internal/pyre-violations-triage-2026-04-25.md
@@ -7,14 +7,13 @@
 ## Summary
 
 > **Reading note**: the bucket totals below reflect the *original* triage
-> (`APPLY=8 + SUPPRESS=39 + DEFER=2 + DISMISS=3 = 52`). This PR collapses the 8
+> (`APPLY=8 + SUPPRESS=39 + DEFER=2 + DISMISS=3 = 52`). PR #210 collapses the 8
 > APPLY items into in-code suppressions (`try/except` + `# pyre-ignore[21]` on
-> the optional `numpy` / `rank_bm25` imports — see commit `697d6d61`) rather
-> than shipping them as separate APPLY commits, and the 3 DISMISS items are
-> handled externally in the GitHub Code Scanning UI. The PR description
-> therefore summarises the *applied* actions as `SUPPRESS=50, DEFER=2,
-> APPLY/DISMISS=0` — not a contradiction with the table, just the post-decision
-> view.
+> the optional `numpy` / `rank_bm25` imports) rather than shipping them as
+> separate APPLY commits, and the 3 DISMISS items are handled externally in
+> the GitHub Code Scanning UI. PR #210's description therefore summarises the
+> *applied* actions as `SUPPRESS=50, DEFER=2, APPLY/DISMISS=0` — not a
+> contradiction with the table, just the post-decision view.
 
 | Bucket | Count | Notes |
 |--------|------:|-------|


### PR DESCRIPTION
## Summary

Follow-up to PR #210 covering both:

### 1. Main CI fix (NEW — discovered after #210 merged)

The triage doc shipped with #210 broke two full-suite tests that only run on `push` to main (the PR's `-m "ci"` subset didn't catch them):

- **`tests/docs/test_doc_file_paths.py`** — 3 failures. The `src/<old-namespace>/...` placeholder paths I used in the DISMISS section to dodge `tests/ci/test_flattened_identity_guardrail.py` were backtick-wrapped, so the doc-path-existence regex matched them as real references. Restructured the section to list path *suffixes* (no `src/` prefix, no backticks around the placeholder); explains in prose how to reconstruct the legacy paths.
- **`tests/docs/test_code_examples.py::test_python_examples_parse`** — 1 failure. The "Proposed fix" Python block in section A1 was indented under a bullet, so the extracted block had `try:` at column 0 but `except` at column 2 → "unindent does not match any outer indentation level at line 4". Moved the code fence to column 0.

Both guardrails (flatten-identity + doc-path-existence) are now satisfied.

### 2. CodeRabbit doc clarifications (original PR #211 scope)

Two minor PR #210 review threads that arrived right around merge time:

- **PRRT_kwDOR_Rkws59pp2A**: bucket totals in the Summary table (`8+39+2+3=52`) appeared to disagree with the PR description (`50+2+0`). They reconcile when you read the table as the *original* triage and the PR as the *applied* actions. Adds a one-line reading note above the table.
- **PRRT_kwDOR_Rkws59pp2B**: rewrites verification line 2 — `"8 + 39 + 2 + 3 (DISMISS not in the local 52) = within current 52 = 49"` was hard to parse. New text: `"local SARIF holds 49 findings (8 APPLY + 39 SUPPRESS + 2 DEFER); 3 DISMISS items external = 52 total"`.

## Test plan

- [x] `tests/docs/test_doc_file_paths.py` passes locally
- [x] `tests/docs/test_code_examples.py` passes locally
- [x] `tests/ci/test_flattened_identity_guardrail.py` still passes (no literal pre-flatten namespace token reintroduced)
- [x] `tests/smoke/test_default_import_boundary.py` still passes (carried over from #210)
- [x] `bash .claude/scripts/pre-commit-validation.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal triage documentation to clarify bucket totals reconciliation and verification procedures, including improved formatting of configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->