### PR TITLE
chore(docs): drop stale Python 3.9 references

### DIFF
--- a/.claude/rules/ci-generation-patterns.md
+++ b/.claude/rules/ci-generation-patterns.md
@@ -248,7 +248,7 @@ When documenting a single number, use the gate that matches the context:
 strategy:
   matrix:
     os: [ubuntu-latest, windows-latest, macos-latest]
-    python-version: ["3.9", "3.10", "3.11", "3.12"]
+    python-version: ["3.11", "3.12", "3.13"]
 ```
 
 **Good**:
@@ -258,7 +258,7 @@ strategy:
 strategy:
   matrix:
     os: ${{ github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["ubuntu-latest", "windows-latest", "macos-latest"]' }}
-    python-version: ${{ github.event_name == 'pull_request' && '["3.11"]' || '["3.9", "3.10", "3.11", "3.12"]' }}
+    python-version: ${{ github.event_name == 'pull_request' && '["3.11"]' || '["3.11", "3.12", "3.13"]' }}
 
 # GOOD — cache dependencies
 - uses: actions/cache@v3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,11 +74,11 @@ skip_below_py312 = pytest.mark.skipif(
 def ensure_default_event_loop(request: pytest.FixtureRequest) -> None:
     """Ensure sync tests can instantiate asyncio-bound widgets across Python versions.
 
-    Some Textual widgets allocate ``asyncio.Lock`` during ``__init__``. On Python 3.9,
-    after async tests run, the default loop policy can be left with no current loop
-    in the main thread, which raises ``RuntimeError`` for later sync widget tests.
-    This fixture gives each sync test an explicit default loop; async tests use
-    ``pytest-asyncio``/``anyio`` loop management and are skipped here.
+    Some Textual widgets allocate ``asyncio.Lock`` during ``__init__``. After async
+    tests run, the default loop policy can be left with no current loop in the main
+    thread, which raises ``RuntimeError`` for later sync widget tests. This fixture
+    gives each sync test an explicit default loop; async tests use
+    ``pytest-asyncio`` / ``anyio`` loop management and are skipped here.
     """
     if request.node.get_closest_marker("asyncio") or request.node.get_closest_marker("anyio"):
         yield


### PR DESCRIPTION
## Summary

Two doc-only references to Python 3.9 that no longer reflect the supported floor.

\`pyproject.toml:14\` declares \`requires-python = \">=3.11\"\` and the project classifiers cover 3.11 and 3.12 only. The two cleanups:

1. **\`.claude/rules/ci-generation-patterns.md\` C6** — the matrix-anti-pattern example used \`[\"3.9\", \"3.10\", \"3.11\", \"3.12\"]\` in both the bad and good code blocks. Reframed as \`[\"3.11\", \"3.12\", \"3.13\"]\` so the teaching example reflects today's supported set (and tomorrow's, since 3.13 is stable).

2. **\`tests/conftest.py\` \`ensure_default_event_loop\`** — the docstring rationale pointed at \"Python 3.9 default loop policy\" specifically. The fixture itself is still load-bearing (Textual sync widgets allocate \`asyncio.Lock\` during \`__init__\` and break without a current loop after async tests run), so the fixture body is unchanged — only the version-specific framing in the docstring is generalised.

## Not changed

- False-positive matches: \`tests/daemon/test_pid.py:252\` (\`{\"pid\": 3.9}\` — a malformed-PID test fixture) and \`src/daemon/pid.py:342\` (\`int(3.9) yields 3\` comment in float-conversion logic). Both are float literals, not version refs.

## Test plan

- [x] \`bash .claude/scripts/pre-commit-validation.sh\` — green
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated fixture documentation to generalize async loop error descriptions and improve formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->