### PR TITLE
ratchet(rails): atomic-write-required guardrail

### DIFF
--- a/.claude/rules/feature-generation-patterns.md
+++ b/.claude/rules/feature-generation-patterns.md
@@ -126,6 +126,28 @@ with self._lock:
       concurrent CI job truncates the file; downstream tooling then reads garbage.
 - [ ] `@lru_cache` on a function reading env vars? → Remove cache
 
+**Mechanical rail**: The atomic-write requirement for persistent state in
+`src/` is enforced by the `atomic-write-required` pre-commit hook
+(`scripts/check_atomic_write.py`) and the corresponding semantic guardrail
+(`tests/ci/test_atomic_write_required.py`). Any `Path.write_text`,
+`Path.write_bytes`, or `open(p, "w"|"wb"|"a"|"ab")` call in `src/` must
+either use one of the `utils.atomic_write` helpers (`atomic_write_text`,
+`atomic_write_bytes`, `atomic_write_with`, `append_durable`) or carry an
+explicit opt-out comment. Accepted opt-out reasons:
+
+| Reason | When to use |
+|--------|-------------|
+| `# atomic-write: ok — manual temp+replace pattern` | Site already uses `tempfile.NamedTemporaryFile` + `os.replace()` (or equivalent `temp_path.replace()` / `temp_file.replace()`). Migration to the helper is a follow-up clean-up. |
+| `# atomic-write: ok — user output` | One-shot CLI export to a user-supplied path. Atomicity isn't required because the user retries on failure (e.g. `fo history export`, deduplication report, analytics dashboard). |
+| `# atomic-write: ok — pid file (single-writer via daemon lifecycle)` | PID file owned by exactly one daemon process; atomicity comes from the daemon-lifecycle invariant, not the write call. |
+| `# atomic-write: ok — fcntl lock file, stable inode required` | Lock file opened in append mode so its inode stays stable across callers; truncate-on-write would break the locking protocol. |
+| `# atomic-write: ok — append_durable pattern (LOCK_EX + fsync below)` | Journal-style append inside a `LOCK_EX` block with explicit `fsync` after the write. |
+| `# atomic-write: ok — journal compaction inside _locked() (caller holds LOCK_EX)` | Whole-journal rewrite under exclusive lock. |
+| `# atomic-write: ok — one-shot migration backup, retry-on-fail safe` | Migration backup written before destructive operation; rerun-safe. |
+
+Files that *implement* the atomic-write primitives are exempt at the file level:
+`src/utils/atomic_write.py`, `src/utils/atomic_io.py`.
+
 ---
 
 ## Pattern F4: SECURITY_VULN — 74 findings (highest-frequency)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,6 +93,21 @@ repos:
         pass_filenames: false
 
       # ----------------------------------------------------------------
+      # Atomic-write rail: persistent file writes in src/ must use the
+      # utils.atomic_write helpers (or carry an explicit
+      # `# atomic-write: ok — <reason>` opt-out comment). Blocks
+      # regressions of the F3 / Epic B.atomic hardening (PRs #176, #195,
+      # #197, #203, #204).  See .claude/rules/feature-generation-patterns.md
+      # F3 and tests/ci/test_atomic_write_required.py for the rail body.
+      # ----------------------------------------------------------------
+      - id: atomic-write-required
+        name: persistent writes in src/ must be atomic
+        entry: python3 scripts/check_atomic_write.py
+        language: system
+        pass_filenames: false
+        files: ^src/.*\.py$
+
+      # ----------------------------------------------------------------
       # G2: No f-strings in logger calls (single or double quote)
       # Matches: logger.debug(f"..."), logger.info(f'...'),
       #          logger.exception( f"..."), etc.

--- a/scripts/check_atomic_write.py
+++ b/scripts/check_atomic_write.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Atomic-write rail: persistent file writes in src/ must be crash-safe.
+
+Background
+----------
+PRs #176 / #195 / #197 / #203 / #204 added the ``utils.atomic_write`` helper
+suite (``atomic_write_text``, ``atomic_write_bytes``, ``atomic_write_with``,
+``append_durable``) and converted 19+ call sites to crash-safe writes.
+
+This rail blocks regressions: any ``Path.write_text``, ``Path.write_bytes``,
+or ``open(p, "w"|"wb"|"a"|"ab")`` call in ``src/`` that is NOT marked with an
+explicit ``# atomic-write: ok — <reason>`` opt-out comment is flagged.
+
+Scope
+-----
+- ``src/**/*.py`` only — tests/scripts/docs are out of scope.
+- Allowlisted files (the helper module itself + cross-platform fsync shim):
+    ``src/utils/atomic_write.py``
+    ``src/utils/atomic_io.py``
+
+Opt-out marker
+--------------
+Add ``# atomic-write: ok — <one-line-reason>`` to the call line. Reason
+categories that are accepted as legitimate non-atomic writes:
+
+    user output      — user-supplied path, one-shot CLI export, retry-on-fail
+    manual temp+replace — site already uses tempfile.NamedTemporaryFile + os.replace
+    pid file         — created via O_EXCL elsewhere (atomicity via the lock file)
+    journal append   — log/journal that uses append_durable semantics elsewhere
+
+Example::
+
+    cache_path.write_text(payload)  # atomic-write: ok — manual temp+replace pattern below
+
+Exit 0 = no violations.
+Exit 1 = violations found. Offending lines are printed to stderr.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SRC_DIR = _ROOT / "src"
+
+# Files that own the atomic-write primitives themselves — exempt from the
+# rail (they implement the pattern; they don't need to opt out of it).
+_ALLOWLISTED_FILES = frozenset(
+    {
+        "src/utils/atomic_write.py",
+        "src/utils/atomic_io.py",
+    }
+)
+
+# Forbidden write patterns: Path.write_text(, Path.write_bytes(,
+# open(<...>, "w"|"wb"|"a"|"ab")
+# Matches are line-based; multi-line ``open()`` calls are rare in practice
+# and can be marked with the opt-out on the line containing the mode string.
+_PATTERNS = (
+    re.compile(r"\.write_text\("),
+    re.compile(r"\.write_bytes\("),
+    re.compile(r"""\bopen\([^)]*['"]w[ba]?['"]"""),
+    re.compile(r"""\bopen\([^)]*['"]a[b]?['"]"""),
+)
+
+# Opt-out marker. Anchored to the trailing comment so a marker embedded
+# inside a string literal earlier on the line doesn't satisfy the rule.
+_OPT_OUT_RE = re.compile(r"#\s*atomic-write:\s*ok\b")
+
+
+def _is_comment_line(line: str) -> bool:
+    """True if the line (after whitespace) starts with ``#``."""
+    return line.lstrip().startswith("#")
+
+
+def _has_opt_out(line: str) -> bool:
+    """True if the line contains the ``# atomic-write: ok`` marker."""
+    return bool(_OPT_OUT_RE.search(line))
+
+
+def _is_in_docstring_or_string(line: str) -> bool:
+    """Heuristic: line is dominated by a docstring/string literal.
+
+    Conservative — a line that contains a forbidden pattern *only* inside a
+    string literal (e.g. an example in a docstring) should not trip the rail.
+    Detection: line, after stripping leading whitespace, starts with a quote
+    char or with the line being part of a triple-quoted block (``\"\"\"`` or
+    ``'''``). Misses some cases but cheap and false-positive-safe.
+    """
+    stripped = line.lstrip()
+    if stripped.startswith(('"""', "'''", '"', "'")):
+        return True
+    return False
+
+
+def _matches_forbidden(line: str) -> bool:
+    """True if the line contains any forbidden write pattern."""
+    return any(pat.search(line) for pat in _PATTERNS)
+
+
+def _iter_src_files() -> list[Path]:
+    """Yield every ``.py`` file under ``src/``."""
+    return sorted(_SRC_DIR.rglob("*.py"))
+
+
+_MARKER_LOOKAHEAD = 6
+"""Number of lines past the matched call to scan for the opt-out marker.
+
+``ruff format`` may split long calls across lines, leaving the
+``# atomic-write: ok`` comment on a later line (typically on the closing
+``)``). A small lookahead window catches these without false positives.
+"""
+
+
+def find_violations(path: Path) -> list[tuple[int, str]]:
+    """Return [(line_number, line_text)] for each unexempted write site.
+
+    Files outside ``_ROOT`` (e.g. ``tmp_path`` synthetic files in unit tests)
+    bypass the allowlist check — they're never the real ``src/utils/atomic_write.py``
+    so there's nothing to exempt at the file level.
+    """
+    if path.is_relative_to(_ROOT):
+        rel = path.relative_to(_ROOT).as_posix()
+        if rel in _ALLOWLISTED_FILES:
+            return []
+
+    violations: list[tuple[int, str]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return violations
+
+    lines = text.splitlines()
+    in_triple_quote = False
+    for idx, raw in enumerate(lines):
+        lineno = idx + 1
+        # Track triple-quoted string blocks so docstring examples don't trip
+        # the rail. The check is heuristic — counts ``\"\"\"`` toggles.
+        triple_count = raw.count('"""') + raw.count("'''")
+        if triple_count % 2 == 1:
+            in_triple_quote = not in_triple_quote
+            continue
+        if in_triple_quote:
+            continue
+        if not _matches_forbidden(raw):
+            continue
+        if _is_comment_line(raw):
+            continue
+        if _is_in_docstring_or_string(raw):
+            continue
+        # Marker may be on the matched line OR on one of the next few
+        # lines (ruff format often moves a long-line trailing comment to
+        # the closing-paren line). Scan a bounded window forward.
+        window = lines[idx : idx + _MARKER_LOOKAHEAD]
+        if any(_has_opt_out(w) for w in window):
+            continue
+        violations.append((lineno, raw.rstrip()))
+    return violations
+
+
+def main() -> int:
+    """Scan ``src/`` and print violations to stderr; exit 1 if any."""
+    all_violations: list[tuple[Path, int, str]] = []
+    for path in _iter_src_files():
+        for lineno, line in find_violations(path):
+            all_violations.append((path.relative_to(_ROOT), lineno, line))
+
+    if not all_violations:
+        return 0
+
+    print(
+        "ERROR (atomic-write): persistent write call in src/ without atomic\n"
+        "helper or opt-out marker. Use one of:\n"
+        "  - utils.atomic_write.atomic_write_text / atomic_write_bytes / atomic_write_with\n"
+        "  - utils.atomic_write.append_durable (for journal/log appends)\n"
+        "Or, for legitimate non-atomic writes, append:\n"
+        "  # atomic-write: ok — <reason>\n"
+        "Accepted reasons: user output, manual temp+replace, pid file, journal append.\n",
+        file=sys.stderr,
+    )
+    for path, lineno, line in all_violations:
+        print(f"  {path}:{lineno}: {line}", file=sys.stderr)
+    print(
+        f"\n{len(all_violations)} violation(s) across "
+        f"{len({v[0] for v in all_violations})} file(s).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_atomic_write.py
+++ b/scripts/check_atomic_write.py
@@ -55,9 +55,10 @@ _ALLOWLISTED_FILES = frozenset(
 )
 
 # Forbidden write patterns: Path.write_text(, Path.write_bytes(,
-# open(<...>, "w"|"wb"|"a"|"ab")
-# Matches are line-based; multi-line ``open()`` calls are rare in practice
-# and can be marked with the opt-out on the line containing the mode string.
+# open(<...>, "w"|"wb"|"a"|"ab").  Single-line forms are matched by
+# _PATTERNS; multi-line ``open()`` calls (where the mode string is on a
+# subsequent line) are detected by _OPEN_RE + _WRITE_MODE_RE in
+# find_violations().
 _PATTERNS = (
     re.compile(r"\.write_text\("),
     re.compile(r"\.write_bytes\("),
@@ -65,8 +66,15 @@ _PATTERNS = (
     re.compile(r"""\bopen\([^)]*['"]a[b]?['"]"""),
 )
 
-# Opt-out marker. Anchored to the trailing comment so a marker embedded
-# inside a string literal earlier on the line doesn't satisfy the rule.
+# Used to detect the *start* of a multi-line open() call.
+_OPEN_RE = re.compile(r"\bopen\(")
+# Matches a write/append mode string used in the lookahead window for
+# multi-line open() detection.
+_WRITE_MODE_RE = re.compile(r"""['"](?:w[ba]?|a[b]?)['"]""")
+
+# Opt-out marker.  Checked against the *comment portion* of the line only
+# (see _comment_portion) so a marker embedded inside a string literal does
+# not incorrectly satisfy the rule.
 _OPT_OUT_RE = re.compile(r"#\s*atomic-write:\s*ok\b")
 
 
@@ -75,9 +83,35 @@ def _is_comment_line(line: str) -> bool:
     return line.lstrip().startswith("#")
 
 
+def _comment_portion(line: str) -> str:
+    """Return everything from the first ``#`` that is outside a string literal.
+
+    Walks *line* left-to-right tracking single- and double-quoted string state
+    (including backslash escapes) and returns the substring starting at the
+    first ``#`` that falls outside any quote. Returns ``""`` when no such
+    ``#`` exists.
+    """
+    in_str: str | None = None
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if in_str:
+            if ch == "\\":
+                i += 2  # skip escaped character
+                continue
+            if ch == in_str:
+                in_str = None
+        elif ch in ('"', "'"):
+            in_str = ch
+        elif ch == "#":
+            return line[i:]
+        i += 1
+    return ""
+
+
 def _has_opt_out(line: str) -> bool:
-    """True if the line contains the ``# atomic-write: ok`` marker."""
-    return bool(_OPT_OUT_RE.search(line))
+    """True if the line's trailing comment contains the ``# atomic-write: ok`` marker."""
+    return bool(_OPT_OUT_RE.search(_comment_portion(line)))
 
 
 def _is_in_docstring_or_string(line: str) -> bool:
@@ -145,7 +179,15 @@ def find_violations(path: Path) -> list[tuple[int, str]]:
         if in_triple_quote:
             continue
         if not _matches_forbidden(raw):
-            continue
+            # Also detect multi-line open() calls: ``open(`` on one line,
+            # mode string on a subsequent line (ruff format splits long
+            # argument lists). Scan the next _MARKER_LOOKAHEAD lines for a
+            # write/append mode string.
+            if not _OPEN_RE.search(raw):
+                continue
+            rest = lines[idx + 1 : idx + _MARKER_LOOKAHEAD]
+            if not any(_WRITE_MODE_RE.search(ln) for ln in rest):
+                continue
         if _is_comment_line(raw):
             continue
         if _is_in_docstring_or_string(raw):

--- a/src/daemon/pid.py
+++ b/src/daemon/pid.py
@@ -84,7 +84,9 @@ class PidFileManager:
         pid = pid if pid is not None else os.getpid()
 
         pid_file.parent.mkdir(parents=True, exist_ok=True)
-        pid_file.write_text(str(pid))
+        pid_file.write_text(
+            str(pid)
+        )  # atomic-write: ok — pid file (single-writer via daemon lifecycle)
         logger.debug("Wrote PID %d to %s", pid, pid_file)
 
     def read_pid(self, pid_file: Path) -> int | None:

--- a/src/history/export.py
+++ b/src/history/export.py
@@ -115,7 +115,7 @@ class HistoryExporter:
 
         # Write to file
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(output_path, "w") as f:
+        with open(output_path, "w") as f:  # atomic-write: ok — user output (one-shot CLI export)
             json.dump(export_data, f, indent=2)
 
         logger.info(f"Exported {len(operations)} operations to {output_path}")
@@ -201,7 +201,9 @@ class HistoryExporter:
 
         # Write to CSV
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(output_path, "w", newline="") as f:
+        with open(
+            output_path, "w", newline=""
+        ) as f:  # atomic-write: ok — user output (one-shot CLI export)
             writer = csv.DictWriter(f, fieldnames=columns)
             writer.writeheader()
 
@@ -266,7 +268,9 @@ class HistoryExporter:
 
         # Write to CSV
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(output_path, "w", newline="") as f:
+        with open(
+            output_path, "w", newline=""
+        ) as f:  # atomic-write: ok — user output (one-shot CLI export)
             writer = csv.DictWriter(f, fieldnames=columns)
             writer.writeheader()
 
@@ -336,7 +340,7 @@ class HistoryExporter:
 
         # Write to file
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(output_path, "w") as f:
+        with open(output_path, "w") as f:  # atomic-write: ok — user output (one-shot CLI export)
             json.dump(stats, f, indent=2)
 
         logger.info(f"Exported statistics to {output_path}")

--- a/src/integrations/obsidian.py
+++ b/src/integrations/obsidian.py
@@ -74,7 +74,7 @@ class ObsidianIntegration(Integration):
         note_dir = (vault / notes_subdir).resolve(strict=False)
         note_dir.mkdir(parents=True, exist_ok=True)
         note_path = note_dir / f"{source.stem}.md"
-        note_path.write_text(
+        note_path.write_text(  # atomic-write: ok — user vault note creation, retry-on-fail safe
             self._build_note_content(source, destination, metadata), encoding="utf-8"
         )
         return True

--- a/src/integrations/workflow.py
+++ b/src/integrations/workflow.py
@@ -83,10 +83,10 @@ class WorkflowIntegration(Integration):
         alfred_path = output_dir / f"alfred-{stem}-{stamp}.json"
         raycast_path = output_dir / f"raycast-{stem}-{stamp}.json"
 
-        alfred_path.write_text(
+        alfred_path.write_text(  # atomic-write: ok — user output (launcher workflow file)
             json.dumps(alfred, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
-        raycast_path.write_text(
+        raycast_path.write_text(  # atomic-write: ok — user output (launcher workflow file)
             json.dumps(raycast, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
         return True

--- a/src/parallel/checkpoint.py
+++ b/src/parallel/checkpoint.py
@@ -150,7 +150,9 @@ class CheckpointManager:
         # Atomic write: write to temp file, fsync, rename, then fsync directory
         temp_path = path.with_suffix(".tmp")
         try:
-            with open(temp_path, "w", encoding="utf-8") as f:
+            with open(
+                temp_path, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — manual temp+replace pattern (lines 151-158)
                 f.write(json.dumps(data, indent=2, default=str))
                 f.flush()
                 os.fsync(f.fileno())

--- a/src/parallel/persistence.py
+++ b/src/parallel/persistence.py
@@ -70,7 +70,9 @@ class JobPersistence:
         # Atomic write: write to temp file, fsync, rename, then fsync directory
         temp_path = path.with_suffix(".tmp")
         try:
-            with open(temp_path, "w", encoding="utf-8") as f:
+            with open(
+                temp_path, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — manual temp+replace pattern (lines 71-78)
                 f.write(json.dumps(data, indent=2, default=str))
                 f.flush()
                 os.fsync(f.fileno())

--- a/src/services/analytics/analytics_service.py
+++ b/src/services/analytics/analytics_service.py
@@ -358,11 +358,15 @@ class AnalyticsService:
         if format == "json":
             import json
 
-            with open(output_path, "w") as f:
+            with open(
+                output_path, "w"
+            ) as f:  # atomic-write: ok — user output (one-shot CLI export)
                 json.dump(dashboard.to_dict(), f, indent=2)
 
         elif format == "text":
-            with open(output_path, "w") as f:
+            with open(
+                output_path, "w"
+            ) as f:  # atomic-write: ok — user output (one-shot CLI export)
                 f.write(self._format_dashboard_text(dashboard))
 
         else:

--- a/src/services/deduplication/reporter.py
+++ b/src/services/deduplication/reporter.py
@@ -99,7 +99,9 @@ class StorageReporter:
             output_path: Output CSV file path
         """
         try:
-            with open(output_path, "w", newline="", encoding="utf-8") as f:
+            with open(
+                output_path, "w", newline="", encoding="utf-8"
+            ) as f:  # atomic-write: ok — user output (one-shot CLI export)
                 writer = csv.writer(f)
 
                 # Header
@@ -141,7 +143,9 @@ class StorageReporter:
             output_path: Output JSON file path
         """
         try:
-            with open(output_path, "w", encoding="utf-8") as f:
+            with open(
+                output_path, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — user output (one-shot CLI export)
                 json.dump(duplicate_results, f, indent=2, default=str)
 
             logger.info(f"Exported duplicate report to {output_path}")

--- a/src/services/intelligence/preference_store.py
+++ b/src/services/intelligence/preference_store.py
@@ -282,7 +282,9 @@ class PreferenceStore:
 
                 # Write to temporary file first (atomic write)
                 temp_file = self.storage_path / f"{self.DEFAULT_FILENAME}.tmp"
-                with open(temp_file, "w", encoding="utf-8") as f:
+                with open(
+                    temp_file, "w", encoding="utf-8"
+                ) as f:  # atomic-write: ok — manual temp+replace pattern (line 293)
                     json.dump(self._preferences, f, indent=2, ensure_ascii=False)
 
                 # Create backup of existing file before overwriting
@@ -482,7 +484,9 @@ class PreferenceStore:
                 output_path = Path(output_path)
                 output_path.parent.mkdir(parents=True, exist_ok=True)
 
-                with open(output_path, "w", encoding="utf-8") as f:
+                with open(
+                    output_path, "w", encoding="utf-8"
+                ) as f:  # atomic-write: ok — user output (one-shot CLI export)
                     json.dump(self._preferences, f, indent=2, ensure_ascii=False)
 
                 return True

--- a/src/services/intelligence/profile_exporter.py
+++ b/src/services/intelligence/profile_exporter.py
@@ -77,7 +77,9 @@ class ProfileExporter:
 
             # Write to temporary file first (atomic write)
             temp_file = file_path.parent / f"{file_path.name}.tmp"
-            with open(temp_file, "w", encoding="utf-8") as f:
+            with open(
+                temp_file, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — manual temp+replace pattern
                 json.dump(export_data, f, indent=2, ensure_ascii=False)
 
             # Validate export file
@@ -167,7 +169,9 @@ class ProfileExporter:
 
             # Write to temporary file first (atomic write)
             temp_file = file_path.parent / f"{file_path.name}.tmp"
-            with open(temp_file, "w", encoding="utf-8") as f:
+            with open(
+                temp_file, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — manual temp+replace pattern
                 json.dump(export_data, f, indent=2, ensure_ascii=False)
 
             # Atomic rename

--- a/src/services/intelligence/profile_manager.py
+++ b/src/services/intelligence/profile_manager.py
@@ -196,7 +196,9 @@ class ProfileManager:
 
             # Write to temporary file first (atomic write)
             temp_file = profile_path.parent / f"{profile_path.name}.tmp"
-            with open(temp_file, "w", encoding="utf-8") as f:
+            with open(
+                temp_file, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — manual temp+replace pattern (line 203)
                 json.dump(profile.to_dict(), f, indent=2, ensure_ascii=False)
 
             # Atomic rename
@@ -265,7 +267,9 @@ class ProfileManager:
         try:
             # Write to temporary file first (atomic write)
             temp_file = self.active_profile_file.parent / f"{self.active_profile_file.name}.tmp"
-            with open(temp_file, "w", encoding="utf-8") as f:
+            with open(
+                temp_file, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — manual temp+replace pattern (line 272)
                 f.write(profile_name)
 
             # Atomic rename

--- a/src/services/intelligence/profile_migrator.py
+++ b/src/services/intelligence/profile_migrator.py
@@ -273,7 +273,9 @@ class ProfileMigrator:
             backup_path = backup_dir / f"{backup_name}.json"
 
             # Write backup
-            with open(backup_path, "w", encoding="utf-8") as f:
+            with open(
+                backup_path, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — one-shot migration backup, retry-on-fail safe
                 json.dump(profile.to_dict(), f, indent=2, ensure_ascii=False)
 
             print(f"Created migration backup: {backup_path}")

--- a/src/services/suggestion_feedback.py
+++ b/src/services/suggestion_feedback.py
@@ -390,7 +390,7 @@ class SuggestionFeedback:
             "exported_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         }
 
-        with open(output_file, "w") as f:
+        with open(output_file, "w") as f:  # atomic-write: ok — user output (one-shot CLI export)
             json.dump(data, f, indent=2)
 
         logger.info(f"Exported feedback to {output_file}")

--- a/src/services/video/scene_detector.py
+++ b/src/services/video/scene_detector.py
@@ -353,7 +353,9 @@ class SceneDetector:
 
         output_path = Path(output_path)
 
-        with open(output_path, "w", newline="") as f:
+        with open(
+            output_path, "w", newline=""
+        ) as f:  # atomic-write: ok — user output (one-shot CLI export)
             writer = csv.writer(f)
             writer.writerow(
                 [

--- a/src/undo/durable_move.py
+++ b/src/undo/durable_move.py
@@ -253,7 +253,9 @@ def _locked(journal: Path, mode: int) -> Iterator[object | None]:
     lock = _lock_path(journal)
     # ``open(..., "a")`` creates the file if absent without truncating
     # it — keeps a stable inode across all callers.
-    fh = open(lock, "a", encoding="utf-8")
+    fh = open(
+        lock, "a", encoding="utf-8"
+    )  # atomic-write: ok — fcntl lock file, stable inode required
     try:
         fcntl.flock(fh.fileno(), mode)
         try:
@@ -679,9 +681,13 @@ def _sweep_unlocked_body(journal: Path) -> None:
     retained = _reconcile_entries(entries)
     if retained:
         lines = [_serialize_entry(e) for e in retained]
-        journal.write_text("\n".join(lines) + "\n")
+        journal.write_text(
+            "\n".join(lines) + "\n"
+        )  # atomic-write: ok — journal compaction inside _locked() (caller holds LOCK_EX)
     else:
-        journal.write_text("")
+        journal.write_text(
+            ""
+        )  # atomic-write: ok — journal truncation inside _locked() (caller holds LOCK_EX)
 
 
 _PlannedVerb = Literal[
@@ -1454,7 +1460,10 @@ def _append_journal(journal: Path, payload: Mapping[str, object]) -> None:
     # compaction without depending on the journal inode.
     if _HAS_FCNTL:
         line = json.dumps(payload) + "\n"
-        with _locked(journal, fcntl.LOCK_EX), open(journal, "a", encoding="utf-8") as fh:
+        with (
+            _locked(journal, fcntl.LOCK_EX),
+            open(journal, "a", encoding="utf-8") as fh,
+        ):  # atomic-write: ok — append_durable pattern (LOCK_EX + fsync below)
             fh.write(line)
             fh.flush()
             os.fsync(fh.fileno())

--- a/src/updater/state.py
+++ b/src/updater/state.py
@@ -80,7 +80,9 @@ class UpdateStateStore:
         )
         temp_path = self._state_path.with_suffix(".tmp")
         try:
-            with open(temp_path, "w", encoding="utf-8") as f:
+            with open(
+                temp_path, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — manual temp+replace pattern (lines 81-88)
                 f.write(payload)
                 f.flush()
                 os.fsync(f.fileno())

--- a/src/utils/epub_enhanced.py
+++ b/src/utils/epub_enhanced.py
@@ -617,7 +617,9 @@ class EnhancedEPUBReader:
             output_path = output_dir / f"{epub_path.stem}_cover.{ext}"
 
             # Save cover
-            with open(output_path, "wb") as f:
+            with open(
+                output_path, "wb"
+            ) as f:  # atomic-write: ok — user output (one-shot extraction)
                 f.write(cover_data)
 
             logger.info(f"Extracted cover to: {output_path}")

--- a/tests/ci/test_atomic_write_required.py
+++ b/tests/ci/test_atomic_write_required.py
@@ -1,0 +1,251 @@
+"""Tests for the atomic-write rail (``scripts/check_atomic_write.py``).
+
+The rail blocks regressions of the persistent-state-write hardening landed in
+PRs #176, #195, #197, #203, #204. Any new ``Path.write_text``,
+``Path.write_bytes``, or ``open(p, "w"|"wb"|"a"|"ab")`` call in ``src/`` must
+either use the ``utils.atomic_write`` helpers or carry an explicit
+``# atomic-write: ok — <reason>`` opt-out comment.
+
+T10 predicate negative-case backfill: every exemption category has a positive
+test (the rail flags the surface shape) AND a negative test (the rail does
+NOT flag when the marker / file allowlist applies).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.ci
+
+_FO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _FO_ROOT / "scripts" / "check_atomic_write.py"
+
+# Import the detector directly so we can unit-test helpers without spawning
+# a subprocess for every case.
+sys.path.insert(0, str(_FO_ROOT / "scripts"))
+from check_atomic_write import (  # noqa: E402
+    _ALLOWLISTED_FILES,
+    _has_opt_out,
+    _is_comment_line,
+    _is_in_docstring_or_string,
+    _matches_forbidden,
+    find_violations,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests: forbidden-pattern detection
+# ---------------------------------------------------------------------------
+
+
+class TestPatternDetection:
+    """The pattern set must match the four forbidden write forms."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            'path.write_text("data")',
+            'p.write_bytes(b"\\x00\\x01")',
+            'with open(p, "w") as f:',
+            'with open(p, "wb") as f:',
+            'with open(p, "a") as f:',
+            'with open(p, "ab") as f:',
+            "fh = open(lock, 'a', encoding='utf-8')",
+            'open(target, "w", encoding="utf-8")',
+        ],
+    )
+    def test_matches_forbidden(self, line: str) -> None:
+        assert _matches_forbidden(line)
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # Read modes are not flagged (T10 negative cases)
+            'with open(p, "r") as f:',
+            'with open(p, "rb") as f:',
+            "data = path.read_text()",
+            "data = path.read_bytes()",
+            # Method-name false friends — must not match
+            "rewrite_text(payload)",
+            "writer.writeheader()",
+            # Fragment in identifier — not a write call
+            "open_writer = make_writer()",
+        ],
+    )
+    def test_does_not_match_non_write(self, line: str) -> None:
+        assert not _matches_forbidden(line)
+
+
+class TestOptOutMarker:
+    """The opt-out marker must be detected only in its canonical form."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            'path.write_text("x")  # atomic-write: ok',
+            'path.write_text("x")  # atomic-write: ok — user output',
+            'path.write_text("x")  # atomic-write:  ok',  # extra space
+            'path.write_text("x")  # atomic-write: ok (legacy single-shot)',
+        ],
+    )
+    def test_recognizes_opt_out(self, line: str) -> None:
+        assert _has_opt_out(line)
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # Marker variations that must NOT count (typos / wrong prefix)
+            'path.write_text("x")  # atomic-write fine',
+            'path.write_text("x")  # atomic_write: ok',  # underscore not hyphen
+            'path.write_text("x")  # ok — atomic write',
+            'path.write_text("x")',  # no marker at all
+        ],
+    )
+    def test_rejects_non_canonical(self, line: str) -> None:
+        assert not _has_opt_out(line)
+
+
+class TestCommentAndDocstringHeuristics:
+    """Comments and docstrings must not trip the rail."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "# path.write_text('foo')",
+            "    # historically used path.write_text",
+        ],
+    )
+    def test_comment_lines_are_skipped(self, line: str) -> None:
+        assert _is_comment_line(line)
+
+    def test_non_comment_with_inline_comment_is_not_a_comment_line(self) -> None:
+        # The whole line isn't a comment, just trailing portion.
+        assert not _is_comment_line("path.write_text('x')  # note")
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            '"""Example: path.write_text("data")"""',
+            "'''Example: open(p, \"w\")'''",
+            '"""docstring start',
+            "'''docstring start",
+        ],
+    )
+    def test_docstring_or_string_lines_are_skipped(self, line: str) -> None:
+        assert _is_in_docstring_or_string(line)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: file-level allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlist:
+    """Files that own the atomic-write primitives are exempt."""
+
+    def test_atomic_write_module_is_allowlisted(self) -> None:
+        assert "src/utils/atomic_write.py" in _ALLOWLISTED_FILES
+
+    def test_atomic_io_module_is_allowlisted(self) -> None:
+        assert "src/utils/atomic_io.py" in _ALLOWLISTED_FILES
+
+    def test_arbitrary_src_file_is_not_allowlisted(self) -> None:
+        assert "src/services/intelligence/preference_store.py" not in _ALLOWLISTED_FILES
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: find_violations on synthetic files
+# ---------------------------------------------------------------------------
+
+
+class TestFindViolationsSynthetic:
+    """End-to-end checks against tmp_path source files."""
+
+    def _write(self, tmp_path: Path, content: str) -> Path:
+        # Mirror the path layout the detector expects so any future
+        # path-relative checks still resolve correctly.
+        src = tmp_path / "src" / "x"
+        src.mkdir(parents=True)
+        target = src / "mod.py"
+        target.write_text(content)
+        return target
+
+    def test_unmarked_write_text_is_flagged(self, tmp_path: Path) -> None:
+        target = self._write(tmp_path, 'p.write_text("payload")\n')
+        violations = find_violations(target)
+        assert len(violations) == 1
+        assert "write_text" in violations[0][1]
+
+    def test_marked_write_text_is_not_flagged(self, tmp_path: Path) -> None:
+        target = self._write(
+            tmp_path,
+            'p.write_text("payload")  # atomic-write: ok — manual temp+replace\n',
+        )
+        assert find_violations(target) == []
+
+    def test_unmarked_open_w_is_flagged(self, tmp_path: Path) -> None:
+        target = self._write(tmp_path, 'with open(p, "w") as f:\n    f.write("x")\n')
+        violations = find_violations(target)
+        assert len(violations) == 1
+
+    def test_marked_open_w_is_not_flagged(self, tmp_path: Path) -> None:
+        target = self._write(
+            tmp_path,
+            'with open(p, "w") as f:  # atomic-write: ok — user output\n    f.write("x")\n',
+        )
+        assert find_violations(target) == []
+
+    def test_open_read_mode_is_not_flagged(self, tmp_path: Path) -> None:
+        # T10 negative case: the same surface (open with mode str) must
+        # not flag for read modes.
+        target = self._write(tmp_path, 'with open(p, "r") as f:\n    data = f.read()\n')
+        assert find_violations(target) == []
+
+    def test_marker_on_following_line_is_not_flagged(self, tmp_path: Path) -> None:
+        # ruff format frequently splits long calls across lines, leaving the
+        # # atomic-write: ok comment on the closing-paren line. The detector
+        # must scan a lookahead window forward.
+        target = self._write(
+            tmp_path,
+            'p.write_text(\n    "payload"\n)  # atomic-write: ok — manual temp+replace\n',
+        )
+        assert find_violations(target) == []
+
+    def test_marker_too_far_after_call_is_still_flagged(self, tmp_path: Path) -> None:
+        # The lookahead is bounded; a marker many lines later does not
+        # silently exempt the call (T10 negative case for the lookahead).
+        body = 'p.write_text("payload")\n' + ("x = 1\n" * 10) + "# atomic-write: ok\n"
+        target = self._write(tmp_path, body)
+        violations = find_violations(target)
+        assert len(violations) == 1
+
+    def test_docstring_example_is_not_flagged(self, tmp_path: Path) -> None:
+        # Triple-quoted block containing a forbidden pattern must not trip.
+        target = self._write(
+            tmp_path,
+            '"""Module docstring.\n\nExample::\n\n    p.write_text("foo")\n"""\n',
+        )
+        assert find_violations(target) == []
+
+
+# ---------------------------------------------------------------------------
+# Full-suite assertion: no unmarked violations on the current branch
+# ---------------------------------------------------------------------------
+
+
+class TestFullSuite:
+    """The rail must pass against the live ``src/`` tree."""
+
+    def test_no_unmarked_violations_on_current_tree(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"atomic-write rail flagged unmarked violation(s):\n{result.stderr}"
+        )

--- a/tests/ci/test_atomic_write_required.py
+++ b/tests/ci/test_atomic_write_required.py
@@ -107,6 +107,11 @@ class TestOptOutMarker:
     def test_rejects_non_canonical(self, line: str) -> None:
         assert not _has_opt_out(line)
 
+    def test_marker_inside_string_literal_is_rejected(self) -> None:
+        # A marker that appears only inside a string literal must not count as
+        # an opt-out; only a bare trailing comment satisfies the rule.
+        assert not _has_opt_out('path.write_text("# atomic-write: ok — user output")')
+
 
 class TestCommentAndDocstringHeuristics:
     """Comments and docstrings must not trip the rail."""
@@ -229,6 +234,39 @@ class TestFindViolationsSynthetic:
             '"""Module docstring.\n\nExample::\n\n    p.write_text("foo")\n"""\n',
         )
         assert find_violations(target) == []
+
+    def test_multiline_open_without_marker_is_flagged(self, tmp_path: Path) -> None:
+        # open( on one line, mode string on the next — no marker anywhere.
+        target = self._write(
+            tmp_path,
+            'with open(\n    p,\n    "w",\n) as f:\n    f.write("x")\n',
+        )
+        violations = find_violations(target)
+        assert len(violations) == 1
+
+    def test_multiline_open_marker_on_closing_paren_is_not_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        # Cover the common ruff-formatted multiline open() shape where the
+        # call starts on one line, the mode string is on a later line, and the
+        # opt-out marker sits on the closing-paren line.
+        target = self._write(
+            tmp_path,
+            'with open(\n    p,\n    "w",\n) as f:  # atomic-write: ok — user output\n    f.write("x")\n',
+        )
+        assert find_violations(target) == []
+
+    def test_multiline_open_in_string_literal_not_flagged_via_opt_out(
+        self, tmp_path: Path
+    ) -> None:
+        # Marker embedded inside a string literal on the open( line must not
+        # exempt the call; the opt-out must appear in an actual comment.
+        target = self._write(
+            tmp_path,
+            'with open(\n    p,\n    "w",\n) as f:\n    f.write("# atomic-write: ok")\n',
+        )
+        violations = find_violations(target)
+        assert len(violations) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1174,7 +1174,6 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "striprtf" },
     { name = "tinytag" },
-    { name = "tqdm" },
     { name = "typer" },
     { name = "watchdog" },
 ]
@@ -1307,7 +1306,7 @@ requires-dist = [
     { name = "codespell", marker = "extra == 'dev'", specifier = "~=2.2" },
     { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.16.0" },
     { name = "diff-cover", marker = "extra == 'dev'", specifier = "~=7.0" },
-    { name = "ebooklib", specifier = ">=0.18" },
+    { name = "ebooklib", specifier = ">=0.18,<1" },
     { name = "ezdxf", marker = "extra == 'cad'", specifier = "~=1.1" },
     { name = "faker", marker = "extra == 'dev'", specifier = "~=40.12" },
     { name = "faster-whisper", marker = "extra == 'media'", specifier = "~=1.0" },
@@ -1315,20 +1314,20 @@ requires-dist = [
     { name = "fo-core", extras = ["dev", "cloud", "llama", "mlx", "claude", "media", "dedup-text", "dedup-image", "scientific", "cad", "build", "search"], marker = "extra == 'all'" },
     { name = "h5py", marker = "extra == 'scientific'", specifier = "~=3.10" },
     { name = "httpx", specifier = "~=0.27" },
-    { name = "imagededup", marker = "extra == 'dedup-image'", specifier = ">=0.3.0" },
+    { name = "imagededup", marker = "extra == 'dedup-image'", specifier = ">=0.3.0,<1" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "~=1.5" },
     { name = "isort", marker = "extra == 'dev'", specifier = "~=8.0" },
     { name = "llama-cpp-python", marker = "extra == 'llama'", specifier = ">=0.2.0" },
-    { name = "loguru", specifier = ">=0.7.0" },
+    { name = "loguru", specifier = ">=0.7.0,<1" },
     { name = "lxml", specifier = "~=6.1" },
     { name = "mako", specifier = ">=1.3.11" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = "~=1.5" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = "~=9.5" },
     { name = "mkdocs-minify-plugin", marker = "extra == 'docs'", specifier = ">=0.8.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.24.0" },
-    { name = "mlx-lm", marker = "sys_platform == 'darwin' and extra == 'mlx'", specifier = ">=0.0.19" },
+    { name = "mlx-lm", marker = "sys_platform == 'darwin' and extra == 'mlx'", specifier = ">=0.0.19,<1" },
     { name = "mutagen", specifier = "~=1.47" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = "~=1.8" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "~=1.8,!=1.20.2" },
     { name = "netcdf4", marker = "extra == 'scientific'", specifier = "~=1.6" },
     { name = "numpy", marker = "extra == 'dedup-text'", specifier = ">=1.24,<3" },
     { name = "numpy", marker = "extra == 'search'", specifier = ">=1.24,<3" },
@@ -1339,11 +1338,11 @@ requires-dist = [
     { name = "pillow", specifier = "~=12.2" },
     { name = "platformdirs", specifier = "~=4.9" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "~=3.6" },
-    { name = "psutil", specifier = "~=5.9" },
-    { name = "py7zr", specifier = ">=0.20.0" },
+    { name = "psutil", specifier = ">=6.1,<7" },
+    { name = "py7zr", specifier = ">=0.20.0,<1" },
     { name = "pydantic", specifier = "~=2.5" },
     { name = "pydantic-settings", specifier = "~=2.1" },
-    { name = "pydub", marker = "extra == 'media'", specifier = ">=0.25.0" },
+    { name = "pydub", marker = "extra == 'media'", specifier = ">=0.25.0,<1" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyinstaller", marker = "extra == 'build'", specifier = "~=6.0" },
     { name = "pymarkdownlnt", marker = "extra == 'dev'", specifier = ">=0.9.25" },
@@ -1360,23 +1359,22 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "~=3.5" },
     { name = "python-docx", specifier = "~=1.0" },
     { name = "python-dotenv", specifier = "~=1.0" },
-    { name = "python-pptx", specifier = ">=0.6.0" },
+    { name = "python-pptx", specifier = ">=0.6.0,<1" },
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "rank-bm25", marker = "extra == 'search'", specifier = ">=0.2.0" },
     { name = "rarfile", specifier = "~=4.1" },
     { name = "rich", specifier = "~=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
-    { name = "scenedetect", extras = ["opencv"], marker = "extra == 'media'", specifier = ">=0.6.0" },
+    { name = "scenedetect", extras = ["opencv"], marker = "extra == 'media'", specifier = ">=0.6.0,<1" },
     { name = "scikit-learn", marker = "extra == 'dedup-text'", specifier = ">=1.4,<1.9" },
     { name = "scikit-learn", marker = "extra == 'search'", specifier = ">=1.4,<1.9" },
     { name = "scipy", marker = "extra == 'scientific'", specifier = "~=1.11" },
     { name = "snowballstemmer", specifier = ">=2.2.0" },
     { name = "sqlalchemy", specifier = "~=2.0" },
-    { name = "striprtf", specifier = ">=0.0.26" },
+    { name = "striprtf", specifier = ">=0.0.26,<1" },
     { name = "tinytag", specifier = "~=2.2" },
     { name = "torch", marker = "extra == 'dedup-image'", specifier = "~=2.1" },
     { name = "torch", marker = "extra == 'media'", specifier = "~=2.1" },
-    { name = "tqdm", specifier = "~=4.66" },
     { name = "typer", extras = ["all"], specifier = "~=0.12" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = "~=6.0" },
     { name = "watchdog", specifier = "~=3.0" },
@@ -3175,16 +3173,17 @@ wheels = [
 
 [[package]]
 name = "psutil"
-version = "5.9.8"
+version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/c7/6dc0a455d111f68ee43f27793971cf03fe29b6ef972042549db29eec39a2/psutil-5.9.8.tar.gz", hash = "sha256:6be126e3225486dff286a8fb9a06246a5253f4c7c53b475ea5f5ac934e64194c", size = 503247, upload-time = "2024-01-19T20:47:09.517Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/5a/07871137bb752428aa4b659f910b399ba6f291156bdea939be3e96cae7cb/psutil-6.1.1.tar.gz", hash = "sha256:cf8496728c18f2d0b45198f06895be52f36611711746b7f30c464b422b50e2f5", size = 508502, upload-time = "2024-12-19T18:21:20.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/e3/07ae864a636d70a8a6f58da27cb1179192f1140d5d1da10886ade9405797/psutil-5.9.8-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:aee678c8720623dc456fa20659af736241f575d79429a0e5e9cf88ae0605cc81", size = 248702, upload-time = "2024-01-19T20:47:36.303Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/bd/28c5f553667116b2598b9cc55908ec435cb7f77a34f2bff3e3ca765b0f78/psutil-5.9.8-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8cb6403ce6d8e047495a701dc7c5bd788add903f8986d523e3e20b98b733e421", size = 285242, upload-time = "2024-01-19T20:47:39.65Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/4f/0e22aaa246f96d6ac87fe5ebb9c5a693fbe8877f537a1022527c47ca43c5/psutil-5.9.8-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d06016f7f8625a1825ba3732081d77c94589dca78b7a3fc072194851e88461a4", size = 288191, upload-time = "2024-01-19T20:47:43.078Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f5/2aa3a4acdc1e5940b59d421742356f133185667dd190b166dbcfcf5d7b43/psutil-5.9.8-cp37-abi3-win32.whl", hash = "sha256:bc56c2a1b0d15aa3eaa5a60c9f3f8e3e565303b465dbf57a1b730e7a2b9844e0", size = 251252, upload-time = "2024-01-19T20:47:52.88Z" },
-    { url = "https://files.pythonhosted.org/packages/93/52/3e39d26feae7df0aa0fd510b14012c3678b36ed068f7d78b8d8784d61f0e/psutil-5.9.8-cp37-abi3-win_amd64.whl", hash = "sha256:8db4c1b57507eef143a15a6884ca10f7c73876cdf5d51e713151c1236a0e68cf", size = 255090, upload-time = "2024-01-19T20:47:56.019Z" },
-    { url = "https://files.pythonhosted.org/packages/05/33/2d74d588408caedd065c2497bdb5ef83ce6082db01289a1e1147f6639802/psutil-5.9.8-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:d16bbddf0693323b8c6123dd804100241da461e41d6e332fb0ba6058f630f8c8", size = 249898, upload-time = "2024-01-19T20:47:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/61/99/ca79d302be46f7bdd8321089762dd4476ee725fce16fc2b2e1dbba8cac17/psutil-6.1.1-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc0ed7fe2231a444fc219b9c42d0376e0a9a1a72f16c5cfa0f68d19f1a0663e8", size = 247511, upload-time = "2024-12-19T18:21:45.163Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/6b/73dbde0dd38f3782905d4587049b9be64d76671042fdcaf60e2430c6796d/psutil-6.1.1-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:0bdd4eab935276290ad3cb718e9809412895ca6b5b334f5a9111ee6d9aff9377", size = 248985, upload-time = "2024-12-19T18:21:49.254Z" },
+    { url = "https://files.pythonhosted.org/packages/17/38/c319d31a1d3f88c5b79c68b3116c129e5133f1822157dd6da34043e32ed6/psutil-6.1.1-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b6e06c20c05fe95a3d7302d74e7097756d4ba1247975ad6905441ae1b5b66003", size = 284488, upload-time = "2024-12-19T18:21:51.638Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/39/0f88a830a1c8a3aba27fededc642da37613c57cbff143412e3536f89784f/psutil-6.1.1-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97f7cb9921fbec4904f522d972f0c0e1f4fabbdd4e0287813b21215074a0f160", size = 287477, upload-time = "2024-12-19T18:21:55.306Z" },
+    { url = "https://files.pythonhosted.org/packages/47/da/99f4345d4ddf2845cb5b5bd0d93d554e84542d116934fde07a0c50bd4e9f/psutil-6.1.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33431e84fee02bc84ea36d9e2c4a6d395d479c9dd9bba2376c1f6ee8f3a4e0b3", size = 289017, upload-time = "2024-12-19T18:21:57.875Z" },
+    { url = "https://files.pythonhosted.org/packages/38/53/bd755c2896f4461fd4f36fa6a6dcb66a88a9e4b9fd4e5b66a77cf9d4a584/psutil-6.1.1-cp37-abi3-win32.whl", hash = "sha256:eaa912e0b11848c4d9279a93d7e2783df352b082f40111e078388701fd479e53", size = 250602, upload-time = "2024-12-19T18:22:08.808Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d7/7831438e6c3ebbfa6e01a927127a6cb42ad3ab844247f3c5b96bea25d73d/psutil-6.1.1-cp37-abi3-win_amd64.whl", hash = "sha256:f35cfccb065fff93529d2afb4a2e89e363fe63ca1e4a5da22b603a85833c2649", size = 254444, upload-time = "2024-12-19T18:22:11.335Z" },
 ]
 
 [[package]]
@@ -3219,10 +3218,9 @@ wheels = [
 
 [[package]]
 name = "py7zr"
-version = "1.1.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-zstd", marker = "python_full_version < '3.14'" },
     { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
     { name = "brotlicffi", marker = "platform_python_implementation == 'PyPy'" },
     { name = "inflate64" },
@@ -3231,11 +3229,12 @@ dependencies = [
     { name = "pybcj" },
     { name = "pycryptodomex" },
     { name = "pyppmd" },
+    { name = "pyzstd" },
     { name = "texttable" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/e6/01fb15361ca75ee5d01df6361825a49816a836c99980c5481da0e40c6877/py7zr-1.1.0.tar.gz", hash = "sha256:087b1a94861ad9eb4d21604f6aaa0a8986a7e00580abd79fedd6f82fecf0592c", size = 70855, upload-time = "2025-12-21T03:27:44.653Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/c3/0e05c711c16af0b9c47f3f77323303b338b9a871ba020d95d2b8dd6605ae/py7zr-0.22.0.tar.gz", hash = "sha256:c6c7aea5913535184003b73938490f9a4d8418598e533f9ca991d3b8e45a139e", size = 4992926, upload-time = "2024-08-08T13:10:01.514Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/9c/762284710ead9076eeecd55fb60509c19cd1f4bea811df5f3603725b44cb/py7zr-1.1.0-py3-none-any.whl", hash = "sha256:5921bc30fb72b5453aafe3b2183664c08ef508cde2655988d5e9bd6078353ef7", size = 71257, upload-time = "2025-12-21T03:27:42.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/59/dd1750002c0f46099281116f8165247bc62dc85edad41cdd26e7b26de19d/py7zr-0.22.0-py3-none-any.whl", hash = "sha256:993b951b313500697d71113da2681386589b7b74f12e48ba13cc12beca79d078", size = 67906, upload-time = "2024-08-08T13:09:58.092Z" },
 ]
 
 [[package]]
@@ -3687,60 +3686,32 @@ wheels = [
 
 [[package]]
 name = "pyppmd"
-version = "1.3.1"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/d7/803232913cab9163a1a97ecf2236cd7135903c46ac8d49613448d88e8759/pyppmd-1.3.1.tar.gz", hash = "sha256:ced527f08ade4408c1bfc5264e9f97ffac8d221c9d13eca4f35ec1ec0c7b6b2e", size = 1351815, upload-time = "2025-11-27T22:08:44.175Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/8e/06581a619ad31cd28fd897bd55aff2ea945d3d566969b8b3f682599e6dee/pyppmd-1.1.1.tar.gz", hash = "sha256:f1a812f1e7628f4c26d05de340b91b72165d7b62778c27d322b82ce2e8ff00cb", size = 1349281, upload-time = "2024-12-23T04:12:09.391Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/40/580b99818c9db3a09cbae8e3740f9b5127ef7fd7314daf009c487ab02eb6/pyppmd-1.3.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:fdf55aa6ee7aef492f6896464e7a5a528f8615bb9e435f55bc8dff226fcc8292", size = 77550, upload-time = "2025-11-27T22:07:37.839Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/a3/f7b4c49ef920f5b2c9812f8f54f48e01435433cb6b46ec82b1b4e740714d/pyppmd-1.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:aa820aac385ac4ee57160b26d92862c69d31c08f92272dbef05fe8e619cea8d1", size = 48000, upload-time = "2025-11-27T22:07:38.983Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/c3/30de6f7892e77b83350e55d54a6913420591cc2c5c4d2394c219a4c461ac/pyppmd-1.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e16593ba4ca0a85821ae698ef06847a52937662f5ce1b130c39cca2979a4e8cd", size = 48439, upload-time = "2025-11-27T22:07:40.428Z" },
-    { url = "https://files.pythonhosted.org/packages/39/22/33889cbe22a617c42df2199be54e9e1bf88393fd8643fe911eb9f982849c/pyppmd-1.3.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:486dde2294ff9b30465ab5bb0f213b20bd5ac0e4adf21be801a1ceb29aa75d9d", size = 141737, upload-time = "2025-11-27T22:07:41.641Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/f7/940ab2fd78caaef3a9e9833adb36e17b9d03016d8b45ae110cbb4bfc83d1/pyppmd-1.3.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89730cf026416ae2546c92738966ecf117c8176d52c229ad621a61c34643818b", size = 143643, upload-time = "2025-11-27T22:07:42.892Z" },
-    { url = "https://files.pythonhosted.org/packages/75/51/129ce02d2b28a4f6788bccfe6d0ae1defc45db10eb1c4e4389cde8994ec7/pyppmd-1.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e77f5a6770950d464b50da760d53e67bce308a3abc8e3bd51db620b3f8cf1fa8", size = 138625, upload-time = "2025-11-27T22:07:44.54Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/89/f8390d1a21951d3d4619c854a839f7b1431746997cd98b475f614a658305/pyppmd-1.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8e3bf8deef44f8e03612689a6067a4a3dd7e50d2ef00af4cf987c59b62ff3006", size = 141663, upload-time = "2025-11-27T22:07:45.814Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/3f/b58dd8875ebbb78436f87567547967bebdf3a5586f5f243c735fc4460843/pyppmd-1.3.1-cp311-cp311-win32.whl", hash = "sha256:a3509b3f881409ebc5522942438108c48a78f8df88bcf3f9d907b74131b9431c", size = 42014, upload-time = "2025-11-27T22:07:47.058Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/d3/5fe05bdccdd7af04461c25a3dc34799f48ad3e9a2bd591aaec9afbc1d10a/pyppmd-1.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:23b83799f33f9a24577f22e092b0feecda8cd1ea33871ad8610a58629874f7bc", size = 46862, upload-time = "2025-11-27T22:07:48.162Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/ba/6414cbe8407c23bacce906dad0599f155b2baf6082da104e64d7f1573717/pyppmd-1.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:234489036a1758670655d1ceafd4caeb93b858bd4c0ca39686837d38aef044c0", size = 45249, upload-time = "2025-11-27T22:07:49.261Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/89/696046e53c7aea98bb563aed3f15c3e2fa20c33e3d6c9de3c20992c586cc/pyppmd-1.3.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3faa58ab2ebe3b13ec23b1904639d687fb727270d2962fd2d239ca00fd6eb865", size = 77796, upload-time = "2025-11-27T22:07:50.362Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/c5/a708cdb58e76889bc65201eda12211486548ffe00ecddc5dfbdce6d4d252/pyppmd-1.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:27703f041ee96912a5410fd3ce31c5cde32f9323bd67f72f100bd960ee67bf13", size = 48185, upload-time = "2025-11-27T22:07:51.736Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/5d/f299535c18009addb866d89a7044f1086e4eecf50542e57ff5bb15840195/pyppmd-1.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e773d8353b36f7e7973a43526993fb276b98a97839cb5dc8f4e6465ad873f41a", size = 48496, upload-time = "2025-11-27T22:07:52.866Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/9d/4a59b73ea8e305f9192ee26ceb7c3d57e17ccb9bcca0e99ef335db29fcf7/pyppmd-1.3.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37b1883accf840cb0b711785d353f8548853a1401d381da007c0aec362f3ffac", size = 142620, upload-time = "2025-11-27T22:07:54.411Z" },
-    { url = "https://files.pythonhosted.org/packages/88/d7/fe32c2a4f8539365e6292aed25545830a5e718a510cdb4caddd6fd8d8056/pyppmd-1.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1bd6d179ad39b6191ca0cbe62fb9592f33f49277b4384ad7bc5eb0e6ca27ebee", size = 144306, upload-time = "2025-11-27T22:07:55.727Z" },
-    { url = "https://files.pythonhosted.org/packages/20/20/e3907cf263b58f4ed4c5315bc1ac91721c85332fd0d73a89e3e2752904ef/pyppmd-1.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:806cf8d33606e44bf5ff5786c57891f57993f1eef1c763da3c58ea97de3a13c8", size = 139522, upload-time = "2025-11-27T22:07:57.034Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/03/22d5f93251e481f23bf741dde7f59cfc3e315f60b32b63f215a2d7bb8944/pyppmd-1.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1826cbce9a2c944aa08df79310a7e6d4a61fd20636b6dff64a77ea4bc43da30f", size = 142340, upload-time = "2025-11-27T22:07:58.49Z" },
-    { url = "https://files.pythonhosted.org/packages/34/88/38d36c1394d5e331db9708dae08863c87c059bd5b6e43b20234be02a0503/pyppmd-1.3.1-cp312-cp312-win32.whl", hash = "sha256:d3ff96671319318d941dd34300d641745048e8a3251b077bddf98652d6ddc513", size = 42102, upload-time = "2025-11-27T22:08:00.124Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/29/1398c6f67dfb66367babeed2980caee837d0a488705e3dff7ff159e017e7/pyppmd-1.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:c8c1ad39e7ebde71bf5a54cf61f489bf4790f1dd0beb70dc2e8f5ad3329d7ca7", size = 46957, upload-time = "2025-11-27T22:08:01.587Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/41/ee3193c16472a5a1c5f1965abb8fa87a7ad455c39688e9a0c2d87d6a7027/pyppmd-1.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:391b2bf76d7dc45b343781754d0b734dcbf539b92667986a343f5488c4bf9ca0", size = 45214, upload-time = "2025-11-27T22:08:02.721Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/01/7cc3854b0e1304b90d2435e946db5e1c42e103adf840a68400002fc838b4/pyppmd-1.3.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4b4edb3e9619fd0bc39c1a07eb03e8731db833a93b23134f36c7ef581a94b37a", size = 77800, upload-time = "2025-11-27T22:08:03.856Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/02/caf6305224b9432ea7373670d101392f620c1ce741d6f95458b1fb9a16a4/pyppmd-1.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b8b5c813e462c91048b88e2adfbcc0c69f2c905f70097001d32066f86f675bd4", size = 48195, upload-time = "2025-11-27T22:08:05.323Z" },
-    { url = "https://files.pythonhosted.org/packages/45/82/8c5d3f0f738a3cf5c209d1471efda105a16417c0aaa91a2ad39efb3d4efb/pyppmd-1.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e8d372d9fac382183e0371cf0c2d736b494b1857a1befe98d563342b1205265b", size = 48482, upload-time = "2025-11-27T22:08:06.441Z" },
-    { url = "https://files.pythonhosted.org/packages/76/9c/09ab8b4f00473f210284dacf837cae8355ad900f3fd8fd98b2bba12de4fa/pyppmd-1.3.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b765ae21f7ed2f4ea8f32bfd9e3a4a8d738e73fc8f8dcddec9cbe2c898d60be", size = 142828, upload-time = "2025-11-27T22:08:07.611Z" },
-    { url = "https://files.pythonhosted.org/packages/64/fd/673d429df719affa1445611288aab6111c0bc87e51eb4677fe2421a1dd64/pyppmd-1.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd00522ddfcc292304577386b6c217758c0c10e1fb9ce7877ad7d3b7b821a808", size = 144502, upload-time = "2025-11-27T22:08:08.869Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/0f/64dad213f56eaf23210ac7d3a5dedb19ad8f186f8b8682f65e7d51d9fa4a/pyppmd-1.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3de62099ff2ca876c2d39bc547bcba6f7b878988663abd782a5bad4edac3bb44", size = 139718, upload-time = "2025-11-27T22:08:10.114Z" },
-    { url = "https://files.pythonhosted.org/packages/74/61/bd5dbe8d7374748687d48f0bc44e6b930470e09552b1bbc65ef899ab673e/pyppmd-1.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:011f845de195d60fe973a635a1f4be981b7d80f357a8acb1b2d83bdf5087c808", size = 142578, upload-time = "2025-11-27T22:08:11.388Z" },
-    { url = "https://files.pythonhosted.org/packages/42/ae/0af00a9b1cd59b6821eb182413033d5ddbe05dfcde7511e3a6b1a5b83f6d/pyppmd-1.3.1-cp313-cp313-win32.whl", hash = "sha256:7d61bd01f25289b6ae54832db4254602fb0c6d105f6e6bf0aee39b803b698b98", size = 42102, upload-time = "2025-11-27T22:08:13.297Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/6d/311d8faca142f39b4d158c94ed7eb237a197d41dd7eb67f53442a7904e04/pyppmd-1.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:df8d84ab72381058a964ba66e5e81ed52dbd0b5ad734a5ef8353452983506098", size = 46962, upload-time = "2025-11-27T22:08:14.759Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/42/24b59b6bb73a3fec96c7f81521d146c2ac89ffcb89cf9e848f62e0660381/pyppmd-1.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:124a04aab6936ba011f9ad57067798c7f052fdb1848b0cc4318606eea55475e6", size = 45209, upload-time = "2025-11-27T22:08:15.933Z" },
-    { url = "https://files.pythonhosted.org/packages/65/10/ac2a011af1c7c40b6482e60d85d267ac5923fb8794b51bfddbb56b04d1ec/pyppmd-1.3.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ea53f71ac16e113599b8441a9d8b6dcd71cfdf15cdb33ba5151810b8e656c5ec", size = 77897, upload-time = "2025-11-27T22:08:17.104Z" },
-    { url = "https://files.pythonhosted.org/packages/20/13/737f4dac06685865d23f51b7061dbe9373c7bcc60b5b6456cd08301bc807/pyppmd-1.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:985c8703b53e5f68fe17f653e96748d60b1f855676c852a6e67cd472eb853671", size = 48268, upload-time = "2025-11-27T22:08:18.263Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/d3/c50ebaee8b8a064fe9a534e98df5051e309efb705728aadff4e6893cd87f/pyppmd-1.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:33daa996ad5203c665c0b55aff6329817b2cb7fa95f2c33a2e83ed0121b400cb", size = 48521, upload-time = "2025-11-27T22:08:19.742Z" },
-    { url = "https://files.pythonhosted.org/packages/80/6c/4a97c0a0ab7640aeddde4843cb6381b80ecb71fe2c6c48b9032d60586b11/pyppmd-1.3.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b49870c6d7194f6eb80f30335ca03596d153e02fcde2c222e4f1202ac25f7fcf", size = 142892, upload-time = "2025-11-27T22:08:20.972Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/22/744c32c7da3de171d9e62a1b2cb4104544ac778358565a3dbc06a2253324/pyppmd-1.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:385e92c97c42e8a6f0bfc0e4acfc6c074cb1ba3a2f650f292696dd9f19e2e603", size = 144550, upload-time = "2025-11-27T22:08:22.594Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/18/84af6808e0754923062122d3ee9f0532050f1612069d558bb5d53978e67a/pyppmd-1.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:017a1e2903f1c3147a1046db486990d401e8a25eb52c320b1fc2fb3e7b83cbeb", size = 139850, upload-time = "2025-11-27T22:08:23.863Z" },
-    { url = "https://files.pythonhosted.org/packages/20/5e/dc6166ea7929d442625301289d99313a5b358e3cb2e927a6bd913047e8ee/pyppmd-1.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f2770a4b777c0c5236b3d9294b7bf4bc15538c95d45b2079eb8ebc1298e62e37", size = 142589, upload-time = "2025-11-27T22:08:25.228Z" },
-    { url = "https://files.pythonhosted.org/packages/77/92/adc6b12ddf11173a02fd631010f88ad4fe4c532363959638d5d53583a3d9/pyppmd-1.3.1-cp314-cp314-win32.whl", hash = "sha256:b9d54cd59ce97f2ba57be1da91b3d874d129faca21c9565d7afec111f942e6a1", size = 42761, upload-time = "2025-11-27T22:08:26.917Z" },
-    { url = "https://files.pythonhosted.org/packages/12/4c/5003a413d9f2743298a070df6713a75dedccc470e7adeeced5b43cad7418/pyppmd-1.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0e64247618cb150d2909beb0137da3084fef1d3479b4cc73b5b47fda7611abf9", size = 47806, upload-time = "2025-11-27T22:08:28.059Z" },
-    { url = "https://files.pythonhosted.org/packages/07/b7/db927e1df7fc3132cb57960f4ea23bf174c7e86ccec22857e6a35cccdae7/pyppmd-1.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:d354d6e551d2630b0ac98f27e3ad63e86cdcac9ce2115b5dfe46e2c9d3f4e82c", size = 46122, upload-time = "2025-11-27T22:08:29.191Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/5f/3150227624f374b06e331a7f67ae3383e796dd90973ee17ec3e35d30524c/pyppmd-1.3.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2d77ed79662c32e2551748d59763cfe3dcd10855bf3495937e3d5e5917507818", size = 78876, upload-time = "2025-11-27T22:08:30.635Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/81/11a3bba62d1d92050f4dd86db810062b506ec76d20b6e00b4ab567ff15e4/pyppmd-1.3.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:6a1f92b94635c23d85270bb26db25cc0db544e436af86efc1cf58302d71d5af1", size = 48830, upload-time = "2025-11-27T22:08:32.087Z" },
-    { url = "https://files.pythonhosted.org/packages/24/47/e8f50cf89c689543d5a16c7be3df3c4afd43cbeb1a019b84ff9e82f13415/pyppmd-1.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:610f214f2405e27eb5a3dad7fa15f385cfc42141a01cda71995d9c1e0b09fab9", size = 48956, upload-time = "2025-11-27T22:08:33.567Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/0f/944b30679a8dea3ea95a66531ee30cb6feb5d011ec7fd6832069d9130bf3/pyppmd-1.3.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae81a14895498d9a23429d92114c98da478b74b8e33251527d7cff3e01c09de0", size = 152872, upload-time = "2025-11-27T22:08:35.098Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/87/1e48ea92994f4c72dc9b5520a6a386b21c524d3d2969c2c2a5c325929ad7/pyppmd-1.3.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d1683e6d1ba09e377e0ae02de3a518191a3d63ccdb0b6037c74e6ddf577b5644", size = 154210, upload-time = "2025-11-27T22:08:36.368Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/21/650911f98c4cb360442724bbdade27cb3679b0587ea77e73512693d2918d/pyppmd-1.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e4d74fa0f3531e9dadc56e0ace41bce82d3c0babed47b3f224101dc0dbde7287", size = 147636, upload-time = "2025-11-27T22:08:37.657Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/29/4f8cfc1dd67b04ced8c10669fa14c4e35a42cf4a84e1101793735a82d5f0/pyppmd-1.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f8d6375b18b9c79127fee0885cfd52e2e983edb67041464309426571d38dcd4", size = 150998, upload-time = "2025-11-27T22:08:38.951Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/da/dc9e5e10bc56056bd8c33e533517cb327752cbaf172688bba3c23f6b2318/pyppmd-1.3.1-cp314-cp314t-win32.whl", hash = "sha256:de87f7acd575fb07a4ff42d41bcc071570fe759a36f345f1f54f574ecfccfc5b", size = 43016, upload-time = "2025-11-27T22:08:40.234Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/a0/46dc15549ad2c0427a9825730e6bdf342045ad410543368afd4389a16f36/pyppmd-1.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:76e4800aa67292b4cc80058fd29b39e02a5dded721af9fe5654f356ef24307f4", size = 48636, upload-time = "2025-11-27T22:08:41.45Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/7b/7e9a83848de928c26f0ab3ee105c0da63a932a0804a94807205e6313e73a/pyppmd-1.3.1-cp314-cp314t-win_arm64.whl", hash = "sha256:e066cbf1d335fe20480cd8ecc10848ba78d99fe6d1e44ea00def48feaf46afdf", size = 46402, upload-time = "2025-11-27T22:08:42.804Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/e5/e4c891ade6fffa0cf9ead432f80a481d069c26a009e78b9f402fe25bad40/pyppmd-1.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:753c5297c91c059443caef33bccbffb10764221739d218046981638aeb9bc5f2", size = 76148, upload-time = "2024-12-23T04:10:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/7d/24d4b61c144e03c1bfaa272636e2b44678d7849b0fbe7c308d53f0926784/pyppmd-1.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9b5a73da09de480a94793c9064876af14a01be117de872737935ac447b7cde3c", size = 47102, upload-time = "2024-12-23T04:10:41.726Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/19/91fc02ef18ae67c8f4cd54a8b8722d3ce58746622adb80506bfc4a80df58/pyppmd-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:89c6febb7114dea02a061143d78d04751a945dfcadff77560e9a3d3c7583c24b", size = 47308, upload-time = "2024-12-23T04:10:43.168Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d8/7d4e7106e744c55af7ac7f21388170a6d3c23cbe7d7b9e1a65524f264e37/pyppmd-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0001e467c35e35e6076a8c32ed9074aa45833615ee16115de9282d5c0985a1d8", size = 138445, upload-time = "2024-12-23T04:10:46.303Z" },
+    { url = "https://files.pythonhosted.org/packages/91/1b/71e47e6dc117f088ab8e7fa3b7ff1dc8e1a6c96d0ffdb0010288c2c42ac6/pyppmd-1.1.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c76820db25596afc859336ba06c01c9be0ff326480beec9c699fd378a546a77f", size = 136543, upload-time = "2024-12-23T04:10:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/46/93/363f6299aa6ab4209e4f91bfa313748c535e348b88b9232957d6175ddda1/pyppmd-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b67f0a228f8c58750a21ba667c170ae957283e08fd580857f13cb686334e5b3e", size = 141274, upload-time = "2024-12-23T04:10:49.597Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/9a/9d52964af47c351f543c546cf0c21876e384c66029a1b3cb75aa71b4651c/pyppmd-1.1.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b18f24c14f0b0f1757a42c458ae7b6fd7aa0bce8147ac1016a9c134068c1ccc2", size = 141887, upload-time = "2024-12-23T04:10:53.218Z" },
+    { url = "https://files.pythonhosted.org/packages/90/22/09bb81e7a0c1512a6efb30c9ddb1b07e1ca7ff050e427fcce5e7aeedadfd/pyppmd-1.1.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c9e43729161cc3b6ad5b04b16bae7665d3c0cc803de047d8a979aa9232a4f94a", size = 136166, upload-time = "2024-12-23T04:10:54.864Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/bf/24162ac82a502a75ac1042617fa0c69350406c79332a1a033cd96cb28cf6/pyppmd-1.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fe057d254528b4eeebe2800baefde47d6af679bae184d3793c13a06f794df442", size = 145209, upload-time = "2024-12-23T04:10:56.599Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a5/1cfafa9eea4723bd6b11d0e34519c1947ab26aeb8c78de67dfdbf7e91de7/pyppmd-1.1.1-cp311-cp311-win32.whl", hash = "sha256:faa51240493a5c53c9b544c99722f70303eea702742bf90f3c3064144342da4a", size = 41805, upload-time = "2024-12-23T04:10:59.524Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/30/fd2fb7e431414b520dc3d1ced7158da04232203c0f18ed8768ecd6a1d939/pyppmd-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:62486f544d6957e1381147e3961eee647b7f4421795be4fb4f1e29d52aee6cb5", size = 46472, upload-time = "2024-12-23T04:11:01.123Z" },
+    { url = "https://files.pythonhosted.org/packages/46/a8/a1fdc1b53466e9a01b0d8a8689ae4024fffa6de20330fb0d6025d745cf0f/pyppmd-1.1.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:9877ef273e2c0efdec740855e28004a708ada9012e0db6673df4bb6eba3b05e0", size = 76238, upload-time = "2024-12-23T04:11:03.362Z" },
+    { url = "https://files.pythonhosted.org/packages/63/54/15a7feae1a258bc67fc2413f82a7f296da7efb076d922d939fe7ef87b537/pyppmd-1.1.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f816a5cbccceced80e15335389eeeaf1b56a605fb7eebe135b1c85bd161e288c", size = 47192, upload-time = "2024-12-23T04:11:04.649Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4f/b5d9086c3479639f1347bc04d6ed1b543a7f87212f68c38f30180cb28e35/pyppmd-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6bddabf8f2c6b991d15d6785e603d9d414ae4a791f131b1a729bb8a5d31133d1", size = 47309, upload-time = "2024-12-23T04:11:07.426Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/2dc8d61008ed5da459fbef13917582b78902867451cb3467d59ca86c945f/pyppmd-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:855bc2b0d19c3fead5815d72dbe350b4f765334336cbf8bcb504d46edc9e9dd2", size = 139378, upload-time = "2024-12-23T04:11:10.525Z" },
+    { url = "https://files.pythonhosted.org/packages/85/cf/9899ec2a5a9b10f42afecdd0635186f38731c100643d9b092f5b6d7f137c/pyppmd-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a95b11b3717c083b912f0879678ba72f301bbdb9b69efed46dbc5df682aa3ce7", size = 137565, upload-time = "2024-12-23T04:11:13.767Z" },
+    { url = "https://files.pythonhosted.org/packages/33/33/c67c41e681e171f9bbbf184eae8899e913845e8e6186cbdad62a3ddf231d/pyppmd-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38b645347b6ea217b0c58e8edac27473802868f152db520344ac8c7490981849", size = 142829, upload-time = "2024-12-23T04:11:15.378Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/c3/18e6f565cb1a3941640fd522a3f02f48e546c2996c7f0048608f35994a51/pyppmd-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f8f94b6222262def5b532f2b9716554ef249ad8411fd4da303596cc8c2e8eda1", size = 143080, upload-time = "2024-12-23T04:11:17.066Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ec/40625be3275bae8470136c98d2e63556537ba5cedb6c0a9fa8f90a541a46/pyppmd-1.1.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:1c0306f69ceddf385ef689ebd0218325b7e523c48333d87157b37393466cfa1e", size = 137254, upload-time = "2024-12-23T04:11:20.568Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f4/92366a1e893f0b04a4bbf1cbc8263d4b58f2ac2f53cee65b11d92d0253bf/pyppmd-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a4ba510457a56535522a660098399e3fa8722e4de55808d089c9d13435d87069", size = 146613, upload-time = "2024-12-23T04:11:22.278Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c2/50ffb30b7787aec4c0cb5a99eaab78d90b0c98e0006d34a22198f954084e/pyppmd-1.1.1-cp312-cp312-win32.whl", hash = "sha256:032f040a89fd8348109e8638f94311bd4c3c693fb4cad213ad06a37c203690b1", size = 41857, upload-time = "2024-12-23T04:11:23.671Z" },
+    { url = "https://files.pythonhosted.org/packages/77/94/03ff304086c5b0823bee966a5ae4915b5341dba8ed5e4c9f1b9532d9a9ff/pyppmd-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:2be8cbd13dd59fad1a0ad38062809e28596f3673b77a799dfe82b287986265ed", size = 46564, upload-time = "2024-12-23T04:11:26.379Z" },
 ]
 
 [[package]]
@@ -3896,17 +3867,16 @@ wheels = [
 
 [[package]]
 name = "python-pptx"
-version = "1.0.2"
+version = "0.6.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lxml" },
     { name = "pillow" },
-    { name = "typing-extensions" },
     { name = "xlsxwriter" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e7/aeaf794b2d440da609684494075e64cfada248026ecb265807d0668cdd00/python-pptx-0.6.23.tar.gz", hash = "sha256:587497ff28e779ab18dbb074f6d4052893c85dedc95ed75df319364f331fedee", size = 10083771, upload-time = "2023-11-02T21:35:31.525Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788, upload-time = "2024-08-07T17:33:28.192Z" },
+    { url = "https://files.pythonhosted.org/packages/72/49/6eee83072983473e9905ffddd5c2032b9a0ca4616425560d6d582287b467/python_pptx-0.6.23-py3-none-any.whl", hash = "sha256:dd0527194627a2b7cc05f3ba23ecaa2d9a0d5ac9b6193a28ed1b7a716f4217d4", size = 471575, upload-time = "2023-11-02T21:35:21.747Z" },
 ]
 
 [[package]]
@@ -4076,6 +4046,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "pyzstd"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-zstd", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/66/59fed71d0d2065e02974b40296f836a237c364c8bbe07295f2d0dc33c278/pyzstd-0.19.1.tar.gz", hash = "sha256:36723d3c915b3981de9198d0a2c82b2f5fe3eaa36e4d8d586937830a8afc7d72", size = 69531, upload-time = "2025-12-13T08:15:33.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/62/f55d1363512d1b1cc122af6ca5951008e42605b63675c7d6781affc7c475/pyzstd-0.19.1-py3-none-any.whl", hash = "sha256:267e2eb0de0291dfcb7ccfebc4ffe75b2f9d84e7007ac38844f6ccafc6dce081", size = 23779, upload-time = "2025-12-13T08:15:31.979Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

PR-B in the **integration/pre-commit-ratchet** integration series. Blocks regressions of the persistent-state-write hardening landed in PRs #176 / #195 / #197 / #203 / #204.

## Rail mechanics

- **Detector**: \`scripts/check_atomic_write.py\` — regex pattern matcher over \`src/\` files with a 6-line lookahead window (handles ruff-split multi-line calls)
- **Pre-commit hook**: \`atomic-write-required\` — runs on \`^src/.*\\.py\$\`
- **Semantic guardrail**: \`tests/ci/test_atomic_write_required.py\` — 40 unit tests + full-suite assertion
- **Forbidden patterns**: \`Path.write_text\`, \`Path.write_bytes\`, \`open(p, \"w\"|\"wb\"|\"a\"|\"ab\")\`
- **File allowlist**: \`src/utils/atomic_write.py\`, \`src/utils/atomic_io.py\` (modules that *implement* the primitives)

## Opt-out marker taxonomy

| Reason | Count | When to use |
|--------|-------|-------------|
| \`manual temp+replace pattern\` | 9 | Site already uses \`tempfile\` + \`os.replace\` |
| \`user output\` | 11 | One-shot CLI export to user-supplied path, retry-on-fail safe |
| \`pid file\` | 1 | Single-writer via daemon lifecycle |
| \`fcntl lock file\` | 1 | Stable inode required for the locking protocol |
| \`append_durable pattern\` | 1 | \`LOCK_EX\` + explicit \`fsync\` below |
| \`journal compaction inside _locked()\` | 2 | Whole-journal rewrite under exclusive lock |
| \`one-shot migration backup\` | 1 | Retry-on-fail safe |
| Legacy user-output | 3 | Workflow files, vault notes, EPUB cover |

## Out of scope

- **Migration of \`manual temp+replace\` sites to the helper** — these already crash-safe; migrating to \`atomic_write_with()\` is a follow-up clean-up, tracked separately. Mass-converting 9 call sites in the rail PR would obscure the new-rule story.
- **AST-based detection** — the regex+lookahead approach is sufficient for the call shapes that exist in this codebase. Can promote to AST later if false positives surface.

## Verification

- \`bash .claude/scripts/pre-commit-validation.sh\` — green
- \`pytest tests/ci/test_atomic_write_required.py\` — 40 passed
- \`python3 scripts/check_atomic_write.py\` — exit 0
- ruff / mypy / pymarkdown / codespell / diff-cover all clean

## Test plan

- [x] Rail flags an unmarked \`Path.write_text\` call
- [x] Rail does NOT flag a marked call (same-line marker)
- [x] Rail does NOT flag a ruff-split call with marker on the closing-paren line
- [x] Rail DOES flag if the marker is too far past the call (lookahead bounded)
- [x] Rail does NOT flag read-mode \`open()\`, false-friend identifiers, comments, docstrings
- [x] Allowlisted files exempt
- [x] Full-suite assertion against live \`src/\` tree passes
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)