### PR TITLE
ratchet(rails): T3 narrow — ban `assert <mock>.called` attribute form

### DIFF
--- a/.claude/rules/test-generation-patterns.md
+++ b/.claude/rules/test-generation-patterns.md
@@ -143,6 +143,37 @@ def test_sends_notification(self, mock_notifier):
     )
 ```
 
+### Mechanical sub-rail (T3 narrow): `assert <mock>.called` is banned
+
+The full T3 surface (call-count comparisons, payload-free `assert_called()`)
+has many legitimate uses (logger spies, control-flow probes), so a strict
+rail would be too noisy. But the **`assert <mock>.<attr>.called` attribute-
+lookup form** has zero legitimate uses — the canonical mock-library
+equivalent `<mock>.<attr>.assert_called()` is one extra character, more
+discoverable in IDEs (it's a documented method, not a flag attribute),
+and consistent with the rest of the test suite's assertion style.
+
+**Bad**:
+
+```python
+assert mock_console.print.called
+assert mock.method.called is True
+assert mock.method.called == True
+```
+
+**Good**:
+
+```python
+mock_console.print.assert_called()
+mock.method.assert_called()
+```
+
+**Mechanical rail**: `scripts/check_called_attribute_assertion.py` —
+regex detector with `# noqa: T3` opt-out for the rare case where the
+attribute access is intentional (e.g. testing the mock library itself).
+Wider T3 (call-count, payload-free `_with`-less calls) remains
+code-review-enforced.
+
 ---
 
 ## Pattern T4: TAUTOLOGICAL_DISJUNCTION

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -121,6 +121,20 @@ repos:
         files: ^tests/.*\.py$
 
       # ----------------------------------------------------------------
+      # T3-narrow: ban `assert <mock>.called` attribute-style assertion.
+      # The canonical mock-library equivalent is `<mock>.assert_called()`
+      # (one extra char, more discoverable, consistent with the rest of
+      # the suite). See .claude/rules/test-generation-patterns.md T3 and
+      # tests/ci/test_called_attribute_assertion.py.
+      # ----------------------------------------------------------------
+      - id: t3-no-bare-called-assertion
+        name: no `assert <mock>.called` (use `.assert_called()` instead)
+        entry: python3 scripts/check_called_attribute_assertion.py
+        language: system
+        pass_filenames: false
+        files: ^tests/.*\.py$
+
+      # ----------------------------------------------------------------
       # G2: No f-strings in logger calls (single or double quote)
       # Matches: logger.debug(f"..."), logger.info(f'...'),
       #          logger.exception( f"..."), etc.

--- a/scripts/check_called_attribute_assertion.py
+++ b/scripts/check_called_attribute_assertion.py
@@ -51,13 +51,21 @@ _TESTS_DIR = _ROOT / "tests"
 # ``assert mock.called == 3`` (that's a count check, T3 allows under
 # noqa).  The precise allowed shapes are bare attribute, `is True`, and
 # `== True`.
+#
+# The expression itself may be parenthesised — `assert (mock.called)` is
+# common when the chain is long enough to wrap, and `(...) is True` is
+# also common.  The regex therefore accepts an optional balanced pair
+# of parens around the ``<chain>.called`` portion (codex r218).
 _PATTERN = re.compile(
-    r"""^\s*assert\s+      # leading 'assert'
-        [\w.]+\.called      # <chain>.called
-        \s*                # optional ws
-        (?:is\s+True|==\s*True)?  # optional truth comparison
-        \s*                # trailing ws
-        (?:\#.*)?          # optional trailing comment
+    r"""^\s*assert\s+               # leading 'assert'
+        (?:                          # one of:
+            [\w.]+\.called           #   <chain>.called  (no parens)
+          | \(\s*[\w.]+\.called\s*\) #   ( <chain>.called )  (parens)
+        )
+        \s*                          # optional ws
+        (?:is\s+True|==\s*True)?     # optional truth comparison
+        \s*                          # trailing ws
+        (?:\#.*)?                    # optional trailing comment
         $""",
     re.VERBOSE,
 )

--- a/scripts/check_called_attribute_assertion.py
+++ b/scripts/check_called_attribute_assertion.py
@@ -85,14 +85,28 @@ def _has_opt_out(line: str) -> bool:
 
 
 def find_violations(path: Path) -> list[tuple[int, str]]:
-    """Return [(line_number, line_text)] for each unexempted match."""
+    """Return [(line_number, line_text)] for each unexempted match.
+
+    Tracks triple-quoted string blocks so that fixtures embedded in
+    docstrings (notably ``tests/ci/test_*.py`` rails that demonstrate
+    the forbidden pattern inside ``dedent('''...''')`` blocks) don't
+    false-flag. The check is heuristic — counts ``\"\"\"`` / ``'''``
+    toggles per line.
+    """
     violations: list[tuple[int, str]] = []
     try:
         text = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
         return violations
 
+    in_triple_quote = False
     for lineno, raw in enumerate(text.splitlines(), start=1):
+        triple_count = raw.count('"""') + raw.count("'''")
+        if triple_count % 2 == 1:
+            in_triple_quote = not in_triple_quote
+            continue
+        if in_triple_quote:
+            continue
         if _is_comment_line(raw):
             continue
         if not _PATTERN.match(raw):

--- a/scripts/check_called_attribute_assertion.py
+++ b/scripts/check_called_attribute_assertion.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""T3 narrow rail: no `assert <mock>.called` attribute-style assertion.
+
+Background
+----------
+T3 (`.claude/rules/test-generation-patterns.md`) catches mock assertions
+that check call count without verifying payload. The full T3 has a wide
+surface (`call_count >= N`, `assert_called()` without args, etc.) and
+many legitimate uses, so a strict rail is too noisy.
+
+This rail enforces the *narrow* form that has zero legitimate uses: the
+`assert <obj>.<attr>.called` attribute lookup. The mock library's
+canonical equivalent — `<obj>.<attr>.assert_called()` — is one extra
+character, more discoverable in IDEs (it's a documented method, not a
+flag attribute), and consistent with the rest of the test suite's
+assertion style.
+
+Recognised forms (all flagged):
+
+    assert <chain>.called
+    assert <chain>.called is True
+    assert <chain>.called == True
+
+The fix is mechanical: replace ``assert mock.X.called`` with
+``mock.X.assert_called()``.
+
+Scope
+-----
+- ``tests/**/*.py`` only.
+- Honors per-site ``# noqa: T3`` opt-out (rare — the canonical fix is
+  cheap, but the marker exists for cases where the attribute access is
+  intentional, e.g. testing the mock library itself).
+
+Exit 0 = no violations.
+Exit 1 = violations found. Offending lines are printed to stderr.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_TESTS_DIR = _ROOT / "tests"
+
+# Match `assert <chain>.called` optionally followed by ` is True` or ` == True`.
+# Anchored to end-of-line (modulo trailing comment / whitespace) so we
+# don't catch substring uses like ``assert obj.called_once_with(x)``
+# (that's a Mock method, not the attribute) or comparisons like
+# ``assert mock.called == 3`` (that's a count check, T3 allows under
+# noqa).  The precise allowed shapes are bare attribute, `is True`, and
+# `== True`.
+_PATTERN = re.compile(
+    r"""^\s*assert\s+      # leading 'assert'
+        [\w.]+\.called      # <chain>.called
+        \s*                # optional ws
+        (?:is\s+True|==\s*True)?  # optional truth comparison
+        \s*                # trailing ws
+        (?:\#.*)?          # optional trailing comment
+        $""",
+    re.VERBOSE,
+)
+
+# Opt-out marker. Matched anywhere in the trailing comment.
+_NOQA_RE = re.compile(r"#\s*noqa:\s*T3\b")
+
+
+def _is_comment_line(line: str) -> bool:
+    """True if the line (after whitespace) starts with ``#``."""
+    return line.lstrip().startswith("#")
+
+
+def _has_opt_out(line: str) -> bool:
+    """True if the line contains a ``# noqa: T3`` marker."""
+    return bool(_NOQA_RE.search(line))
+
+
+def find_violations(path: Path) -> list[tuple[int, str]]:
+    """Return [(line_number, line_text)] for each unexempted match."""
+    violations: list[tuple[int, str]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return violations
+
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        if _is_comment_line(raw):
+            continue
+        if not _PATTERN.match(raw):
+            continue
+        if _has_opt_out(raw):
+            continue
+        violations.append((lineno, raw.rstrip()))
+    return violations
+
+
+def _iter_test_files() -> list[Path]:
+    """Yield every ``.py`` file under ``tests/``."""
+    return sorted(_TESTS_DIR.rglob("*.py"))
+
+
+def main() -> int:
+    """Scan ``tests/`` and print violations to stderr; exit 1 if any."""
+    all_violations: list[tuple[Path, int, str]] = []
+    for path in _iter_test_files():
+        for lineno, line in find_violations(path):
+            all_violations.append((path.relative_to(_ROOT), lineno, line))
+
+    if not all_violations:
+        return 0
+
+    print(
+        "ERROR (T3): `assert <mock>.called` attribute-style assertion found.\n"
+        "Replace with the canonical mock-library equivalent:\n"
+        "  - `assert mock.X.called`  →  `mock.X.assert_called()`\n"
+        "  - `assert mock.X.called is True`  →  `mock.X.assert_called()`\n"
+        "Or, for an intentional attribute-style check (rare), add\n"
+        "`# noqa: T3 reason: <one-line justification>`.\n",
+        file=sys.stderr,
+    )
+    for path, lineno, line in all_violations:
+        print(f"  {path}:{lineno}: {line}", file=sys.stderr)
+    print(
+        f"\n{len(all_violations)} violation(s) across "
+        f"{len({v[0] for v in all_violations})} file(s).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_called_attribute_assertion.py
+++ b/tests/ci/test_called_attribute_assertion.py
@@ -1,0 +1,181 @@
+"""Tests for the T3-narrow rail (``scripts/check_called_attribute_assertion.py``).
+
+Bans the ``assert <mock>.called`` attribute lookup form. The canonical
+mock-library equivalent ``<mock>.assert_called()`` is one extra
+character, more discoverable in IDEs (it's a documented method, not a
+flag attribute), and consistent with the rest of the test suite.
+
+Detection forms:
+
+  - ``assert <chain>.called``
+  - ``assert <chain>.called is True``
+  - ``assert <chain>.called == True``
+
+T10 predicate negative-case backfill: every detection form has a
+positive test (rail flags) AND a negative test (rail does NOT flag a
+similar shape that is genuinely correct).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.ci
+
+_FO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _FO_ROOT / "scripts" / "check_called_attribute_assertion.py"
+
+# Import the detector directly so we can unit-test helpers without spawning
+# a subprocess for every case.
+sys.path.insert(0, str(_FO_ROOT / "scripts"))
+from check_called_attribute_assertion import (  # noqa: E402
+    _PATTERN,
+    _has_opt_out,
+    _is_comment_line,
+    find_violations,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests: pattern detection
+# ---------------------------------------------------------------------------
+
+
+class TestPatternDetection:
+    """The regex must match the three forbidden forms."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "assert mock.called",
+            "    assert mock.method.called",
+            "        assert obj.attr.deep.chain.called",
+            "assert mock.called is True",
+            "assert mock.called == True",
+            "assert mock.called  # trailing comment",
+            "    assert mock.method.called is True",
+        ],
+    )
+    def test_matches_forbidden(self, line: str) -> None:
+        assert _PATTERN.match(line) is not None
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # T10 negative cases — must NOT match
+            "mock.assert_called()",  # canonical fix — the method form
+            "mock.method.assert_called_once()",  # other Mock methods
+            "assert mock.called == 3",  # count comparison (T3 has separate noqa for this)
+            "assert mock.called is False",  # `is False` is rare but legitimate
+            "assert obj.is_called",  # not the .called attribute
+            "assert mock.call_count >= 1",  # not the bare-called form
+            "called = mock.called",  # assignment, not assert
+            "if mock.called:",  # conditional, not assert
+            "assert called",  # local variable named 'called' — no chain
+        ],
+    )
+    def test_does_not_match_legitimate(self, line: str) -> None:
+        assert _PATTERN.match(line) is None
+
+
+class TestOptOutMarker:
+    """The opt-out marker must be detected only in its canonical form."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "assert mock.called  # noqa: T3",
+            "assert mock.called  # noqa: T3 reason: testing the mock library itself",
+            "assert mock.called  #noqa: T3",  # tighter spacing
+        ],
+    )
+    def test_recognises_opt_out(self, line: str) -> None:
+        assert _has_opt_out(line)
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "assert mock.called",  # no marker
+            "assert mock.called  # noqa: T1",  # different rule
+            "assert mock.called  # T3",  # missing noqa: prefix
+        ],
+    )
+    def test_rejects_non_canonical(self, line: str) -> None:
+        assert not _has_opt_out(line)
+
+
+class TestCommentLines:
+    """Comments must not trip the rail even if they contain the forbidden form."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "# assert mock.called",
+            "    # assert mock.called  (historical example)",
+        ],
+    )
+    def test_comment_lines_are_skipped(self, line: str) -> None:
+        assert _is_comment_line(line)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: find_violations on synthetic files
+# ---------------------------------------------------------------------------
+
+
+class TestFindViolationsSynthetic:
+    """End-to-end checks against tmp_path test files."""
+
+    def _write(self, tmp_path: Path, content: str) -> Path:
+        target = tmp_path / "test_synth.py"
+        target.write_text(content)
+        return target
+
+    def test_unmarked_assertion_is_flagged(self, tmp_path: Path) -> None:
+        target = self._write(tmp_path, "assert mock.method.called\n")
+        violations = find_violations(target)
+        assert len(violations) == 1
+
+    def test_marked_assertion_is_not_flagged(self, tmp_path: Path) -> None:
+        target = self._write(
+            tmp_path, "assert mock.method.called  # noqa: T3 reason: legacy test\n"
+        )
+        assert find_violations(target) == []
+
+    def test_method_form_is_not_flagged(self, tmp_path: Path) -> None:
+        # Canonical fix — the method call form. Not flagged.
+        target = self._write(tmp_path, "mock.method.assert_called()\n")
+        assert find_violations(target) == []
+
+    def test_comment_with_forbidden_text_not_flagged(self, tmp_path: Path) -> None:
+        target = self._write(tmp_path, "# example: assert mock.called\n")
+        assert find_violations(target) == []
+
+    def test_count_comparison_not_flagged(self, tmp_path: Path) -> None:
+        # T10 negative case: ``call_count`` checks are out of scope for this
+        # narrow rail (full T3 covers them under code review, not here).
+        target = self._write(tmp_path, "assert mock.call_count >= 1\n")
+        assert find_violations(target) == []
+
+
+# ---------------------------------------------------------------------------
+# Full-suite assertion: zero violations on the live tree
+# ---------------------------------------------------------------------------
+
+
+class TestFullSuite:
+    """The rail must pass against the live ``tests/`` tree."""
+
+    def test_no_violations_on_current_tree(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"T3 narrow rail flagged unmarked violation(s):\n{result.stderr}"
+        )

--- a/tests/ci/test_called_attribute_assertion.py
+++ b/tests/ci/test_called_attribute_assertion.py
@@ -57,6 +57,12 @@ class TestPatternDetection:
             "assert mock.called == True",
             "assert mock.called  # trailing comment",
             "    assert mock.method.called is True",
+            # Codex r218 — parenthesised forms must also match
+            "assert (mock.method.called)",
+            "    assert (mock.method.called)",
+            "assert (mock.method.called) is True",
+            "assert (mock.method.called) == True",
+            "assert ( mock.method.called )",  # whitespace inside parens
         ],
     )
     def test_matches_forbidden(self, line: str) -> None:

--- a/tests/ci/test_called_attribute_assertion.py
+++ b/tests/ci/test_called_attribute_assertion.py
@@ -166,6 +166,16 @@ class TestFindViolationsSynthetic:
         target = self._write(tmp_path, "assert mock.call_count >= 1\n")
         assert find_violations(target) == []
 
+    def test_inside_triple_quoted_docstring_not_flagged(self, tmp_path: Path) -> None:
+        # Fixtures embedded in docstrings (common in tests/ci/test_*.py
+        # rails that demonstrate the forbidden pattern in dedent blocks)
+        # must not false-flag.
+        target = self._write(
+            tmp_path,
+            '"""Example fixture:\n\n    assert mock.method.called\n"""\n',
+        )
+        assert find_violations(target) == []
+
 
 # ---------------------------------------------------------------------------
 # Full-suite assertion: zero violations on the live tree

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -319,7 +319,7 @@ class TestDisplayRecommendations:
             with patch("cli.doctor.console") as mock_console:
                 display_recommendations(extension_counts, detected_groups)
                 # Should print a table
-                assert mock_console.print.called
+                mock_console.print.assert_called()
 
     def test_display_with_missing_group(self):
         extension_counts = {".mp3": 5}
@@ -328,7 +328,7 @@ class TestDisplayRecommendations:
         with patch("cli.doctor.is_group_installed", return_value=False):
             with patch("cli.doctor.console") as mock_console:
                 display_recommendations(extension_counts, detected_groups)
-                assert mock_console.print.called
+                mock_console.print.assert_called()
 
     def test_display_multiple_groups(self):
         extension_counts = {".mp3": 5, ".mp4": 3, ".pdf": 2}
@@ -337,7 +337,7 @@ class TestDisplayRecommendations:
         with patch("cli.doctor.is_group_installed", return_value=False):
             with patch("cli.doctor.console") as mock_console:
                 display_recommendations(extension_counts, detected_groups)
-                assert mock_console.print.called
+                mock_console.print.assert_called()
 
     def test_display_with_prerequisites(self):
         extension_counts = {".mp3": 5}
@@ -347,7 +347,7 @@ class TestDisplayRecommendations:
         with patch("cli.doctor.is_group_installed", return_value=False):
             with patch("cli.doctor.console") as mock_console:
                 display_recommendations(extension_counts, detected_groups)
-                assert mock_console.print.called
+                mock_console.print.assert_called()
 
 
 # ============================================================================
@@ -546,7 +546,7 @@ class TestDoctorCommand:
 
             assert exc_info.value.exit_code == 0
             # Should output JSON
-            assert mock_echo.called
+            mock_echo.assert_called()
             import json
 
             output = json.loads(mock_echo.call_args[0][0])
@@ -616,7 +616,7 @@ class TestDoctorCommand:
                         doctor(path=tmp_path, install=True, json_output=False)
 
                         # Should have attempted installation
-                        assert mock_run.called
+                        mock_run.assert_called()
 
     def test_compound_extension_detection(self, tmp_path):
         # Test that compound extensions are properly detected
@@ -1214,7 +1214,7 @@ class TestInstallGroupsOrdering:
             with patch("cli.doctor.console") as mock_console:
                 display_recommendations(extension_counts, detected_groups)
                 # Just verify it was called without error (sorting happens internally)
-                assert mock_console.print.called
+                mock_console.print.assert_called()
 
 
 @pytest.mark.unit

--- a/tests/integration/config/test_provider_env.py
+++ b/tests/integration/config/test_provider_env.py
@@ -46,7 +46,7 @@ class TestGetCurrentProviderUnknownValue:
         with patch("config.provider_env.logger.warning") as mock_warn:
             get_current_provider()
 
-        assert mock_warn.called
+        mock_warn.assert_called()
         # Warning message should mention the unrecognised value
         call_args = mock_warn.call_args_list[0]
         assert "bogus" in str(call_args) or "FO_PROVIDER" in str(call_args)

--- a/tests/integration/test_doctor_e2e.py
+++ b/tests/integration/test_doctor_e2e.py
@@ -349,7 +349,7 @@ class TestDoctorInstallation:
                     result = runner.invoke(app, ["doctor", str(audio_files_dir), "--install"])
                     assert result.exit_code == 0
                     # Should have called subprocess to install
-                    assert mock_run.called
+                    mock_run.assert_called()
 
     def test_install_with_yes_flag_auto_confirms(
         self, audio_files_dir: Path, monkeypatch: pytest.MonkeyPatch
@@ -363,7 +363,7 @@ class TestDoctorInstallation:
                 result = runner.invoke(app, ["--yes", "doctor", str(audio_files_dir), "--install"])
                 # Should succeed without prompting
                 assert result.exit_code == 0
-                assert mock_run.called
+                mock_run.assert_called()
 
     def test_install_with_dry_run_flag(self, audio_files_dir: Path) -> None:
         """Global --dry-run flag prevents actual installation."""
@@ -676,7 +676,7 @@ class TestDoctorEndToEndWorkflows:
                 with patch("subprocess.run", return_value=mock_result) as mock_run:
                     result = runner.invoke(app, ["doctor", str(mixed_media_dir), "--install"])
                     assert result.exit_code == 0
-                    assert mock_run.called
+                    mock_run.assert_called()
 
     def test_ci_automation_workflow(self, audio_files_dir: Path) -> None:
         """Simulate CI/automation usage with --dry-run and --json flags."""

--- a/tests/integration/test_pipeline_orchestrator_and_services.py
+++ b/tests/integration/test_pipeline_orchestrator_and_services.py
@@ -289,7 +289,7 @@ class TestPipelineOrchestratorStagedProcessing:
         f = tmp_path / "file.txt"
         f.write_text("hello")
         result = orch.process_file(f)
-        assert stage.process.called
+        stage.process.assert_called()
         assert result.success is True
 
     def test_stage_returning_none_marks_failure(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

PR-D (narrow) in the **integration/pre-commit-ratchet** integration series. Bans the \`assert <mock>.<attr>.called\` attribute-lookup form. The canonical mock-library equivalent \`<mock>.<attr>.assert_called()\` is one extra character, more discoverable in IDEs (it's a documented method, not a flag attribute), and consistent with the rest of the test suite.

The full T3 surface (call_count comparisons, payload-free \`assert_called()\`) remains code-review-enforced — this rail targets only the unambiguous attribute form.

## What's detected

\`\`\`python
assert mock_console.print.called          # ← FLAGGED
assert mock.method.called is True         # ← FLAGGED
assert mock.method.called == True         # ← FLAGGED
\`\`\`

The fix is mechanical:

\`\`\`python
mock_console.print.assert_called()
mock.method.assert_called()
\`\`\`

Both forms are semantically identical. The method-call form is preferred for IDE discoverability and consistency.

## Backlog cleanup (12 sites)

| File | Sites | Context |
|------|-------|---------|
| \`tests/cli/test_doctor.py\` | 7 | \`display_recommendations\`, \`install_groups\`, doctor command paths |
| \`tests/integration/test_doctor_e2e.py\` | 3 | \`subprocess.run\` spies inside install workflow tests |
| \`tests/integration/config/test_provider_env.py\` | 1 | \`logger.warning\` spy in unrecognised-FO_PROVIDER test |
| \`tests/integration/test_pipeline_orchestrator_and_services.py\` | 1 | \`stage.process\` delegation spy |

All 12 converted to the method-call form. **302 tests across the touched files still pass.**

## False-positive coverage (T10 negative cases)

The rail does NOT flag:
- \`mock.assert_called()\` — the canonical fix
- \`mock.assert_called_once()\` / other Mock methods
- \`assert mock.call_count >= 1\` — count comparison (out of scope)
- \`assert mock.called is False\` — rare but legitimate
- \`assert obj.is_called\` — different attribute name
- \`called = mock.called\` — assignment, not assert
- Comment lines containing the forbidden text
- Lines with \`# noqa: T3\` opt-out (rare, e.g. testing the mock library itself)

## Verification

- \`pytest tests/ci/test_called_attribute_assertion.py\` — 30 passed
- \`pytest tests/cli/test_doctor.py tests/integration/test_doctor_e2e.py tests/integration/config/test_provider_env.py tests/integration/test_pipeline_orchestrator_and_services.py\` — 302 passed
- \`bash .claude/scripts/pre-commit-validation.sh\` — green
- ruff / mypy / pymarkdown / codespell / diff-cover all clean

## Test plan

- [x] Rail flags all three forbidden forms
- [x] Rail does NOT flag method-call form, count comparison, or comments
- [x] \`# noqa: T3\` opt-out works
- [x] All 12 converted sites still pass
- [x] Full-suite assertion against live \`tests/\` tree passes
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)