### PR TITLE
ratchet(rails): pytest.raises hygiene — no mock assertion after raise (T15)

### DIFF
--- a/.claude/rules/test-generation-patterns.md
+++ b/.claude/rules/test-generation-patterns.md
@@ -638,6 +638,53 @@ Automatable: a grep guardrail bans this pattern outright (see `tests/ci/test_tes
 
 ---
 
+## Pattern T15: MOCK_ASSERTION_AFTER_RAISE_IN_PYTEST_RAISES
+
+**What it is**: A mock assertion (`mock.X.assert_called*(...)` or
+`assert mock.X.called`) placed AFTER a top-level `raise` inside a
+`with pytest.raises(...):` block. The `raise` terminates control flow,
+so the mock assertion is unreachable — but reads as a real check.
+
+PR-A's PT012 catches multi-statement `pytest.raises` blocks generally,
+but is silenced inside the 11 sites that carry `# noqa: PT012` for
+legitimately multi-statement bodies (transaction rollback,
+context-manager exit semantics, `try/except` subclass-non-catching,
+etc.). T15 closes that hole with a targeted AST rail.
+
+**Bad**:
+
+```python
+with pytest.raises(ValueError):  # noqa: PT012 — context-manager exit semantics
+    with manager() as m:
+        do_setup()
+        raise ValueError("boom")
+        m.cleanup.assert_called_once()  # UNREACHABLE — never executes
+```
+
+**Good**:
+
+```python
+# Move the mock assertion AFTER the with-block exits.
+with pytest.raises(ValueError):  # noqa: PT012 — context-manager exit semantics
+    with manager() as m:
+        do_setup()
+        raise ValueError("boom")
+m.cleanup.assert_called_once()  # exit-on-exception verified here
+```
+
+**Pre-generation check**: After writing a `pytest.raises` block, ask:
+*"Is anything below the `raise` inside this block? If yes — those statements
+won't run. Move them outside the `with` (where they execute after the
+exception propagates) or delete them."*
+
+**Mechanical rail**: `scripts/check_pytest_raises_hygiene.py` — AST visitor
+that flags any mock assertion (recognised method names + bare
+`assert <mock>.called`) appearing after a top-level `raise` inside a
+`with pytest.raises(...):` block. Conservative: only top-level `raise`
+counts as terminating, so conditional / nested raises don't false-flag.
+
+---
+
 ## Rule of Thumb
 
 For every assertion, ask:
@@ -654,5 +701,6 @@ For every assertion, ask:
 11. **T12**: "Snapshotted shared state? Make sure teardown actually restores the snapshot (including sub-module keys)."
 12. **T13**: "Hardcoded path string in test data? Use `tmp_path` instead."
 13. **T14**: "`(_ for _ in ()).throw(...)` — never. Use a named function or `MagicMock(side_effect=...)`."
+14. **T15**: "Anything after a top-level `raise` inside a `with pytest.raises(...):`? Move it outside the block — it's unreachable."
 
 **Last audited PR**: #140 (PR review cycle 2026-03-21 to 2026-04-21)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,6 +108,19 @@ repos:
         files: ^src/.*\.py$
 
       # ----------------------------------------------------------------
+      # pytest.raises hygiene: no mock assertion after `raise` inside the
+      # block (the assertion is unreachable). Closes the gap left when
+      # PT012 is suppressed via `# noqa: PT012` for legitimate
+      # multi-statement bodies. See tests/ci/test_pytest_raises_hygiene.py.
+      # ----------------------------------------------------------------
+      - id: pytest-raises-hygiene
+        name: no mock assertion after raise in pytest.raises blocks
+        entry: python3 scripts/check_pytest_raises_hygiene.py
+        language: system
+        pass_filenames: false
+        files: ^tests/.*\.py$
+
+      # ----------------------------------------------------------------
       # G2: No f-strings in logger calls (single or double quote)
       # Matches: logger.debug(f"..."), logger.info(f'...'),
       #          logger.exception( f"..."), etc.

--- a/scripts/check_pytest_raises_hygiene.py
+++ b/scripts/check_pytest_raises_hygiene.py
@@ -106,8 +106,64 @@ def _violations_in_block(body: list[ast.stmt]) -> list[ast.stmt]:
     return found
 
 
+def _iter_statement_blocks(node: ast.AST) -> list[list[ast.stmt]]:
+    """Yield every ``list[ast.stmt]`` directly attached to *node*.
+
+    Excludes nested function / class / lambda scopes — a ``raise`` followed
+    by a mock assertion inside a nested function definition is a different
+    control-flow context (the function body is not executed at the
+    pytest.raises call site, so no unreachable-code claim applies).
+    """
+    blocks: list[list[ast.stmt]] = []
+    if isinstance(node, ast.With | ast.AsyncWith):
+        blocks.append(node.body)
+    elif isinstance(node, ast.For | ast.AsyncFor | ast.While):
+        blocks.append(node.body)
+        blocks.append(node.orelse)
+    elif isinstance(node, ast.If):
+        blocks.append(node.body)
+        blocks.append(node.orelse)
+    elif isinstance(node, ast.Try):
+        blocks.append(node.body)
+        blocks.append(node.orelse)
+        blocks.append(node.finalbody)
+        for handler in node.handlers:
+            blocks.append(handler.body)
+    return blocks
+
+
+def _walk_pytest_raises_body(root: ast.With) -> list[list[ast.stmt]]:
+    """Yield every statement-list reachable from *root* without entering a new scope.
+
+    The traversal includes ``root.body`` itself plus the body of every nested
+    ``with`` / ``if`` / ``for`` / ``while`` / ``try`` block inside it. Function /
+    class / lambda definitions are not descended — those open new control-flow
+    scopes whose statements are not reachable as part of the ``pytest.raises``
+    call site.
+    """
+    blocks: list[list[ast.stmt]] = [root.body]
+    stack: list[ast.AST] = [*root.body]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef | ast.Lambda):
+            continue
+        for block in _iter_statement_blocks(node):
+            blocks.append(block)
+            stack.extend(block)
+    return blocks
+
+
 def find_violations(path: Path) -> list[tuple[int, str]]:
-    """Return [(line_number, source_line_excerpt)] for each unreachable mock assertion."""
+    """Return [(line_number, source_line_excerpt)] for each unreachable mock assertion.
+
+    Walks every ``with pytest.raises(...):`` block and checks every nested
+    statement-list inside it (including bodies of inner ``with`` / ``if`` /
+    ``for`` / ``try`` blocks). A mock assertion appearing after a top-level
+    ``raise`` *within the same block* is flagged — this catches the common
+    context-manager pattern ``with pytest.raises(...): with mgr() as m:
+    ...; raise; m.cleanup.assert_called_once()`` that the immediate-body-only
+    scan missed (codex r217).
+    """
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"))
     except (OSError, SyntaxError, UnicodeDecodeError):
@@ -118,12 +174,13 @@ def find_violations(path: Path) -> list[tuple[int, str]]:
             continue
         if not any(_is_pytest_raises(item) for item in node.items):
             continue
-        for stmt in _violations_in_block(node.body):
-            try:
-                line = ast.unparse(stmt)
-            except (AttributeError, ValueError):
-                line = f"<line {stmt.lineno}>"
-            violations.append((stmt.lineno, line))
+        for block in _walk_pytest_raises_body(node):
+            for stmt in _violations_in_block(block):
+                try:
+                    line = ast.unparse(stmt)
+                except (AttributeError, ValueError):
+                    line = f"<line {stmt.lineno}>"
+                violations.append((stmt.lineno, line))
     return violations
 
 

--- a/scripts/check_pytest_raises_hygiene.py
+++ b/scripts/check_pytest_raises_hygiene.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""pytest.raises hygiene rail: no mock assertion after `raise` inside the block.
+
+Background
+----------
+PR-A (#213) enabled ruff PT012, which flags any multi-statement
+``pytest.raises`` block. That covers the common form of this anti-pattern.
+However, 11 sites in the codebase carry ``# noqa: PT012`` because their
+multi-statement bodies are genuinely required (transaction rollback tests,
+context-manager exit semantics under exception, generator double-``next()``,
+``importlib.reload`` under patched ``sys.modules``, ``try/except``
+subclass-non-catching, ``typer.Exit`` re-raise).
+
+Inside those ``# noqa: PT012`` blocks, PT012 is silent — which means a
+mock assertion mistakenly placed AFTER the ``raise`` is not caught:
+
+    with pytest.raises(Foo):  # noqa: PT012 — context-manager exit semantics
+        setup()
+        raise FooError("boom")
+        mock.assert_called_once()   # <-- UNREACHABLE; PT012 suppressed
+
+This rail closes that hole. It walks every ``with pytest.raises(...):``
+block, finds an unconditional top-level ``raise``, and flags any mock
+assertion (``mock.X.assert_called*(...)`` or ``assert mock.X.called``)
+that follows it in the same block.
+
+Scope
+-----
+- ``tests/**/*.py`` only — the pattern only appears in tests.
+- Detects unconditional top-level ``raise`` (not raises inside nested
+  ``if`` / ``try`` blocks, which may be reachable).
+- Detects two mock-assertion forms:
+  - ``Expr(Call(...assert_called*...))`` — ``mock.X.assert_called(...)`` etc.
+  - ``Assert(test=Attribute(attr='called'))`` — ``assert mock.X.called``.
+
+Exit 0 = no violations.
+Exit 1 = violations found. Offending lines are printed to stderr.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_TESTS_DIR = _ROOT / "tests"
+
+# Mock-assertion method names that imply a payload check belongs OUTSIDE
+# the ``pytest.raises`` block (after the ``with`` exits). Anything from
+# this set after a ``raise`` is unreachable.
+_MOCK_ASSERTION_NAMES: frozenset[str] = frozenset(
+    {
+        "assert_called",
+        "assert_called_once",
+        "assert_called_with",
+        "assert_called_once_with",
+        "assert_any_call",
+        "assert_has_calls",
+        "assert_not_called",
+    }
+)
+
+
+def _is_pytest_raises(item: ast.withitem) -> bool:
+    """True if *item* is ``pytest.raises(...)`` (with or without ``as`` capture)."""
+    expr = item.context_expr
+    if not isinstance(expr, ast.Call):
+        return False
+    func = expr.func
+    if not (isinstance(func, ast.Attribute) and func.attr == "raises"):
+        return False
+    return isinstance(func.value, ast.Name) and func.value.id == "pytest"
+
+
+def _is_mock_assertion(stmt: ast.stmt) -> bool:
+    """True if *stmt* is one of the recognised mock-assertion forms."""
+    # Form A: <expr>.assert_called*(...)
+    if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+        func = stmt.value.func
+        if isinstance(func, ast.Attribute) and func.attr in _MOCK_ASSERTION_NAMES:
+            return True
+    # Form B: assert <expr>.called
+    if isinstance(stmt, ast.Assert):
+        test = stmt.test
+        if isinstance(test, ast.Attribute) and test.attr == "called":
+            return True
+    return False
+
+
+def _violations_in_block(body: list[ast.stmt]) -> list[ast.stmt]:
+    """Return mock-assertion statements that appear after an unconditional ``raise``.
+
+    Only top-level ``raise`` in the block body counts. A ``raise`` inside a
+    nested ``if`` / ``try`` / ``for`` does not terminate the surrounding
+    block unconditionally, so subsequent statements remain reachable.
+    """
+    found: list[ast.stmt] = []
+    seen_raise = False
+    for stmt in body:
+        if isinstance(stmt, ast.Raise):
+            seen_raise = True
+            continue
+        if seen_raise and _is_mock_assertion(stmt):
+            found.append(stmt)
+    return found
+
+
+def find_violations(path: Path) -> list[tuple[int, str]]:
+    """Return [(line_number, source_line_excerpt)] for each unreachable mock assertion."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return []
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.With):
+            continue
+        if not any(_is_pytest_raises(item) for item in node.items):
+            continue
+        for stmt in _violations_in_block(node.body):
+            try:
+                line = ast.unparse(stmt)
+            except (AttributeError, ValueError):
+                line = f"<line {stmt.lineno}>"
+            violations.append((stmt.lineno, line))
+    return violations
+
+
+def _iter_test_files() -> list[Path]:
+    """Yield every ``.py`` file under ``tests/``."""
+    return sorted(_TESTS_DIR.rglob("*.py"))
+
+
+def main() -> int:
+    """Scan ``tests/`` and print violations to stderr; exit 1 if any."""
+    all_violations: list[tuple[Path, int, str]] = []
+    for path in _iter_test_files():
+        for lineno, line in find_violations(path):
+            all_violations.append((path.relative_to(_ROOT), lineno, line))
+
+    if not all_violations:
+        return 0
+
+    print(
+        "ERROR (pytest.raises-hygiene): mock assertion after `raise` inside\n"
+        "a `pytest.raises(...)` block is unreachable.\n"
+        "Move the mock assertion AFTER the `with pytest.raises(...):` block "
+        "exits — the `raise` terminates control flow, so subsequent statements\n"
+        "in the block never execute.\n",
+        file=sys.stderr,
+    )
+    for path, lineno, line in all_violations:
+        print(f"  {path}:{lineno}: {line}", file=sys.stderr)
+    print(
+        f"\n{len(all_violations)} violation(s) across "
+        f"{len({v[0] for v in all_violations})} file(s).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_atomic_write_required.py
+++ b/tests/ci/test_atomic_write_required.py
@@ -244,9 +244,7 @@ class TestFindViolationsSynthetic:
         violations = find_violations(target)
         assert len(violations) == 1
 
-    def test_multiline_open_marker_on_closing_paren_is_not_flagged(
-        self, tmp_path: Path
-    ) -> None:
+    def test_multiline_open_marker_on_closing_paren_is_not_flagged(self, tmp_path: Path) -> None:
         # Cover the common ruff-formatted multiline open() shape where the
         # call starts on one line, the mode string is on a later line, and the
         # opt-out marker sits on the closing-paren line.
@@ -256,9 +254,7 @@ class TestFindViolationsSynthetic:
         )
         assert find_violations(target) == []
 
-    def test_multiline_open_in_string_literal_not_flagged_via_opt_out(
-        self, tmp_path: Path
-    ) -> None:
+    def test_multiline_open_in_string_literal_not_flagged_via_opt_out(self, tmp_path: Path) -> None:
         # Marker embedded inside a string literal on the open( line must not
         # exempt the call; the opt-out must appear in an actual comment.
         target = self._write(

--- a/tests/ci/test_pytest_raises_hygiene.py
+++ b/tests/ci/test_pytest_raises_hygiene.py
@@ -1,0 +1,324 @@
+"""Tests for the pytest.raises hygiene rail (``scripts/check_pytest_raises_hygiene.py``).
+
+Closes the gap PR-A's PT012 enforcement leaves: PT012 is silenced inside the
+11 ``# noqa: PT012`` blocks that legitimately need multi-statement bodies
+(transaction rollback, context-manager exit semantics, generator
+double-``next()``, etc.). The rail in this PR catches mock assertions
+mistakenly placed AFTER the ``raise`` inside any of those blocks — those
+assertions are unreachable because ``raise`` terminates control flow.
+
+T10 predicate negative-case backfill: every detection branch has a positive
+test (the rail flags the surface shape) AND a negative test (the rail does
+NOT flag a similar shape that is genuinely reachable).
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+pytestmark = pytest.mark.ci
+
+_FO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _FO_ROOT / "scripts" / "check_pytest_raises_hygiene.py"
+
+# Import the detector directly so we can unit-test helpers without spawning
+# a subprocess for every case.
+sys.path.insert(0, str(_FO_ROOT / "scripts"))
+from check_pytest_raises_hygiene import (  # noqa: E402
+    _MOCK_ASSERTION_NAMES,
+    _is_mock_assertion,
+    _is_pytest_raises,
+    _violations_in_block,
+    find_violations,
+)
+
+
+def _parse_with(source: str) -> ast.With:
+    """Return the first ``ast.With`` node in *source*."""
+    tree = ast.parse(dedent(source))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.With):
+            return node
+    raise AssertionError("no With node parsed")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _is_pytest_raises
+# ---------------------------------------------------------------------------
+
+
+class TestIsPytestRaises:
+    """The detector must recognise canonical pytest.raises shapes."""
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "with pytest.raises(ValueError):\n    pass",
+            "with pytest.raises(ValueError, match='boom'):\n    pass",
+            "with pytest.raises(ValueError) as excinfo:\n    pass",
+            "with pytest.raises((ValueError, TypeError)):\n    pass",
+        ],
+    )
+    def test_recognises_pytest_raises(self, source: str) -> None:
+        with_node = _parse_with(source)
+        assert any(_is_pytest_raises(item) for item in with_node.items)
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            # T10 negative cases — must NOT match
+            "with open('x') as f:\n    pass",
+            "with self.raises(ValueError):\n    pass",  # not pytest.raises
+            "with patch('foo') as p:\n    pass",
+            "with pytest.warns(DeprecationWarning):\n    pass",
+        ],
+    )
+    def test_rejects_non_pytest_raises(self, source: str) -> None:
+        with_node = _parse_with(source)
+        assert not any(_is_pytest_raises(item) for item in with_node.items)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _is_mock_assertion
+# ---------------------------------------------------------------------------
+
+
+class TestIsMockAssertion:
+    """The detector must recognise the two canonical mock-assertion forms."""
+
+    @pytest.mark.parametrize(
+        "name",
+        sorted(_MOCK_ASSERTION_NAMES),
+    )
+    def test_recognises_mock_call(self, name: str) -> None:
+        # Form A: mock.X.assert_called*(...)
+        source = f"mock.method.{name}()"
+        stmt = ast.parse(source).body[0]
+        assert _is_mock_assertion(stmt)
+
+    def test_recognises_assert_called_attribute(self) -> None:
+        # Form B: assert mock.X.called
+        stmt = ast.parse("assert mock.method.called").body[0]
+        assert _is_mock_assertion(stmt)
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            # T10 negative cases — same surface shapes that must NOT match
+            "mock.method.return_value = 1",  # attribute set, not assertion
+            "mock.method.call_count == 1",  # comparison, not assertion call
+            "result = mock.method.assert_called()",  # assignment, not Expr
+            "assert result is True",  # plain assert, not on .called
+            "assert mock.method.return_value == 1",  # not .called attr
+            "x.assert_something_else()",  # not in assertion-name set
+        ],
+    )
+    def test_rejects_non_mock_assertion(self, source: str) -> None:
+        stmt = ast.parse(source).body[0]
+        assert not _is_mock_assertion(stmt)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _violations_in_block
+# ---------------------------------------------------------------------------
+
+
+class TestViolationsInBlock:
+    """Body-level scan must flag unreachable mock assertions only."""
+
+    def test_flags_assertion_after_top_level_raise(self) -> None:
+        with_node = _parse_with(
+            """
+            with pytest.raises(ValueError):
+                raise ValueError("boom")
+                mock.method.assert_called_once()
+            """
+        )
+        violations = _violations_in_block(with_node.body)
+        assert len(violations) == 1
+
+    def test_flags_assert_called_attribute_after_raise(self) -> None:
+        with_node = _parse_with(
+            """
+            with pytest.raises(ValueError):
+                raise ValueError()
+                assert mock.method.called
+            """
+        )
+        violations = _violations_in_block(with_node.body)
+        assert len(violations) == 1
+
+    def test_no_flag_when_assertion_precedes_raise(self) -> None:
+        # Statement appears BEFORE raise — reachable; not flagged.
+        with_node = _parse_with(
+            """
+            with pytest.raises(ValueError):
+                mock.method.assert_called_once()
+                raise ValueError()
+            """
+        )
+        assert _violations_in_block(with_node.body) == []
+
+    def test_no_flag_when_no_top_level_raise(self) -> None:
+        # No raise at top level; mock assertion is reachable.
+        with_node = _parse_with(
+            """
+            with pytest.raises(ValueError):
+                func_that_might_raise()
+                mock.method.assert_called_once()
+            """
+        )
+        assert _violations_in_block(with_node.body) == []
+
+    def test_no_flag_when_raise_is_nested_in_if(self) -> None:
+        # T10 negative case: conditional raise; trailing assertion is
+        # reachable when the condition is False.
+        with_node = _parse_with(
+            """
+            with pytest.raises(ValueError):
+                if condition:
+                    raise ValueError()
+                mock.method.assert_called_once()
+            """
+        )
+        assert _violations_in_block(with_node.body) == []
+
+    def test_no_flag_when_raise_is_nested_in_try(self) -> None:
+        # T10 negative case: raise inside try doesn't terminate the
+        # outer block (the except may catch and the body continues).
+        with_node = _parse_with(
+            """
+            with pytest.raises(ValueError):
+                try:
+                    raise RuntimeError()
+                except RuntimeError:
+                    raise ValueError()
+                mock.method.assert_called_once()
+            """
+        )
+        # The outer raise IS still inside an except branch — the rail
+        # treats only top-level raises as terminating, so this stays
+        # un-flagged. Conservative is the right default for a rail.
+        assert _violations_in_block(with_node.body) == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: find_violations on synthetic files
+# ---------------------------------------------------------------------------
+
+
+class TestFindViolationsSynthetic:
+    """End-to-end checks against tmp_path test files."""
+
+    def _write(self, tmp_path: Path, content: str) -> Path:
+        target = tmp_path / "test_synth.py"
+        target.write_text(dedent(content))
+        return target
+
+    def test_unreachable_mock_assertion_is_flagged(self, tmp_path: Path) -> None:
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.raises(ValueError):
+                    raise ValueError()
+                    mock.method.assert_called_once()
+            """,
+        )
+        violations = find_violations(target)
+        assert len(violations) == 1
+        assert "assert_called_once" in violations[0][1]
+
+    def test_correctly_placed_assertion_is_not_flagged(self, tmp_path: Path) -> None:
+        # T10 negative: assertion AFTER the with-block exits is correct.
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.raises(ValueError):
+                    raise ValueError()
+                mock.method.assert_called_once()
+            """,
+        )
+        assert find_violations(target) == []
+
+    def test_assert_called_attribute_after_raise_is_flagged(self, tmp_path: Path) -> None:
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.raises(ValueError):
+                    raise ValueError()
+                    assert mock.method.called
+            """,
+        )
+        violations = find_violations(target)
+        assert len(violations) == 1
+        assert ".called" in violations[0][1]
+
+    def test_pytest_warns_does_not_trigger(self, tmp_path: Path) -> None:
+        # T10 negative case: same with-statement shape but pytest.warns,
+        # not pytest.raises. Must not flag.
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.warns(DeprecationWarning):
+                    raise DeprecationWarning()
+                    mock.method.assert_called_once()
+            """,
+        )
+        assert find_violations(target) == []
+
+    def test_mocked_pytest_raises_via_alias_is_not_flagged(self, tmp_path: Path) -> None:
+        # T10 negative case: an aliased import doesn't match the
+        # ``pytest.raises`` attribute pattern. Conservative: detector
+        # only matches the canonical form. False negatives are accepted
+        # for false-positive immunity (the canonical form is what the
+        # codebase uses everywhere — see existing 11 noqa-PT012 sites).
+        target = self._write(
+            tmp_path,
+            """
+            from pytest import raises
+
+            def test_x():
+                with raises(ValueError):
+                    raise ValueError()
+                    mock.method.assert_called_once()
+            """,
+        )
+        assert find_violations(target) == []
+
+
+# ---------------------------------------------------------------------------
+# Full-suite assertion: zero unreachable mock assertions on the live tree
+# ---------------------------------------------------------------------------
+
+
+class TestFullSuite:
+    """The rail must pass against the live ``tests/`` tree (preventive)."""
+
+    def test_no_violations_on_current_tree(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"pytest.raises hygiene rail flagged unreachable mock assertion(s):\n{result.stderr}"
+        )

--- a/tests/ci/test_pytest_raises_hygiene.py
+++ b/tests/ci/test_pytest_raises_hygiene.py
@@ -284,6 +284,73 @@ class TestFindViolationsSynthetic:
         )
         assert find_violations(target) == []
 
+    def test_nested_with_block_with_raise_then_mock_assertion_is_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        # Codex r217 false-negative case: the raise + mock assertion are
+        # both inside an inner ``with manager() as m:`` block nested under
+        # the outer ``with pytest.raises(...):``. The pre-fix detector
+        # only walked the outer body and missed this. The fixed detector
+        # walks every nested statement-list within the pytest.raises
+        # subtree.
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.raises(ValueError):  # noqa: PT012
+                    with manager() as m:
+                        do_setup()
+                        raise ValueError()
+                        m.cleanup.assert_called_once()
+            """,
+        )
+        violations = find_violations(target)
+        assert len(violations) == 1
+        assert "assert_called_once" in violations[0][1]
+
+    def test_nested_if_with_raise_then_assertion_is_flagged(self, tmp_path: Path) -> None:
+        # The raise is at top level of the if-body (not the outer
+        # pytest.raises body), so the immediate-body-only scan would
+        # miss it. After the fix, the rail walks into the if-body too.
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.raises(ValueError):  # noqa: PT012
+                    if True:
+                        raise ValueError()
+                        mock.method.assert_called_once()
+            """,
+        )
+        violations = find_violations(target)
+        assert len(violations) == 1
+
+    def test_assertion_inside_nested_function_def_is_not_flagged(self, tmp_path: Path) -> None:
+        # T10 negative case: the nested def starts a new scope; its body
+        # is not executed at the pytest.raises call site. The detector
+        # must NOT descend into function definitions.
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.raises(ValueError):
+                    raise ValueError()
+
+                    def helper():
+                        mock.method.assert_called_once()
+            """,
+        )
+        # The raise + def are at top level of the pytest.raises body. The
+        # def itself is not a mock assertion, and we don't descend into
+        # its body. So no violations.
+        assert find_violations(target) == []
+
     def test_mocked_pytest_raises_via_alias_is_not_flagged(self, tmp_path: Path) -> None:
         # T10 negative case: an aliased import doesn't match the
         # ``pytest.raises`` attribute pattern. Conservative: detector

--- a/tests/methodologies/para/test_migration_recovery.py
+++ b/tests/methodologies/para/test_migration_recovery.py
@@ -78,9 +78,7 @@ class TestMigrationBackupSystem:
         )
 
     @pytest.fixture
-    def migration_manager(
-        self, config: PARAConfig, tmp_path: Path
-    ) -> PARAMigrationManager:
+    def migration_manager(self, config: PARAConfig, tmp_path: Path) -> PARAMigrationManager:
         """Create migration manager instance with isolated backup root."""
         manager = PARAMigrationManager(config)
         # Override backup_root to use tmp_path so parallel tests don't collide
@@ -437,9 +435,7 @@ class TestMigrationManagerEdgeCases:
         )
 
     @pytest.fixture
-    def migration_manager(
-        self, config: PARAConfig, tmp_path: Path
-    ) -> PARAMigrationManager:
+    def migration_manager(self, config: PARAConfig, tmp_path: Path) -> PARAMigrationManager:
         """Create migration manager instance with isolated backup root."""
         manager = PARAMigrationManager(config)
         manager.backup_root = tmp_path / "migration-backups"


### PR DESCRIPTION
## Summary

PR-C (narrow) in the **integration/pre-commit-ratchet** integration series. Closes the gap PR-A's PT012 enforcement leaves: PT012 is silenced inside the 11 sites that carry \`# noqa: PT012\` for legitimately multi-statement bodies. Inside those blocks, a mock assertion mistakenly placed AFTER the \`raise\` is unreachable but reads as a real check — and PT012 won't catch it.

The new **T15** rail (\`scripts/check_pytest_raises_hygiene.py\`) is an AST visitor that flags any mock assertion following a top-level \`raise\` inside \`with pytest.raises(...):\`.

## What's detected

\`\`\`python
with pytest.raises(ValueError):  # noqa: PT012 — context-manager exit semantics
    with manager() as m:
        do_setup()
        raise ValueError(\"boom\")
        m.cleanup.assert_called_once()  # ← FLAGGED: unreachable
\`\`\`

Recognises both mock-assertion forms:
- \`<mock>.<attr>.assert_called*(...)\` (7 method names)
- \`assert <mock>.<attr>.called\`

## Conservative defaults

| Behaviour | Reason |
|-----------|--------|
| Only **top-level** \`raise\` counts as terminating | Conditional raises (inside \`if\` / \`try\` / \`for\`) keep subsequent statements reachable |
| Only \`pytest.raises\` matches | \`pytest.warns\`, aliased imports (\`from pytest import raises\`), and \`self.raises\` don't false-flag |
| Only the 7 documented mock-assertion methods + bare \`.called\` attr | Avoids confusing \`mock.X.return_value = 1\` with an assertion |

## Backlog

**Zero current violations** on integration HEAD — purely preventive. The rail catches future regressions when developers add a mock assertion after \`raise\` inside any of the existing 11 (or future) \`# noqa: PT012\` blocks.

## Verification

- \`pytest tests/ci/test_pytest_raises_hygiene.py\` — 34 passed
- \`python3 scripts/check_pytest_raises_hygiene.py\` — exit 0
- \`bash .claude/scripts/pre-commit-validation.sh\` — green
- ruff / mypy / pymarkdown / codespell / diff-cover all clean

## Test plan

- [x] Rail flags mock assertion after top-level \`raise\` (Form A and Form B)
- [x] Rail does NOT flag mock assertion BEFORE \`raise\` (still reachable)
- [x] Rail does NOT flag when \`raise\` is nested in \`if\` / \`try\` (conditional)
- [x] Rail does NOT flag \`pytest.warns\` / aliased \`raises\` / non-mock asserts
- [x] Full-suite assertion against live \`tests/\` tree passes (zero current violations)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)