### PR TITLE
ratchet: pre-commit guardrails — atomic-write + pytest.raises hygiene + T3-narrow (5 review rounds)

### DIFF
--- a/.claude/rules/feature-generation-patterns.md
+++ b/.claude/rules/feature-generation-patterns.md
@@ -126,6 +126,28 @@ with self._lock:
       concurrent CI job truncates the file; downstream tooling then reads garbage.
 - [ ] `@lru_cache` on a function reading env vars? → Remove cache
 
+**Mechanical rail**: The atomic-write requirement for persistent state in
+`src/` is enforced by the `atomic-write-required` pre-commit hook
+(`scripts/check_atomic_write.py`) and the corresponding semantic guardrail
+(`tests/ci/test_atomic_write_required.py`). Any `Path.write_text`,
+`Path.write_bytes`, or `open(p, "w"|"wb"|"a"|"ab")` call in `src/` must
+either use one of the `utils.atomic_write` helpers (`atomic_write_text`,
+`atomic_write_bytes`, `atomic_write_with`, `append_durable`) or carry an
+explicit opt-out comment. Accepted opt-out reasons:
+
+| Reason | When to use |
+|--------|-------------|
+| `# atomic-write: ok — manual temp+replace pattern` | Site already uses `tempfile.NamedTemporaryFile` + `os.replace()` (or equivalent `temp_path.replace()` / `temp_file.replace()`). Migration to the helper is a follow-up clean-up. |
+| `# atomic-write: ok — user output` | One-shot CLI export to a user-supplied path. Atomicity isn't required because the user retries on failure (e.g. `fo history export`, deduplication report, analytics dashboard). |
+| `# atomic-write: ok — pid file (single-writer via daemon lifecycle)` | PID file owned by exactly one daemon process; atomicity comes from the daemon-lifecycle invariant, not the write call. |
+| `# atomic-write: ok — fcntl lock file, stable inode required` | Lock file opened in append mode so its inode stays stable across callers; truncate-on-write would break the locking protocol. |
+| `# atomic-write: ok — append_durable pattern (LOCK_EX + fsync below)` | Journal-style append inside a `LOCK_EX` block with explicit `fsync` after the write. |
+| `# atomic-write: ok — journal compaction inside _locked() (caller holds LOCK_EX)` | Whole-journal rewrite under exclusive lock. |
+| `# atomic-write: ok — one-shot migration backup, retry-on-fail safe` | Migration backup written before destructive operation; rerun-safe. |
+
+Files that *implement* the atomic-write primitives are exempt at the file level:
+`src/utils/atomic_write.py`, `src/utils/atomic_io.py`.
+
 ---
 
 ## Pattern F4: SECURITY_VULN — 74 findings (highest-frequency)

--- a/.claude/rules/test-generation-patterns.md
+++ b/.claude/rules/test-generation-patterns.md
@@ -638,6 +638,53 @@ Automatable: a grep guardrail bans this pattern outright (see `tests/ci/test_tes
 
 ---
 
+## Pattern T15: MOCK_ASSERTION_AFTER_RAISE_IN_PYTEST_RAISES
+
+**What it is**: A mock assertion (`mock.X.assert_called*(...)` or
+`assert mock.X.called`) placed AFTER a top-level `raise` inside a
+`with pytest.raises(...):` block. The `raise` terminates control flow,
+so the mock assertion is unreachable — but reads as a real check.
+
+PR-A's PT012 catches multi-statement `pytest.raises` blocks generally,
+but is silenced inside the 11 sites that carry `# noqa: PT012` for
+legitimately multi-statement bodies (transaction rollback,
+context-manager exit semantics, `try/except` subclass-non-catching,
+etc.). T15 closes that hole with a targeted AST rail.
+
+**Bad**:
+
+```python
+with pytest.raises(ValueError):  # noqa: PT012 — context-manager exit semantics
+    with manager() as m:
+        do_setup()
+        raise ValueError("boom")
+        m.cleanup.assert_called_once()  # UNREACHABLE — never executes
+```
+
+**Good**:
+
+```python
+# Move the mock assertion AFTER the with-block exits.
+with pytest.raises(ValueError):  # noqa: PT012 — context-manager exit semantics
+    with manager() as m:
+        do_setup()
+        raise ValueError("boom")
+m.cleanup.assert_called_once()  # exit-on-exception verified here
+```
+
+**Pre-generation check**: After writing a `pytest.raises` block, ask:
+*"Is anything below the `raise` inside this block? If yes — those statements
+won't run. Move them outside the `with` (where they execute after the
+exception propagates) or delete them."*
+
+**Mechanical rail**: `scripts/check_pytest_raises_hygiene.py` — AST visitor
+that flags any mock assertion (recognised method names + bare
+`assert <mock>.called`) appearing after a top-level `raise` inside a
+`with pytest.raises(...):` block. Conservative: only top-level `raise`
+counts as terminating, so conditional / nested raises don't false-flag.
+
+---
+
 ## Rule of Thumb
 
 For every assertion, ask:
@@ -654,5 +701,6 @@ For every assertion, ask:
 11. **T12**: "Snapshotted shared state? Make sure teardown actually restores the snapshot (including sub-module keys)."
 12. **T13**: "Hardcoded path string in test data? Use `tmp_path` instead."
 13. **T14**: "`(_ for _ in ()).throw(...)` — never. Use a named function or `MagicMock(side_effect=...)`."
+14. **T15**: "Anything after a top-level `raise` inside a `with pytest.raises(...):`? Move it outside the block — it's unreachable."
 
 **Last audited PR**: #140 (PR review cycle 2026-03-21 to 2026-04-21)

--- a/.claude/rules/test-generation-patterns.md
+++ b/.claude/rules/test-generation-patterns.md
@@ -143,6 +143,37 @@ def test_sends_notification(self, mock_notifier):
     )
 ```
 
+### Mechanical sub-rail (T3 narrow): `assert <mock>.called` is banned
+
+The full T3 surface (call-count comparisons, payload-free `assert_called()`)
+has many legitimate uses (logger spies, control-flow probes), so a strict
+rail would be too noisy. But the **`assert <mock>.<attr>.called` attribute-
+lookup form** has zero legitimate uses — the canonical mock-library
+equivalent `<mock>.<attr>.assert_called()` is one extra character, more
+discoverable in IDEs (it's a documented method, not a flag attribute),
+and consistent with the rest of the test suite's assertion style.
+
+**Bad**:
+
+```python
+assert mock_console.print.called
+assert mock.method.called is True
+assert mock.method.called == True
+```
+
+**Good**:
+
+```python
+mock_console.print.assert_called()
+mock.method.assert_called()
+```
+
+**Mechanical rail**: `scripts/check_called_attribute_assertion.py` —
+regex detector with `# noqa: T3` opt-out for the rare case where the
+attribute access is intentional (e.g. testing the mock library itself).
+Wider T3 (call-count, payload-free `_with`-less calls) remains
+code-review-enforced.
+
 ---
 
 ## Pattern T4: TAUTOLOGICAL_DISJUNCTION

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,6 +93,21 @@ repos:
         pass_filenames: false
 
       # ----------------------------------------------------------------
+      # Atomic-write rail: persistent file writes in src/ must use the
+      # utils.atomic_write helpers (or carry an explicit
+      # `# atomic-write: ok — <reason>` opt-out comment). Blocks
+      # regressions of the F3 / Epic B.atomic hardening (PRs #176, #195,
+      # #197, #203, #204).  See .claude/rules/feature-generation-patterns.md
+      # F3 and tests/ci/test_atomic_write_required.py for the rail body.
+      # ----------------------------------------------------------------
+      - id: atomic-write-required
+        name: persistent writes in src/ must be atomic
+        entry: python3 scripts/check_atomic_write.py
+        language: system
+        pass_filenames: false
+        files: ^src/.*\.py$
+
+      # ----------------------------------------------------------------
       # G2: No f-strings in logger calls (single or double quote)
       # Matches: logger.debug(f"..."), logger.info(f'...'),
       #          logger.exception( f"..."), etc.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,6 +108,19 @@ repos:
         files: ^src/.*\.py$
 
       # ----------------------------------------------------------------
+      # pytest.raises hygiene: no mock assertion after `raise` inside the
+      # block (the assertion is unreachable). Closes the gap left when
+      # PT012 is suppressed via `# noqa: PT012` for legitimate
+      # multi-statement bodies. See tests/ci/test_pytest_raises_hygiene.py.
+      # ----------------------------------------------------------------
+      - id: pytest-raises-hygiene
+        name: no mock assertion after raise in pytest.raises blocks
+        entry: python3 scripts/check_pytest_raises_hygiene.py
+        language: system
+        pass_filenames: false
+        files: ^tests/.*\.py$
+
+      # ----------------------------------------------------------------
       # G2: No f-strings in logger calls (single or double quote)
       # Matches: logger.debug(f"..."), logger.info(f'...'),
       #          logger.exception( f"..."), etc.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -121,6 +121,20 @@ repos:
         files: ^tests/.*\.py$
 
       # ----------------------------------------------------------------
+      # T3-narrow: ban `assert <mock>.called` attribute-style assertion.
+      # The canonical mock-library equivalent is `<mock>.assert_called()`
+      # (one extra char, more discoverable, consistent with the rest of
+      # the suite). See .claude/rules/test-generation-patterns.md T3 and
+      # tests/ci/test_called_attribute_assertion.py.
+      # ----------------------------------------------------------------
+      - id: t3-no-bare-called-assertion
+        name: no `assert <mock>.called` (use `.assert_called()` instead)
+        entry: python3 scripts/check_called_attribute_assertion.py
+        language: system
+        pass_filenames: false
+        files: ^tests/.*\.py$
+
+      # ----------------------------------------------------------------
       # G2: No f-strings in logger calls (single or double quote)
       # Matches: logger.debug(f"..."), logger.info(f'...'),
       #          logger.exception( f"..."), etc.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,6 +217,9 @@ select = [
     "D",   # pydocstyle (google convention)
     "RUF100",  # stale noqa comments
     "DTZ",  # datetime timezone rules (DTZ001-DTZ007, DTZ011-DTZ012)
+    "PT012",  # pytest-raises-with-multiple-statements
+    "PT017",  # assertion-in-except-block (use pytest.raises with `as` capture)
+    "PT022",  # pytest-useless-yield-fixture
 ]
 ignore = [
     "E501",   # line too long (handled by formatter)

--- a/scripts/check_atomic_write.py
+++ b/scripts/check_atomic_write.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Atomic-write rail: persistent file writes in src/ must be crash-safe.
+
+Background
+----------
+PRs #176 / #195 / #197 / #203 / #204 added the ``utils.atomic_write`` helper
+suite (``atomic_write_text``, ``atomic_write_bytes``, ``atomic_write_with``,
+``append_durable``) and converted 19+ call sites to crash-safe writes.
+
+This rail blocks regressions: any ``Path.write_text``, ``Path.write_bytes``,
+or ``open(p, "w"|"wb"|"a"|"ab")`` call in ``src/`` that is NOT marked with an
+explicit ``# atomic-write: ok — <reason>`` opt-out comment is flagged.
+
+Scope
+-----
+- ``src/**/*.py`` only — tests/scripts/docs are out of scope.
+- Allowlisted files (the helper module itself + cross-platform fsync shim):
+    ``src/utils/atomic_write.py``
+    ``src/utils/atomic_io.py``
+
+Opt-out marker
+--------------
+Add ``# atomic-write: ok — <one-line-reason>`` to the call line. Reason
+categories that are accepted as legitimate non-atomic writes:
+
+    user output      — user-supplied path, one-shot CLI export, retry-on-fail
+    manual temp+replace — site already uses tempfile.NamedTemporaryFile + os.replace
+    pid file         — created via O_EXCL elsewhere (atomicity via the lock file)
+    journal append   — log/journal that uses append_durable semantics elsewhere
+
+Example::
+
+    cache_path.write_text(payload)  # atomic-write: ok — manual temp+replace pattern below
+
+Exit 0 = no violations.
+Exit 1 = violations found. Offending lines are printed to stderr.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SRC_DIR = _ROOT / "src"
+
+# Files that own the atomic-write primitives themselves — exempt from the
+# rail (they implement the pattern; they don't need to opt out of it).
+_ALLOWLISTED_FILES = frozenset(
+    {
+        "src/utils/atomic_write.py",
+        "src/utils/atomic_io.py",
+    }
+)
+
+# Forbidden write patterns: Path.write_text(, Path.write_bytes(,
+# open(<...>, "w"|"wb"|"a"|"ab").  Single-line forms are matched by
+# _PATTERNS; multi-line ``open()`` calls (where the mode string is on a
+# subsequent line) are detected by _OPEN_RE + _WRITE_MODE_RE in
+# find_violations().
+_PATTERNS = (
+    re.compile(r"\.write_text\("),
+    re.compile(r"\.write_bytes\("),
+    re.compile(r"""\bopen\([^)]*['"]w[ba]?['"]"""),
+    re.compile(r"""\bopen\([^)]*['"]a[b]?['"]"""),
+)
+
+# Used to detect the *start* of a multi-line open() call.
+_OPEN_RE = re.compile(r"\bopen\(")
+# Matches a write/append mode string used in the lookahead window for
+# multi-line open() detection.
+_WRITE_MODE_RE = re.compile(r"""['"](?:w[ba]?|a[b]?)['"]""")
+
+# Opt-out marker.  Checked against the *comment portion* of the line only
+# (see _comment_portion) so a marker embedded inside a string literal does
+# not incorrectly satisfy the rule.
+_OPT_OUT_RE = re.compile(r"#\s*atomic-write:\s*ok\b")
+
+
+def _is_comment_line(line: str) -> bool:
+    """True if the line (after whitespace) starts with ``#``."""
+    return line.lstrip().startswith("#")
+
+
+def _comment_portion(line: str) -> str:
+    """Return everything from the first ``#`` that is outside a string literal.
+
+    Walks *line* left-to-right tracking single- and double-quoted string state
+    (including backslash escapes) and returns the substring starting at the
+    first ``#`` that falls outside any quote. Returns ``""`` when no such
+    ``#`` exists.
+    """
+    in_str: str | None = None
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if in_str:
+            if ch == "\\":
+                i += 2  # skip escaped character
+                continue
+            if ch == in_str:
+                in_str = None
+        elif ch in ('"', "'"):
+            in_str = ch
+        elif ch == "#":
+            return line[i:]
+        i += 1
+    return ""
+
+
+def _has_opt_out(line: str) -> bool:
+    """True if the line's trailing comment contains the ``# atomic-write: ok`` marker."""
+    return bool(_OPT_OUT_RE.search(_comment_portion(line)))
+
+
+def _is_in_docstring_or_string(line: str) -> bool:
+    """Heuristic: line is dominated by a docstring/string literal.
+
+    Conservative — a line that contains a forbidden pattern *only* inside a
+    string literal (e.g. an example in a docstring) should not trip the rail.
+    Detection: line, after stripping leading whitespace, starts with a quote
+    char or with the line being part of a triple-quoted block (``\"\"\"`` or
+    ``'''``). Misses some cases but cheap and false-positive-safe.
+    """
+    stripped = line.lstrip()
+    if stripped.startswith(('"""', "'''", '"', "'")):
+        return True
+    return False
+
+
+def _matches_forbidden(line: str) -> bool:
+    """True if the line contains any forbidden write pattern."""
+    return any(pat.search(line) for pat in _PATTERNS)
+
+
+def _iter_src_files() -> list[Path]:
+    """Yield every ``.py`` file under ``src/``."""
+    return sorted(_SRC_DIR.rglob("*.py"))
+
+
+_MARKER_LOOKAHEAD = 6
+"""Number of lines past the matched call to scan for the opt-out marker.
+
+``ruff format`` may split long calls across lines, leaving the
+``# atomic-write: ok`` comment on a later line (typically on the closing
+``)``). A small lookahead window catches these without false positives.
+"""
+
+
+def find_violations(path: Path) -> list[tuple[int, str]]:
+    """Return [(line_number, line_text)] for each unexempted write site.
+
+    Files outside ``_ROOT`` (e.g. ``tmp_path`` synthetic files in unit tests)
+    bypass the allowlist check — they're never the real ``src/utils/atomic_write.py``
+    so there's nothing to exempt at the file level.
+    """
+    if path.is_relative_to(_ROOT):
+        rel = path.relative_to(_ROOT).as_posix()
+        if rel in _ALLOWLISTED_FILES:
+            return []
+
+    violations: list[tuple[int, str]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return violations
+
+    lines = text.splitlines()
+    in_triple_quote = False
+    for idx, raw in enumerate(lines):
+        lineno = idx + 1
+        # Track triple-quoted string blocks so docstring examples don't trip
+        # the rail. The check is heuristic — counts ``\"\"\"`` toggles.
+        triple_count = raw.count('"""') + raw.count("'''")
+        if triple_count % 2 == 1:
+            in_triple_quote = not in_triple_quote
+            continue
+        if in_triple_quote:
+            continue
+        if not _matches_forbidden(raw):
+            # Also detect multi-line open() calls: ``open(`` on one line,
+            # mode string on a subsequent line (ruff format splits long
+            # argument lists). Scan the next _MARKER_LOOKAHEAD lines for a
+            # write/append mode string.
+            if not _OPEN_RE.search(raw):
+                continue
+            rest = lines[idx + 1 : idx + _MARKER_LOOKAHEAD]
+            if not any(_WRITE_MODE_RE.search(ln) for ln in rest):
+                continue
+        if _is_comment_line(raw):
+            continue
+        if _is_in_docstring_or_string(raw):
+            continue
+        # Marker may be on the matched line OR on one of the next few
+        # lines (ruff format often moves a long-line trailing comment to
+        # the closing-paren line). Scan a bounded window forward.
+        window = lines[idx : idx + _MARKER_LOOKAHEAD]
+        if any(_has_opt_out(w) for w in window):
+            continue
+        violations.append((lineno, raw.rstrip()))
+    return violations
+
+
+def main() -> int:
+    """Scan ``src/`` and print violations to stderr; exit 1 if any."""
+    all_violations: list[tuple[Path, int, str]] = []
+    for path in _iter_src_files():
+        for lineno, line in find_violations(path):
+            all_violations.append((path.relative_to(_ROOT), lineno, line))
+
+    if not all_violations:
+        return 0
+
+    print(
+        "ERROR (atomic-write): persistent write call in src/ without atomic\n"
+        "helper or opt-out marker. Use one of:\n"
+        "  - utils.atomic_write.atomic_write_text / atomic_write_bytes / atomic_write_with\n"
+        "  - utils.atomic_write.append_durable (for journal/log appends)\n"
+        "Or, for legitimate non-atomic writes, append:\n"
+        "  # atomic-write: ok — <reason>\n"
+        "Accepted reasons: user output, manual temp+replace, pid file, journal append.\n",
+        file=sys.stderr,
+    )
+    for path, lineno, line in all_violations:
+        print(f"  {path}:{lineno}: {line}", file=sys.stderr)
+    print(
+        f"\n{len(all_violations)} violation(s) across "
+        f"{len({v[0] for v in all_violations})} file(s).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_atomic_write.py
+++ b/scripts/check_atomic_write.py
@@ -183,29 +183,59 @@ def _is_open_call(node: ast.Call) -> bool:
     return False
 
 
-def _extract_mode_string(node: ast.Call) -> str | None:
-    """Return the mode string passed to ``open(path, mode)`` if statically known.
+_MODE_CHARS = frozenset("rwaxbt+")
 
-    Two call shapes:
 
-    - Builtin ``open(path, mode, ...)``: the mode is the second positional
-      argument (``args[1]``).
-    - Method ``<obj>.open(mode, ...)`` (e.g. ``Path("x").open("w")``): the
-      receiver is implicit, so the mode is the *first* positional argument
-      (``args[0]``).
+def _looks_like_mode_literal(value: object) -> bool:
+    """True if *value* is a string that plausibly is a Python ``open()`` mode.
 
-    The ``mode=`` keyword form works for both shapes.
-
-    Returns ``None`` if the mode is dynamic (variable, computed, etc.) — a
-    dynamic mode could be a write or read; we conservatively skip rather
-    than false-flag.
+    A Python mode string is short (1-4 chars) and consists of characters
+    drawn from ``rwaxbt+`` with exactly one of the primary action chars
+    ``rwax``. This rejects things that happen to be string Constants but
+    are clearly file paths (``"write.log"`` has ``.`` and ``l``, ``o``,
+    ``g``) — important because attribute-style calls like
+    ``tarfile.open("write.log", "wb")`` have the path at args[0] and the
+    mode at args[1], while ``Path("x").open("w")`` has the mode at
+    args[0]. The strict pattern lets us check BOTH positions safely.
     """
-    is_method = isinstance(node.func, ast.Attribute)
-    mode_pos = 0 if is_method else 1
-    if len(node.args) > mode_pos:
-        mode_arg = node.args[mode_pos]
-        if isinstance(mode_arg, ast.Constant) and isinstance(mode_arg.value, str):
-            return mode_arg.value
+    if not isinstance(value, str):
+        return False
+    if not 1 <= len(value) <= 4:
+        return False
+    if not all(c in _MODE_CHARS for c in value):
+        return False
+    primary_chars = sum(1 for c in value if c in "rwax")
+    return primary_chars == 1
+
+
+def _extract_mode_string(node: ast.Call) -> str | None:
+    """Return the mode string passed to ``open()`` if statically known.
+
+    Three call shapes the rail must handle:
+
+    - Builtin ``open(path, mode, ...)``: mode at ``args[1]``.
+    - Module-level ``<module>.open(path, mode, ...)`` such as
+      ``tarfile.open(path, "w")`` or ``gzip.open(path, "wb")``:
+      mode at ``args[1]`` (codex r219 #6 thread).
+    - Instance-method ``<obj>.open(mode, ...)`` such as
+      ``Path("x").open("w")``: mode at ``args[0]``.
+
+    From the AST alone we cannot tell whether an attribute call is a
+    module-level function or an instance method — so we check both
+    positions and pick the FIRST argument that looks like a real Python
+    mode literal (``_looks_like_mode_literal``). The strict pattern
+    (length ≤ 4, characters drawn from ``rwaxbt+``, exactly one primary
+    action char) keeps file-path strings from being mistaken for modes.
+
+    The ``mode=`` keyword form works for every shape.
+
+    Returns ``None`` if no statically-known mode is present — a dynamic
+    mode (variable, computed, etc.) could be a write or read; we skip
+    rather than false-flag.
+    """
+    for arg in node.args[:2]:
+        if isinstance(arg, ast.Constant) and _looks_like_mode_literal(arg.value):
+            return arg.value
     for kw in node.keywords:
         if kw.arg == "mode":
             if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):

--- a/scripts/check_atomic_write.py
+++ b/scripts/check_atomic_write.py
@@ -8,22 +8,27 @@ suite (``atomic_write_text``, ``atomic_write_bytes``, ``atomic_write_with``,
 ``append_durable``) and converted 19+ call sites to crash-safe writes.
 
 This rail blocks regressions: any ``Path.write_text``, ``Path.write_bytes``,
-or ``open(p, "w"|"wb"|"a"|"ab")`` call in ``src/`` that is NOT marked with an
-explicit ``# atomic-write: ok — <reason>`` opt-out comment is flagged.
+or ``open(p, mode)`` call in ``src/`` whose mode is one of
+``w``, ``wb``, ``a``, ``ab``, ``w+``, ``wb+``, ``a+``, ``ab+`` and which is
+NOT marked with an explicit ``# atomic-write: ok — <reason>`` opt-out comment
+is flagged.
 
 Detection
 ---------
 AST-based. Walks every Python source file in ``src/`` looking for:
 
 - ``<expr>.write_text(...)`` / ``<expr>.write_bytes(...)`` calls.
-- ``open(...)`` calls where the mode argument is a string literal matching
-  ``w``, ``wb``, ``a``, or ``ab``. The mode may be the second positional
-  argument or a ``mode=`` keyword. The first argument can be any expression
+- ``open(...)`` calls where the mode argument is a string literal in the
+  ``_FORBIDDEN_MODES`` set. The mode may be the second positional argument
+  or a ``mode=`` keyword. The first argument can be any expression
   (including nested calls like ``open(Path(name).with_suffix('.json'), 'w')``
-  — codex r219).
+  — codex r219 #1).
 
 String-literal forbidden patterns are NOT matched (e.g.
-``logger.debug("open(path, 'w')")`` is a string, not a call — codex r219).
+``logger.debug("open(path, 'w')")`` is a string, not a call — codex r219 #2).
+The opt-out marker is matched against tokenised comments only, so a
+string-literal containing the marker text (``msg = "# atomic-write: ok"``)
+cannot bypass the rail (CodeRabbit r219).
 
 Scope
 -----
@@ -34,16 +39,18 @@ Scope
 
 Opt-out marker
 --------------
-Add ``# atomic-write: ok — <one-line-reason>`` somewhere within ±6 lines of
-the call.  Three placements are accepted:
+Add ``# atomic-write: ok — <one-line-reason>`` somewhere in the
+``-2 / +6`` line window around the call line (2 lines above through 6 lines
+below — see ``_MARKER_WINDOW_ABOVE`` / ``_MARKER_WINDOW_BELOW``). Three
+placements are accepted:
 
 - Trailing comment on the call line itself.
 - Trailing comment on the closing-paren line of a multi-line call (ruff
-  format frequently splits long calls).
-- Standalone comment line on the line(s) immediately above the call. This
-  placement avoids modifying the call line itself, which keeps the
-  diff-coverage gate from flagging the (already-uncovered) call line as a
-  newly-changed-but-uncovered line.
+  format frequently splits long calls — covered by the +6 lookahead).
+- Standalone comment line on the line(s) immediately above the call (covered
+  by the -2 lookback). This placement avoids modifying the call line itself,
+  which keeps the diff-coverage gate from flagging the (already-uncovered)
+  call line as a newly-changed-but-uncovered line.
 
 Reason categories that are accepted as legitimate non-atomic writes:
 
@@ -65,8 +72,10 @@ Exit 1 = violations found. Offending lines are printed to stderr.
 from __future__ import annotations
 
 import ast
+import io
 import re
 import sys
+import tokenize
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parent.parent
@@ -137,17 +146,41 @@ def _is_forbidden_open(node: ast.Call) -> bool:
     return mode is not None and mode in _FORBIDDEN_MODES
 
 
-def _has_opt_out_in_window(lines: list[str], call_line: int) -> bool:
-    """True if any line in the marker window contains ``# atomic-write: ok``.
+def _collect_marker_comment_lines(source: str) -> set[int]:
+    """Return the 1-based line numbers of every Python comment carrying the marker.
+
+    Tokenises *source* and only inspects ``tokenize.COMMENT`` tokens — string
+    literals containing ``# atomic-write: ok`` (e.g. ``msg = "# atomic-write: ok"``)
+    are NOT comments and therefore cannot exempt a real write call (CodeRabbit
+    r219 #2 — bypass-via-string-literal).
+
+    Falls back to an empty set on tokenise failure (e.g. an unterminated
+    string literal in a syntactically broken file). The caller's AST parse
+    will already have failed in that case, so no violations are reported
+    either way.
+    """
+    marker_lines: set[int] = set()
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            if tok.type == tokenize.COMMENT and _OPT_OUT_RE.search(tok.string):
+                marker_lines.add(tok.start[0])
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        return set()
+    return marker_lines
+
+
+def _has_opt_out_in_window(marker_lines: set[int], call_line: int, total_lines: int) -> bool:
+    """True if any *marker_lines* entry falls inside the call's marker window.
 
     *call_line* is 1-based. The window covers ``call_line - _MARKER_WINDOW_ABOVE``
     through ``call_line + _MARKER_WINDOW_BELOW`` (inclusive), clamped to the
-    file bounds.
+    file bounds. *marker_lines* is the set returned by
+    ``_collect_marker_comment_lines`` — only real comment tokens.
     """
     start = max(1, call_line - _MARKER_WINDOW_ABOVE)
-    end = min(len(lines), call_line + _MARKER_WINDOW_BELOW)
+    end = min(total_lines, call_line + _MARKER_WINDOW_BELOW)
     for lineno in range(start, end + 1):
-        if _OPT_OUT_RE.search(lines[lineno - 1]):
+        if lineno in marker_lines:
             return True
     return False
 
@@ -187,13 +220,14 @@ def find_violations(path: Path) -> list[tuple[int, str]]:
         return []
 
     lines = source.splitlines()
+    marker_lines = _collect_marker_comment_lines(source)
     violations: list[tuple[int, str]] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         if not (_is_write_text_or_bytes(node) or _is_forbidden_open(node)):
             continue
-        if _has_opt_out_in_window(lines, node.lineno):
+        if _has_opt_out_in_window(marker_lines, node.lineno, len(lines)):
             continue
         violations.append((node.lineno, _line_excerpt(lines, node.lineno)))
     return violations
@@ -219,7 +253,8 @@ def main() -> int:
         "helper or opt-out marker. Use one of:\n"
         "  - utils.atomic_write.atomic_write_text / atomic_write_bytes / atomic_write_with\n"
         "  - utils.atomic_write.append_durable (for journal/log appends)\n"
-        "Or, for legitimate non-atomic writes, place a comment within ±6 lines:\n"
+        "Or, for legitimate non-atomic writes, place a comment in the -2 / +6\n"
+        "line window around the call:\n"
         "  # atomic-write: ok — <reason>\n"
         "Accepted reasons: user output, manual temp+replace, pid file, journal append.\n",
         file=sys.stderr,

--- a/scripts/check_atomic_write.py
+++ b/scripts/check_atomic_write.py
@@ -11,6 +11,20 @@ This rail blocks regressions: any ``Path.write_text``, ``Path.write_bytes``,
 or ``open(p, "w"|"wb"|"a"|"ab")`` call in ``src/`` that is NOT marked with an
 explicit ``# atomic-write: ok — <reason>`` opt-out comment is flagged.
 
+Detection
+---------
+AST-based. Walks every Python source file in ``src/`` looking for:
+
+- ``<expr>.write_text(...)`` / ``<expr>.write_bytes(...)`` calls.
+- ``open(...)`` calls where the mode argument is a string literal matching
+  ``w``, ``wb``, ``a``, or ``ab``. The mode may be the second positional
+  argument or a ``mode=`` keyword. The first argument can be any expression
+  (including nested calls like ``open(Path(name).with_suffix('.json'), 'w')``
+  — codex r219).
+
+String-literal forbidden patterns are NOT matched (e.g.
+``logger.debug("open(path, 'w')")`` is a string, not a call — codex r219).
+
 Scope
 -----
 - ``src/**/*.py`` only — tests/scripts/docs are out of scope.
@@ -20,8 +34,18 @@ Scope
 
 Opt-out marker
 --------------
-Add ``# atomic-write: ok — <one-line-reason>`` to the call line. Reason
-categories that are accepted as legitimate non-atomic writes:
+Add ``# atomic-write: ok — <one-line-reason>`` somewhere within ±6 lines of
+the call.  Three placements are accepted:
+
+- Trailing comment on the call line itself.
+- Trailing comment on the closing-paren line of a multi-line call (ruff
+  format frequently splits long calls).
+- Standalone comment line on the line(s) immediately above the call. This
+  placement avoids modifying the call line itself, which keeps the
+  diff-coverage gate from flagging the (already-uncovered) call line as a
+  newly-changed-but-uncovered line.
+
+Reason categories that are accepted as legitimate non-atomic writes:
 
     user output      — user-supplied path, one-shot CLI export, retry-on-fail
     manual temp+replace — site already uses tempfile.NamedTemporaryFile + os.replace
@@ -30,7 +54,9 @@ categories that are accepted as legitimate non-atomic writes:
 
 Example::
 
-    cache_path.write_text(payload)  # atomic-write: ok — manual temp+replace pattern below
+    # atomic-write: ok — manual temp+replace pattern below
+    with open(temp_path, "w", encoding="utf-8") as f:
+        ...
 
 Exit 0 = no violations.
 Exit 1 = violations found. Offending lines are printed to stderr.
@@ -38,6 +64,7 @@ Exit 1 = violations found. Offending lines are printed to stderr.
 
 from __future__ import annotations
 
+import ast
 import re
 import sys
 from pathlib import Path
@@ -54,152 +81,127 @@ _ALLOWLISTED_FILES = frozenset(
     }
 )
 
-# Forbidden write patterns: Path.write_text(, Path.write_bytes(,
-# open(<...>, "w"|"wb"|"a"|"ab").  Single-line forms are matched by
-# _PATTERNS; multi-line ``open()`` calls (where the mode string is on a
-# subsequent line) are detected by _OPEN_RE + _WRITE_MODE_RE in
-# find_violations().
-_PATTERNS = (
-    re.compile(r"\.write_text\("),
-    re.compile(r"\.write_bytes\("),
-    re.compile(r"""\bopen\([^)]*['"]w[ba]?['"]"""),
-    re.compile(r"""\bopen\([^)]*['"]a[b]?['"]"""),
-)
+# Modes that constitute a forbidden write/append.  Read modes (``r``,
+# ``rb``, etc.) are not forbidden.
+_FORBIDDEN_MODES: frozenset[str] = frozenset({"w", "wb", "a", "ab", "w+", "wb+", "a+", "ab+"})
 
-# Used to detect the *start* of a multi-line open() call.
-_OPEN_RE = re.compile(r"\bopen\(")
-# Matches a write/append mode string used in the lookahead window for
-# multi-line open() detection.
-_WRITE_MODE_RE = re.compile(r"""['"](?:w[ba]?|a[b]?)['"]""")
-
-# Opt-out marker.  Checked against the *comment portion* of the line only
-# (see _comment_portion) so a marker embedded inside a string literal does
-# not incorrectly satisfy the rule.
+# Opt-out marker.  Searched for in trailing comments AND on standalone
+# comment lines within the configured window (see ``_MARKER_WINDOW``).
 _OPT_OUT_RE = re.compile(r"#\s*atomic-write:\s*ok\b")
 
+# How far above / below the call line to scan for the opt-out marker.
+# ABOVE accommodates the standalone-comment placement; BELOW accommodates
+# ruff-format splitting a long call across multiple lines.
+_MARKER_WINDOW_ABOVE = 2
+_MARKER_WINDOW_BELOW = 6
 
-def _is_comment_line(line: str) -> bool:
-    """True if the line (after whitespace) starts with ``#``."""
-    return line.lstrip().startswith("#")
+
+def _is_write_text_or_bytes(node: ast.Call) -> bool:
+    """True if *node* is ``<expr>.write_text(...)`` or ``<expr>.write_bytes(...)``."""
+    func = node.func
+    if not isinstance(func, ast.Attribute):
+        return False
+    return func.attr in ("write_text", "write_bytes")
 
 
-def _comment_portion(line: str) -> str:
-    """Return everything from the first ``#`` that is outside a string literal.
+def _is_open_call(node: ast.Call) -> bool:
+    """True if *node* is ``open(...)`` (the bare builtin, not ``<obj>.open(...)``)."""
+    func = node.func
+    return isinstance(func, ast.Name) and func.id == "open"
 
-    Walks *line* left-to-right tracking single- and double-quoted string state
-    (including backslash escapes) and returns the substring starting at the
-    first ``#`` that falls outside any quote. Returns ``""`` when no such
-    ``#`` exists.
+
+def _extract_mode_string(node: ast.Call) -> str | None:
+    """Return the mode string passed to ``open(path, mode)`` if statically known.
+
+    Handles both the positional second argument and the ``mode=`` keyword.
+    Returns ``None`` if the mode is dynamic (variable, computed, etc.) — a
+    dynamic mode could be a write or read; we conservatively skip rather
+    than false-flag.
     """
-    in_str: str | None = None
-    i = 0
-    while i < len(line):
-        ch = line[i]
-        if in_str:
-            if ch == "\\":
-                i += 2  # skip escaped character
-                continue
-            if ch == in_str:
-                in_str = None
-        elif ch in ('"', "'"):
-            in_str = ch
-        elif ch == "#":
-            return line[i:]
-        i += 1
-    return ""
+    if len(node.args) >= 2:
+        mode_arg = node.args[1]
+        if isinstance(mode_arg, ast.Constant) and isinstance(mode_arg.value, str):
+            return mode_arg.value
+    for kw in node.keywords:
+        if kw.arg == "mode":
+            if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                return kw.value.value
+    return None
 
 
-def _has_opt_out(line: str) -> bool:
-    """True if the line's trailing comment contains the ``# atomic-write: ok`` marker."""
-    return bool(_OPT_OUT_RE.search(_comment_portion(line)))
+def _is_forbidden_open(node: ast.Call) -> bool:
+    """True if *node* is ``open(<path>, "<write-mode>")``."""
+    if not _is_open_call(node):
+        return False
+    mode = _extract_mode_string(node)
+    return mode is not None and mode in _FORBIDDEN_MODES
 
 
-def _is_in_docstring_or_string(line: str) -> bool:
-    """Heuristic: line is dominated by a docstring/string literal.
+def _has_opt_out_in_window(lines: list[str], call_line: int) -> bool:
+    """True if any line in the marker window contains ``# atomic-write: ok``.
 
-    Conservative — a line that contains a forbidden pattern *only* inside a
-    string literal (e.g. an example in a docstring) should not trip the rail.
-    Detection: line, after stripping leading whitespace, starts with a quote
-    char or with the line being part of a triple-quoted block (``\"\"\"`` or
-    ``'''``). Misses some cases but cheap and false-positive-safe.
+    *call_line* is 1-based. The window covers ``call_line - _MARKER_WINDOW_ABOVE``
+    through ``call_line + _MARKER_WINDOW_BELOW`` (inclusive), clamped to the
+    file bounds.
     """
-    stripped = line.lstrip()
-    if stripped.startswith(('"""', "'''", '"', "'")):
-        return True
+    start = max(1, call_line - _MARKER_WINDOW_ABOVE)
+    end = min(len(lines), call_line + _MARKER_WINDOW_BELOW)
+    for lineno in range(start, end + 1):
+        if _OPT_OUT_RE.search(lines[lineno - 1]):
+            return True
     return False
 
 
-def _matches_forbidden(line: str) -> bool:
-    """True if the line contains any forbidden write pattern."""
-    return any(pat.search(line) for pat in _PATTERNS)
-
-
-def _iter_src_files() -> list[Path]:
-    """Yield every ``.py`` file under ``src/``."""
-    return sorted(_SRC_DIR.rglob("*.py"))
-
-
-_MARKER_LOOKAHEAD = 6
-"""Number of lines past the matched call to scan for the opt-out marker.
-
-``ruff format`` may split long calls across lines, leaving the
-``# atomic-write: ok`` comment on a later line (typically on the closing
-``)``). A small lookahead window catches these without false positives.
-"""
+def _line_excerpt(lines: list[str], lineno: int) -> str:
+    """Return the source line at *lineno* (1-based), trimmed of trailing whitespace."""
+    if 1 <= lineno <= len(lines):
+        return lines[lineno - 1].rstrip()
+    return f"<line {lineno}>"
 
 
 def find_violations(path: Path) -> list[tuple[int, str]]:
-    """Return [(line_number, line_text)] for each unexempted write site.
+    """Return [(line_number, line_text)] for each unexempted write call.
 
-    Files outside ``_ROOT`` (e.g. ``tmp_path`` synthetic files in unit tests)
-    bypass the allowlist check — they're never the real ``src/utils/atomic_write.py``
-    so there's nothing to exempt at the file level.
+    Uses the AST to locate ``Path.write_text``, ``Path.write_bytes``, and
+    ``open(p, "w"|"wb"|"a"|"ab")`` calls. Files outside ``_ROOT`` (e.g.
+    ``tmp_path`` synthetic files in unit tests) bypass the allowlist check —
+    they're never the real ``src/utils/atomic_write.py`` so there's nothing
+    to exempt at the file level.
+
+    Files that fail to parse (invalid Python) yield zero violations — a
+    syntax error is a separate problem and shouldn't be conflated with
+    rail enforcement.
     """
     if path.is_relative_to(_ROOT):
         rel = path.relative_to(_ROOT).as_posix()
         if rel in _ALLOWLISTED_FILES:
             return []
 
-    violations: list[tuple[int, str]] = []
     try:
-        text = path.read_text(encoding="utf-8")
+        source = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
-        return violations
+        return []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
 
-    lines = text.splitlines()
-    in_triple_quote = False
-    for idx, raw in enumerate(lines):
-        lineno = idx + 1
-        # Track triple-quoted string blocks so docstring examples don't trip
-        # the rail. The check is heuristic — counts ``\"\"\"`` toggles.
-        triple_count = raw.count('"""') + raw.count("'''")
-        if triple_count % 2 == 1:
-            in_triple_quote = not in_triple_quote
+    lines = source.splitlines()
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
             continue
-        if in_triple_quote:
+        if not (_is_write_text_or_bytes(node) or _is_forbidden_open(node)):
             continue
-        if not _matches_forbidden(raw):
-            # Also detect multi-line open() calls: ``open(`` on one line,
-            # mode string on a subsequent line (ruff format splits long
-            # argument lists). Scan the next _MARKER_LOOKAHEAD lines for a
-            # write/append mode string.
-            if not _OPEN_RE.search(raw):
-                continue
-            rest = lines[idx + 1 : idx + _MARKER_LOOKAHEAD]
-            if not any(_WRITE_MODE_RE.search(ln) for ln in rest):
-                continue
-        if _is_comment_line(raw):
+        if _has_opt_out_in_window(lines, node.lineno):
             continue
-        if _is_in_docstring_or_string(raw):
-            continue
-        # Marker may be on the matched line OR on one of the next few
-        # lines (ruff format often moves a long-line trailing comment to
-        # the closing-paren line). Scan a bounded window forward.
-        window = lines[idx : idx + _MARKER_LOOKAHEAD]
-        if any(_has_opt_out(w) for w in window):
-            continue
-        violations.append((lineno, raw.rstrip()))
+        violations.append((node.lineno, _line_excerpt(lines, node.lineno)))
     return violations
+
+
+def _iter_src_files() -> list[Path]:
+    """Yield every ``.py`` file under ``src/``."""
+    return sorted(_SRC_DIR.rglob("*.py"))
 
 
 def main() -> int:
@@ -217,7 +219,7 @@ def main() -> int:
         "helper or opt-out marker. Use one of:\n"
         "  - utils.atomic_write.atomic_write_text / atomic_write_bytes / atomic_write_with\n"
         "  - utils.atomic_write.append_durable (for journal/log appends)\n"
-        "Or, for legitimate non-atomic writes, append:\n"
+        "Or, for legitimate non-atomic writes, place a comment within ±6 lines:\n"
         "  # atomic-write: ok — <reason>\n"
         "Accepted reasons: user output, manual temp+replace, pid file, journal append.\n",
         file=sys.stderr,

--- a/scripts/check_atomic_write.py
+++ b/scripts/check_atomic_write.py
@@ -90,9 +90,69 @@ _ALLOWLISTED_FILES = frozenset(
     }
 )
 
-# Modes that constitute a forbidden write/append.  Read modes (``r``,
-# ``rb``, etc.) are not forbidden.
-_FORBIDDEN_MODES: frozenset[str] = frozenset({"w", "wb", "a", "ab", "w+", "wb+", "a+", "ab+"})
+# Characters that signal a write/append/exclusive-create mode in
+# ``open(path, mode)``.  Python ``open`` modes are character flags whose
+# order doesn't matter (``"wb"`` == ``"bw"``, ``"w+b"`` == ``"wb+"``,
+# etc.) and which can include ``b``/``t``/``+`` flags. Any mode string
+# containing ``w``, ``a``, or ``x`` opens the file for writing in a way
+# that requires atomicity:
+#
+# - ``w``/``w+`` truncate the file before writing.
+# - ``a``/``a+`` append, but a torn-write at the end is still observable.
+# - ``x``/``x+`` create-or-fail; a torn write leaves a partial file the
+#   next ``x`` open will refuse.
+#
+# Pure read modes (``r``, ``rb``, ``rt``, ``r+`` — read+write WITHOUT
+# truncation, file must exist) are not in scope.  ``r+`` does write, but
+# a crash leaves the original file modified-in-place rather than torn,
+# which is a different concern from the rail's truncate/append target.
+#
+# Codex r219 #3: the previous literal set ``{"w", "wb", "a", "ab", ...}``
+# missed valid aliases like ``"wt"``, ``"at"``, ``"w+b"``, ``"a+t"``.
+# Character-based detection covers every order/flag combination.
+_FORBIDDEN_MODE_CHARS: frozenset[str] = frozenset("wax")
+
+
+def _mode_is_forbidden(mode: str) -> bool:
+    """True if *mode* opens for writing/appending/exclusive-create.
+
+    Order-and-flag-independent: ``"wb"``, ``"bw"``, ``"w+b"``, ``"wt+"``
+    all map to forbidden because each contains ``w``. Pure-read modes
+    (``"r"``, ``"rb"``, ``"r+"``) contain no character in
+    ``_FORBIDDEN_MODE_CHARS`` and are allowed.
+    """
+    return any(c in _FORBIDDEN_MODE_CHARS for c in mode)
+
+
+# Backwards-compat: tests historically asserted membership in this set.
+# Keep it as the explicit canonical-string enumeration; runtime detection
+# uses _mode_is_forbidden, which is strictly more permissive.
+_FORBIDDEN_MODES: frozenset[str] = frozenset(
+    {
+        "w",
+        "wb",
+        "wt",
+        "a",
+        "ab",
+        "at",
+        "x",
+        "xb",
+        "xt",
+        "w+",
+        "wb+",
+        "w+b",
+        "wt+",
+        "w+t",
+        "a+",
+        "ab+",
+        "a+b",
+        "at+",
+        "a+t",
+        "x+",
+        "xb+",
+        "x+b",
+    }
+)
 
 # Opt-out marker.  Searched for in trailing comments AND on standalone
 # comment lines within the configured window (see ``_MARKER_WINDOW``).
@@ -143,7 +203,7 @@ def _is_forbidden_open(node: ast.Call) -> bool:
     if not _is_open_call(node):
         return False
     mode = _extract_mode_string(node)
-    return mode is not None and mode in _FORBIDDEN_MODES
+    return mode is not None and _mode_is_forbidden(mode)
 
 
 def _collect_marker_comment_lines(source: str) -> set[int]:

--- a/scripts/check_atomic_write.py
+++ b/scripts/check_atomic_write.py
@@ -241,18 +241,23 @@ def _extract_mode_string(node: ast.Call) -> str | None:
     mode (variable, computed, etc.) could be a write or read; we skip
     rather than false-flag.
     """
+    # 1. args[1] — builtin / module-level positional shape: open(path, mode)
     if len(node.args) >= 2:
         arg = node.args[1]
         if isinstance(arg, ast.Constant) and _looks_like_mode_literal(arg.value):
             return arg.value
-    if len(node.args) >= 1:
-        arg = node.args[0]
-        if isinstance(arg, ast.Constant) and _looks_like_mode_literal(arg.value):
-            return arg.value
+    # 2. mode= keyword — explicit mode beats any args[0] fallback
+    #    (codex r219 #8: `open("a", mode="r")` was misread as `"a"` because
+    #    the args[0] fallback fired before the kwarg scan).
     for kw in node.keywords:
         if kw.arg == "mode":
             if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
                 return kw.value.value
+    # 3. args[0] — instance-method shape: Path("x").open(mode)
+    if len(node.args) >= 1:
+        arg = node.args[0]
+        if isinstance(arg, ast.Constant) and _looks_like_mode_literal(arg.value):
+            return arg.value
     return None
 
 

--- a/scripts/check_atomic_write.py
+++ b/scripts/check_atomic_write.py
@@ -174,21 +174,36 @@ def _is_write_text_or_bytes(node: ast.Call) -> bool:
 
 
 def _is_open_call(node: ast.Call) -> bool:
-    """True if *node* is ``open(...)`` (the bare builtin, not ``<obj>.open(...)``)."""
+    """True if *node* is ``open(...)`` or ``<obj>.open(...)``."""
     func = node.func
-    return isinstance(func, ast.Name) and func.id == "open"
+    if isinstance(func, ast.Name) and func.id == "open":
+        return True
+    if isinstance(func, ast.Attribute) and func.attr == "open":
+        return True
+    return False
 
 
 def _extract_mode_string(node: ast.Call) -> str | None:
     """Return the mode string passed to ``open(path, mode)`` if statically known.
 
-    Handles both the positional second argument and the ``mode=`` keyword.
+    Two call shapes:
+
+    - Builtin ``open(path, mode, ...)``: the mode is the second positional
+      argument (``args[1]``).
+    - Method ``<obj>.open(mode, ...)`` (e.g. ``Path("x").open("w")``): the
+      receiver is implicit, so the mode is the *first* positional argument
+      (``args[0]``).
+
+    The ``mode=`` keyword form works for both shapes.
+
     Returns ``None`` if the mode is dynamic (variable, computed, etc.) — a
     dynamic mode could be a write or read; we conservatively skip rather
     than false-flag.
     """
-    if len(node.args) >= 2:
-        mode_arg = node.args[1]
+    is_method = isinstance(node.func, ast.Attribute)
+    mode_pos = 0 if is_method else 1
+    if len(node.args) > mode_pos:
+        mode_arg = node.args[mode_pos]
         if isinstance(mode_arg, ast.Constant) and isinstance(mode_arg.value, str):
             return mode_arg.value
     for kw in node.keywords:
@@ -290,7 +305,7 @@ def find_violations(path: Path) -> list[tuple[int, str]]:
         if _has_opt_out_in_window(marker_lines, node.lineno, len(lines)):
             continue
         violations.append((node.lineno, _line_excerpt(lines, node.lineno)))
-    return violations
+    return sorted(violations)
 
 
 def _iter_src_files() -> list[Path]:

--- a/scripts/check_atomic_write.py
+++ b/scripts/check_atomic_write.py
@@ -216,24 +216,37 @@ def _extract_mode_string(node: ast.Call) -> str | None:
     - Builtin ``open(path, mode, ...)``: mode at ``args[1]``.
     - Module-level ``<module>.open(path, mode, ...)`` such as
       ``tarfile.open(path, "w")`` or ``gzip.open(path, "wb")``:
-      mode at ``args[1]`` (codex r219 #6 thread).
+      mode at ``args[1]``.
     - Instance-method ``<obj>.open(mode, ...)`` such as
       ``Path("x").open("w")``: mode at ``args[0]``.
 
-    From the AST alone we cannot tell whether an attribute call is a
-    module-level function or an instance method — so we check both
-    positions and pick the FIRST argument that looks like a real Python
-    mode literal (``_looks_like_mode_literal``). The strict pattern
-    (length ≤ 4, characters drawn from ``rwaxbt+``, exactly one primary
-    action char) keeps file-path strings from being mistaken for modes.
+    Disambiguation strategy (codex r219 #7):
 
-    The ``mode=`` keyword form works for every shape.
+    1. If the call has 2+ positional args, prefer ``args[1]`` — that's
+       the mode position for the builtin / module-level shapes (the
+       majority case). This avoids the false-negative
+       ``open("r", "w")`` (where the previous "first-matching-wins"
+       returned ``"r"``) and the false-positive ``open("a", "r")``.
+    2. Fall back to ``args[0]`` if it's a literal mode — this handles
+       the instance-method shape ``Path("x").open("w")`` where there's
+       only one positional arg, or where ``args[1]`` is a non-mode
+       value like a buffering int.
+    3. Finally check the ``mode=`` keyword.
+
+    The strict ``_looks_like_mode_literal`` pattern (length ≤ 4,
+    characters from ``rwaxbt+``, exactly one primary action char) keeps
+    file-path strings like ``"write.log"`` from being mistaken for modes.
 
     Returns ``None`` if no statically-known mode is present — a dynamic
     mode (variable, computed, etc.) could be a write or read; we skip
     rather than false-flag.
     """
-    for arg in node.args[:2]:
+    if len(node.args) >= 2:
+        arg = node.args[1]
+        if isinstance(arg, ast.Constant) and _looks_like_mode_literal(arg.value):
+            return arg.value
+    if len(node.args) >= 1:
+        arg = node.args[0]
         if isinstance(arg, ast.Constant) and _looks_like_mode_literal(arg.value):
             return arg.value
     for kw in node.keywords:

--- a/scripts/check_called_attribute_assertion.py
+++ b/scripts/check_called_attribute_assertion.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""T3 narrow rail: no `assert <mock>.called` attribute-style assertion.
+
+Background
+----------
+T3 (`.claude/rules/test-generation-patterns.md`) catches mock assertions
+that check call count without verifying payload. The full T3 has a wide
+surface (`call_count >= N`, `assert_called()` without args, etc.) and
+many legitimate uses, so a strict rail is too noisy.
+
+This rail enforces the *narrow* form that has zero legitimate uses: the
+`assert <obj>.<attr>.called` attribute lookup. The mock library's
+canonical equivalent — `<obj>.<attr>.assert_called()` — is one extra
+character, more discoverable in IDEs (it's a documented method, not a
+flag attribute), and consistent with the rest of the test suite's
+assertion style.
+
+Recognised forms (all flagged):
+
+    assert <chain>.called
+    assert <chain>.called is True
+    assert <chain>.called == True
+
+The fix is mechanical: replace ``assert mock.X.called`` with
+``mock.X.assert_called()``.
+
+Scope
+-----
+- ``tests/**/*.py`` only.
+- Honors per-site ``# noqa: T3`` opt-out (rare — the canonical fix is
+  cheap, but the marker exists for cases where the attribute access is
+  intentional, e.g. testing the mock library itself).
+
+Exit 0 = no violations.
+Exit 1 = violations found. Offending lines are printed to stderr.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_TESTS_DIR = _ROOT / "tests"
+
+# Match `assert <chain>.called` optionally followed by ` is True` or ` == True`.
+# Anchored to end-of-line (modulo trailing comment / whitespace) so we
+# don't catch substring uses like ``assert obj.called_once_with(x)``
+# (that's a Mock method, not the attribute) or comparisons like
+# ``assert mock.called == 3`` (that's a count check, T3 allows under
+# noqa).  The precise allowed shapes are bare attribute, `is True`, and
+# `== True`.
+#
+# The expression itself may be parenthesised — `assert (mock.called)` is
+# common when the chain is long enough to wrap, and `(...) is True` is
+# also common.  The regex therefore accepts an optional balanced pair
+# of parens around the ``<chain>.called`` portion (codex r218).
+_PATTERN = re.compile(
+    r"""^\s*assert\s+               # leading 'assert'
+        (?:                          # one of:
+            [\w.]+\.called           #   <chain>.called  (no parens)
+          | \(\s*[\w.]+\.called\s*\) #   ( <chain>.called )  (parens)
+        )
+        \s*                          # optional ws
+        (?:is\s+True|==\s*True)?     # optional truth comparison
+        \s*                          # trailing ws
+        (?:\#.*)?                    # optional trailing comment
+        $""",
+    re.VERBOSE,
+)
+
+# Opt-out marker. Matched anywhere in the trailing comment.
+_NOQA_RE = re.compile(r"#\s*noqa:\s*T3\b")
+
+
+def _is_comment_line(line: str) -> bool:
+    """True if the line (after whitespace) starts with ``#``."""
+    return line.lstrip().startswith("#")
+
+
+def _has_opt_out(line: str) -> bool:
+    """True if the line contains a ``# noqa: T3`` marker."""
+    return bool(_NOQA_RE.search(line))
+
+
+def find_violations(path: Path) -> list[tuple[int, str]]:
+    """Return [(line_number, line_text)] for each unexempted match.
+
+    Tracks triple-quoted string blocks so that fixtures embedded in
+    docstrings (notably ``tests/ci/test_*.py`` rails that demonstrate
+    the forbidden pattern inside ``dedent('''...''')`` blocks) don't
+    false-flag. The check is heuristic — counts ``\"\"\"`` / ``'''``
+    toggles per line.
+    """
+    violations: list[tuple[int, str]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return violations
+
+    in_triple_quote = False
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        triple_count = raw.count('"""') + raw.count("'''")
+        if triple_count % 2 == 1:
+            in_triple_quote = not in_triple_quote
+            continue
+        if in_triple_quote:
+            continue
+        if _is_comment_line(raw):
+            continue
+        if not _PATTERN.match(raw):
+            continue
+        if _has_opt_out(raw):
+            continue
+        violations.append((lineno, raw.rstrip()))
+    return violations
+
+
+def _iter_test_files() -> list[Path]:
+    """Yield every ``.py`` file under ``tests/``."""
+    return sorted(_TESTS_DIR.rglob("*.py"))
+
+
+def main() -> int:
+    """Scan ``tests/`` and print violations to stderr; exit 1 if any."""
+    all_violations: list[tuple[Path, int, str]] = []
+    for path in _iter_test_files():
+        for lineno, line in find_violations(path):
+            all_violations.append((path.relative_to(_ROOT), lineno, line))
+
+    if not all_violations:
+        return 0
+
+    print(
+        "ERROR (T3): `assert <mock>.called` attribute-style assertion found.\n"
+        "Replace with the canonical mock-library equivalent:\n"
+        "  - `assert mock.X.called`  →  `mock.X.assert_called()`\n"
+        "  - `assert mock.X.called is True`  →  `mock.X.assert_called()`\n"
+        "Or, for an intentional attribute-style check (rare), add\n"
+        "`# noqa: T3 reason: <one-line justification>`.\n",
+        file=sys.stderr,
+    )
+    for path, lineno, line in all_violations:
+        print(f"  {path}:{lineno}: {line}", file=sys.stderr)
+    print(
+        f"\n{len(all_violations)} violation(s) across "
+        f"{len({v[0] for v in all_violations})} file(s).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_called_attribute_assertion.py
+++ b/scripts/check_called_attribute_assertion.py
@@ -98,12 +98,20 @@ def find_violations(path: Path) -> list[tuple[int, str]]:
     for node in ast.walk(tree):
         if not isinstance(node, ast.Assert):
             continue
-        if _is_called_attribute_assertion(node):
-            lineno = node.lineno
-            if 0 < lineno <= len(lines):
-                line_text = lines[lineno - 1]
-                if not _has_opt_out(line_text):
-                    violations.append((lineno, line_text.rstrip()))
+        if not _is_called_attribute_assertion(node):
+            continue
+        start = node.lineno
+        end = getattr(node, "end_lineno", None) or start
+        # CodeRabbit r219: a ``# noqa: T3`` placed on the closing-paren
+        # line of a multi-line ``assert (\n    mock.called\n)`` form is
+        # a natural, ruff-format-friendly placement.  Scan every line
+        # the assert spans so the opt-out works for that placement too.
+        if any(
+            0 < ln <= len(lines) and _has_opt_out(lines[ln - 1]) for ln in range(start, end + 1)
+        ):
+            continue
+        if 0 < start <= len(lines):
+            violations.append((start, lines[start - 1].rstrip()))
 
     return sorted(violations)
 

--- a/scripts/check_called_attribute_assertion.py
+++ b/scripts/check_called_attribute_assertion.py
@@ -37,6 +37,7 @@ Exit 1 = violations found. Offending lines are printed to stderr.
 
 from __future__ import annotations
 
+import ast
 import re
 import sys
 from pathlib import Path
@@ -44,39 +45,8 @@ from pathlib import Path
 _ROOT = Path(__file__).resolve().parent.parent
 _TESTS_DIR = _ROOT / "tests"
 
-# Match `assert <chain>.called` optionally followed by ` is True` or ` == True`.
-# Anchored to end-of-line (modulo trailing comment / whitespace) so we
-# don't catch substring uses like ``assert obj.called_once_with(x)``
-# (that's a Mock method, not the attribute) or comparisons like
-# ``assert mock.called == 3`` (that's a count check, T3 allows under
-# noqa).  The precise allowed shapes are bare attribute, `is True`, and
-# `== True`.
-#
-# The expression itself may be parenthesised — `assert (mock.called)` is
-# common when the chain is long enough to wrap, and `(...) is True` is
-# also common.  The regex therefore accepts an optional balanced pair
-# of parens around the ``<chain>.called`` portion (codex r218).
-_PATTERN = re.compile(
-    r"""^\s*assert\s+               # leading 'assert'
-        (?:                          # one of:
-            [\w.]+\.called           #   <chain>.called  (no parens)
-          | \(\s*[\w.]+\.called\s*\) #   ( <chain>.called )  (parens)
-        )
-        \s*                          # optional ws
-        (?:is\s+True|==\s*True)?     # optional truth comparison
-        \s*                          # trailing ws
-        (?:\#.*)?                    # optional trailing comment
-        $""",
-    re.VERBOSE,
-)
-
 # Opt-out marker. Matched anywhere in the trailing comment.
 _NOQA_RE = re.compile(r"#\s*noqa:\s*T3\b")
-
-
-def _is_comment_line(line: str) -> bool:
-    """True if the line (after whitespace) starts with ``#``."""
-    return line.lstrip().startswith("#")
 
 
 def _has_opt_out(line: str) -> bool:
@@ -84,14 +54,33 @@ def _has_opt_out(line: str) -> bool:
     return bool(_NOQA_RE.search(line))
 
 
+def _is_called_attribute_assertion(node: ast.Assert) -> bool:
+    """True if *node* is an `assert <expr>.called` or similar."""
+    test = node.test
+    # Case 1: assert mock.called
+    if isinstance(test, ast.Attribute) and test.attr == "called":
+        return True
+
+    # Case 2: assert mock.called is True  OR  assert mock.called == True
+    if isinstance(test, ast.Compare):
+        if len(test.ops) == 1 and len(test.comparators) == 1:
+            left = test.left
+            op = test.ops[0]
+            right = test.comparators[0]
+
+            if isinstance(left, ast.Attribute) and left.attr == "called":
+                if isinstance(op, (ast.Is, ast.Eq)):
+                    if isinstance(right, ast.Constant) and right.value is True:
+                        return True
+
+    return False
+
+
 def find_violations(path: Path) -> list[tuple[int, str]]:
     """Return [(line_number, line_text)] for each unexempted match.
 
-    Tracks triple-quoted string blocks so that fixtures embedded in
-    docstrings (notably ``tests/ci/test_*.py`` rails that demonstrate
-    the forbidden pattern inside ``dedent('''...''')`` blocks) don't
-    false-flag. The check is heuristic — counts ``\"\"\"`` / ``'''``
-    toggles per line.
+    Uses AST parsing to accurately find assertions and avoid false positives
+    inside strings, docstrings, or multi-statement lines.
     """
     violations: list[tuple[int, str]] = []
     try:
@@ -99,22 +88,24 @@ def find_violations(path: Path) -> list[tuple[int, str]]:
     except (OSError, UnicodeDecodeError):
         return violations
 
-    in_triple_quote = False
-    for lineno, raw in enumerate(text.splitlines(), start=1):
-        triple_count = raw.count('"""') + raw.count("'''")
-        if triple_count % 2 == 1:
-            in_triple_quote = not in_triple_quote
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return violations
+
+    lines = text.splitlines()
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assert):
             continue
-        if in_triple_quote:
-            continue
-        if _is_comment_line(raw):
-            continue
-        if not _PATTERN.match(raw):
-            continue
-        if _has_opt_out(raw):
-            continue
-        violations.append((lineno, raw.rstrip()))
-    return violations
+        if _is_called_attribute_assertion(node):
+            lineno = node.lineno
+            if 0 < lineno <= len(lines):
+                line_text = lines[lineno - 1]
+                if not _has_opt_out(line_text):
+                    violations.append((lineno, line_text.rstrip()))
+
+    return sorted(violations)
 
 
 def _iter_test_files() -> list[Path]:

--- a/scripts/check_called_attribute_assertion.py
+++ b/scripts/check_called_attribute_assertion.py
@@ -38,19 +38,52 @@ Exit 1 = violations found. Offending lines are printed to stderr.
 from __future__ import annotations
 
 import ast
+import io
 import re
 import sys
+import tokenize
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parent.parent
 _TESTS_DIR = _ROOT / "tests"
 
-# Opt-out marker. Matched anywhere in the trailing comment.
+# Opt-out marker. Searched against tokenised ``COMMENT`` tokens only —
+# never against raw line text — so a marker text inside a string literal
+# (``assert mock.called, "# noqa: T3"``) cannot bypass the rail (codex
+# r219 #9).
 _NOQA_RE = re.compile(r"#\s*noqa:\s*T3\b")
 
 
+def _collect_noqa_comment_lines(source: str) -> set[int]:
+    """Return the 1-based line numbers of every ``# noqa: T3`` *comment* token.
+
+    Tokenises *source* and only inspects ``tokenize.COMMENT`` tokens —
+    string literals containing the marker text (e.g.
+    ``assert mock.called, "# noqa: T3"``) are NOT comments and therefore
+    cannot exempt a real assertion (codex r219 #9 — bypass-via-string-literal).
+
+    Falls back to an empty set on tokenise failure (e.g. an unterminated
+    string literal in a syntactically broken file). The caller's AST
+    parse will already have failed in that case, so no violations are
+    reported either way.
+    """
+    marker_lines: set[int] = set()
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            if tok.type == tokenize.COMMENT and _NOQA_RE.search(tok.string):
+                marker_lines.add(tok.start[0])
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        return set()
+    return marker_lines
+
+
 def _has_opt_out(line: str) -> bool:
-    """True if the line contains a ``# noqa: T3`` marker."""
+    """True if the line contains a ``# noqa: T3`` marker (raw-text fallback for unit tests).
+
+    The runtime detector uses ``_collect_noqa_comment_lines`` (token-based)
+    to avoid bypass via string literals; this helper is preserved for
+    direct unit tests of the marker regex.
+    """
     return bool(_NOQA_RE.search(line))
 
 
@@ -94,6 +127,9 @@ def find_violations(path: Path) -> list[tuple[int, str]]:
         return violations
 
     lines = text.splitlines()
+    # Token-aware marker collection — string literals containing the
+    # marker text cannot exempt a real assertion (codex r219 #9).
+    noqa_lines = _collect_noqa_comment_lines(text)
 
     for node in ast.walk(tree):
         if not isinstance(node, ast.Assert):
@@ -106,9 +142,7 @@ def find_violations(path: Path) -> list[tuple[int, str]]:
         # line of a multi-line ``assert (\n    mock.called\n)`` form is
         # a natural, ruff-format-friendly placement.  Scan every line
         # the assert spans so the opt-out works for that placement too.
-        if any(
-            0 < ln <= len(lines) and _has_opt_out(lines[ln - 1]) for ln in range(start, end + 1)
-        ):
+        if any(ln in noqa_lines for ln in range(start, end + 1)):
             continue
         if 0 < start <= len(lines):
             violations.append((start, lines[start - 1].rstrip()))

--- a/scripts/check_cli_path_validation.py
+++ b/scripts/check_cli_path_validation.py
@@ -71,6 +71,9 @@ def _is_path_annotation(node: ast.expr | None) -> bool:
         # Union form: ``Path | None``, ``Path | str``, etc.
         return _is_path_annotation(node.left) or _is_path_annotation(node.right)
     if isinstance(node, ast.Subscript):
+        if isinstance(node.value, ast.Name) and node.value.id == "Annotated":
+            if isinstance(node.slice, ast.Tuple) and node.slice.elts:
+                return _is_path_annotation(node.slice.elts[0])
         # ``Optional[Path]``, ``list[Path]`` — recurse into the slice.
         return _is_path_annotation(node.slice)
     return False
@@ -121,6 +124,9 @@ def _collect_validator_call_targets(body: list[ast.stmt]) -> set[str]:
                 for arg in node.args:
                     if isinstance(arg, ast.Name):
                         targets.add(arg.id)
+                for kw in node.keywords:
+                    if isinstance(kw.value, ast.Name):
+                        targets.add(kw.value.id)
             self.generic_visit(node)
 
         # Nested scopes are NOT part of the command body's execution
@@ -210,7 +216,7 @@ def find_violations(path: Path) -> list[tuple[int, str, str]]:
             if arg.arg not in validated:
                 violations.append((func.lineno, func.name, arg.arg))
 
-    return violations
+    return sorted(violations)
 
 
 def main() -> int:

--- a/scripts/check_pytest_raises_hygiene.py
+++ b/scripts/check_pytest_raises_hygiene.py
@@ -132,37 +132,54 @@ def _iter_statement_blocks(node: ast.AST) -> list[list[ast.stmt]]:
     return blocks
 
 
-def _walk_pytest_raises_body(root: ast.With) -> list[list[ast.stmt]]:
-    """Yield every statement-list reachable from *root* without entering a new scope.
+_NEW_SCOPE_TYPES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
 
-    The traversal includes ``root.body`` itself plus the body of every nested
-    ``with`` / ``if`` / ``for`` / ``while`` / ``try`` block inside it. Function /
-    class / lambda definitions are not descended — those open new control-flow
-    scopes whose statements are not reachable as part of the ``pytest.raises``
-    call site.
+
+def _walk_unreachable_mock_assertions(
+    body: list[ast.stmt], parent_unreachable: bool
+) -> list[ast.stmt]:
+    """Return mock-assertion statements that are unreachable in *body*.
+
+    Reachability is propagated across nested blocks (codex r219 #4): once a
+    top-level ``ast.Raise`` is seen in *body*, every subsequent statement —
+    including its nested ``if`` / ``for`` / ``while`` / ``try`` / ``with``
+    bodies — is unreachable. Mock assertions found in those statements are
+    flagged regardless of how deeply nested they are.
+
+    Function / class / lambda definitions are NOT descended: a ``raise``
+    in the enclosing pytest.raises body doesn't make a *defined-but-not-yet-
+    called* function body unreachable. Those open new control-flow scopes
+    not exercised at the pytest.raises call site.
+
+    *parent_unreachable* propagates from a caller block whose own
+    top-level ``Raise`` already fired before the nested scope was entered.
     """
-    blocks: list[list[ast.stmt]] = [root.body]
-    stack: list[ast.AST] = [*root.body]
-    while stack:
-        node = stack.pop()
-        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef | ast.Lambda):
-            continue
-        for block in _iter_statement_blocks(node):
-            blocks.append(block)
-            stack.extend(block)
-    return blocks
+    found: list[ast.stmt] = []
+    seen_raise = False
+    for stmt in body:
+        unreachable = parent_unreachable or seen_raise
+        if unreachable and _is_mock_assertion(stmt):
+            found.append(stmt)
+        if not isinstance(stmt, _NEW_SCOPE_TYPES):
+            for nested in _iter_statement_blocks(stmt):
+                found.extend(
+                    _walk_unreachable_mock_assertions(nested, parent_unreachable=unreachable)
+                )
+        if isinstance(stmt, ast.Raise):
+            seen_raise = True
+    return found
 
 
 def find_violations(path: Path) -> list[tuple[int, str]]:
     """Return [(line_number, source_line_excerpt)] for each unreachable mock assertion.
 
-    Walks every ``with pytest.raises(...):`` block and checks every nested
-    statement-list inside it (including bodies of inner ``with`` / ``if`` /
-    ``for`` / ``try`` blocks). A mock assertion appearing after a top-level
-    ``raise`` *within the same block* is flagged — this catches the common
-    context-manager pattern ``with pytest.raises(...): with mgr() as m:
-    ...; raise; m.cleanup.assert_called_once()`` that the immediate-body-only
-    scan missed (codex r217).
+    Walks every ``with pytest.raises(...):`` block. Reachability is
+    propagated across all nested blocks via
+    ``_walk_unreachable_mock_assertions`` — a top-level ``raise`` makes
+    everything below it (including statements inside nested ``if`` /
+    ``for`` / ``while`` / ``try`` / ``with`` bodies) unreachable, so a
+    mock assertion buried under those nested constructs is still flagged
+    (codex r219 #4).
     """
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"))
@@ -174,13 +191,12 @@ def find_violations(path: Path) -> list[tuple[int, str]]:
             continue
         if not any(_is_pytest_raises(item) for item in node.items):
             continue
-        for block in _walk_pytest_raises_body(node):
-            for stmt in _violations_in_block(block):
-                try:
-                    line = ast.unparse(stmt)
-                except (AttributeError, ValueError):
-                    line = f"<line {stmt.lineno}>"
-                violations.append((stmt.lineno, line))
+        for stmt in _walk_unreachable_mock_assertions(node.body, parent_unreachable=False):
+            try:
+                line = ast.unparse(stmt)
+            except (AttributeError, ValueError):
+                line = f"<line {stmt.lineno}>"
+            violations.append((stmt.lineno, line))
     return violations
 
 

--- a/scripts/check_pytest_raises_hygiene.py
+++ b/scripts/check_pytest_raises_hygiene.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""pytest.raises hygiene rail: no mock assertion after `raise` inside the block.
+
+Background
+----------
+PR-A (#213) enabled ruff PT012, which flags any multi-statement
+``pytest.raises`` block. That covers the common form of this anti-pattern.
+However, 11 sites in the codebase carry ``# noqa: PT012`` because their
+multi-statement bodies are genuinely required (transaction rollback tests,
+context-manager exit semantics under exception, generator double-``next()``,
+``importlib.reload`` under patched ``sys.modules``, ``try/except``
+subclass-non-catching, ``typer.Exit`` re-raise).
+
+Inside those ``# noqa: PT012`` blocks, PT012 is silent — which means a
+mock assertion mistakenly placed AFTER the ``raise`` is not caught:
+
+    with pytest.raises(Foo):  # noqa: PT012 — context-manager exit semantics
+        setup()
+        raise FooError("boom")
+        mock.assert_called_once()   # <-- UNREACHABLE; PT012 suppressed
+
+This rail closes that hole. It walks every ``with pytest.raises(...):``
+block, finds an unconditional top-level ``raise``, and flags any mock
+assertion (``mock.X.assert_called*(...)`` or ``assert mock.X.called``)
+that follows it in the same block.
+
+Scope
+-----
+- ``tests/**/*.py`` only — the pattern only appears in tests.
+- Detects unconditional top-level ``raise`` (not raises inside nested
+  ``if`` / ``try`` blocks, which may be reachable).
+- Detects two mock-assertion forms:
+  - ``Expr(Call(...assert_called*...))`` — ``mock.X.assert_called(...)`` etc.
+  - ``Assert(test=Attribute(attr='called'))`` — ``assert mock.X.called``.
+
+Exit 0 = no violations.
+Exit 1 = violations found. Offending lines are printed to stderr.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_TESTS_DIR = _ROOT / "tests"
+
+# Mock-assertion method names that imply a payload check belongs OUTSIDE
+# the ``pytest.raises`` block (after the ``with`` exits). Anything from
+# this set after a ``raise`` is unreachable.
+_MOCK_ASSERTION_NAMES: frozenset[str] = frozenset(
+    {
+        "assert_called",
+        "assert_called_once",
+        "assert_called_with",
+        "assert_called_once_with",
+        "assert_any_call",
+        "assert_has_calls",
+        "assert_not_called",
+    }
+)
+
+
+def _is_pytest_raises(item: ast.withitem) -> bool:
+    """True if *item* is ``pytest.raises(...)`` (with or without ``as`` capture)."""
+    expr = item.context_expr
+    if not isinstance(expr, ast.Call):
+        return False
+    func = expr.func
+    if not (isinstance(func, ast.Attribute) and func.attr == "raises"):
+        return False
+    return isinstance(func.value, ast.Name) and func.value.id == "pytest"
+
+
+def _is_mock_assertion(stmt: ast.stmt) -> bool:
+    """True if *stmt* is one of the recognised mock-assertion forms."""
+    # Form A: <expr>.assert_called*(...)
+    if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+        func = stmt.value.func
+        if isinstance(func, ast.Attribute) and func.attr in _MOCK_ASSERTION_NAMES:
+            return True
+    # Form B: assert <expr>.called
+    if isinstance(stmt, ast.Assert):
+        test = stmt.test
+        if isinstance(test, ast.Attribute) and test.attr == "called":
+            return True
+    return False
+
+
+def _violations_in_block(body: list[ast.stmt]) -> list[ast.stmt]:
+    """Return mock-assertion statements that appear after an unconditional ``raise``.
+
+    Only top-level ``raise`` in the block body counts. A ``raise`` inside a
+    nested ``if`` / ``try`` / ``for`` does not terminate the surrounding
+    block unconditionally, so subsequent statements remain reachable.
+    """
+    found: list[ast.stmt] = []
+    seen_raise = False
+    for stmt in body:
+        if isinstance(stmt, ast.Raise):
+            seen_raise = True
+            continue
+        if seen_raise and _is_mock_assertion(stmt):
+            found.append(stmt)
+    return found
+
+
+def _iter_statement_blocks(node: ast.AST) -> list[list[ast.stmt]]:
+    """Yield every ``list[ast.stmt]`` directly attached to *node*.
+
+    Excludes nested function / class / lambda scopes — a ``raise`` followed
+    by a mock assertion inside a nested function definition is a different
+    control-flow context (the function body is not executed at the
+    pytest.raises call site, so no unreachable-code claim applies).
+    """
+    blocks: list[list[ast.stmt]] = []
+    if isinstance(node, ast.With | ast.AsyncWith):
+        blocks.append(node.body)
+    elif isinstance(node, ast.For | ast.AsyncFor | ast.While):
+        blocks.append(node.body)
+        blocks.append(node.orelse)
+    elif isinstance(node, ast.If):
+        blocks.append(node.body)
+        blocks.append(node.orelse)
+    elif isinstance(node, ast.Try):
+        blocks.append(node.body)
+        blocks.append(node.orelse)
+        blocks.append(node.finalbody)
+        for handler in node.handlers:
+            blocks.append(handler.body)
+    return blocks
+
+
+def _walk_pytest_raises_body(root: ast.With) -> list[list[ast.stmt]]:
+    """Yield every statement-list reachable from *root* without entering a new scope.
+
+    The traversal includes ``root.body`` itself plus the body of every nested
+    ``with`` / ``if`` / ``for`` / ``while`` / ``try`` block inside it. Function /
+    class / lambda definitions are not descended — those open new control-flow
+    scopes whose statements are not reachable as part of the ``pytest.raises``
+    call site.
+    """
+    blocks: list[list[ast.stmt]] = [root.body]
+    stack: list[ast.AST] = [*root.body]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef | ast.Lambda):
+            continue
+        for block in _iter_statement_blocks(node):
+            blocks.append(block)
+            stack.extend(block)
+    return blocks
+
+
+def find_violations(path: Path) -> list[tuple[int, str]]:
+    """Return [(line_number, source_line_excerpt)] for each unreachable mock assertion.
+
+    Walks every ``with pytest.raises(...):`` block and checks every nested
+    statement-list inside it (including bodies of inner ``with`` / ``if`` /
+    ``for`` / ``try`` blocks). A mock assertion appearing after a top-level
+    ``raise`` *within the same block* is flagged — this catches the common
+    context-manager pattern ``with pytest.raises(...): with mgr() as m:
+    ...; raise; m.cleanup.assert_called_once()`` that the immediate-body-only
+    scan missed (codex r217).
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return []
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.With):
+            continue
+        if not any(_is_pytest_raises(item) for item in node.items):
+            continue
+        for block in _walk_pytest_raises_body(node):
+            for stmt in _violations_in_block(block):
+                try:
+                    line = ast.unparse(stmt)
+                except (AttributeError, ValueError):
+                    line = f"<line {stmt.lineno}>"
+                violations.append((stmt.lineno, line))
+    return violations
+
+
+def _iter_test_files() -> list[Path]:
+    """Yield every ``.py`` file under ``tests/``."""
+    return sorted(_TESTS_DIR.rglob("*.py"))
+
+
+def main() -> int:
+    """Scan ``tests/`` and print violations to stderr; exit 1 if any."""
+    all_violations: list[tuple[Path, int, str]] = []
+    for path in _iter_test_files():
+        for lineno, line in find_violations(path):
+            all_violations.append((path.relative_to(_ROOT), lineno, line))
+
+    if not all_violations:
+        return 0
+
+    print(
+        "ERROR (pytest.raises-hygiene): mock assertion after `raise` inside\n"
+        "a `pytest.raises(...)` block is unreachable.\n"
+        "Move the mock assertion AFTER the `with pytest.raises(...):` block "
+        "exits — the `raise` terminates control flow, so subsequent statements\n"
+        "in the block never execute.\n",
+        file=sys.stderr,
+    )
+    for path, lineno, line in all_violations:
+        print(f"  {path}:{lineno}: {line}", file=sys.stderr)
+    print(
+        f"\n{len(all_violations)} violation(s) across "
+        f"{len({v[0] for v in all_violations})} file(s).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_pytest_raises_hygiene.py
+++ b/scripts/check_pytest_raises_hygiene.py
@@ -123,7 +123,10 @@ def _iter_statement_blocks(node: ast.AST) -> list[list[ast.stmt]]:
     elif isinstance(node, ast.If):
         blocks.append(node.body)
         blocks.append(node.orelse)
-    elif isinstance(node, ast.Try):
+    elif isinstance(node, ast.Try | ast.TryStar):
+        # ``ast.TryStar`` (Python 3.11+) covers ``try/except*`` PEP 654
+        # exception-group handlers; same body/orelse/finalbody/handlers
+        # structure as ``ast.Try``, so the same iteration logic applies.
         blocks.append(node.body)
         blocks.append(node.orelse)
         blocks.append(node.finalbody)

--- a/scripts/check_pytest_raises_hygiene.py
+++ b/scripts/check_pytest_raises_hygiene.py
@@ -197,7 +197,7 @@ def find_violations(path: Path) -> list[tuple[int, str]]:
             except (AttributeError, ValueError):
                 line = f"<line {stmt.lineno}>"
             violations.append((stmt.lineno, line))
-    return violations
+    return sorted(violations)
 
 
 def _iter_test_files() -> list[Path]:

--- a/scripts/scratch.py
+++ b/scripts/scratch.py
@@ -1,0 +1,5 @@
+import ast
+code = "open('file.txt', f'w')"
+tree = ast.parse(code)
+call = tree.body[0].value
+print(type(call.args[1]))

--- a/scripts/scratch.py
+++ b/scripts/scratch.py
@@ -1,5 +1,0 @@
-import ast
-code = "open('file.txt', f'w')"
-tree = ast.parse(code)
-call = tree.body[0].value
-print(type(call.args[1]))

--- a/src/daemon/pid.py
+++ b/src/daemon/pid.py
@@ -84,7 +84,9 @@ class PidFileManager:
         pid = pid if pid is not None else os.getpid()
 
         pid_file.parent.mkdir(parents=True, exist_ok=True)
-        pid_file.write_text(str(pid))
+        pid_file.write_text(
+            str(pid)
+        )  # atomic-write: ok — pid file (single-writer via daemon lifecycle)
         logger.debug("Wrote PID %d to %s", pid, pid_file)
 
     def read_pid(self, pid_file: Path) -> int | None:

--- a/src/daemon/pid.py
+++ b/src/daemon/pid.py
@@ -84,9 +84,8 @@ class PidFileManager:
         pid = pid if pid is not None else os.getpid()
 
         pid_file.parent.mkdir(parents=True, exist_ok=True)
-        pid_file.write_text(
-            str(pid)
-        )  # atomic-write: ok — pid file (single-writer via daemon lifecycle)
+        # atomic-write: ok — pid file (single-writer via daemon lifecycle)
+        pid_file.write_text(str(pid))
         logger.debug("Wrote PID %d to %s", pid, pid_file)
 
     def read_pid(self, pid_file: Path) -> int | None:

--- a/src/history/export.py
+++ b/src/history/export.py
@@ -115,7 +115,8 @@ class HistoryExporter:
 
         # Write to file
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(output_path, "w") as f:  # atomic-write: ok — user output (one-shot CLI export)
+        # atomic-write: ok — user output (one-shot CLI export)
+        with open(output_path, "w") as f:
             json.dump(export_data, f, indent=2)
 
         logger.info(f"Exported {len(operations)} operations to {output_path}")
@@ -201,9 +202,8 @@ class HistoryExporter:
 
         # Write to CSV
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(
-            output_path, "w", newline=""
-        ) as f:  # atomic-write: ok — user output (one-shot CLI export)
+        # atomic-write: ok — user output (one-shot CLI export)
+        with open(output_path, "w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=columns)
             writer.writeheader()
 
@@ -268,9 +268,8 @@ class HistoryExporter:
 
         # Write to CSV
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(
-            output_path, "w", newline=""
-        ) as f:  # atomic-write: ok — user output (one-shot CLI export)
+        # atomic-write: ok — user output (one-shot CLI export)
+        with open(output_path, "w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=columns)
             writer.writeheader()
 
@@ -340,7 +339,8 @@ class HistoryExporter:
 
         # Write to file
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(output_path, "w") as f:  # atomic-write: ok — user output (one-shot CLI export)
+        # atomic-write: ok — user output (one-shot CLI export)
+        with open(output_path, "w") as f:
             json.dump(stats, f, indent=2)
 
         logger.info(f"Exported statistics to {output_path}")

--- a/src/history/export.py
+++ b/src/history/export.py
@@ -116,7 +116,7 @@ class HistoryExporter:
         # Write to file
         output_path.parent.mkdir(parents=True, exist_ok=True)
         # atomic-write: ok — user output (one-shot CLI export)
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             json.dump(export_data, f, indent=2)
 
         logger.info(f"Exported {len(operations)} operations to {output_path}")
@@ -203,7 +203,7 @@ class HistoryExporter:
         # Write to CSV
         output_path.parent.mkdir(parents=True, exist_ok=True)
         # atomic-write: ok — user output (one-shot CLI export)
-        with open(output_path, "w", newline="") as f:
+        with open(output_path, "w", newline="", encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=columns)
             writer.writeheader()
 
@@ -269,7 +269,7 @@ class HistoryExporter:
         # Write to CSV
         output_path.parent.mkdir(parents=True, exist_ok=True)
         # atomic-write: ok — user output (one-shot CLI export)
-        with open(output_path, "w", newline="") as f:
+        with open(output_path, "w", newline="", encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=columns)
             writer.writeheader()
 
@@ -340,7 +340,7 @@ class HistoryExporter:
         # Write to file
         output_path.parent.mkdir(parents=True, exist_ok=True)
         # atomic-write: ok — user output (one-shot CLI export)
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             json.dump(stats, f, indent=2)
 
         logger.info(f"Exported statistics to {output_path}")

--- a/src/history/export.py
+++ b/src/history/export.py
@@ -115,7 +115,7 @@ class HistoryExporter:
 
         # Write to file
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(output_path, "w") as f:
+        with open(output_path, "w") as f:  # atomic-write: ok — user output (one-shot CLI export)
             json.dump(export_data, f, indent=2)
 
         logger.info(f"Exported {len(operations)} operations to {output_path}")
@@ -201,7 +201,9 @@ class HistoryExporter:
 
         # Write to CSV
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(output_path, "w", newline="") as f:
+        with open(
+            output_path, "w", newline=""
+        ) as f:  # atomic-write: ok — user output (one-shot CLI export)
             writer = csv.DictWriter(f, fieldnames=columns)
             writer.writeheader()
 
@@ -266,7 +268,9 @@ class HistoryExporter:
 
         # Write to CSV
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(output_path, "w", newline="") as f:
+        with open(
+            output_path, "w", newline=""
+        ) as f:  # atomic-write: ok — user output (one-shot CLI export)
             writer = csv.DictWriter(f, fieldnames=columns)
             writer.writeheader()
 
@@ -336,7 +340,7 @@ class HistoryExporter:
 
         # Write to file
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(output_path, "w") as f:
+        with open(output_path, "w") as f:  # atomic-write: ok — user output (one-shot CLI export)
             json.dump(stats, f, indent=2)
 
         logger.info(f"Exported statistics to {output_path}")

--- a/src/integrations/obsidian.py
+++ b/src/integrations/obsidian.py
@@ -69,14 +69,22 @@ class ObsidianIntegration(Integration):
         target_dir.mkdir(parents=True, exist_ok=True)
         destination = target_dir / source.name
 
-        shutil.copy2(source, destination)
-
         note_dir = (vault / notes_subdir).resolve(strict=False)
         note_dir.mkdir(parents=True, exist_ok=True)
         note_path = note_dir / f"{source.stem}.md"
-        note_path.write_text(  # atomic-write: ok — user vault note creation, retry-on-fail safe
-            self._build_note_content(source, destination, metadata), encoding="utf-8"
-        )
+
+        # send_file's contract is bool (success / failure). Wrap the two
+        # external writes — attachment copy and note creation — so an OSError
+        # surfaces as `return False` rather than escaping the bool contract.
+        try:
+            shutil.copy2(source, destination)
+            # atomic-write: ok — user vault note creation, retry-on-fail safe
+            note_path.write_text(
+                self._build_note_content(source, destination, metadata),
+                encoding="utf-8",
+            )
+        except OSError:
+            return False
         return True
 
     async def get_status(self) -> IntegrationStatus:

--- a/src/integrations/obsidian.py
+++ b/src/integrations/obsidian.py
@@ -74,7 +74,7 @@ class ObsidianIntegration(Integration):
         note_dir = (vault / notes_subdir).resolve(strict=False)
         note_dir.mkdir(parents=True, exist_ok=True)
         note_path = note_dir / f"{source.stem}.md"
-        note_path.write_text(
+        note_path.write_text(  # atomic-write: ok — user vault note creation, retry-on-fail safe
             self._build_note_content(source, destination, metadata), encoding="utf-8"
         )
         return True

--- a/src/integrations/workflow.py
+++ b/src/integrations/workflow.py
@@ -83,10 +83,12 @@ class WorkflowIntegration(Integration):
         alfred_path = output_dir / f"alfred-{stem}-{stamp}.json"
         raycast_path = output_dir / f"raycast-{stem}-{stamp}.json"
 
-        alfred_path.write_text(  # atomic-write: ok — user output (launcher workflow file)
+        # atomic-write: ok — user output (launcher workflow file)
+        alfred_path.write_text(
             json.dumps(alfred, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
-        raycast_path.write_text(  # atomic-write: ok — user output (launcher workflow file)
+        # atomic-write: ok — user output (launcher workflow file)
+        raycast_path.write_text(
             json.dumps(raycast, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
         return True

--- a/src/integrations/workflow.py
+++ b/src/integrations/workflow.py
@@ -83,10 +83,10 @@ class WorkflowIntegration(Integration):
         alfred_path = output_dir / f"alfred-{stem}-{stamp}.json"
         raycast_path = output_dir / f"raycast-{stem}-{stamp}.json"
 
-        alfred_path.write_text(
+        alfred_path.write_text(  # atomic-write: ok — user output (launcher workflow file)
             json.dumps(alfred, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
-        raycast_path.write_text(
+        raycast_path.write_text(  # atomic-write: ok — user output (launcher workflow file)
             json.dumps(raycast, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
         return True

--- a/src/parallel/checkpoint.py
+++ b/src/parallel/checkpoint.py
@@ -150,9 +150,8 @@ class CheckpointManager:
         # Atomic write: write to temp file, fsync, rename, then fsync directory
         temp_path = path.with_suffix(".tmp")
         try:
-            with open(
-                temp_path, "w", encoding="utf-8"
-            ) as f:  # atomic-write: ok — manual temp+replace pattern (lines 151-158)
+            # atomic-write: ok — manual temp+replace pattern (lines 151-158)
+            with open(temp_path, "w", encoding="utf-8") as f:
                 f.write(json.dumps(data, indent=2, default=str))
                 f.flush()
                 os.fsync(f.fileno())

--- a/src/parallel/checkpoint.py
+++ b/src/parallel/checkpoint.py
@@ -150,7 +150,9 @@ class CheckpointManager:
         # Atomic write: write to temp file, fsync, rename, then fsync directory
         temp_path = path.with_suffix(".tmp")
         try:
-            with open(temp_path, "w", encoding="utf-8") as f:
+            with open(
+                temp_path, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — manual temp+replace pattern (lines 151-158)
                 f.write(json.dumps(data, indent=2, default=str))
                 f.flush()
                 os.fsync(f.fileno())

--- a/src/parallel/persistence.py
+++ b/src/parallel/persistence.py
@@ -70,7 +70,9 @@ class JobPersistence:
         # Atomic write: write to temp file, fsync, rename, then fsync directory
         temp_path = path.with_suffix(".tmp")
         try:
-            with open(temp_path, "w", encoding="utf-8") as f:
+            with open(
+                temp_path, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — manual temp+replace pattern (lines 71-78)
                 f.write(json.dumps(data, indent=2, default=str))
                 f.flush()
                 os.fsync(f.fileno())

--- a/src/parallel/persistence.py
+++ b/src/parallel/persistence.py
@@ -70,9 +70,8 @@ class JobPersistence:
         # Atomic write: write to temp file, fsync, rename, then fsync directory
         temp_path = path.with_suffix(".tmp")
         try:
-            with open(
-                temp_path, "w", encoding="utf-8"
-            ) as f:  # atomic-write: ok — manual temp+replace pattern (lines 71-78)
+            # atomic-write: ok — manual temp+replace pattern (lines 71-78)
+            with open(temp_path, "w", encoding="utf-8") as f:
                 f.write(json.dumps(data, indent=2, default=str))
                 f.flush()
                 os.fsync(f.fileno())

--- a/src/services/analytics/analytics_service.py
+++ b/src/services/analytics/analytics_service.py
@@ -359,12 +359,12 @@ class AnalyticsService:
             import json
 
             # atomic-write: ok — user output (one-shot CLI export)
-            with open(output_path, "w") as f:
+            with open(output_path, "w", encoding="utf-8") as f:
                 json.dump(dashboard.to_dict(), f, indent=2)
 
         elif format == "text":
             # atomic-write: ok — user output (one-shot CLI export)
-            with open(output_path, "w") as f:
+            with open(output_path, "w", encoding="utf-8") as f:
                 f.write(self._format_dashboard_text(dashboard))
 
         else:

--- a/src/services/analytics/analytics_service.py
+++ b/src/services/analytics/analytics_service.py
@@ -358,15 +358,13 @@ class AnalyticsService:
         if format == "json":
             import json
 
-            with open(
-                output_path, "w"
-            ) as f:  # atomic-write: ok — user output (one-shot CLI export)
+            # atomic-write: ok — user output (one-shot CLI export)
+            with open(output_path, "w") as f:
                 json.dump(dashboard.to_dict(), f, indent=2)
 
         elif format == "text":
-            with open(
-                output_path, "w"
-            ) as f:  # atomic-write: ok — user output (one-shot CLI export)
+            # atomic-write: ok — user output (one-shot CLI export)
+            with open(output_path, "w") as f:
                 f.write(self._format_dashboard_text(dashboard))
 
         else:

--- a/src/services/analytics/analytics_service.py
+++ b/src/services/analytics/analytics_service.py
@@ -358,11 +358,15 @@ class AnalyticsService:
         if format == "json":
             import json
 
-            with open(output_path, "w") as f:
+            with open(
+                output_path, "w"
+            ) as f:  # atomic-write: ok — user output (one-shot CLI export)
                 json.dump(dashboard.to_dict(), f, indent=2)
 
         elif format == "text":
-            with open(output_path, "w") as f:
+            with open(
+                output_path, "w"
+            ) as f:  # atomic-write: ok — user output (one-shot CLI export)
                 f.write(self._format_dashboard_text(dashboard))
 
         else:

--- a/src/services/deduplication/reporter.py
+++ b/src/services/deduplication/reporter.py
@@ -99,7 +99,9 @@ class StorageReporter:
             output_path: Output CSV file path
         """
         try:
-            with open(output_path, "w", newline="", encoding="utf-8") as f:
+            with open(
+                output_path, "w", newline="", encoding="utf-8"
+            ) as f:  # atomic-write: ok — user output (one-shot CLI export)
                 writer = csv.writer(f)
 
                 # Header
@@ -141,7 +143,9 @@ class StorageReporter:
             output_path: Output JSON file path
         """
         try:
-            with open(output_path, "w", encoding="utf-8") as f:
+            with open(
+                output_path, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — user output (one-shot CLI export)
                 json.dump(duplicate_results, f, indent=2, default=str)
 
             logger.info(f"Exported duplicate report to {output_path}")

--- a/src/services/deduplication/reporter.py
+++ b/src/services/deduplication/reporter.py
@@ -99,9 +99,8 @@ class StorageReporter:
             output_path: Output CSV file path
         """
         try:
-            with open(
-                output_path, "w", newline="", encoding="utf-8"
-            ) as f:  # atomic-write: ok — user output (one-shot CLI export)
+            # atomic-write: ok — user output (one-shot CLI export)
+            with open(output_path, "w", newline="", encoding="utf-8") as f:
                 writer = csv.writer(f)
 
                 # Header
@@ -143,9 +142,8 @@ class StorageReporter:
             output_path: Output JSON file path
         """
         try:
-            with open(
-                output_path, "w", encoding="utf-8"
-            ) as f:  # atomic-write: ok — user output (one-shot CLI export)
+            # atomic-write: ok — user output (one-shot CLI export)
+            with open(output_path, "w", encoding="utf-8") as f:
                 json.dump(duplicate_results, f, indent=2, default=str)
 
             logger.info(f"Exported duplicate report to {output_path}")

--- a/src/services/intelligence/preference_store.py
+++ b/src/services/intelligence/preference_store.py
@@ -282,9 +282,8 @@ class PreferenceStore:
 
                 # Write to temporary file first (atomic write)
                 temp_file = self.storage_path / f"{self.DEFAULT_FILENAME}.tmp"
-                with open(
-                    temp_file, "w", encoding="utf-8"
-                ) as f:  # atomic-write: ok — manual temp+replace pattern (line 293)
+                # atomic-write: ok — manual temp+replace pattern (line 293)
+                with open(temp_file, "w", encoding="utf-8") as f:
                     json.dump(self._preferences, f, indent=2, ensure_ascii=False)
 
                 # Create backup of existing file before overwriting
@@ -484,9 +483,8 @@ class PreferenceStore:
                 output_path = Path(output_path)
                 output_path.parent.mkdir(parents=True, exist_ok=True)
 
-                with open(
-                    output_path, "w", encoding="utf-8"
-                ) as f:  # atomic-write: ok — user output (one-shot CLI export)
+                # atomic-write: ok — user output (one-shot CLI export)
+                with open(output_path, "w", encoding="utf-8") as f:
                     json.dump(self._preferences, f, indent=2, ensure_ascii=False)
 
                 return True

--- a/src/services/intelligence/preference_store.py
+++ b/src/services/intelligence/preference_store.py
@@ -282,7 +282,9 @@ class PreferenceStore:
 
                 # Write to temporary file first (atomic write)
                 temp_file = self.storage_path / f"{self.DEFAULT_FILENAME}.tmp"
-                with open(temp_file, "w", encoding="utf-8") as f:
+                with open(
+                    temp_file, "w", encoding="utf-8"
+                ) as f:  # atomic-write: ok — manual temp+replace pattern (line 293)
                     json.dump(self._preferences, f, indent=2, ensure_ascii=False)
 
                 # Create backup of existing file before overwriting
@@ -482,7 +484,9 @@ class PreferenceStore:
                 output_path = Path(output_path)
                 output_path.parent.mkdir(parents=True, exist_ok=True)
 
-                with open(output_path, "w", encoding="utf-8") as f:
+                with open(
+                    output_path, "w", encoding="utf-8"
+                ) as f:  # atomic-write: ok — user output (one-shot CLI export)
                     json.dump(self._preferences, f, indent=2, ensure_ascii=False)
 
                 return True

--- a/src/services/intelligence/profile_exporter.py
+++ b/src/services/intelligence/profile_exporter.py
@@ -77,7 +77,9 @@ class ProfileExporter:
 
             # Write to temporary file first (atomic write)
             temp_file = file_path.parent / f"{file_path.name}.tmp"
-            with open(temp_file, "w", encoding="utf-8") as f:
+            with open(
+                temp_file, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — manual temp+replace pattern
                 json.dump(export_data, f, indent=2, ensure_ascii=False)
 
             # Validate export file
@@ -167,7 +169,9 @@ class ProfileExporter:
 
             # Write to temporary file first (atomic write)
             temp_file = file_path.parent / f"{file_path.name}.tmp"
-            with open(temp_file, "w", encoding="utf-8") as f:
+            with open(
+                temp_file, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — manual temp+replace pattern
                 json.dump(export_data, f, indent=2, ensure_ascii=False)
 
             # Atomic rename

--- a/src/services/intelligence/profile_exporter.py
+++ b/src/services/intelligence/profile_exporter.py
@@ -77,9 +77,8 @@ class ProfileExporter:
 
             # Write to temporary file first (atomic write)
             temp_file = file_path.parent / f"{file_path.name}.tmp"
-            with open(
-                temp_file, "w", encoding="utf-8"
-            ) as f:  # atomic-write: ok — manual temp+replace pattern
+            # atomic-write: ok — manual temp+replace pattern
+            with open(temp_file, "w", encoding="utf-8") as f:
                 json.dump(export_data, f, indent=2, ensure_ascii=False)
 
             # Validate export file
@@ -169,9 +168,8 @@ class ProfileExporter:
 
             # Write to temporary file first (atomic write)
             temp_file = file_path.parent / f"{file_path.name}.tmp"
-            with open(
-                temp_file, "w", encoding="utf-8"
-            ) as f:  # atomic-write: ok — manual temp+replace pattern
+            # atomic-write: ok — manual temp+replace pattern
+            with open(temp_file, "w", encoding="utf-8") as f:
                 json.dump(export_data, f, indent=2, ensure_ascii=False)
 
             # Atomic rename

--- a/src/services/intelligence/profile_manager.py
+++ b/src/services/intelligence/profile_manager.py
@@ -196,7 +196,9 @@ class ProfileManager:
 
             # Write to temporary file first (atomic write)
             temp_file = profile_path.parent / f"{profile_path.name}.tmp"
-            with open(temp_file, "w", encoding="utf-8") as f:
+            with open(
+                temp_file, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — manual temp+replace pattern (line 203)
                 json.dump(profile.to_dict(), f, indent=2, ensure_ascii=False)
 
             # Atomic rename
@@ -265,7 +267,9 @@ class ProfileManager:
         try:
             # Write to temporary file first (atomic write)
             temp_file = self.active_profile_file.parent / f"{self.active_profile_file.name}.tmp"
-            with open(temp_file, "w", encoding="utf-8") as f:
+            with open(
+                temp_file, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — manual temp+replace pattern (line 272)
                 f.write(profile_name)
 
             # Atomic rename

--- a/src/services/intelligence/profile_manager.py
+++ b/src/services/intelligence/profile_manager.py
@@ -196,9 +196,8 @@ class ProfileManager:
 
             # Write to temporary file first (atomic write)
             temp_file = profile_path.parent / f"{profile_path.name}.tmp"
-            with open(
-                temp_file, "w", encoding="utf-8"
-            ) as f:  # atomic-write: ok — manual temp+replace pattern (line 203)
+            # atomic-write: ok — manual temp+replace pattern (line 203)
+            with open(temp_file, "w", encoding="utf-8") as f:
                 json.dump(profile.to_dict(), f, indent=2, ensure_ascii=False)
 
             # Atomic rename
@@ -267,9 +266,8 @@ class ProfileManager:
         try:
             # Write to temporary file first (atomic write)
             temp_file = self.active_profile_file.parent / f"{self.active_profile_file.name}.tmp"
-            with open(
-                temp_file, "w", encoding="utf-8"
-            ) as f:  # atomic-write: ok — manual temp+replace pattern (line 272)
+            # atomic-write: ok — manual temp+replace pattern (line 272)
+            with open(temp_file, "w", encoding="utf-8") as f:
                 f.write(profile_name)
 
             # Atomic rename

--- a/src/services/intelligence/profile_migrator.py
+++ b/src/services/intelligence/profile_migrator.py
@@ -273,7 +273,9 @@ class ProfileMigrator:
             backup_path = backup_dir / f"{backup_name}.json"
 
             # Write backup
-            with open(backup_path, "w", encoding="utf-8") as f:
+            with open(
+                backup_path, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — one-shot migration backup, retry-on-fail safe
                 json.dump(profile.to_dict(), f, indent=2, ensure_ascii=False)
 
             print(f"Created migration backup: {backup_path}")

--- a/src/services/intelligence/profile_migrator.py
+++ b/src/services/intelligence/profile_migrator.py
@@ -273,9 +273,8 @@ class ProfileMigrator:
             backup_path = backup_dir / f"{backup_name}.json"
 
             # Write backup
-            with open(
-                backup_path, "w", encoding="utf-8"
-            ) as f:  # atomic-write: ok — one-shot migration backup, retry-on-fail safe
+            # atomic-write: ok — one-shot migration backup, retry-on-fail safe
+            with open(backup_path, "w", encoding="utf-8") as f:
                 json.dump(profile.to_dict(), f, indent=2, ensure_ascii=False)
 
             print(f"Created migration backup: {backup_path}")

--- a/src/services/suggestion_feedback.py
+++ b/src/services/suggestion_feedback.py
@@ -390,7 +390,7 @@ class SuggestionFeedback:
             "exported_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         }
 
-        with open(output_file, "w") as f:
+        with open(output_file, "w") as f:  # atomic-write: ok — user output (one-shot CLI export)
             json.dump(data, f, indent=2)
 
         logger.info(f"Exported feedback to {output_file}")

--- a/src/services/suggestion_feedback.py
+++ b/src/services/suggestion_feedback.py
@@ -390,7 +390,12 @@ class SuggestionFeedback:
             "exported_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         }
 
-        with open(output_file, "w") as f:  # atomic-write: ok — user output (one-shot CLI export)
-            json.dump(data, f, indent=2)
+        try:
+            # atomic-write: ok — user output (one-shot CLI export)
+            with open(output_file, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+        except (OSError, TypeError, ValueError):
+            logger.exception("Failed to export feedback to %s", output_file)
+            raise
 
         logger.info(f"Exported feedback to {output_file}")

--- a/src/services/video/scene_detector.py
+++ b/src/services/video/scene_detector.py
@@ -353,7 +353,9 @@ class SceneDetector:
 
         output_path = Path(output_path)
 
-        with open(output_path, "w", newline="") as f:
+        with open(
+            output_path, "w", newline=""
+        ) as f:  # atomic-write: ok — user output (one-shot CLI export)
             writer = csv.writer(f)
             writer.writerow(
                 [

--- a/src/services/video/scene_detector.py
+++ b/src/services/video/scene_detector.py
@@ -353,9 +353,8 @@ class SceneDetector:
 
         output_path = Path(output_path)
 
-        with open(
-            output_path, "w", newline=""
-        ) as f:  # atomic-write: ok — user output (one-shot CLI export)
+        # atomic-write: ok — user output (one-shot CLI export)
+        with open(output_path, "w", newline="") as f:
             writer = csv.writer(f)
             writer.writerow(
                 [

--- a/src/undo/durable_move.py
+++ b/src/undo/durable_move.py
@@ -253,7 +253,9 @@ def _locked(journal: Path, mode: int) -> Iterator[object | None]:
     lock = _lock_path(journal)
     # ``open(..., "a")`` creates the file if absent without truncating
     # it — keeps a stable inode across all callers.
-    fh = open(lock, "a", encoding="utf-8")
+    fh = open(
+        lock, "a", encoding="utf-8"
+    )  # atomic-write: ok — fcntl lock file, stable inode required
     try:
         fcntl.flock(fh.fileno(), mode)
         try:
@@ -679,9 +681,13 @@ def _sweep_unlocked_body(journal: Path) -> None:
     retained = _reconcile_entries(entries)
     if retained:
         lines = [_serialize_entry(e) for e in retained]
-        journal.write_text("\n".join(lines) + "\n")
+        journal.write_text(
+            "\n".join(lines) + "\n"
+        )  # atomic-write: ok — journal compaction inside _locked() (caller holds LOCK_EX)
     else:
-        journal.write_text("")
+        journal.write_text(
+            ""
+        )  # atomic-write: ok — journal truncation inside _locked() (caller holds LOCK_EX)
 
 
 _PlannedVerb = Literal[
@@ -1454,7 +1460,10 @@ def _append_journal(journal: Path, payload: Mapping[str, object]) -> None:
     # compaction without depending on the journal inode.
     if _HAS_FCNTL:
         line = json.dumps(payload) + "\n"
-        with _locked(journal, fcntl.LOCK_EX), open(journal, "a", encoding="utf-8") as fh:
+        with (
+            _locked(journal, fcntl.LOCK_EX),
+            open(journal, "a", encoding="utf-8") as fh,
+        ):  # atomic-write: ok — append_durable pattern (LOCK_EX + fsync below)
             fh.write(line)
             fh.flush()
             os.fsync(fh.fileno())

--- a/src/undo/durable_move.py
+++ b/src/undo/durable_move.py
@@ -90,7 +90,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from utils.atomic_io import fsync_directory
-from utils.atomic_write import append_durable
+from utils.atomic_write import append_durable, atomic_write_with
 
 # F9 top-level optional import: ``fcntl`` is POSIX-only. Wrapped in a
 # try/except so the module imports cleanly on Windows; functions that
@@ -253,9 +253,8 @@ def _locked(journal: Path, mode: int) -> Iterator[object | None]:
     lock = _lock_path(journal)
     # ``open(..., "a")`` creates the file if absent without truncating
     # it — keeps a stable inode across all callers.
-    fh = open(
-        lock, "a", encoding="utf-8"
-    )  # atomic-write: ok — fcntl lock file, stable inode required
+    # atomic-write: ok — fcntl lock file, stable inode required
+    fh = open(lock, "a", encoding="utf-8")
     try:
         fcntl.flock(fh.fileno(), mode)
         try:
@@ -679,15 +678,15 @@ def _sweep_unlocked_body(journal: Path) -> None:
     if not entries:
         return
     retained = _reconcile_entries(entries)
-    if retained:
-        lines = [_serialize_entry(e) for e in retained]
-        journal.write_text(
-            "\n".join(lines) + "\n"
-        )  # atomic-write: ok — journal compaction inside _locked() (caller holds LOCK_EX)
-    else:
-        journal.write_text(
-            ""
-        )  # atomic-write: ok — journal truncation inside _locked() (caller holds LOCK_EX)
+    # The unlocked path (no fcntl, e.g. Windows) cannot rely on advisory
+    # locking, so we use the atomic temp-file + os.replace primitive to
+    # guarantee a crashed compaction never leaves a half-written journal.
+    # CodeRabbit r219 caught the previous in-place ``Path.write_text`` here
+    # which could truncate-then-fail and corrupt recovery state.
+    payload = "\n".join(_serialize_entry(e) for e in retained)
+    if payload:
+        payload += "\n"
+    atomic_write_with(journal, lambda fh: fh.write(payload), mode="w")
 
 
 _PlannedVerb = Literal[
@@ -1462,8 +1461,9 @@ def _append_journal(journal: Path, payload: Mapping[str, object]) -> None:
         line = json.dumps(payload) + "\n"
         with (
             _locked(journal, fcntl.LOCK_EX),
+            # atomic-write: ok — append_durable pattern (LOCK_EX + fsync below)
             open(journal, "a", encoding="utf-8") as fh,
-        ):  # atomic-write: ok — append_durable pattern (LOCK_EX + fsync below)
+        ):
             fh.write(line)
             fh.flush()
             os.fsync(fh.fileno())

--- a/src/updater/state.py
+++ b/src/updater/state.py
@@ -80,7 +80,9 @@ class UpdateStateStore:
         )
         temp_path = self._state_path.with_suffix(".tmp")
         try:
-            with open(temp_path, "w", encoding="utf-8") as f:
+            with open(
+                temp_path, "w", encoding="utf-8"
+            ) as f:  # atomic-write: ok — manual temp+replace pattern (lines 81-88)
                 f.write(payload)
                 f.flush()
                 os.fsync(f.fileno())

--- a/src/updater/state.py
+++ b/src/updater/state.py
@@ -80,9 +80,8 @@ class UpdateStateStore:
         )
         temp_path = self._state_path.with_suffix(".tmp")
         try:
-            with open(
-                temp_path, "w", encoding="utf-8"
-            ) as f:  # atomic-write: ok — manual temp+replace pattern (lines 81-88)
+            # atomic-write: ok — manual temp+replace pattern (lines 81-88)
+            with open(temp_path, "w", encoding="utf-8") as f:
                 f.write(payload)
                 f.flush()
                 os.fsync(f.fileno())

--- a/src/utils/epub_enhanced.py
+++ b/src/utils/epub_enhanced.py
@@ -617,9 +617,8 @@ class EnhancedEPUBReader:
             output_path = output_dir / f"{epub_path.stem}_cover.{ext}"
 
             # Save cover
-            with open(
-                output_path, "wb"
-            ) as f:  # atomic-write: ok — user output (one-shot extraction)
+            # atomic-write: ok — user output (one-shot extraction)
+            with open(output_path, "wb") as f:
                 f.write(cover_data)
 
             logger.info(f"Extracted cover to: {output_path}")

--- a/src/utils/epub_enhanced.py
+++ b/src/utils/epub_enhanced.py
@@ -617,7 +617,9 @@ class EnhancedEPUBReader:
             output_path = output_dir / f"{epub_path.stem}_cover.{ext}"
 
             # Save cover
-            with open(output_path, "wb") as f:
+            with open(
+                output_path, "wb"
+            ) as f:  # atomic-write: ok — user output (one-shot extraction)
                 f.write(cover_data)
 
             logger.info(f"Extracted cover to: {output_path}")

--- a/tests/ci/test_atomic_write_required.py
+++ b/tests/ci/test_atomic_write_required.py
@@ -244,9 +244,7 @@ class TestFindViolationsSynthetic:
         violations = find_violations(target)
         assert len(violations) == 1
 
-    def test_multiline_open_marker_on_closing_paren_is_not_flagged(
-        self, tmp_path: Path
-    ) -> None:
+    def test_multiline_open_marker_on_closing_paren_is_not_flagged(self, tmp_path: Path) -> None:
         # Cover the common ruff-formatted multiline open() shape where the
         # call starts on one line, the mode string is on a later line, and the
         # opt-out marker sits on the closing-paren line.
@@ -256,9 +254,7 @@ class TestFindViolationsSynthetic:
         )
         assert find_violations(target) == []
 
-    def test_multiline_open_in_string_literal_not_flagged_via_opt_out(
-        self, tmp_path: Path
-    ) -> None:
+    def test_multiline_open_in_string_literal_not_flagged_via_opt_out(self, tmp_path: Path) -> None:
         # Marker embedded inside a string literal on the open( line must not
         # exempt the call; the opt-out must appear in an actual comment.
         target = self._write(

--- a/tests/ci/test_atomic_write_required.py
+++ b/tests/ci/test_atomic_write_required.py
@@ -6,9 +6,14 @@ PRs #176, #195, #197, #203, #204. Any new ``Path.write_text``,
 either use the ``utils.atomic_write`` helpers or carry an explicit
 ``# atomic-write: ok — <reason>`` opt-out comment.
 
+The detector is AST-based (codex r219 #1 + #2) — regex-on-raw-lines failed
+to handle nested parentheses in ``open(Path(name).with_suffix('.json'), 'w')``
+and false-flagged forbidden patterns inside string literals.
+
 T10 predicate negative-case backfill: every exemption category has a positive
 test (the rail flags the surface shape) AND a negative test (the rail does
-NOT flag when the marker / file allowlist applies).
+NOT flag when the marker / file allowlist applies / the pattern is inside a
+string literal).
 """
 
 from __future__ import annotations
@@ -29,118 +34,36 @@ _SCRIPT = _FO_ROOT / "scripts" / "check_atomic_write.py"
 sys.path.insert(0, str(_FO_ROOT / "scripts"))
 from check_atomic_write import (  # noqa: E402
     _ALLOWLISTED_FILES,
-    _has_opt_out,
-    _is_comment_line,
-    _is_in_docstring_or_string,
-    _matches_forbidden,
+    _FORBIDDEN_MODES,
+    _has_opt_out_in_window,
     find_violations,
 )
 
+
+def _synth(tmp_path: Path, content: str) -> Path:
+    """Write *content* to a synthetic Python file under ``tmp_path/src/x/mod.py``."""
+    src = tmp_path / "src" / "x"
+    src.mkdir(parents=True)
+    target = src / "mod.py"
+    target.write_text(content)
+    return target
+
+
 # ---------------------------------------------------------------------------
-# Unit tests: forbidden-pattern detection
+# Unit tests: forbidden mode set
 # ---------------------------------------------------------------------------
 
 
-class TestPatternDetection:
-    """The pattern set must match the four forbidden write forms."""
+class TestForbiddenModes:
+    """The mode set defines what counts as a write/append open()."""
 
-    @pytest.mark.parametrize(
-        "line",
-        [
-            'path.write_text("data")',
-            'p.write_bytes(b"\\x00\\x01")',
-            'with open(p, "w") as f:',
-            'with open(p, "wb") as f:',
-            'with open(p, "a") as f:',
-            'with open(p, "ab") as f:',
-            "fh = open(lock, 'a', encoding='utf-8')",
-            'open(target, "w", encoding="utf-8")',
-        ],
-    )
-    def test_matches_forbidden(self, line: str) -> None:
-        assert _matches_forbidden(line)
+    @pytest.mark.parametrize("mode", ["w", "wb", "a", "ab", "w+", "wb+", "a+", "ab+"])
+    def test_write_modes_in_set(self, mode: str) -> None:
+        assert mode in _FORBIDDEN_MODES
 
-    @pytest.mark.parametrize(
-        "line",
-        [
-            # Read modes are not flagged (T10 negative cases)
-            'with open(p, "r") as f:',
-            'with open(p, "rb") as f:',
-            "data = path.read_text()",
-            "data = path.read_bytes()",
-            # Method-name false friends — must not match
-            "rewrite_text(payload)",
-            "writer.writeheader()",
-            # Fragment in identifier — not a write call
-            "open_writer = make_writer()",
-        ],
-    )
-    def test_does_not_match_non_write(self, line: str) -> None:
-        assert not _matches_forbidden(line)
-
-
-class TestOptOutMarker:
-    """The opt-out marker must be detected only in its canonical form."""
-
-    @pytest.mark.parametrize(
-        "line",
-        [
-            'path.write_text("x")  # atomic-write: ok',
-            'path.write_text("x")  # atomic-write: ok — user output',
-            'path.write_text("x")  # atomic-write:  ok',  # extra space
-            'path.write_text("x")  # atomic-write: ok (legacy single-shot)',
-        ],
-    )
-    def test_recognizes_opt_out(self, line: str) -> None:
-        assert _has_opt_out(line)
-
-    @pytest.mark.parametrize(
-        "line",
-        [
-            # Marker variations that must NOT count (typos / wrong prefix)
-            'path.write_text("x")  # atomic-write fine',
-            'path.write_text("x")  # atomic_write: ok',  # underscore not hyphen
-            'path.write_text("x")  # ok — atomic write',
-            'path.write_text("x")',  # no marker at all
-        ],
-    )
-    def test_rejects_non_canonical(self, line: str) -> None:
-        assert not _has_opt_out(line)
-
-    def test_marker_inside_string_literal_is_rejected(self) -> None:
-        # A marker that appears only inside a string literal must not count as
-        # an opt-out; only a bare trailing comment satisfies the rule.
-        assert not _has_opt_out('path.write_text("# atomic-write: ok — user output")')
-
-
-class TestCommentAndDocstringHeuristics:
-    """Comments and docstrings must not trip the rail."""
-
-    @pytest.mark.parametrize(
-        "line",
-        [
-            "# path.write_text('foo')",
-            "    # historically used path.write_text",
-        ],
-    )
-    def test_comment_lines_are_skipped(self, line: str) -> None:
-        assert _is_comment_line(line)
-
-    def test_non_comment_with_inline_comment_is_not_a_comment_line(self) -> None:
-        # The whole line isn't a comment, just trailing portion.
-        assert not _is_comment_line("path.write_text('x')  # note")
-
-    @pytest.mark.parametrize(
-        "line",
-        [
-            '"""Example: path.write_text("data")"""',
-            "'''Example: open(p, \"w\")'''",
-            '"""docstring start',
-            "'''docstring start",
-        ],
-    )
-    def test_docstring_or_string_lines_are_skipped(self, line: str) -> None:
-        assert _is_in_docstring_or_string(line)
+    @pytest.mark.parametrize("mode", ["r", "rb", "r+", "rb+"])
+    def test_read_modes_not_in_set(self, mode: str) -> None:
+        assert mode not in _FORBIDDEN_MODES
 
 
 # ---------------------------------------------------------------------------
@@ -162,107 +85,189 @@ class TestAllowlist:
 
 
 # ---------------------------------------------------------------------------
-# Unit tests: find_violations on synthetic files
+# Unit tests: marker window detection
 # ---------------------------------------------------------------------------
 
 
-class TestFindViolationsSynthetic:
-    """End-to-end checks against tmp_path source files."""
+class TestMarkerWindow:
+    """Markers inside the ±N-line window around the call line are recognised."""
 
-    def _write(self, tmp_path: Path, content: str) -> Path:
-        # Mirror the path layout the detector expects so any future
-        # path-relative checks still resolve correctly.
-        src = tmp_path / "src" / "x"
-        src.mkdir(parents=True)
-        target = src / "mod.py"
-        target.write_text(content)
-        return target
+    def test_marker_on_call_line_is_recognised(self) -> None:
+        lines = ['p.write_text("x")  # atomic-write: ok — user output']
+        assert _has_opt_out_in_window(lines, call_line=1)
+
+    def test_marker_on_line_above_is_recognised(self) -> None:
+        # New placement (codex r219 + diff-coverage fix): a standalone
+        # comment line immediately above the call is accepted.
+        lines = [
+            "# atomic-write: ok — manual temp+replace",
+            'p.write_text("x")',
+        ]
+        assert _has_opt_out_in_window(lines, call_line=2)
+
+    def test_marker_on_closing_paren_line_is_recognised(self) -> None:
+        # ruff format splits long calls; marker may land on the )-line.
+        lines = [
+            "p.write_text(",
+            '    "payload"',
+            ")  # atomic-write: ok — user output",
+        ]
+        assert _has_opt_out_in_window(lines, call_line=1)
+
+    def test_marker_too_far_above_is_not_recognised(self) -> None:
+        lines = [
+            "# atomic-write: ok",
+            "x = 1",
+            "x = 2",
+            "x = 3",
+            "x = 4",
+            'p.write_text("x")',
+        ]
+        assert not _has_opt_out_in_window(lines, call_line=6)
+
+    def test_marker_too_far_below_is_not_recognised(self) -> None:
+        lines = ['p.write_text("x")'] + ["x = 1"] * 10 + ["# atomic-write: ok"]
+        assert not _has_opt_out_in_window(lines, call_line=1)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: AST-based detection on synthetic files
+# ---------------------------------------------------------------------------
+
+
+class TestWriteTextAndBytes:
+    """Both ``Path.write_text`` and ``Path.write_bytes`` are flagged."""
 
     def test_unmarked_write_text_is_flagged(self, tmp_path: Path) -> None:
-        target = self._write(tmp_path, 'p.write_text("payload")\n')
-        violations = find_violations(target)
-        assert len(violations) == 1
-        assert "write_text" in violations[0][1]
+        target = _synth(tmp_path, 'p.write_text("payload")\n')
+        assert len(find_violations(target)) == 1
+
+    def test_unmarked_write_bytes_is_flagged(self, tmp_path: Path) -> None:
+        target = _synth(tmp_path, 'p.write_bytes(b"\\x00")\n')
+        assert len(find_violations(target)) == 1
 
     def test_marked_write_text_is_not_flagged(self, tmp_path: Path) -> None:
-        target = self._write(
+        target = _synth(
             tmp_path,
             'p.write_text("payload")  # atomic-write: ok — manual temp+replace\n',
         )
         assert find_violations(target) == []
 
-    def test_unmarked_open_w_is_flagged(self, tmp_path: Path) -> None:
-        target = self._write(tmp_path, 'with open(p, "w") as f:\n    f.write("x")\n')
-        violations = find_violations(target)
-        assert len(violations) == 1
-
-    def test_marked_open_w_is_not_flagged(self, tmp_path: Path) -> None:
-        target = self._write(
+    def test_write_text_with_marker_above_is_not_flagged(self, tmp_path: Path) -> None:
+        # New placement: marker on the line immediately above the call.
+        target = _synth(
             tmp_path,
-            'with open(p, "w") as f:  # atomic-write: ok — user output\n    f.write("x")\n',
+            '# atomic-write: ok — manual temp+replace\np.write_text("payload")\n',
         )
         assert find_violations(target) == []
 
-    def test_open_read_mode_is_not_flagged(self, tmp_path: Path) -> None:
-        # T10 negative case: the same surface (open with mode str) must
-        # not flag for read modes.
-        target = self._write(tmp_path, 'with open(p, "r") as f:\n    data = f.read()\n')
+
+class TestOpenCalls:
+    """``open()`` is flagged only for write/append modes."""
+
+    @pytest.mark.parametrize("mode", ["w", "wb", "a", "ab"])
+    def test_write_modes_are_flagged(self, mode: str, tmp_path: Path) -> None:
+        target = _synth(tmp_path, f'with open(p, "{mode}") as f:\n    f.write("x")\n')
+        assert len(find_violations(target)) == 1
+
+    @pytest.mark.parametrize("mode", ["r", "rb"])
+    def test_read_modes_are_not_flagged(self, mode: str, tmp_path: Path) -> None:
+        # T10 negative case: same call shape, read mode → not flagged.
+        target = _synth(tmp_path, f'with open(p, "{mode}") as f:\n    f.read()\n')
         assert find_violations(target) == []
 
-    def test_marker_on_following_line_is_not_flagged(self, tmp_path: Path) -> None:
-        # ruff format frequently splits long calls across lines, leaving the
-        # # atomic-write: ok comment on the closing-paren line. The detector
-        # must scan a lookahead window forward.
-        target = self._write(
+    def test_mode_keyword_argument_is_recognised(self, tmp_path: Path) -> None:
+        target = _synth(tmp_path, 'with open(p, mode="w") as f:\n    f.write("x")\n')
+        assert len(find_violations(target)) == 1
+
+    def test_open_with_nested_call_in_first_arg_is_flagged(self, tmp_path: Path) -> None:
+        # Codex r219 #1 — the regex-based predecessor stopped at the first
+        # ``)`` so this shape silently bypassed the rail. The AST detector
+        # walks the call structure and sees the mode regardless of how
+        # nested the path expression is.
+        target = _synth(
             tmp_path,
-            'p.write_text(\n    "payload"\n)  # atomic-write: ok — manual temp+replace\n',
+            'with open(Path(name).with_suffix(".json"), "w") as f:\n    f.write("x")\n',
+        )
+        assert len(find_violations(target)) == 1
+
+    def test_method_named_open_is_not_flagged(self, tmp_path: Path) -> None:
+        # T10 negative case: ``self.open(...)`` is a method call, not the
+        # builtin. The AST detector matches only ``ast.Name(id='open')``.
+        target = _synth(tmp_path, 'self.open(p, "w")\n')
+        assert find_violations(target) == []
+
+    def test_dynamic_mode_is_not_flagged(self, tmp_path: Path) -> None:
+        # The mode is a variable reference; we can't statically determine
+        # if it's a write or read mode, so we conservatively skip rather
+        # than false-flag. ``mode`` could be either.
+        target = _synth(tmp_path, "with open(p, mode) as f:\n    pass\n")
+        assert find_violations(target) == []
+
+
+class TestStringLiteralFalsePositives:
+    """Forbidden patterns inside string literals must NOT be flagged.
+
+    Codex r219 #2: regex-on-raw-lines flagged ``logger.debug("open(path, 'w')")``
+    even though the ``open(...)`` is inside a string literal, not a real
+    call. The AST detector only matches actual ``ast.Call`` nodes.
+    """
+
+    def test_open_inside_string_literal_not_flagged(self, tmp_path: Path) -> None:
+        target = _synth(
+            tmp_path,
+            "logger.debug(\"open(path, 'w')\")\n",
         )
         assert find_violations(target) == []
 
-    def test_marker_too_far_after_call_is_still_flagged(self, tmp_path: Path) -> None:
-        # The lookahead is bounded; a marker many lines later does not
-        # silently exempt the call (T10 negative case for the lookahead).
-        body = 'p.write_text("payload")\n' + ("x = 1\n" * 10) + "# atomic-write: ok\n"
-        target = self._write(tmp_path, body)
-        violations = find_violations(target)
-        assert len(violations) == 1
-
-    def test_docstring_example_is_not_flagged(self, tmp_path: Path) -> None:
-        # Triple-quoted block containing a forbidden pattern must not trip.
-        target = self._write(
+    def test_write_text_inside_string_literal_not_flagged(self, tmp_path: Path) -> None:
+        target = _synth(
             tmp_path,
-            '"""Module docstring.\n\nExample::\n\n    p.write_text("foo")\n"""\n',
+            'message = "use path.write_text(content) for atomic writes"\n',
         )
         assert find_violations(target) == []
+
+    def test_open_in_docstring_not_flagged(self, tmp_path: Path) -> None:
+        target = _synth(
+            tmp_path,
+            '"""Module docstring.\n\nExample::\n\n    open(p, "w")\n"""\n',
+        )
+        assert find_violations(target) == []
+
+
+class TestMultilineOpen:
+    """``open()`` calls split across lines by ruff format are still detected."""
 
     def test_multiline_open_without_marker_is_flagged(self, tmp_path: Path) -> None:
-        # open( on one line, mode string on the next — no marker anywhere.
-        target = self._write(
+        target = _synth(
             tmp_path,
             'with open(\n    p,\n    "w",\n) as f:\n    f.write("x")\n',
         )
-        violations = find_violations(target)
-        assert len(violations) == 1
+        assert len(find_violations(target)) == 1
 
     def test_multiline_open_marker_on_closing_paren_is_not_flagged(self, tmp_path: Path) -> None:
-        # Cover the common ruff-formatted multiline open() shape where the
-        # call starts on one line, the mode string is on a later line, and the
-        # opt-out marker sits on the closing-paren line.
-        target = self._write(
+        target = _synth(
             tmp_path,
-            'with open(\n    p,\n    "w",\n) as f:  # atomic-write: ok — user output\n    f.write("x")\n',
+            'with open(\n    p,\n    "w",\n) as f:  # atomic-write: ok — user output\n'
+            '    f.write("x")\n',
         )
         assert find_violations(target) == []
 
-    def test_multiline_open_in_string_literal_not_flagged_via_opt_out(self, tmp_path: Path) -> None:
-        # Marker embedded inside a string literal on the open( line must not
-        # exempt the call; the opt-out must appear in an actual comment.
-        target = self._write(
+    def test_multiline_open_marker_above_is_not_flagged(self, tmp_path: Path) -> None:
+        target = _synth(
             tmp_path,
-            'with open(\n    p,\n    "w",\n) as f:\n    f.write("# atomic-write: ok")\n',
+            "# atomic-write: ok — user output\n"
+            'with open(\n    p,\n    "w",\n) as f:\n    f.write("x")\n',
         )
-        violations = find_violations(target)
-        assert len(violations) == 1
+        assert find_violations(target) == []
+
+
+class TestSyntaxError:
+    """A file that fails to parse yields zero violations (rail bows out)."""
+
+    def test_syntax_error_yields_no_violations(self, tmp_path: Path) -> None:
+        target = _synth(tmp_path, "def broken(\n")
+        assert find_violations(target) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ci/test_atomic_write_required.py
+++ b/tests/ci/test_atomic_write_required.py
@@ -369,6 +369,21 @@ class TestOpenCalls:
         target = _synth(tmp_path, 'Path("x").open("w", -1)\n')
         assert len(find_violations(target)) == 1
 
+    def test_mode_kwarg_overrides_args0_path_literal(self, tmp_path: Path) -> None:
+        """Codex r219 #8: ``open("a", mode="r")`` — kwarg wins over args[0] fallback.
+
+        Round-5's args[0] fallback fired before the kwarg scan, so
+        ``open("a", mode="r")`` returned ``"a"`` (false-positive write flag).
+        Reordered: args[1] → kwarg → args[0].
+        """
+        target = _synth(tmp_path, 'open("a", mode="r")\n')
+        assert find_violations(target) == []
+
+    def test_module_level_open_mode_kwarg_overrides_args0_literal(self, tmp_path: Path) -> None:
+        """Codex r219 #8: ``tarfile.open("r", mode="w")`` — kwarg wins; flagged correctly."""
+        target = _synth(tmp_path, 'tarfile.open("r", mode="w")\n')
+        assert len(find_violations(target)) == 1
+
     def test_dynamic_mode_is_not_flagged(self, tmp_path: Path) -> None:
         # The mode is a variable reference; we can't statically determine
         # if it's a write or read mode, so we conservatively skip rather

--- a/tests/ci/test_atomic_write_required.py
+++ b/tests/ci/test_atomic_write_required.py
@@ -37,6 +37,7 @@ from check_atomic_write import (  # noqa: E402
     _FORBIDDEN_MODES,
     _collect_marker_comment_lines,
     _has_opt_out_in_window,
+    _mode_is_forbidden,
     find_violations,
 )
 
@@ -56,17 +57,51 @@ def _synth(tmp_path: Path, content: str) -> Path:
 
 
 class TestForbiddenModes:
-    """The mode set defines what counts as a write/append open()."""
+    """The mode-classifier flags every write/append/exclusive-create form."""
+
+    @pytest.mark.parametrize(
+        "mode",
+        [
+            # Canonical forms enumerated in _FORBIDDEN_MODES
+            "w",
+            "wb",
+            "wt",
+            "a",
+            "ab",
+            "at",
+            "x",
+            "xb",
+            "xt",
+            "w+",
+            "wb+",
+            "w+b",
+            "a+",
+            "ab+",
+            "a+b",
+            "x+",
+            # Codex r219 #3 — alias / mixed-flag forms that bypassed the
+            # original literal set.
+            "wt+",
+            "w+t",
+            "at+",
+            "a+t",
+            "xb+",
+            "x+b",
+        ],
+    )
+    def test_write_modes_classified_forbidden(self, mode: str) -> None:
+        """Every write/append/exclusive form must be classified forbidden."""
+        assert _mode_is_forbidden(mode)
+
+    @pytest.mark.parametrize("mode", ["r", "rb", "rt", "r+", "rb+", "r+b", "rt+", "r+t"])
+    def test_read_modes_classified_allowed(self, mode: str) -> None:
+        """Pure read modes (no w/a/x) must be classified allowed."""
+        assert not _mode_is_forbidden(mode)
 
     @pytest.mark.parametrize("mode", ["w", "wb", "a", "ab", "w+", "wb+", "a+", "ab+"])
-    def test_write_modes_in_set(self, mode: str) -> None:
-        """Write modes in set."""
+    def test_canonical_modes_in_legacy_set(self, mode: str) -> None:
+        """The legacy ``_FORBIDDEN_MODES`` set still contains the canonical strings."""
         assert mode in _FORBIDDEN_MODES
-
-    @pytest.mark.parametrize("mode", ["r", "rb", "r+", "rb+"])
-    def test_read_modes_not_in_set(self, mode: str) -> None:
-        """Read modes not in set."""
-        assert mode not in _FORBIDDEN_MODES
 
 
 # ---------------------------------------------------------------------------
@@ -192,9 +227,36 @@ class TestWriteTextAndBytes:
 class TestOpenCalls:
     """``open()`` is flagged only for write/append modes."""
 
-    @pytest.mark.parametrize("mode", ["w", "wb", "a", "ab"])
+    @pytest.mark.parametrize(
+        "mode",
+        [
+            "w",
+            "wb",
+            "wt",
+            "a",
+            "ab",
+            "at",
+            "x",
+            "xb",
+            "xt",
+            "w+",
+            "wb+",
+            "w+b",
+            "wt+",
+            "w+t",
+            "a+",
+            "ab+",
+            "a+b",
+            "x+",
+            "xb+",
+        ],
+    )
     def test_write_modes_are_flagged(self, mode: str, tmp_path: Path) -> None:
-        """Write modes are flagged."""
+        """Every write/append/exclusive mode (including alias forms) is flagged.
+
+        Codex r219 #3: the previous literal-set check silently let
+        ``"wt"``, ``"at"``, ``"w+b"``, ``"a+t"``, etc. bypass the rail.
+        """
         target = _synth(tmp_path, f'with open(p, "{mode}") as f:\n    f.write("x")\n')
         assert len(find_violations(target)) == 1
 

--- a/tests/ci/test_atomic_write_required.py
+++ b/tests/ci/test_atomic_write_required.py
@@ -1,0 +1,289 @@
+"""Tests for the atomic-write rail (``scripts/check_atomic_write.py``).
+
+The rail blocks regressions of the persistent-state-write hardening landed in
+PRs #176, #195, #197, #203, #204. Any new ``Path.write_text``,
+``Path.write_bytes``, or ``open(p, "w"|"wb"|"a"|"ab")`` call in ``src/`` must
+either use the ``utils.atomic_write`` helpers or carry an explicit
+``# atomic-write: ok — <reason>`` opt-out comment.
+
+T10 predicate negative-case backfill: every exemption category has a positive
+test (the rail flags the surface shape) AND a negative test (the rail does
+NOT flag when the marker / file allowlist applies).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.ci
+
+_FO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _FO_ROOT / "scripts" / "check_atomic_write.py"
+
+# Import the detector directly so we can unit-test helpers without spawning
+# a subprocess for every case.
+sys.path.insert(0, str(_FO_ROOT / "scripts"))
+from check_atomic_write import (  # noqa: E402
+    _ALLOWLISTED_FILES,
+    _has_opt_out,
+    _is_comment_line,
+    _is_in_docstring_or_string,
+    _matches_forbidden,
+    find_violations,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests: forbidden-pattern detection
+# ---------------------------------------------------------------------------
+
+
+class TestPatternDetection:
+    """The pattern set must match the four forbidden write forms."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            'path.write_text("data")',
+            'p.write_bytes(b"\\x00\\x01")',
+            'with open(p, "w") as f:',
+            'with open(p, "wb") as f:',
+            'with open(p, "a") as f:',
+            'with open(p, "ab") as f:',
+            "fh = open(lock, 'a', encoding='utf-8')",
+            'open(target, "w", encoding="utf-8")',
+        ],
+    )
+    def test_matches_forbidden(self, line: str) -> None:
+        assert _matches_forbidden(line)
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # Read modes are not flagged (T10 negative cases)
+            'with open(p, "r") as f:',
+            'with open(p, "rb") as f:',
+            "data = path.read_text()",
+            "data = path.read_bytes()",
+            # Method-name false friends — must not match
+            "rewrite_text(payload)",
+            "writer.writeheader()",
+            # Fragment in identifier — not a write call
+            "open_writer = make_writer()",
+        ],
+    )
+    def test_does_not_match_non_write(self, line: str) -> None:
+        assert not _matches_forbidden(line)
+
+
+class TestOptOutMarker:
+    """The opt-out marker must be detected only in its canonical form."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            'path.write_text("x")  # atomic-write: ok',
+            'path.write_text("x")  # atomic-write: ok — user output',
+            'path.write_text("x")  # atomic-write:  ok',  # extra space
+            'path.write_text("x")  # atomic-write: ok (legacy single-shot)',
+        ],
+    )
+    def test_recognizes_opt_out(self, line: str) -> None:
+        assert _has_opt_out(line)
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # Marker variations that must NOT count (typos / wrong prefix)
+            'path.write_text("x")  # atomic-write fine',
+            'path.write_text("x")  # atomic_write: ok',  # underscore not hyphen
+            'path.write_text("x")  # ok — atomic write',
+            'path.write_text("x")',  # no marker at all
+        ],
+    )
+    def test_rejects_non_canonical(self, line: str) -> None:
+        assert not _has_opt_out(line)
+
+    def test_marker_inside_string_literal_is_rejected(self) -> None:
+        # A marker that appears only inside a string literal must not count as
+        # an opt-out; only a bare trailing comment satisfies the rule.
+        assert not _has_opt_out('path.write_text("# atomic-write: ok — user output")')
+
+
+class TestCommentAndDocstringHeuristics:
+    """Comments and docstrings must not trip the rail."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "# path.write_text('foo')",
+            "    # historically used path.write_text",
+        ],
+    )
+    def test_comment_lines_are_skipped(self, line: str) -> None:
+        assert _is_comment_line(line)
+
+    def test_non_comment_with_inline_comment_is_not_a_comment_line(self) -> None:
+        # The whole line isn't a comment, just trailing portion.
+        assert not _is_comment_line("path.write_text('x')  # note")
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            '"""Example: path.write_text("data")"""',
+            "'''Example: open(p, \"w\")'''",
+            '"""docstring start',
+            "'''docstring start",
+        ],
+    )
+    def test_docstring_or_string_lines_are_skipped(self, line: str) -> None:
+        assert _is_in_docstring_or_string(line)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: file-level allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlist:
+    """Files that own the atomic-write primitives are exempt."""
+
+    def test_atomic_write_module_is_allowlisted(self) -> None:
+        assert "src/utils/atomic_write.py" in _ALLOWLISTED_FILES
+
+    def test_atomic_io_module_is_allowlisted(self) -> None:
+        assert "src/utils/atomic_io.py" in _ALLOWLISTED_FILES
+
+    def test_arbitrary_src_file_is_not_allowlisted(self) -> None:
+        assert "src/services/intelligence/preference_store.py" not in _ALLOWLISTED_FILES
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: find_violations on synthetic files
+# ---------------------------------------------------------------------------
+
+
+class TestFindViolationsSynthetic:
+    """End-to-end checks against tmp_path source files."""
+
+    def _write(self, tmp_path: Path, content: str) -> Path:
+        # Mirror the path layout the detector expects so any future
+        # path-relative checks still resolve correctly.
+        src = tmp_path / "src" / "x"
+        src.mkdir(parents=True)
+        target = src / "mod.py"
+        target.write_text(content)
+        return target
+
+    def test_unmarked_write_text_is_flagged(self, tmp_path: Path) -> None:
+        target = self._write(tmp_path, 'p.write_text("payload")\n')
+        violations = find_violations(target)
+        assert len(violations) == 1
+        assert "write_text" in violations[0][1]
+
+    def test_marked_write_text_is_not_flagged(self, tmp_path: Path) -> None:
+        target = self._write(
+            tmp_path,
+            'p.write_text("payload")  # atomic-write: ok — manual temp+replace\n',
+        )
+        assert find_violations(target) == []
+
+    def test_unmarked_open_w_is_flagged(self, tmp_path: Path) -> None:
+        target = self._write(tmp_path, 'with open(p, "w") as f:\n    f.write("x")\n')
+        violations = find_violations(target)
+        assert len(violations) == 1
+
+    def test_marked_open_w_is_not_flagged(self, tmp_path: Path) -> None:
+        target = self._write(
+            tmp_path,
+            'with open(p, "w") as f:  # atomic-write: ok — user output\n    f.write("x")\n',
+        )
+        assert find_violations(target) == []
+
+    def test_open_read_mode_is_not_flagged(self, tmp_path: Path) -> None:
+        # T10 negative case: the same surface (open with mode str) must
+        # not flag for read modes.
+        target = self._write(tmp_path, 'with open(p, "r") as f:\n    data = f.read()\n')
+        assert find_violations(target) == []
+
+    def test_marker_on_following_line_is_not_flagged(self, tmp_path: Path) -> None:
+        # ruff format frequently splits long calls across lines, leaving the
+        # # atomic-write: ok comment on the closing-paren line. The detector
+        # must scan a lookahead window forward.
+        target = self._write(
+            tmp_path,
+            'p.write_text(\n    "payload"\n)  # atomic-write: ok — manual temp+replace\n',
+        )
+        assert find_violations(target) == []
+
+    def test_marker_too_far_after_call_is_still_flagged(self, tmp_path: Path) -> None:
+        # The lookahead is bounded; a marker many lines later does not
+        # silently exempt the call (T10 negative case for the lookahead).
+        body = 'p.write_text("payload")\n' + ("x = 1\n" * 10) + "# atomic-write: ok\n"
+        target = self._write(tmp_path, body)
+        violations = find_violations(target)
+        assert len(violations) == 1
+
+    def test_docstring_example_is_not_flagged(self, tmp_path: Path) -> None:
+        # Triple-quoted block containing a forbidden pattern must not trip.
+        target = self._write(
+            tmp_path,
+            '"""Module docstring.\n\nExample::\n\n    p.write_text("foo")\n"""\n',
+        )
+        assert find_violations(target) == []
+
+    def test_multiline_open_without_marker_is_flagged(self, tmp_path: Path) -> None:
+        # open( on one line, mode string on the next — no marker anywhere.
+        target = self._write(
+            tmp_path,
+            'with open(\n    p,\n    "w",\n) as f:\n    f.write("x")\n',
+        )
+        violations = find_violations(target)
+        assert len(violations) == 1
+
+    def test_multiline_open_marker_on_closing_paren_is_not_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        # Cover the common ruff-formatted multiline open() shape where the
+        # call starts on one line, the mode string is on a later line, and the
+        # opt-out marker sits on the closing-paren line.
+        target = self._write(
+            tmp_path,
+            'with open(\n    p,\n    "w",\n) as f:  # atomic-write: ok — user output\n    f.write("x")\n',
+        )
+        assert find_violations(target) == []
+
+    def test_multiline_open_in_string_literal_not_flagged_via_opt_out(
+        self, tmp_path: Path
+    ) -> None:
+        # Marker embedded inside a string literal on the open( line must not
+        # exempt the call; the opt-out must appear in an actual comment.
+        target = self._write(
+            tmp_path,
+            'with open(\n    p,\n    "w",\n) as f:\n    f.write("# atomic-write: ok")\n',
+        )
+        violations = find_violations(target)
+        assert len(violations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Full-suite assertion: no unmarked violations on the current branch
+# ---------------------------------------------------------------------------
+
+
+class TestFullSuite:
+    """The rail must pass against the live ``src/`` tree."""
+
+    def test_no_unmarked_violations_on_current_tree(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"atomic-write rail flagged unmarked violation(s):\n{result.stderr}"
+        )

--- a/tests/ci/test_atomic_write_required.py
+++ b/tests/ci/test_atomic_write_required.py
@@ -284,11 +284,23 @@ class TestOpenCalls:
         )
         assert len(find_violations(target)) == 1
 
-    def test_method_named_open_is_not_flagged(self, tmp_path: Path) -> None:
-        # T10 negative case: ``self.open(...)`` is a method call, not the
-        # builtin. The AST detector matches only ``ast.Name(id='open')``.
-        """Method named open is not flagged."""
-        target = _synth(tmp_path, 'self.open(p, "w")\n')
+    def test_method_call_open_with_write_mode_is_flagged(self, tmp_path: Path) -> None:
+        """Codex r219 #5: ``Path("out.json").open("w")`` is also a forbidden write.
+
+        The detector now matches both ``open(...)`` (builtin Name) and
+        ``<obj>.open(...)`` (Attribute call). Bare-method bypass closed.
+        """
+        target = _synth(tmp_path, 'Path("out.json").open("w")\n')
+        assert len(find_violations(target)) == 1
+
+    def test_method_call_open_with_read_mode_is_not_flagged(self, tmp_path: Path) -> None:
+        """T10 negative: a method-style ``open()`` with a read mode stays unflagged."""
+        target = _synth(tmp_path, 'Path("out.json").open("r")\n')
+        assert find_violations(target) == []
+
+    def test_method_call_open_without_mode_is_not_flagged(self, tmp_path: Path) -> None:
+        """T10 negative: a method-style ``open()`` with no mode arg defaults to read; not flagged."""
+        target = _synth(tmp_path, 'Path("out.json").open()\n')
         assert find_violations(target) == []
 
     def test_dynamic_mode_is_not_flagged(self, tmp_path: Path) -> None:

--- a/tests/ci/test_atomic_write_required.py
+++ b/tests/ci/test_atomic_write_required.py
@@ -59,10 +59,12 @@ class TestForbiddenModes:
 
     @pytest.mark.parametrize("mode", ["w", "wb", "a", "ab", "w+", "wb+", "a+", "ab+"])
     def test_write_modes_in_set(self, mode: str) -> None:
+        """Write modes in set."""
         assert mode in _FORBIDDEN_MODES
 
     @pytest.mark.parametrize("mode", ["r", "rb", "r+", "rb+"])
     def test_read_modes_not_in_set(self, mode: str) -> None:
+        """Read modes not in set."""
         assert mode not in _FORBIDDEN_MODES
 
 
@@ -75,12 +77,15 @@ class TestAllowlist:
     """Files that own the atomic-write primitives are exempt."""
 
     def test_atomic_write_module_is_allowlisted(self) -> None:
+        """Atomic write module is allowlisted."""
         assert "src/utils/atomic_write.py" in _ALLOWLISTED_FILES
 
     def test_atomic_io_module_is_allowlisted(self) -> None:
+        """Atomic io module is allowlisted."""
         assert "src/utils/atomic_io.py" in _ALLOWLISTED_FILES
 
     def test_arbitrary_src_file_is_not_allowlisted(self) -> None:
+        """Arbitrary src file is not allowlisted."""
         assert "src/services/intelligence/preference_store.py" not in _ALLOWLISTED_FILES
 
 
@@ -93,12 +98,14 @@ class TestMarkerWindow:
     """Markers inside the ±N-line window around the call line are recognised."""
 
     def test_marker_on_call_line_is_recognised(self) -> None:
+        """Marker on call line is recognised."""
         lines = ['p.write_text("x")  # atomic-write: ok — user output']
         assert _has_opt_out_in_window(lines, call_line=1)
 
     def test_marker_on_line_above_is_recognised(self) -> None:
         # New placement (codex r219 + diff-coverage fix): a standalone
         # comment line immediately above the call is accepted.
+        """Marker on line above is recognised."""
         lines = [
             "# atomic-write: ok — manual temp+replace",
             'p.write_text("x")',
@@ -107,6 +114,7 @@ class TestMarkerWindow:
 
     def test_marker_on_closing_paren_line_is_recognised(self) -> None:
         # ruff format splits long calls; marker may land on the )-line.
+        """Marker on closing paren line is recognised."""
         lines = [
             "p.write_text(",
             '    "payload"',
@@ -115,6 +123,7 @@ class TestMarkerWindow:
         assert _has_opt_out_in_window(lines, call_line=1)
 
     def test_marker_too_far_above_is_not_recognised(self) -> None:
+        """Marker too far above is not recognised."""
         lines = [
             "# atomic-write: ok",
             "x = 1",
@@ -126,6 +135,7 @@ class TestMarkerWindow:
         assert not _has_opt_out_in_window(lines, call_line=6)
 
     def test_marker_too_far_below_is_not_recognised(self) -> None:
+        """Marker too far below is not recognised."""
         lines = ['p.write_text("x")'] + ["x = 1"] * 10 + ["# atomic-write: ok"]
         assert not _has_opt_out_in_window(lines, call_line=1)
 
@@ -139,14 +149,17 @@ class TestWriteTextAndBytes:
     """Both ``Path.write_text`` and ``Path.write_bytes`` are flagged."""
 
     def test_unmarked_write_text_is_flagged(self, tmp_path: Path) -> None:
+        """Unmarked write text is flagged."""
         target = _synth(tmp_path, 'p.write_text("payload")\n')
         assert len(find_violations(target)) == 1
 
     def test_unmarked_write_bytes_is_flagged(self, tmp_path: Path) -> None:
+        """Unmarked write bytes is flagged."""
         target = _synth(tmp_path, 'p.write_bytes(b"\\x00")\n')
         assert len(find_violations(target)) == 1
 
     def test_marked_write_text_is_not_flagged(self, tmp_path: Path) -> None:
+        """Marked write text is not flagged."""
         target = _synth(
             tmp_path,
             'p.write_text("payload")  # atomic-write: ok — manual temp+replace\n',
@@ -155,6 +168,7 @@ class TestWriteTextAndBytes:
 
     def test_write_text_with_marker_above_is_not_flagged(self, tmp_path: Path) -> None:
         # New placement: marker on the line immediately above the call.
+        """Write text with marker above is not flagged."""
         target = _synth(
             tmp_path,
             '# atomic-write: ok — manual temp+replace\np.write_text("payload")\n',
@@ -167,16 +181,19 @@ class TestOpenCalls:
 
     @pytest.mark.parametrize("mode", ["w", "wb", "a", "ab"])
     def test_write_modes_are_flagged(self, mode: str, tmp_path: Path) -> None:
+        """Write modes are flagged."""
         target = _synth(tmp_path, f'with open(p, "{mode}") as f:\n    f.write("x")\n')
         assert len(find_violations(target)) == 1
 
     @pytest.mark.parametrize("mode", ["r", "rb"])
     def test_read_modes_are_not_flagged(self, mode: str, tmp_path: Path) -> None:
         # T10 negative case: same call shape, read mode → not flagged.
+        """Read modes are not flagged."""
         target = _synth(tmp_path, f'with open(p, "{mode}") as f:\n    f.read()\n')
         assert find_violations(target) == []
 
     def test_mode_keyword_argument_is_recognised(self, tmp_path: Path) -> None:
+        """Mode keyword argument is recognised."""
         target = _synth(tmp_path, 'with open(p, mode="w") as f:\n    f.write("x")\n')
         assert len(find_violations(target)) == 1
 
@@ -185,6 +202,7 @@ class TestOpenCalls:
         # ``)`` so this shape silently bypassed the rail. The AST detector
         # walks the call structure and sees the mode regardless of how
         # nested the path expression is.
+        """Open with nested call in first arg is flagged."""
         target = _synth(
             tmp_path,
             'with open(Path(name).with_suffix(".json"), "w") as f:\n    f.write("x")\n',
@@ -194,6 +212,7 @@ class TestOpenCalls:
     def test_method_named_open_is_not_flagged(self, tmp_path: Path) -> None:
         # T10 negative case: ``self.open(...)`` is a method call, not the
         # builtin. The AST detector matches only ``ast.Name(id='open')``.
+        """Method named open is not flagged."""
         target = _synth(tmp_path, 'self.open(p, "w")\n')
         assert find_violations(target) == []
 
@@ -201,6 +220,7 @@ class TestOpenCalls:
         # The mode is a variable reference; we can't statically determine
         # if it's a write or read mode, so we conservatively skip rather
         # than false-flag. ``mode`` could be either.
+        """Dynamic mode is not flagged."""
         target = _synth(tmp_path, "with open(p, mode) as f:\n    pass\n")
         assert find_violations(target) == []
 
@@ -214,6 +234,7 @@ class TestStringLiteralFalsePositives:
     """
 
     def test_open_inside_string_literal_not_flagged(self, tmp_path: Path) -> None:
+        """Open inside string literal not flagged."""
         target = _synth(
             tmp_path,
             "logger.debug(\"open(path, 'w')\")\n",
@@ -221,6 +242,7 @@ class TestStringLiteralFalsePositives:
         assert find_violations(target) == []
 
     def test_write_text_inside_string_literal_not_flagged(self, tmp_path: Path) -> None:
+        """Write text inside string literal not flagged."""
         target = _synth(
             tmp_path,
             'message = "use path.write_text(content) for atomic writes"\n',
@@ -228,6 +250,7 @@ class TestStringLiteralFalsePositives:
         assert find_violations(target) == []
 
     def test_open_in_docstring_not_flagged(self, tmp_path: Path) -> None:
+        """Open in docstring not flagged."""
         target = _synth(
             tmp_path,
             '"""Module docstring.\n\nExample::\n\n    open(p, "w")\n"""\n',
@@ -239,6 +262,7 @@ class TestMultilineOpen:
     """``open()`` calls split across lines by ruff format are still detected."""
 
     def test_multiline_open_without_marker_is_flagged(self, tmp_path: Path) -> None:
+        """Multiline open without marker is flagged."""
         target = _synth(
             tmp_path,
             'with open(\n    p,\n    "w",\n) as f:\n    f.write("x")\n',
@@ -246,6 +270,7 @@ class TestMultilineOpen:
         assert len(find_violations(target)) == 1
 
     def test_multiline_open_marker_on_closing_paren_is_not_flagged(self, tmp_path: Path) -> None:
+        """Multiline open marker on closing paren is not flagged."""
         target = _synth(
             tmp_path,
             'with open(\n    p,\n    "w",\n) as f:  # atomic-write: ok — user output\n'
@@ -254,6 +279,7 @@ class TestMultilineOpen:
         assert find_violations(target) == []
 
     def test_multiline_open_marker_above_is_not_flagged(self, tmp_path: Path) -> None:
+        """Multiline open marker above is not flagged."""
         target = _synth(
             tmp_path,
             "# atomic-write: ok — user output\n"
@@ -266,6 +292,7 @@ class TestSyntaxError:
     """A file that fails to parse yields zero violations (rail bows out)."""
 
     def test_syntax_error_yields_no_violations(self, tmp_path: Path) -> None:
+        """Syntax error yields no violations."""
         target = _synth(tmp_path, "def broken(\n")
         assert find_violations(target) == []
 
@@ -279,6 +306,7 @@ class TestFullSuite:
     """The rail must pass against the live ``src/`` tree."""
 
     def test_no_unmarked_violations_on_current_tree(self) -> None:
+        """No unmarked violations on current tree."""
         result = subprocess.run(
             [sys.executable, str(_SCRIPT)],
             capture_output=True,

--- a/tests/ci/test_atomic_write_required.py
+++ b/tests/ci/test_atomic_write_required.py
@@ -342,6 +342,33 @@ class TestOpenCalls:
         target = _synth(tmp_path, 'tarfile.open(p, "r")\n')
         assert find_violations(target) == []
 
+    def test_open_with_mode_like_path_string_at_args0_uses_args1(self, tmp_path: Path) -> None:
+        """Codex r219 #7: ``open("r", "w")`` — args[0] looks like read but real mode is "w" at args[1].
+
+        Previous "first-matching-wins" returned ``"r"`` (read) and silently
+        let the write through. The position-priority logic (args[1] before
+        args[0] when both are present) returns ``"w"`` and flags it.
+        """
+        target = _synth(tmp_path, 'open("r", "w")\n')
+        assert len(find_violations(target)) == 1
+
+    def test_open_with_append_like_path_and_read_mode_not_falsely_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex r219 #7: ``open("a", "r")`` — args[0] is path ``"a"``, args[1] ``"r"`` is the mode.
+
+        The position priority avoids the false-positive that
+        "first-matching-wins" produced when args[0] looked like an
+        append-mode literal.
+        """
+        target = _synth(tmp_path, 'open("a", "r")\n')
+        assert find_violations(target) == []
+
+    def test_path_open_with_buffering_positional_still_extracts_mode(self, tmp_path: Path) -> None:
+        """``Path("x").open("w", -1)`` — args[1] (buffering) isn't a mode; fall back to args[0]."""
+        target = _synth(tmp_path, 'Path("x").open("w", -1)\n')
+        assert len(find_violations(target)) == 1
+
     def test_dynamic_mode_is_not_flagged(self, tmp_path: Path) -> None:
         # The mode is a variable reference; we can't statically determine
         # if it's a write or read mode, so we conservatively skip rather

--- a/tests/ci/test_atomic_write_required.py
+++ b/tests/ci/test_atomic_write_required.py
@@ -35,6 +35,7 @@ sys.path.insert(0, str(_FO_ROOT / "scripts"))
 from check_atomic_write import (  # noqa: E402
     _ALLOWLISTED_FILES,
     _FORBIDDEN_MODES,
+    _collect_marker_comment_lines,
     _has_opt_out_in_window,
     find_violations,
 )
@@ -95,49 +96,61 @@ class TestAllowlist:
 
 
 class TestMarkerWindow:
-    """Markers inside the ±N-line window around the call line are recognised."""
+    """Markers inside the -2 / +6 line window around the call line are recognised.
+
+    Each test sets up a synthetic source string, runs it through
+    ``_collect_marker_comment_lines`` (which tokenises and only collects real
+    comment-token markers), then asks ``_has_opt_out_in_window`` whether the
+    call line falls inside any marker's window.
+    """
+
+    def _check(self, source: str, call_line: int) -> bool:
+        """Return ``_has_opt_out_in_window`` result for *source* at *call_line*."""
+        lines = source.splitlines()
+        marker_lines = _collect_marker_comment_lines(source)
+        return _has_opt_out_in_window(marker_lines, call_line, len(lines))
 
     def test_marker_on_call_line_is_recognised(self) -> None:
         """Marker on call line is recognised."""
-        lines = ['p.write_text("x")  # atomic-write: ok — user output']
-        assert _has_opt_out_in_window(lines, call_line=1)
+        source = 'p.write_text("x")  # atomic-write: ok — user output\n'
+        assert self._check(source, call_line=1)
 
     def test_marker_on_line_above_is_recognised(self) -> None:
-        # New placement (codex r219 + diff-coverage fix): a standalone
-        # comment line immediately above the call is accepted.
-        """Marker on line above is recognised."""
-        lines = [
-            "# atomic-write: ok — manual temp+replace",
-            'p.write_text("x")',
-        ]
-        assert _has_opt_out_in_window(lines, call_line=2)
+        """Standalone comment line immediately above the call is accepted (codex r219 + diff-coverage fix)."""
+        source = '# atomic-write: ok — manual temp+replace\np.write_text("x")\n'
+        assert self._check(source, call_line=2)
 
     def test_marker_on_closing_paren_line_is_recognised(self) -> None:
-        # ruff format splits long calls; marker may land on the )-line.
-        """Marker on closing paren line is recognised."""
-        lines = [
-            "p.write_text(",
-            '    "payload"',
-            ")  # atomic-write: ok — user output",
-        ]
-        assert _has_opt_out_in_window(lines, call_line=1)
+        """ruff format splits long calls; marker may land on the )-line."""
+        source = 'p.write_text(\n    "payload"\n)  # atomic-write: ok — user output\n'
+        assert self._check(source, call_line=1)
 
     def test_marker_too_far_above_is_not_recognised(self) -> None:
         """Marker too far above is not recognised."""
-        lines = [
-            "# atomic-write: ok",
-            "x = 1",
-            "x = 2",
-            "x = 3",
-            "x = 4",
-            'p.write_text("x")',
-        ]
-        assert not _has_opt_out_in_window(lines, call_line=6)
+        source = "# atomic-write: ok\nx = 1\nx = 2\nx = 3\nx = 4\np.write_text('x')\n"
+        assert not self._check(source, call_line=6)
 
     def test_marker_too_far_below_is_not_recognised(self) -> None:
         """Marker too far below is not recognised."""
-        lines = ['p.write_text("x")'] + ["x = 1"] * 10 + ["# atomic-write: ok"]
-        assert not _has_opt_out_in_window(lines, call_line=1)
+        source = "p.write_text('x')\n" + ("x = 1\n" * 10) + "# atomic-write: ok\n"
+        assert not self._check(source, call_line=1)
+
+    def test_marker_inside_string_literal_is_ignored(self) -> None:
+        """Marker text inside a string literal must NOT exempt a real call.
+
+        CodeRabbit r219 #2: the previous regex-on-raw-lines marker check
+        treated ``msg = "# atomic-write: ok"`` as an opt-out, which would
+        let any forbidden write within the window through. The tokeniser
+        only emits ``COMMENT`` tokens for real comments, so the string
+        literal is filtered out.
+        """
+        source = 'msg = "# atomic-write: ok — bypass attempt"\np.write_text("payload")\n'
+        assert not self._check(source, call_line=2)
+
+    def test_marker_inside_string_literal_does_not_match_via_collector(self) -> None:
+        """``_collect_marker_comment_lines`` ignores string literals containing the marker."""
+        source = 'msg = "# atomic-write: ok"\n'
+        assert _collect_marker_comment_lines(source) == set()
 
 
 # ---------------------------------------------------------------------------
@@ -240,6 +253,23 @@ class TestStringLiteralFalsePositives:
             "logger.debug(\"open(path, 'w')\")\n",
         )
         assert find_violations(target) == []
+
+    def test_marker_inside_string_literal_does_not_exempt_real_call(self, tmp_path: Path) -> None:
+        """End-to-end CodeRabbit r219 case: a real write call within window of a string-literal marker IS flagged.
+
+        Before the tokeniser fix, ``msg = "# atomic-write: ok"`` near a real
+        ``open(p, "w")`` would silently exempt the write. The tokeniser-based
+        marker collector ignores string literals, so the rail correctly flags
+        the write.
+        """
+        target = _synth(
+            tmp_path,
+            'msg = "# atomic-write: ok — bypass attempt"\n'
+            'with open(p, "w") as f:\n'
+            '    f.write("data")\n',
+        )
+        violations = find_violations(target)
+        assert len(violations) == 1
 
     def test_write_text_inside_string_literal_not_flagged(self, tmp_path: Path) -> None:
         """Write text inside string literal not flagged."""

--- a/tests/ci/test_atomic_write_required.py
+++ b/tests/ci/test_atomic_write_required.py
@@ -303,6 +303,45 @@ class TestOpenCalls:
         target = _synth(tmp_path, 'Path("out.json").open()\n')
         assert find_violations(target) == []
 
+    def test_module_level_attribute_open_with_path_at_args0_is_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex r219 #6: ``tarfile.open(path, "w")`` and ``gzip.open(path, "wb")``.
+
+        These are module-level functions called via attribute access. The
+        path is at args[0] and the mode is at args[1] — same positional
+        layout as the builtin ``open(path, mode)``. The detector must NOT
+        treat args[0] (the path) as the mode.
+        """
+        target = _synth(
+            tmp_path,
+            'tarfile.open(p, "w")\ngzip.open(p, "wb")\n',
+        )
+        assert len(find_violations(target)) == 2
+
+    def test_module_level_attribute_open_with_string_path_not_misread_as_mode(
+        self, tmp_path: Path
+    ) -> None:
+        """T10 negative: ``tarfile.open("write.log", "wb")``.
+
+        Codex r219 #6 regression case: with a literal string path that
+        happens to contain the letter ``w``, the detector must still pick
+        the real mode out of args[1], not misread args[0] as a mode.
+        Strict mode-literal pattern (``[rwaxbt+]{1,4}`` with exactly one
+        primary action char) ensures ``"write.log"`` is rejected as a
+        candidate mode.
+        """
+        target = _synth(tmp_path, 'tarfile.open("write.log", "wb")\n')
+        violations = find_violations(target)
+        assert len(violations) == 1
+        # The violation should be on the call line itself (line 1), not
+        # silently dropped by the path being misread as a mode.
+
+    def test_module_level_attribute_open_read_mode_not_flagged(self, tmp_path: Path) -> None:
+        """``tarfile.open(path, "r")`` is a read; not flagged."""
+        target = _synth(tmp_path, 'tarfile.open(p, "r")\n')
+        assert find_violations(target) == []
+
     def test_dynamic_mode_is_not_flagged(self, tmp_path: Path) -> None:
         # The mode is a variable reference; we can't statically determine
         # if it's a write or read mode, so we conservatively skip rather

--- a/tests/ci/test_called_attribute_assertion.py
+++ b/tests/ci/test_called_attribute_assertion.py
@@ -1,0 +1,197 @@
+"""Tests for the T3-narrow rail (``scripts/check_called_attribute_assertion.py``).
+
+Bans the ``assert <mock>.called`` attribute lookup form. The canonical
+mock-library equivalent ``<mock>.assert_called()`` is one extra
+character, more discoverable in IDEs (it's a documented method, not a
+flag attribute), and consistent with the rest of the test suite.
+
+Detection forms:
+
+  - ``assert <chain>.called``
+  - ``assert <chain>.called is True``
+  - ``assert <chain>.called == True``
+
+T10 predicate negative-case backfill: every detection form has a
+positive test (rail flags) AND a negative test (rail does NOT flag a
+similar shape that is genuinely correct).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.ci
+
+_FO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _FO_ROOT / "scripts" / "check_called_attribute_assertion.py"
+
+# Import the detector directly so we can unit-test helpers without spawning
+# a subprocess for every case.
+sys.path.insert(0, str(_FO_ROOT / "scripts"))
+from check_called_attribute_assertion import (  # noqa: E402
+    _PATTERN,
+    _has_opt_out,
+    _is_comment_line,
+    find_violations,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests: pattern detection
+# ---------------------------------------------------------------------------
+
+
+class TestPatternDetection:
+    """The regex must match the three forbidden forms."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "assert mock.called",
+            "    assert mock.method.called",
+            "        assert obj.attr.deep.chain.called",
+            "assert mock.called is True",
+            "assert mock.called == True",
+            "assert mock.called  # trailing comment",
+            "    assert mock.method.called is True",
+            # Codex r218 — parenthesised forms must also match
+            "assert (mock.method.called)",
+            "    assert (mock.method.called)",
+            "assert (mock.method.called) is True",
+            "assert (mock.method.called) == True",
+            "assert ( mock.method.called )",  # whitespace inside parens
+        ],
+    )
+    def test_matches_forbidden(self, line: str) -> None:
+        assert _PATTERN.match(line) is not None
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # T10 negative cases — must NOT match
+            "mock.assert_called()",  # canonical fix — the method form
+            "mock.method.assert_called_once()",  # other Mock methods
+            "assert mock.called == 3",  # count comparison (T3 has separate noqa for this)
+            "assert mock.called is False",  # `is False` is rare but legitimate
+            "assert obj.is_called",  # not the .called attribute
+            "assert mock.call_count >= 1",  # not the bare-called form
+            "called = mock.called",  # assignment, not assert
+            "if mock.called:",  # conditional, not assert
+            "assert called",  # local variable named 'called' — no chain
+        ],
+    )
+    def test_does_not_match_legitimate(self, line: str) -> None:
+        assert _PATTERN.match(line) is None
+
+
+class TestOptOutMarker:
+    """The opt-out marker must be detected only in its canonical form."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "assert mock.called  # noqa: T3",
+            "assert mock.called  # noqa: T3 reason: testing the mock library itself",
+            "assert mock.called  #noqa: T3",  # tighter spacing
+        ],
+    )
+    def test_recognises_opt_out(self, line: str) -> None:
+        assert _has_opt_out(line)
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "assert mock.called",  # no marker
+            "assert mock.called  # noqa: T1",  # different rule
+            "assert mock.called  # T3",  # missing noqa: prefix
+        ],
+    )
+    def test_rejects_non_canonical(self, line: str) -> None:
+        assert not _has_opt_out(line)
+
+
+class TestCommentLines:
+    """Comments must not trip the rail even if they contain the forbidden form."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "# assert mock.called",
+            "    # assert mock.called  (historical example)",
+        ],
+    )
+    def test_comment_lines_are_skipped(self, line: str) -> None:
+        assert _is_comment_line(line)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: find_violations on synthetic files
+# ---------------------------------------------------------------------------
+
+
+class TestFindViolationsSynthetic:
+    """End-to-end checks against tmp_path test files."""
+
+    def _write(self, tmp_path: Path, content: str) -> Path:
+        target = tmp_path / "test_synth.py"
+        target.write_text(content)
+        return target
+
+    def test_unmarked_assertion_is_flagged(self, tmp_path: Path) -> None:
+        target = self._write(tmp_path, "assert mock.method.called\n")
+        violations = find_violations(target)
+        assert len(violations) == 1
+
+    def test_marked_assertion_is_not_flagged(self, tmp_path: Path) -> None:
+        target = self._write(
+            tmp_path, "assert mock.method.called  # noqa: T3 reason: legacy test\n"
+        )
+        assert find_violations(target) == []
+
+    def test_method_form_is_not_flagged(self, tmp_path: Path) -> None:
+        # Canonical fix — the method call form. Not flagged.
+        target = self._write(tmp_path, "mock.method.assert_called()\n")
+        assert find_violations(target) == []
+
+    def test_comment_with_forbidden_text_not_flagged(self, tmp_path: Path) -> None:
+        target = self._write(tmp_path, "# example: assert mock.called\n")
+        assert find_violations(target) == []
+
+    def test_count_comparison_not_flagged(self, tmp_path: Path) -> None:
+        # T10 negative case: ``call_count`` checks are out of scope for this
+        # narrow rail (full T3 covers them under code review, not here).
+        target = self._write(tmp_path, "assert mock.call_count >= 1\n")
+        assert find_violations(target) == []
+
+    def test_inside_triple_quoted_docstring_not_flagged(self, tmp_path: Path) -> None:
+        # Fixtures embedded in docstrings (common in tests/ci/test_*.py
+        # rails that demonstrate the forbidden pattern in dedent blocks)
+        # must not false-flag.
+        target = self._write(
+            tmp_path,
+            '"""Example fixture:\n\n    assert mock.method.called\n"""\n',
+        )
+        assert find_violations(target) == []
+
+
+# ---------------------------------------------------------------------------
+# Full-suite assertion: zero violations on the live tree
+# ---------------------------------------------------------------------------
+
+
+class TestFullSuite:
+    """The rail must pass against the live ``tests/`` tree."""
+
+    def test_no_violations_on_current_tree(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"T3 narrow rail flagged unmarked violation(s):\n{result.stderr}"
+        )

--- a/tests/ci/test_called_attribute_assertion.py
+++ b/tests/ci/test_called_attribute_assertion.py
@@ -230,6 +230,30 @@ class TestFindViolationsSynthetic:
         )
         assert find_violations(target) == []
 
+    def test_noqa_inside_assertion_message_string_does_not_exempt(self, tmp_path: Path) -> None:
+        """Codex r219 #9: ``assert mock.called, "# noqa: T3"`` must NOT bypass.
+
+        The previous raw-line marker check treated the string-literal
+        message as a comment.  Token-based collection only emits real
+        ``COMMENT`` tokens, so the string-literal marker is ignored and
+        the assertion is correctly flagged.
+        """
+        target = _synth(
+            tmp_path,
+            'assert mock.method.called, "# noqa: T3"\n',
+        )
+        assert len(find_violations(target)) == 1
+
+    def test_noqa_inside_string_literal_near_assertion_does_not_exempt(
+        self, tmp_path: Path
+    ) -> None:
+        """A nearby string literal containing the marker must not exempt the assertion."""
+        target = _synth(
+            tmp_path,
+            'msg = "# noqa: T3"\nassert mock.method.called\n',
+        )
+        assert len(find_violations(target)) == 1
+
     def test_marked_multiline_assertion_on_closing_paren_is_not_flagged(
         self, tmp_path: Path
     ) -> None:

--- a/tests/ci/test_called_attribute_assertion.py
+++ b/tests/ci/test_called_attribute_assertion.py
@@ -66,6 +66,7 @@ class TestPatternDetection:
         ],
     )
     def test_matches_forbidden(self, line: str) -> None:
+        """Matches forbidden."""
         assert _PATTERN.match(line) is not None
 
     @pytest.mark.parametrize(
@@ -84,6 +85,7 @@ class TestPatternDetection:
         ],
     )
     def test_does_not_match_legitimate(self, line: str) -> None:
+        """Does not match legitimate."""
         assert _PATTERN.match(line) is None
 
 
@@ -99,6 +101,7 @@ class TestOptOutMarker:
         ],
     )
     def test_recognises_opt_out(self, line: str) -> None:
+        """Recognises opt out."""
         assert _has_opt_out(line)
 
     @pytest.mark.parametrize(
@@ -110,6 +113,7 @@ class TestOptOutMarker:
         ],
     )
     def test_rejects_non_canonical(self, line: str) -> None:
+        """Rejects non canonical."""
         assert not _has_opt_out(line)
 
 
@@ -124,6 +128,7 @@ class TestCommentLines:
         ],
     )
     def test_comment_lines_are_skipped(self, line: str) -> None:
+        """Comment lines are skipped."""
         assert _is_comment_line(line)
 
 
@@ -136,16 +141,19 @@ class TestFindViolationsSynthetic:
     """End-to-end checks against tmp_path test files."""
 
     def _write(self, tmp_path: Path, content: str) -> Path:
+        """Write."""
         target = tmp_path / "test_synth.py"
         target.write_text(content)
         return target
 
     def test_unmarked_assertion_is_flagged(self, tmp_path: Path) -> None:
+        """Unmarked assertion is flagged."""
         target = self._write(tmp_path, "assert mock.method.called\n")
         violations = find_violations(target)
         assert len(violations) == 1
 
     def test_marked_assertion_is_not_flagged(self, tmp_path: Path) -> None:
+        """Marked assertion is not flagged."""
         target = self._write(
             tmp_path, "assert mock.method.called  # noqa: T3 reason: legacy test\n"
         )
@@ -153,16 +161,19 @@ class TestFindViolationsSynthetic:
 
     def test_method_form_is_not_flagged(self, tmp_path: Path) -> None:
         # Canonical fix — the method call form. Not flagged.
+        """Method form is not flagged."""
         target = self._write(tmp_path, "mock.method.assert_called()\n")
         assert find_violations(target) == []
 
     def test_comment_with_forbidden_text_not_flagged(self, tmp_path: Path) -> None:
+        """Comment with forbidden text not flagged."""
         target = self._write(tmp_path, "# example: assert mock.called\n")
         assert find_violations(target) == []
 
     def test_count_comparison_not_flagged(self, tmp_path: Path) -> None:
         # T10 negative case: ``call_count`` checks are out of scope for this
         # narrow rail (full T3 covers them under code review, not here).
+        """Count comparison not flagged."""
         target = self._write(tmp_path, "assert mock.call_count >= 1\n")
         assert find_violations(target) == []
 
@@ -170,6 +181,7 @@ class TestFindViolationsSynthetic:
         # Fixtures embedded in docstrings (common in tests/ci/test_*.py
         # rails that demonstrate the forbidden pattern in dedent blocks)
         # must not false-flag.
+        """Inside triple quoted docstring not flagged."""
         target = self._write(
             tmp_path,
             '"""Example fixture:\n\n    assert mock.method.called\n"""\n',
@@ -186,6 +198,7 @@ class TestFullSuite:
     """The rail must pass against the live ``tests/`` tree."""
 
     def test_no_violations_on_current_tree(self) -> None:
+        """No violations on current tree."""
         result = subprocess.run(
             [sys.executable, str(_SCRIPT)],
             capture_output=True,

--- a/tests/ci/test_called_attribute_assertion.py
+++ b/tests/ci/test_called_attribute_assertion.py
@@ -230,6 +230,31 @@ class TestFindViolationsSynthetic:
         )
         assert find_violations(target) == []
 
+    def test_marked_multiline_assertion_on_closing_paren_is_not_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        """CodeRabbit r219: ``# noqa: T3`` on closing-paren of multi-line assert exempts the site.
+
+        Without scanning ``node.lineno..node.end_lineno`` the marker on
+        the ``)`` line is silently ignored and the multi-line opt-out
+        becomes unusable. The fix scans every line the assert spans.
+        """
+        target = _synth(
+            tmp_path,
+            "assert (\n    mock.method.called\n)  # noqa: T3 reason: legacy multi-line\n",
+        )
+        assert find_violations(target) == []
+
+    def test_marked_multiline_assertion_on_opening_paren_is_not_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        """``# noqa: T3`` on the assert line of a multi-line assert exempts the site."""
+        target = _synth(
+            tmp_path,
+            "assert (  # noqa: T3 reason: legacy\n    mock.method.called\n)\n",
+        )
+        assert find_violations(target) == []
+
     def test_syntax_error_yields_no_violations(self, tmp_path: Path) -> None:
         """A file that fails to parse yields zero violations."""
         target = _synth(tmp_path, "def broken(\n")

--- a/tests/ci/test_called_attribute_assertion.py
+++ b/tests/ci/test_called_attribute_assertion.py
@@ -5,19 +5,27 @@ mock-library equivalent ``<mock>.assert_called()`` is one extra
 character, more discoverable in IDEs (it's a documented method, not a
 flag attribute), and consistent with the rest of the test suite.
 
-Detection forms:
+Detector is **AST-based**.  Earlier regex-on-raw-lines versions were
+bypassed by:
 
-  - ``assert <chain>.called``
-  - ``assert <chain>.called is True``
-  - ``assert <chain>.called == True``
+- Multi-line parenthesised assertions (codex r218 / r219, issue #222):
+  ``assert (\\n    mock.called\\n)``
+- Assert-with-message form (codex r218):
+  ``assert mock.called, "must be called"``
+- String literals containing the marker text in a way that matched the
+  regex but wasn't a real assertion.
 
-T10 predicate negative-case backfill: every detection form has a
-positive test (rail flags) AND a negative test (rail does NOT flag a
-similar shape that is genuinely correct).
+The AST detector reads the structure of each ``ast.Assert`` node, so
+all three classes of bypass are closed by construction.
+
+T10 predicate negative-case backfill: every detection branch has a
+positive test (the rail flags) AND a negative test (the rail does NOT
+flag a similar surface shape that is genuinely correct).
 """
 
 from __future__ import annotations
 
+import ast
 import subprocess
 import sys
 from pathlib import Path
@@ -33,64 +41,79 @@ _SCRIPT = _FO_ROOT / "scripts" / "check_called_attribute_assertion.py"
 # a subprocess for every case.
 sys.path.insert(0, str(_FO_ROOT / "scripts"))
 from check_called_attribute_assertion import (  # noqa: E402
-    _PATTERN,
     _has_opt_out,
-    _is_comment_line,
+    _is_called_attribute_assertion,
     find_violations,
 )
 
+
+def _synth(tmp_path: Path, content: str) -> Path:
+    """Write *content* to a synthetic Python file under *tmp_path*."""
+    target = tmp_path / "test_synth.py"
+    target.write_text(content)
+    return target
+
+
+def _parse_assert(source: str) -> ast.Assert:
+    """Parse *source* and return its first ``ast.Assert`` node."""
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assert):
+            return node
+    raise AssertionError(f"no Assert node parsed from: {source!r}")
+
+
 # ---------------------------------------------------------------------------
-# Unit tests: pattern detection
+# Unit tests: _is_called_attribute_assertion
 # ---------------------------------------------------------------------------
 
 
-class TestPatternDetection:
-    """The regex must match the three forbidden forms."""
+class TestIsCalledAttributeAssertion:
+    """The AST predicate must match the three forbidden shapes only."""
 
     @pytest.mark.parametrize(
-        "line",
+        "source",
         [
             "assert mock.called",
-            "    assert mock.method.called",
-            "        assert obj.attr.deep.chain.called",
+            "assert mock.method.called",
+            "assert obj.attr.deep.chain.called",
             "assert mock.called is True",
             "assert mock.called == True",
-            "assert mock.called  # trailing comment",
-            "    assert mock.method.called is True",
-            # Codex r218 — parenthesised forms must also match
-            "assert (mock.method.called)",
-            "    assert (mock.method.called)",
-            "assert (mock.method.called) is True",
-            "assert (mock.method.called) == True",
-            "assert ( mock.method.called )",  # whitespace inside parens
+            "assert mock.method.called is True",
+            "assert mock.method.called == True",
         ],
     )
-    def test_matches_forbidden(self, line: str) -> None:
-        """Matches forbidden."""
-        assert _PATTERN.match(line) is not None
+    def test_canonical_forms_flagged(self, source: str) -> None:
+        """Each canonical bare-attribute or truth-comparison form is flagged."""
+        assert _is_called_attribute_assertion(_parse_assert(source))
 
     @pytest.mark.parametrize(
-        "line",
+        "source",
         [
-            # T10 negative cases — must NOT match
-            "mock.assert_called()",  # canonical fix — the method form
-            "mock.method.assert_called_once()",  # other Mock methods
-            "assert mock.called == 3",  # count comparison (T3 has separate noqa for this)
-            "assert mock.called is False",  # `is False` is rare but legitimate
-            "assert obj.is_called",  # not the .called attribute
-            "assert mock.call_count >= 1",  # not the bare-called form
-            "called = mock.called",  # assignment, not assert
-            "if mock.called:",  # conditional, not assert
-            "assert called",  # local variable named 'called' — no chain
+            # Count comparison — out of scope for the narrow rail
+            "assert mock.call_count >= 1",
+            "assert mock.called == 3",
+            # is False — rare but legitimate
+            "assert mock.called is False",
+            # Identifier collisions
+            "assert obj.is_called",
+            "assert called",
+            # T10 negative — same-shape but wrong attribute
+            "assert mock.method.return_value == 1",
         ],
     )
-    def test_does_not_match_legitimate(self, line: str) -> None:
-        """Does not match legitimate."""
-        assert _PATTERN.match(line) is None
+    def test_non_called_assertions_not_flagged(self, source: str) -> None:
+        """Same-shape assertions that aren't the bare ``.called`` form pass."""
+        assert not _is_called_attribute_assertion(_parse_assert(source))
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: opt-out marker
+# ---------------------------------------------------------------------------
 
 
 class TestOptOutMarker:
-    """The opt-out marker must be detected only in its canonical form."""
+    """``# noqa: T3`` opt-out is recognised on the assertion line."""
 
     @pytest.mark.parametrize(
         "line",
@@ -101,7 +124,7 @@ class TestOptOutMarker:
         ],
     )
     def test_recognises_opt_out(self, line: str) -> None:
-        """Recognises opt out."""
+        """Canonical and tighter-spacing forms of the marker are recognised."""
         assert _has_opt_out(line)
 
     @pytest.mark.parametrize(
@@ -113,23 +136,8 @@ class TestOptOutMarker:
         ],
     )
     def test_rejects_non_canonical(self, line: str) -> None:
-        """Rejects non canonical."""
+        """Marker text without the exact ``noqa: T3`` form is rejected."""
         assert not _has_opt_out(line)
-
-
-class TestCommentLines:
-    """Comments must not trip the rail even if they contain the forbidden form."""
-
-    @pytest.mark.parametrize(
-        "line",
-        [
-            "# assert mock.called",
-            "    # assert mock.called  (historical example)",
-        ],
-    )
-    def test_comment_lines_are_skipped(self, line: str) -> None:
-        """Comment lines are skipped."""
-        assert _is_comment_line(line)
 
 
 # ---------------------------------------------------------------------------
@@ -138,54 +146,93 @@ class TestCommentLines:
 
 
 class TestFindViolationsSynthetic:
-    """End-to-end checks against tmp_path test files."""
+    """End-to-end checks against ``tmp_path`` source files."""
 
-    def _write(self, tmp_path: Path, content: str) -> Path:
-        """Write."""
-        target = tmp_path / "test_synth.py"
-        target.write_text(content)
-        return target
+    # ----- Canonical forms (positive) -----
 
-    def test_unmarked_assertion_is_flagged(self, tmp_path: Path) -> None:
-        """Unmarked assertion is flagged."""
-        target = self._write(tmp_path, "assert mock.method.called\n")
-        violations = find_violations(target)
-        assert len(violations) == 1
+    def test_bare_called_is_flagged(self, tmp_path: Path) -> None:
+        """``assert mock.method.called`` is flagged."""
+        target = _synth(tmp_path, "assert mock.method.called\n")
+        assert len(find_violations(target)) == 1
 
-    def test_marked_assertion_is_not_flagged(self, tmp_path: Path) -> None:
-        """Marked assertion is not flagged."""
-        target = self._write(
-            tmp_path, "assert mock.method.called  # noqa: T3 reason: legacy test\n"
-        )
-        assert find_violations(target) == []
+    def test_called_is_true_is_flagged(self, tmp_path: Path) -> None:
+        """``assert mock.method.called is True`` is flagged."""
+        target = _synth(tmp_path, "assert mock.method.called is True\n")
+        assert len(find_violations(target)) == 1
 
-    def test_method_form_is_not_flagged(self, tmp_path: Path) -> None:
-        # Canonical fix — the method call form. Not flagged.
-        """Method form is not flagged."""
-        target = self._write(tmp_path, "mock.method.assert_called()\n")
-        assert find_violations(target) == []
+    def test_called_eq_true_is_flagged(self, tmp_path: Path) -> None:
+        """``assert mock.method.called == True`` is flagged."""
+        target = _synth(tmp_path, "assert mock.method.called == True\n")
+        assert len(find_violations(target)) == 1
 
-    def test_comment_with_forbidden_text_not_flagged(self, tmp_path: Path) -> None:
-        """Comment with forbidden text not flagged."""
-        target = self._write(tmp_path, "# example: assert mock.called\n")
+    # ----- Codex r218 / #222 cases the previous regex missed -----
+
+    def test_parenthesised_form_is_flagged(self, tmp_path: Path) -> None:
+        """``assert (mock.method.called)`` (codex r218 #1, issue #222)."""
+        target = _synth(tmp_path, "assert (mock.method.called)\n")
+        assert len(find_violations(target)) == 1
+
+    def test_multiline_parenthesised_form_is_flagged(self, tmp_path: Path) -> None:
+        """Multi-line parenthesised — codex r219 multi-line bypass case (#222)."""
+        target = _synth(tmp_path, "assert (\n    mock.method.called\n)\n")
+        assert len(find_violations(target)) == 1
+
+    def test_assert_with_message_is_flagged(self, tmp_path: Path) -> None:
+        """``assert mock.method.called, 'must be called'`` (codex r218 #2, #222)."""
+        target = _synth(tmp_path, 'assert mock.method.called, "must be called"\n')
+        assert len(find_violations(target)) == 1
+
+    def test_assert_with_message_and_truth_compare_is_flagged(self, tmp_path: Path) -> None:
+        """Combined: ``assert mock.method.called is True, "msg"``."""
+        target = _synth(tmp_path, 'assert mock.method.called is True, "msg"\n')
+        assert len(find_violations(target)) == 1
+
+    # ----- Negative / opt-out cases -----
+
+    def test_method_form_not_flagged(self, tmp_path: Path) -> None:
+        """The canonical ``mock.assert_called()`` form is NOT flagged."""
+        target = _synth(tmp_path, "mock.method.assert_called()\n")
         assert find_violations(target) == []
 
     def test_count_comparison_not_flagged(self, tmp_path: Path) -> None:
-        # T10 negative case: ``call_count`` checks are out of scope for this
-        # narrow rail (full T3 covers them under code review, not here).
-        """Count comparison not flagged."""
-        target = self._write(tmp_path, "assert mock.call_count >= 1\n")
+        """``assert mock.call_count >= 1`` is out of scope for the narrow rail."""
+        target = _synth(tmp_path, "assert mock.call_count >= 1\n")
         assert find_violations(target) == []
 
-    def test_inside_triple_quoted_docstring_not_flagged(self, tmp_path: Path) -> None:
-        # Fixtures embedded in docstrings (common in tests/ci/test_*.py
-        # rails that demonstrate the forbidden pattern in dedent blocks)
-        # must not false-flag.
-        """Inside triple quoted docstring not flagged."""
-        target = self._write(
+    def test_is_false_not_flagged(self, tmp_path: Path) -> None:
+        """``assert mock.called is False`` is rare but legitimate."""
+        target = _synth(tmp_path, "assert mock.called is False\n")
+        assert find_violations(target) == []
+
+    def test_string_literal_containing_pattern_not_flagged(self, tmp_path: Path) -> None:
+        """A string literal containing the pattern text is not an assertion."""
+        target = _synth(tmp_path, 'msg = "assert mock.called"\n')
+        assert find_violations(target) == []
+
+    def test_docstring_containing_pattern_not_flagged(self, tmp_path: Path) -> None:
+        """A docstring containing the pattern text is not an assertion."""
+        target = _synth(
             tmp_path,
             '"""Example fixture:\n\n    assert mock.method.called\n"""\n',
         )
+        assert find_violations(target) == []
+
+    def test_comment_with_pattern_not_flagged(self, tmp_path: Path) -> None:
+        """A comment with the pattern text is not an assertion."""
+        target = _synth(tmp_path, "# example: assert mock.called\n")
+        assert find_violations(target) == []
+
+    def test_marked_assertion_is_not_flagged(self, tmp_path: Path) -> None:
+        """``# noqa: T3`` opt-out exempts the line."""
+        target = _synth(
+            tmp_path,
+            "assert mock.method.called  # noqa: T3 reason: legacy\n",
+        )
+        assert find_violations(target) == []
+
+    def test_syntax_error_yields_no_violations(self, tmp_path: Path) -> None:
+        """A file that fails to parse yields zero violations."""
+        target = _synth(tmp_path, "def broken(\n")
         assert find_violations(target) == []
 
 
@@ -198,7 +245,7 @@ class TestFullSuite:
     """The rail must pass against the live ``tests/`` tree."""
 
     def test_no_violations_on_current_tree(self) -> None:
-        """No violations on current tree."""
+        """The live ``tests/`` tree has no unmarked ``assert <mock>.called``."""
         result = subprocess.run(
             [sys.executable, str(_SCRIPT)],
             capture_output=True,

--- a/tests/ci/test_pytest_raises_hygiene.py
+++ b/tests/ci/test_pytest_raises_hygiene.py
@@ -1,0 +1,391 @@
+"""Tests for the pytest.raises hygiene rail (``scripts/check_pytest_raises_hygiene.py``).
+
+Closes the gap PR-A's PT012 enforcement leaves: PT012 is silenced inside the
+11 ``# noqa: PT012`` blocks that legitimately need multi-statement bodies
+(transaction rollback, context-manager exit semantics, generator
+double-``next()``, etc.). The rail in this PR catches mock assertions
+mistakenly placed AFTER the ``raise`` inside any of those blocks — those
+assertions are unreachable because ``raise`` terminates control flow.
+
+T10 predicate negative-case backfill: every detection branch has a positive
+test (the rail flags the surface shape) AND a negative test (the rail does
+NOT flag a similar shape that is genuinely reachable).
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+pytestmark = pytest.mark.ci
+
+_FO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _FO_ROOT / "scripts" / "check_pytest_raises_hygiene.py"
+
+# Import the detector directly so we can unit-test helpers without spawning
+# a subprocess for every case.
+sys.path.insert(0, str(_FO_ROOT / "scripts"))
+from check_pytest_raises_hygiene import (  # noqa: E402
+    _MOCK_ASSERTION_NAMES,
+    _is_mock_assertion,
+    _is_pytest_raises,
+    _violations_in_block,
+    find_violations,
+)
+
+
+def _parse_with(source: str) -> ast.With:
+    """Return the first ``ast.With`` node in *source*."""
+    tree = ast.parse(dedent(source))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.With):
+            return node
+    raise AssertionError("no With node parsed")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _is_pytest_raises
+# ---------------------------------------------------------------------------
+
+
+class TestIsPytestRaises:
+    """The detector must recognise canonical pytest.raises shapes."""
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "with pytest.raises(ValueError):\n    pass",
+            "with pytest.raises(ValueError, match='boom'):\n    pass",
+            "with pytest.raises(ValueError) as excinfo:\n    pass",
+            "with pytest.raises((ValueError, TypeError)):\n    pass",
+        ],
+    )
+    def test_recognises_pytest_raises(self, source: str) -> None:
+        with_node = _parse_with(source)
+        assert any(_is_pytest_raises(item) for item in with_node.items)
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            # T10 negative cases — must NOT match
+            "with open('x') as f:\n    pass",
+            "with self.raises(ValueError):\n    pass",  # not pytest.raises
+            "with patch('foo') as p:\n    pass",
+            "with pytest.warns(DeprecationWarning):\n    pass",
+        ],
+    )
+    def test_rejects_non_pytest_raises(self, source: str) -> None:
+        with_node = _parse_with(source)
+        assert not any(_is_pytest_raises(item) for item in with_node.items)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _is_mock_assertion
+# ---------------------------------------------------------------------------
+
+
+class TestIsMockAssertion:
+    """The detector must recognise the two canonical mock-assertion forms."""
+
+    @pytest.mark.parametrize(
+        "name",
+        sorted(_MOCK_ASSERTION_NAMES),
+    )
+    def test_recognises_mock_call(self, name: str) -> None:
+        # Form A: mock.X.assert_called*(...)
+        source = f"mock.method.{name}()"
+        stmt = ast.parse(source).body[0]
+        assert _is_mock_assertion(stmt)
+
+    def test_recognises_assert_called_attribute(self) -> None:
+        # Form B: assert mock.X.called
+        stmt = ast.parse("assert mock.method.called").body[0]
+        assert _is_mock_assertion(stmt)
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            # T10 negative cases — same surface shapes that must NOT match
+            "mock.method.return_value = 1",  # attribute set, not assertion
+            "mock.method.call_count == 1",  # comparison, not assertion call
+            "result = mock.method.assert_called()",  # assignment, not Expr
+            "assert result is True",  # plain assert, not on .called
+            "assert mock.method.return_value == 1",  # not .called attr
+            "x.assert_something_else()",  # not in assertion-name set
+        ],
+    )
+    def test_rejects_non_mock_assertion(self, source: str) -> None:
+        stmt = ast.parse(source).body[0]
+        assert not _is_mock_assertion(stmt)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _violations_in_block
+# ---------------------------------------------------------------------------
+
+
+class TestViolationsInBlock:
+    """Body-level scan must flag unreachable mock assertions only."""
+
+    def test_flags_assertion_after_top_level_raise(self) -> None:
+        with_node = _parse_with(
+            """
+            with pytest.raises(ValueError):
+                raise ValueError("boom")
+                mock.method.assert_called_once()
+            """
+        )
+        violations = _violations_in_block(with_node.body)
+        assert len(violations) == 1
+
+    def test_flags_assert_called_attribute_after_raise(self) -> None:
+        with_node = _parse_with(
+            """
+            with pytest.raises(ValueError):
+                raise ValueError()
+                assert mock.method.called
+            """
+        )
+        violations = _violations_in_block(with_node.body)
+        assert len(violations) == 1
+
+    def test_no_flag_when_assertion_precedes_raise(self) -> None:
+        # Statement appears BEFORE raise — reachable; not flagged.
+        with_node = _parse_with(
+            """
+            with pytest.raises(ValueError):
+                mock.method.assert_called_once()
+                raise ValueError()
+            """
+        )
+        assert _violations_in_block(with_node.body) == []
+
+    def test_no_flag_when_no_top_level_raise(self) -> None:
+        # No raise at top level; mock assertion is reachable.
+        with_node = _parse_with(
+            """
+            with pytest.raises(ValueError):
+                func_that_might_raise()
+                mock.method.assert_called_once()
+            """
+        )
+        assert _violations_in_block(with_node.body) == []
+
+    def test_no_flag_when_raise_is_nested_in_if(self) -> None:
+        # T10 negative case: conditional raise; trailing assertion is
+        # reachable when the condition is False.
+        with_node = _parse_with(
+            """
+            with pytest.raises(ValueError):
+                if condition:
+                    raise ValueError()
+                mock.method.assert_called_once()
+            """
+        )
+        assert _violations_in_block(with_node.body) == []
+
+    def test_no_flag_when_raise_is_nested_in_try(self) -> None:
+        # T10 negative case: raise inside try doesn't terminate the
+        # outer block (the except may catch and the body continues).
+        with_node = _parse_with(
+            """
+            with pytest.raises(ValueError):
+                try:
+                    raise RuntimeError()
+                except RuntimeError:
+                    raise ValueError()
+                mock.method.assert_called_once()
+            """
+        )
+        # The outer raise IS still inside an except branch — the rail
+        # treats only top-level raises as terminating, so this stays
+        # un-flagged. Conservative is the right default for a rail.
+        assert _violations_in_block(with_node.body) == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: find_violations on synthetic files
+# ---------------------------------------------------------------------------
+
+
+class TestFindViolationsSynthetic:
+    """End-to-end checks against tmp_path test files."""
+
+    def _write(self, tmp_path: Path, content: str) -> Path:
+        target = tmp_path / "test_synth.py"
+        target.write_text(dedent(content))
+        return target
+
+    def test_unreachable_mock_assertion_is_flagged(self, tmp_path: Path) -> None:
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.raises(ValueError):
+                    raise ValueError()
+                    mock.method.assert_called_once()
+            """,
+        )
+        violations = find_violations(target)
+        assert len(violations) == 1
+        assert "assert_called_once" in violations[0][1]
+
+    def test_correctly_placed_assertion_is_not_flagged(self, tmp_path: Path) -> None:
+        # T10 negative: assertion AFTER the with-block exits is correct.
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.raises(ValueError):
+                    raise ValueError()
+                mock.method.assert_called_once()
+            """,
+        )
+        assert find_violations(target) == []
+
+    def test_assert_called_attribute_after_raise_is_flagged(self, tmp_path: Path) -> None:
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.raises(ValueError):
+                    raise ValueError()
+                    assert mock.method.called
+            """,
+        )
+        violations = find_violations(target)
+        assert len(violations) == 1
+        assert ".called" in violations[0][1]
+
+    def test_pytest_warns_does_not_trigger(self, tmp_path: Path) -> None:
+        # T10 negative case: same with-statement shape but pytest.warns,
+        # not pytest.raises. Must not flag.
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.warns(DeprecationWarning):
+                    raise DeprecationWarning()
+                    mock.method.assert_called_once()
+            """,
+        )
+        assert find_violations(target) == []
+
+    def test_nested_with_block_with_raise_then_mock_assertion_is_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        # Codex r217 false-negative case: the raise + mock assertion are
+        # both inside an inner ``with manager() as m:`` block nested under
+        # the outer ``with pytest.raises(...):``. The pre-fix detector
+        # only walked the outer body and missed this. The fixed detector
+        # walks every nested statement-list within the pytest.raises
+        # subtree.
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.raises(ValueError):  # noqa: PT012
+                    with manager() as m:
+                        do_setup()
+                        raise ValueError()
+                        m.cleanup.assert_called_once()
+            """,
+        )
+        violations = find_violations(target)
+        assert len(violations) == 1
+        assert "assert_called_once" in violations[0][1]
+
+    def test_nested_if_with_raise_then_assertion_is_flagged(self, tmp_path: Path) -> None:
+        # The raise is at top level of the if-body (not the outer
+        # pytest.raises body), so the immediate-body-only scan would
+        # miss it. After the fix, the rail walks into the if-body too.
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.raises(ValueError):  # noqa: PT012
+                    if True:
+                        raise ValueError()
+                        mock.method.assert_called_once()
+            """,
+        )
+        violations = find_violations(target)
+        assert len(violations) == 1
+
+    def test_assertion_inside_nested_function_def_is_not_flagged(self, tmp_path: Path) -> None:
+        # T10 negative case: the nested def starts a new scope; its body
+        # is not executed at the pytest.raises call site. The detector
+        # must NOT descend into function definitions.
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.raises(ValueError):
+                    raise ValueError()
+
+                    def helper():
+                        mock.method.assert_called_once()
+            """,
+        )
+        # The raise + def are at top level of the pytest.raises body. The
+        # def itself is not a mock assertion, and we don't descend into
+        # its body. So no violations.
+        assert find_violations(target) == []
+
+    def test_mocked_pytest_raises_via_alias_is_not_flagged(self, tmp_path: Path) -> None:
+        # T10 negative case: an aliased import doesn't match the
+        # ``pytest.raises`` attribute pattern. Conservative: detector
+        # only matches the canonical form. False negatives are accepted
+        # for false-positive immunity (the canonical form is what the
+        # codebase uses everywhere — see existing 11 noqa-PT012 sites).
+        target = self._write(
+            tmp_path,
+            """
+            from pytest import raises
+
+            def test_x():
+                with raises(ValueError):
+                    raise ValueError()
+                    mock.method.assert_called_once()
+            """,
+        )
+        assert find_violations(target) == []
+
+
+# ---------------------------------------------------------------------------
+# Full-suite assertion: zero unreachable mock assertions on the live tree
+# ---------------------------------------------------------------------------
+
+
+class TestFullSuite:
+    """The rail must pass against the live ``tests/`` tree (preventive)."""
+
+    def test_no_violations_on_current_tree(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"pytest.raises hygiene rail flagged unreachable mock assertion(s):\n{result.stderr}"
+        )

--- a/tests/ci/test_pytest_raises_hygiene.py
+++ b/tests/ci/test_pytest_raises_hygiene.py
@@ -66,6 +66,7 @@ class TestIsPytestRaises:
         ],
     )
     def test_recognises_pytest_raises(self, source: str) -> None:
+        """Recognises pytest raises."""
         with_node = _parse_with(source)
         assert any(_is_pytest_raises(item) for item in with_node.items)
 
@@ -80,6 +81,7 @@ class TestIsPytestRaises:
         ],
     )
     def test_rejects_non_pytest_raises(self, source: str) -> None:
+        """Rejects non pytest raises."""
         with_node = _parse_with(source)
         assert not any(_is_pytest_raises(item) for item in with_node.items)
 
@@ -98,12 +100,14 @@ class TestIsMockAssertion:
     )
     def test_recognises_mock_call(self, name: str) -> None:
         # Form A: mock.X.assert_called*(...)
+        """Recognises mock call."""
         source = f"mock.method.{name}()"
         stmt = ast.parse(source).body[0]
         assert _is_mock_assertion(stmt)
 
     def test_recognises_assert_called_attribute(self) -> None:
         # Form B: assert mock.X.called
+        """Recognises assert called attribute."""
         stmt = ast.parse("assert mock.method.called").body[0]
         assert _is_mock_assertion(stmt)
 
@@ -120,6 +124,7 @@ class TestIsMockAssertion:
         ],
     )
     def test_rejects_non_mock_assertion(self, source: str) -> None:
+        """Rejects non mock assertion."""
         stmt = ast.parse(source).body[0]
         assert not _is_mock_assertion(stmt)
 
@@ -133,6 +138,7 @@ class TestViolationsInBlock:
     """Body-level scan must flag unreachable mock assertions only."""
 
     def test_flags_assertion_after_top_level_raise(self) -> None:
+        """Flags assertion after top level raise."""
         with_node = _parse_with(
             """
             with pytest.raises(ValueError):
@@ -144,6 +150,7 @@ class TestViolationsInBlock:
         assert len(violations) == 1
 
     def test_flags_assert_called_attribute_after_raise(self) -> None:
+        """Flags assert called attribute after raise."""
         with_node = _parse_with(
             """
             with pytest.raises(ValueError):
@@ -156,6 +163,7 @@ class TestViolationsInBlock:
 
     def test_no_flag_when_assertion_precedes_raise(self) -> None:
         # Statement appears BEFORE raise — reachable; not flagged.
+        """No flag when assertion precedes raise."""
         with_node = _parse_with(
             """
             with pytest.raises(ValueError):
@@ -167,6 +175,7 @@ class TestViolationsInBlock:
 
     def test_no_flag_when_no_top_level_raise(self) -> None:
         # No raise at top level; mock assertion is reachable.
+        """No flag when no top level raise."""
         with_node = _parse_with(
             """
             with pytest.raises(ValueError):
@@ -179,6 +188,7 @@ class TestViolationsInBlock:
     def test_no_flag_when_raise_is_nested_in_if(self) -> None:
         # T10 negative case: conditional raise; trailing assertion is
         # reachable when the condition is False.
+        """No flag when raise is nested in if."""
         with_node = _parse_with(
             """
             with pytest.raises(ValueError):
@@ -192,6 +202,7 @@ class TestViolationsInBlock:
     def test_no_flag_when_raise_is_nested_in_try(self) -> None:
         # T10 negative case: raise inside try doesn't terminate the
         # outer block (the except may catch and the body continues).
+        """No flag when raise is nested in try."""
         with_node = _parse_with(
             """
             with pytest.raises(ValueError):
@@ -220,11 +231,13 @@ class TestFindViolationsSynthetic:
     """End-to-end checks against tmp_path test files."""
 
     def _write(self, tmp_path: Path, content: str) -> Path:
+        """Write."""
         target = tmp_path / "test_synth.py"
         target.write_text(dedent(content))
         return target
 
     def test_unreachable_mock_assertion_is_flagged(self, tmp_path: Path) -> None:
+        """Unreachable mock assertion is flagged."""
         target = self._write(
             tmp_path,
             """
@@ -242,6 +255,7 @@ class TestFindViolationsSynthetic:
 
     def test_correctly_placed_assertion_is_not_flagged(self, tmp_path: Path) -> None:
         # T10 negative: assertion AFTER the with-block exits is correct.
+        """Correctly placed assertion is not flagged."""
         target = self._write(
             tmp_path,
             """
@@ -256,6 +270,7 @@ class TestFindViolationsSynthetic:
         assert find_violations(target) == []
 
     def test_assert_called_attribute_after_raise_is_flagged(self, tmp_path: Path) -> None:
+        """Assert called attribute after raise is flagged."""
         target = self._write(
             tmp_path,
             """
@@ -274,6 +289,7 @@ class TestFindViolationsSynthetic:
     def test_pytest_warns_does_not_trigger(self, tmp_path: Path) -> None:
         # T10 negative case: same with-statement shape but pytest.warns,
         # not pytest.raises. Must not flag.
+        """Pytest warns does not trigger."""
         target = self._write(
             tmp_path,
             """
@@ -296,6 +312,7 @@ class TestFindViolationsSynthetic:
         # only walked the outer body and missed this. The fixed detector
         # walks every nested statement-list within the pytest.raises
         # subtree.
+        """Nested with block with raise then mock assertion is flagged."""
         target = self._write(
             tmp_path,
             """
@@ -317,6 +334,7 @@ class TestFindViolationsSynthetic:
         # The raise is at top level of the if-body (not the outer
         # pytest.raises body), so the immediate-body-only scan would
         # miss it. After the fix, the rail walks into the if-body too.
+        """Nested if with raise then assertion is flagged."""
         target = self._write(
             tmp_path,
             """
@@ -336,6 +354,7 @@ class TestFindViolationsSynthetic:
         # T10 negative case: the nested def starts a new scope; its body
         # is not executed at the pytest.raises call site. The detector
         # must NOT descend into function definitions.
+        """Assertion inside nested function def is not flagged."""
         target = self._write(
             tmp_path,
             """
@@ -360,6 +379,7 @@ class TestFindViolationsSynthetic:
         # only matches the canonical form. False negatives are accepted
         # for false-positive immunity (the canonical form is what the
         # codebase uses everywhere — see existing 11 noqa-PT012 sites).
+        """Mocked pytest raises via alias is not flagged."""
         target = self._write(
             tmp_path,
             """
@@ -383,6 +403,7 @@ class TestFullSuite:
     """The rail must pass against the live ``tests/`` tree (preventive)."""
 
     def test_no_violations_on_current_tree(self) -> None:
+        """No violations on current tree."""
         result = subprocess.run(
             [sys.executable, str(_SCRIPT)],
             capture_output=True,

--- a/tests/ci/test_pytest_raises_hygiene.py
+++ b/tests/ci/test_pytest_raises_hygiene.py
@@ -350,6 +350,83 @@ class TestFindViolationsSynthetic:
         violations = find_violations(target)
         assert len(violations) == 1
 
+    def test_top_level_raise_then_nested_if_assertion_is_flagged(self, tmp_path: Path) -> None:
+        """Codex r219 #4: top-level ``raise`` followed by nested ``if`` body.
+
+        ``raise ValueError(); if True: mock.method.assert_called_once()`` —
+        the nested assertion is unreachable because the outer-block raise
+        terminates control flow before the if is evaluated. The previous
+        per-block walker reset ``seen_raise`` and missed this; the
+        reachability propagator now flags it.
+        """
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.raises(ValueError):
+                    raise ValueError()
+                    if True:
+                        mock.method.assert_called_once()
+            """,
+        )
+        violations = find_violations(target)
+        assert len(violations) == 1
+        assert "assert_called_once" in violations[0][1]
+
+    def test_top_level_raise_then_nested_for_assertion_is_flagged(self, tmp_path: Path) -> None:
+        """Same case as the if-nested test but with a ``for`` loop body."""
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.raises(ValueError):
+                    raise ValueError()
+                    for x in items:
+                        mock.method.assert_called_once()
+            """,
+        )
+        assert len(find_violations(target)) == 1
+
+    def test_top_level_raise_then_nested_with_assertion_is_flagged(self, tmp_path: Path) -> None:
+        """Top-level raise followed by nested ``with`` body."""
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.raises(ValueError):
+                    raise ValueError()
+                    with manager() as m:
+                        m.cleanup.assert_called_once()
+            """,
+        )
+        assert len(find_violations(target)) == 1
+
+    def test_conditional_raise_does_not_make_subsequent_unreachable(self, tmp_path: Path) -> None:
+        """T10 negative case: a conditional raise leaves the subsequent assertion reachable."""
+        target = self._write(
+            tmp_path,
+            """
+            import pytest
+
+            def test_x():
+                with pytest.raises(ValueError):
+                    if condition:
+                        raise ValueError()
+                    if True:
+                        mock.method.assert_called_once()
+            """,
+        )
+        # The outer-block ``if`` is not a top-level raise — the second if's
+        # body is reachable when ``condition`` is False, so the assertion
+        # is reachable.
+        assert find_violations(target) == []
+
     def test_assertion_inside_nested_function_def_is_not_flagged(self, tmp_path: Path) -> None:
         # T10 negative case: the nested def starts a new scope; its body
         # is not executed at the pytest.raises call site. The detector

--- a/tests/ci/test_pytest_raises_hygiene.py
+++ b/tests/ci/test_pytest_raises_hygiene.py
@@ -202,9 +202,12 @@ class TestViolationsInBlock:
                 mock.method.assert_called_once()
             """
         )
-        # The outer raise IS still inside an except branch — the rail
-        # treats only top-level raises as terminating, so this stays
-        # un-flagged. Conservative is the right default for a rail.
+        # Neither ``raise`` is at the with-body's top level (both are
+        # nested inside ``try``/``except``). ``_violations_in_block``
+        # only inspects direct children, so without a top-level
+        # ``Raise`` the trailing assertion is treated as reachable.
+        # Conservative is the right default for this body-level helper;
+        # nested traversal happens in ``find_violations``.
         assert _violations_in_block(with_node.body) == []
 
 

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -319,7 +319,7 @@ class TestDisplayRecommendations:
             with patch("cli.doctor.console") as mock_console:
                 display_recommendations(extension_counts, detected_groups)
                 # Should print a table
-                assert mock_console.print.called
+                mock_console.print.assert_called()
 
     def test_display_with_missing_group(self):
         extension_counts = {".mp3": 5}
@@ -328,7 +328,7 @@ class TestDisplayRecommendations:
         with patch("cli.doctor.is_group_installed", return_value=False):
             with patch("cli.doctor.console") as mock_console:
                 display_recommendations(extension_counts, detected_groups)
-                assert mock_console.print.called
+                mock_console.print.assert_called()
 
     def test_display_multiple_groups(self):
         extension_counts = {".mp3": 5, ".mp4": 3, ".pdf": 2}
@@ -337,7 +337,7 @@ class TestDisplayRecommendations:
         with patch("cli.doctor.is_group_installed", return_value=False):
             with patch("cli.doctor.console") as mock_console:
                 display_recommendations(extension_counts, detected_groups)
-                assert mock_console.print.called
+                mock_console.print.assert_called()
 
     def test_display_with_prerequisites(self):
         extension_counts = {".mp3": 5}
@@ -347,7 +347,7 @@ class TestDisplayRecommendations:
         with patch("cli.doctor.is_group_installed", return_value=False):
             with patch("cli.doctor.console") as mock_console:
                 display_recommendations(extension_counts, detected_groups)
-                assert mock_console.print.called
+                mock_console.print.assert_called()
 
 
 # ============================================================================
@@ -546,7 +546,7 @@ class TestDoctorCommand:
 
             assert exc_info.value.exit_code == 0
             # Should output JSON
-            assert mock_echo.called
+            mock_echo.assert_called()
             import json
 
             output = json.loads(mock_echo.call_args[0][0])
@@ -616,7 +616,7 @@ class TestDoctorCommand:
                         doctor(path=tmp_path, install=True, json_output=False)
 
                         # Should have attempted installation
-                        assert mock_run.called
+                        mock_run.assert_called()
 
     def test_compound_extension_detection(self, tmp_path):
         # Test that compound extensions are properly detected
@@ -1214,7 +1214,7 @@ class TestInstallGroupsOrdering:
             with patch("cli.doctor.console") as mock_console:
                 display_recommendations(extension_counts, detected_groups)
                 # Just verify it was called without error (sorting happens internally)
-                assert mock_console.print.called
+                mock_console.print.assert_called()
 
 
 @pytest.mark.unit

--- a/tests/events/test_stream.py
+++ b/tests/events/test_stream.py
@@ -589,7 +589,7 @@ class TestRedisStreamManagerContextManager:
         mock_client.ping.return_value = True
         mock_redis_module.Redis.from_url.return_value = mock_client
 
-        with pytest.raises(ValueError, match="test error"):
+        with pytest.raises(ValueError, match="test error"):  # noqa: PT012 — context-manager exit semantics under exception
             with RedisStreamManager() as manager:
                 assert manager.is_connected is True
                 raise ValueError("test error")

--- a/tests/events/test_stream_branches.py
+++ b/tests/events/test_stream_branches.py
@@ -45,7 +45,7 @@ class TestRedisConnectionError:
 
     def test_not_caught_by_value_error(self):
         """RedisConnectionError is not a subtype of ValueError."""
-        with pytest.raises(RedisConnectionError):
+        with pytest.raises(RedisConnectionError):  # noqa: PT012 — verifies inner except does not catch
             try:
                 raise RedisConnectionError("oops")
             except ValueError:

--- a/tests/integration/config/test_provider_env.py
+++ b/tests/integration/config/test_provider_env.py
@@ -46,7 +46,7 @@ class TestGetCurrentProviderUnknownValue:
         with patch("config.provider_env.logger.warning") as mock_warn:
             get_current_provider()
 
-        assert mock_warn.called
+        mock_warn.assert_called()
         # Warning message should mention the unrecognised value
         call_args = mock_warn.call_args_list[0]
         assert "bogus" in str(call_args) or "FO_PROVIDER" in str(call_args)

--- a/tests/integration/test_cli_benchmark.py
+++ b/tests/integration/test_cli_benchmark.py
@@ -755,7 +755,7 @@ class TestResolveProcessedCount:
         from cli.benchmark import _resolve_processed_count
 
         console = MagicMock()
-        with pytest.raises(SystemExit) as excinfo:
+        with pytest.raises(SystemExit) as excinfo:  # noqa: PT012 — re-raising typer.Exit as SystemExit requires try/except body
             try:
                 _resolve_processed_count([1, 2, 3], warmup=0, suite="io", console=console)
             except typer.Exit as e:

--- a/tests/integration/test_doctor_e2e.py
+++ b/tests/integration/test_doctor_e2e.py
@@ -349,7 +349,7 @@ class TestDoctorInstallation:
                     result = runner.invoke(app, ["doctor", str(audio_files_dir), "--install"])
                     assert result.exit_code == 0
                     # Should have called subprocess to install
-                    assert mock_run.called
+                    mock_run.assert_called()
 
     def test_install_with_yes_flag_auto_confirms(
         self, audio_files_dir: Path, monkeypatch: pytest.MonkeyPatch
@@ -363,7 +363,7 @@ class TestDoctorInstallation:
                 result = runner.invoke(app, ["--yes", "doctor", str(audio_files_dir), "--install"])
                 # Should succeed without prompting
                 assert result.exit_code == 0
-                assert mock_run.called
+                mock_run.assert_called()
 
     def test_install_with_dry_run_flag(self, audio_files_dir: Path) -> None:
         """Global --dry-run flag prevents actual installation."""
@@ -676,7 +676,7 @@ class TestDoctorEndToEndWorkflows:
                 with patch("subprocess.run", return_value=mock_result) as mock_run:
                     result = runner.invoke(app, ["doctor", str(mixed_media_dir), "--install"])
                     assert result.exit_code == 0
-                    assert mock_run.called
+                    mock_run.assert_called()
 
     def test_ci_automation_workflow(self, audio_files_dir: Path) -> None:
         """Simulate CI/automation usage with --dry-run and --json flags."""

--- a/tests/integration/test_fallback_no_ollama.py
+++ b/tests/integration/test_fallback_no_ollama.py
@@ -175,16 +175,28 @@ class TestFallbackDoesNotCrash:
         ):
             organizer.organize(source_dir, output_dir)
 
-        # AI processing paths were called with actual file lists (not fallback)
-        mock_text.assert_called()
-        # Verify files were passed (text_files call + cad_files call)
+        # AI processing paths were called with EXACT routed payloads (not just
+        # invocation count). The source_dir fixture creates one file of each
+        # fallback-supported type, so we know precisely which files should
+        # land in each branch.  See lines 32-39 above for the file roster.
         all_text_args = [call.args[0] for call in mock_text.call_args_list]
-        all_text_files = [f for batch in all_text_args for f in batch]
-        assert len(all_text_files) > 0, "AI text processing received no files"
+        all_text_files = {f for batch in all_text_args for f in batch}
+        expected_text_files = {
+            source_dir / "report.txt",
+            source_dir / "invoice.pdf",
+            source_dir / "budget.xlsx",
+            source_dir / "slides.pptx",
+            source_dir / "data.csv",
+            source_dir / "book.epub",
+            source_dir / "part.dwg",
+        }
+        assert all_text_files == expected_text_files, (
+            f"AI text processing received wrong files: "
+            f"missing={expected_text_files - all_text_files}, "
+            f"unexpected={all_text_files - expected_text_files}"
+        )
 
-        mock_image.assert_called_once()
-        image_args = mock_image.call_args.args[0]
-        assert len(image_args) == 1, f"Expected 1 image file, got {len(image_args)}"
+        mock_image.assert_called_once_with([source_dir / "photo.jpg"])
 
         # Fallback must NOT have been used when Ollama recovered
         mock_fallback.assert_not_called()

--- a/tests/integration/test_fallback_no_ollama.py
+++ b/tests/integration/test_fallback_no_ollama.py
@@ -115,7 +115,7 @@ class TestFallbackDoesNotCrash:
         assert result.total_files == expected
         assert result.failed_files == 0
         # Verify fallback path was used with exactly the collected source files.
-        assert mock_fallback.called, "Expected fallback to be invoked when Ollama is down"
+        mock_fallback.assert_called()
         fallback_files = {
             file_path
             for call in mock_fallback.call_args_list
@@ -176,7 +176,7 @@ class TestFallbackDoesNotCrash:
             organizer.organize(source_dir, output_dir)
 
         # AI processing paths were called with actual file lists (not fallback)
-        assert mock_text.called, "Expected AI text processing, got fallback"
+        mock_text.assert_called()
         # Verify files were passed (text_files call + cad_files call)
         all_text_args = [call.args[0] for call in mock_text.call_args_list]
         all_text_files = [f for batch in all_text_args for f in batch]

--- a/tests/integration/test_history_branches.py
+++ b/tests/integration/test_history_branches.py
@@ -86,7 +86,7 @@ class TestDatabaseManagerBranches:
     def test_transaction_context_exception_rolls_back(self, tmp_path: Path) -> None:
         """Exception inside db.transaction() triggers rollback (lines 186-189)."""
         db = _make_db(tmp_path)
-        with pytest.raises(RuntimeError, match="deliberate"):
+        with pytest.raises(RuntimeError, match="deliberate"):  # noqa: PT012 — db.transaction rollback requires multi-stmt body
             with db.transaction() as conn:
                 conn.execute(
                     "INSERT INTO operations (operation_type, source_path, timestamp, status)"

--- a/tests/integration/test_history_workflow.py
+++ b/tests/integration/test_history_workflow.py
@@ -229,7 +229,7 @@ class TestOperationTransaction:
 
     def test_auto_rollback_on_exception(self, history: OperationHistory) -> None:
         txn_id = None
-        with pytest.raises(ValueError, match="test error"):
+        with pytest.raises(ValueError, match="test error"):  # noqa: PT012 — transaction rollback on exception requires multi-stmt body
             with OperationTransaction(history) as txn:
                 txn.log_move(Path("/src/a.txt"), Path("/dst/a.txt"))
                 txn_id = txn.get_transaction_id()
@@ -308,7 +308,7 @@ class TestOperationTransaction:
 
         txn1_id = txn1.get_transaction_id()
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError):  # noqa: PT012 — transaction rollback test requires multi-stmt body
             with OperationTransaction(history) as txn2:
                 txn2.log_move(Path("/s2.txt"), Path("/d2.txt"))
                 raise RuntimeError("abort txn2")

--- a/tests/integration/test_integrations_and_methodologies_ai.py
+++ b/tests/integration/test_integrations_and_methodologies_ai.py
@@ -451,6 +451,60 @@ class TestObsidianIntegration:
         result = _run(integration.send_file(str(tmp_path / "missing.txt")))
         assert result is False
 
+    def test_send_file_returns_false_on_copy_oserror(self, tmp_path: Path) -> None:
+        """When ``shutil.copy2`` raises OSError, ``send_file`` returns False instead of leaking."""
+        from unittest.mock import patch
+
+        from integrations.base import IntegrationConfig, IntegrationType
+        from integrations.obsidian import ObsidianIntegration
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        source = tmp_path / "report.txt"
+        source.write_text("data", encoding="utf-8")
+
+        config = IntegrationConfig(
+            name="obsidian",
+            integration_type=IntegrationType.DESKTOP_APP,
+            settings={"vault_path": str(vault)},
+        )
+        integration = ObsidianIntegration(config)
+        _run(integration.connect())
+
+        with patch(
+            "integrations.obsidian.shutil.copy2",
+            side_effect=OSError("disk full"),
+        ):
+            result = _run(integration.send_file(str(source)))
+        assert result is False
+
+    def test_send_file_returns_false_on_note_write_oserror(self, tmp_path: Path) -> None:
+        """When ``note_path.write_text`` raises OSError, ``send_file`` returns False."""
+        from unittest.mock import patch
+
+        from integrations.base import IntegrationConfig, IntegrationType
+        from integrations.obsidian import ObsidianIntegration
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        source = tmp_path / "report.txt"
+        source.write_text("data", encoding="utf-8")
+
+        config = IntegrationConfig(
+            name="obsidian",
+            integration_type=IntegrationType.DESKTOP_APP,
+            settings={"vault_path": str(vault)},
+        )
+        integration = ObsidianIntegration(config)
+        _run(integration.connect())
+
+        with patch(
+            "pathlib.Path.write_text",
+            side_effect=OSError("permission denied"),
+        ):
+            result = _run(integration.send_file(str(source)))
+        assert result is False
+
     def test_get_status_reflects_vault_state(self, tmp_path: Path) -> None:
         from integrations.base import IntegrationConfig, IntegrationType
         from integrations.obsidian import ObsidianIntegration

--- a/tests/integration/test_integrations_and_methodologies_ai.py
+++ b/tests/integration/test_integrations_and_methodologies_ai.py
@@ -451,6 +451,7 @@ class TestObsidianIntegration:
         result = _run(integration.send_file(str(tmp_path / "missing.txt")))
         assert result is False
 
+    @pytest.mark.ci
     def test_send_file_returns_false_on_copy_oserror(self, tmp_path: Path) -> None:
         """When ``shutil.copy2`` raises OSError, ``send_file`` returns False instead of leaking."""
         from unittest.mock import patch
@@ -478,6 +479,7 @@ class TestObsidianIntegration:
             result = _run(integration.send_file(str(source)))
         assert result is False
 
+    @pytest.mark.ci
     def test_send_file_returns_false_on_note_write_oserror(self, tmp_path: Path) -> None:
         """When ``note_path.write_text`` raises OSError, ``send_file`` returns False."""
         from unittest.mock import patch

--- a/tests/integration/test_models_generation.py
+++ b/tests/integration/test_models_generation.py
@@ -178,7 +178,7 @@ class TestTextModelStreaming:
         next(it)
         with pytest.raises(StopIteration):
             next(it)
-        on_close.assert_called()
+        on_close.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_models_generation.py
+++ b/tests/integration/test_models_generation.py
@@ -175,8 +175,8 @@ class TestTextModelStreaming:
     def test_guarded_iterator_stopiteration_fires_callback(self) -> None:
         on_close = MagicMock()
         it = _GuardedIterator(iter(["x"]), on_close)
+        next(it)
         with pytest.raises(StopIteration):
-            next(it)
             next(it)
         on_close.assert_called()
 

--- a/tests/integration/test_models_optional_providers.py
+++ b/tests/integration/test_models_optional_providers.py
@@ -270,29 +270,25 @@ class TestLlamaCppTextModelMocked:
         from models.llama_cpp_text_model import LlamaCppTextModel
 
         config = LlamaCppTextModel.get_default_config("/models/bad.gguf")
-        with (
-            patch(
-                "models.llama_cpp_text_model.Llama",
-                side_effect=OSError("file not found"),
-            ),
-            pytest.raises(RuntimeError, match="Could not load GGUF model"),
+        with patch(
+            "models.llama_cpp_text_model.Llama",
+            side_effect=OSError("file not found"),
         ):
             model = LlamaCppTextModel(config)
-            model.initialize()
+            with pytest.raises(RuntimeError, match="Could not load GGUF model"):
+                model.initialize()
 
     def test_initialize_wraps_value_error(self) -> None:
         from models.llama_cpp_text_model import LlamaCppTextModel
 
         config = LlamaCppTextModel.get_default_config("/models/bad.gguf")
-        with (
-            patch(
-                "models.llama_cpp_text_model.Llama",
-                side_effect=ValueError("invalid params"),
-            ),
-            pytest.raises(RuntimeError, match="Could not load GGUF model"),
+        with patch(
+            "models.llama_cpp_text_model.Llama",
+            side_effect=ValueError("invalid params"),
         ):
             model = LlamaCppTextModel(config)
-            model.initialize()
+            with pytest.raises(RuntimeError, match="Could not load GGUF model"):
+                model.initialize()
 
     def test_generate_returns_stripped_text(self) -> None:
         model = _make_llama_model_mocked()
@@ -526,43 +522,37 @@ class TestMLXTextModelMocked:
         from models.mlx_text_model import MLXTextModel
 
         config = MLXTextModel.get_default_config("bad/path")
-        with (
-            patch(
-                "models.mlx_text_model.mlx_load",
-                side_effect=OSError("cannot load"),
-            ),
-            pytest.raises(RuntimeError, match="Could not load MLX model"),
+        with patch(
+            "models.mlx_text_model.mlx_load",
+            side_effect=OSError("cannot load"),
         ):
             model = MLXTextModel(config)
-            model.initialize()
+            with pytest.raises(RuntimeError, match="Could not load MLX model"):
+                model.initialize()
 
     def test_initialize_raises_if_load_returns_non_tuple(self) -> None:
         from models.mlx_text_model import MLXTextModel
 
         config = MLXTextModel.get_default_config("some/model")
-        with (
-            patch(
-                "models.mlx_text_model.mlx_load",
-                return_value="not_a_tuple",
-            ),
-            pytest.raises(RuntimeError, match="unexpected value"),
+        with patch(
+            "models.mlx_text_model.mlx_load",
+            return_value="not_a_tuple",
         ):
             model = MLXTextModel(config)
-            model.initialize()
+            with pytest.raises(RuntimeError, match="unexpected value"):
+                model.initialize()
 
     def test_initialize_raises_if_load_returns_single_element_tuple(self) -> None:
         from models.mlx_text_model import MLXTextModel
 
         config = MLXTextModel.get_default_config("some/model")
-        with (
-            patch(
-                "models.mlx_text_model.mlx_load",
-                return_value=(MagicMock(),),
-            ),
-            pytest.raises(RuntimeError, match="unexpected value"),
+        with patch(
+            "models.mlx_text_model.mlx_load",
+            return_value=(MagicMock(),),
         ):
             model = MLXTextModel(config)
-            model.initialize()
+            with pytest.raises(RuntimeError, match="unexpected value"):
+                model.initialize()
 
     def test_generate_returns_stripped_text(self) -> None:
         model = _make_mlx_model_mocked()

--- a/tests/integration/test_models_vision_text_config_registry.py
+++ b/tests/integration/test_models_vision_text_config_registry.py
@@ -253,8 +253,8 @@ class TestTextModelStreaming:
             yield "x"
 
         gi = _GuardedIterator(gen(), lambda: fired.append(True))
+        next(gi)
         with pytest.raises(StopIteration):
-            next(gi)
             next(gi)
         assert fired == [True]
 

--- a/tests/integration/test_pipeline_orchestrator_and_services.py
+++ b/tests/integration/test_pipeline_orchestrator_and_services.py
@@ -289,7 +289,7 @@ class TestPipelineOrchestratorStagedProcessing:
         f = tmp_path / "file.txt"
         f.write_text("hello")
         result = orch.process_file(f)
-        assert stage.process.called
+        stage.process.assert_called()
         assert result.success is True
 
     def test_stage_returning_none_marks_failure(self, tmp_path: Path) -> None:

--- a/tests/integration/test_preference_database_branches.py
+++ b/tests/integration/test_preference_database_branches.py
@@ -253,7 +253,7 @@ class TestPreferenceDatabaseTransaction:
         """Exception inside transaction() triggers rollback (lines 239-243)."""
         db = _make_db(tmp_path)
 
-        with pytest.raises(ValueError, match="tx_fail"):
+        with pytest.raises(ValueError, match="tx_fail"):  # noqa: PT012 — db.transaction rollback requires multi-stmt body
             with db.transaction() as conn:
                 conn.execute(
                     "INSERT INTO preferences "

--- a/tests/integration/test_services_auto_tagging_copilot_feedback.py
+++ b/tests/integration/test_services_auto_tagging_copilot_feedback.py
@@ -1191,6 +1191,33 @@ class TestSuggestionFeedback:
         assert "stats" in data
         assert "exported_at" in data
 
+    def test_export_feedback_logs_and_reraises_on_oserror(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When the output write fails (e.g. permission denied), the error is logged and reraised.
+
+        Covers the try/except wrap added in the PR-#219 review cycle so the
+        caller sees the failure with context rather than a bare propagation.
+        """
+        from unittest.mock import patch
+
+        from services.suggestion_feedback import SuggestionFeedback
+
+        fb = SuggestionFeedback(feedback_file=tmp_path / "feedback.json")
+        fb.record_action(self._make_suggestion(), "accepted")
+        out = tmp_path / "denied.json"
+
+        with (
+            caplog.at_level("ERROR"),
+            patch(
+                "services.suggestion_feedback.open",
+                side_effect=OSError("permission denied"),
+            ),
+            pytest.raises(OSError, match="permission denied"),
+        ):
+            fb.export_feedback(out)
+        assert any("Failed to export feedback" in r.message for r in caplog.records)
+
     def test_feedback_entry_serialization(self) -> None:
         from models.suggestion_types import SuggestionType
         from services.suggestion_feedback import FeedbackEntry

--- a/tests/integration/test_services_auto_tagging_copilot_feedback.py
+++ b/tests/integration/test_services_auto_tagging_copilot_feedback.py
@@ -1200,8 +1200,6 @@ class TestSuggestionFeedback:
         Covers the try/except wrap added in the PR-#219 review cycle so the
         caller sees the failure with context rather than a bare propagation.
         """
-        from unittest.mock import patch
-
         from services.suggestion_feedback import SuggestionFeedback
 
         fb = SuggestionFeedback(feedback_file=tmp_path / "feedback.json")

--- a/tests/integration/test_services_auto_tagging_copilot_feedback.py
+++ b/tests/integration/test_services_auto_tagging_copilot_feedback.py
@@ -1191,6 +1191,7 @@ class TestSuggestionFeedback:
         assert "stats" in data
         assert "exported_at" in data
 
+    @pytest.mark.ci
     def test_export_feedback_logs_and_reraises_on_oserror(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:

--- a/tests/methodologies/para/test_migration_recovery.py
+++ b/tests/methodologies/para/test_migration_recovery.py
@@ -78,9 +78,7 @@ class TestMigrationBackupSystem:
         )
 
     @pytest.fixture
-    def migration_manager(
-        self, config: PARAConfig, tmp_path: Path
-    ) -> PARAMigrationManager:
+    def migration_manager(self, config: PARAConfig, tmp_path: Path) -> PARAMigrationManager:
         """Create migration manager instance with isolated backup root."""
         manager = PARAMigrationManager(config)
         # Override backup_root to use tmp_path so parallel tests don't collide
@@ -437,9 +435,7 @@ class TestMigrationManagerEdgeCases:
         )
 
     @pytest.fixture
-    def migration_manager(
-        self, config: PARAConfig, tmp_path: Path
-    ) -> PARAMigrationManager:
+    def migration_manager(self, config: PARAConfig, tmp_path: Path) -> PARAMigrationManager:
         """Create migration manager instance with isolated backup root."""
         manager = PARAMigrationManager(config)
         manager.backup_root = tmp_path / "migration-backups"

--- a/tests/methodologies/para/test_migration_recovery.py
+++ b/tests/methodologies/para/test_migration_recovery.py
@@ -11,7 +11,6 @@ import os
 import shutil
 import tempfile
 import time
-from collections.abc import Generator
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -81,13 +80,13 @@ class TestMigrationBackupSystem:
     @pytest.fixture
     def migration_manager(
         self, config: PARAConfig, tmp_path: Path
-    ) -> Generator[PARAMigrationManager, None, None]:
+    ) -> PARAMigrationManager:
         """Create migration manager instance with isolated backup root."""
         manager = PARAMigrationManager(config)
         # Override backup_root to use tmp_path so parallel tests don't collide
         manager.backup_root = tmp_path / "migration-backups"
         manager.backup_root.mkdir(parents=True, exist_ok=True)
-        yield manager
+        return manager
 
     def test_backup_creation(self, migration_manager, temp_source, temp_target):
         """Test backup creation for migration files."""
@@ -440,12 +439,12 @@ class TestMigrationManagerEdgeCases:
     @pytest.fixture
     def migration_manager(
         self, config: PARAConfig, tmp_path: Path
-    ) -> Generator[PARAMigrationManager, None, None]:
+    ) -> PARAMigrationManager:
         """Create migration manager instance with isolated backup root."""
         manager = PARAMigrationManager(config)
         manager.backup_root = tmp_path / "migration-backups"
         manager.backup_root.mkdir(parents=True, exist_ok=True)
-        yield manager
+        return manager
 
     def test_migration_manager_with_custom_heuristic_engine(self, config, tmp_path):
         """Test migration manager with custom heuristic engine."""

--- a/tests/services/deduplication/test_dedup_embedder.py
+++ b/tests/services/deduplication/test_dedup_embedder.py
@@ -99,7 +99,7 @@ class TestDocumentEmbedderInit:
                 "sklearn.feature_extraction.text": None,
             },
         ):
-            with pytest.raises(ImportError, match="scikit-learn"):
+            with pytest.raises(ImportError, match="scikit-learn"):  # noqa: PT012 — importlib.reload + instantiation must run inside the patched sys.modules
                 # Force reimport
                 import importlib
 

--- a/tests/services/intelligence/test_preference_database_coverage.py
+++ b/tests/services/intelligence/test_preference_database_coverage.py
@@ -77,7 +77,7 @@ class TestTransaction:
         assert pref is not None
 
     def test_transaction_rollback_on_error(self, db):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT012 — db.transaction rollback requires multi-stmt body
             with db.transaction() as conn:
                 conn.execute(
                     "INSERT INTO preferences "

--- a/uv.lock
+++ b/uv.lock
@@ -1174,7 +1174,6 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "striprtf" },
     { name = "tinytag" },
-    { name = "tqdm" },
     { name = "typer" },
     { name = "watchdog" },
 ]
@@ -1307,7 +1306,7 @@ requires-dist = [
     { name = "codespell", marker = "extra == 'dev'", specifier = "~=2.2" },
     { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.16.0" },
     { name = "diff-cover", marker = "extra == 'dev'", specifier = "~=7.0" },
-    { name = "ebooklib", specifier = ">=0.18" },
+    { name = "ebooklib", specifier = ">=0.18,<1" },
     { name = "ezdxf", marker = "extra == 'cad'", specifier = "~=1.1" },
     { name = "faker", marker = "extra == 'dev'", specifier = "~=40.12" },
     { name = "faster-whisper", marker = "extra == 'media'", specifier = "~=1.0" },
@@ -1315,20 +1314,20 @@ requires-dist = [
     { name = "fo-core", extras = ["dev", "cloud", "llama", "mlx", "claude", "media", "dedup-text", "dedup-image", "scientific", "cad", "build", "search"], marker = "extra == 'all'" },
     { name = "h5py", marker = "extra == 'scientific'", specifier = "~=3.10" },
     { name = "httpx", specifier = "~=0.27" },
-    { name = "imagededup", marker = "extra == 'dedup-image'", specifier = ">=0.3.0" },
+    { name = "imagededup", marker = "extra == 'dedup-image'", specifier = ">=0.3.0,<1" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "~=1.5" },
     { name = "isort", marker = "extra == 'dev'", specifier = "~=8.0" },
     { name = "llama-cpp-python", marker = "extra == 'llama'", specifier = ">=0.2.0" },
-    { name = "loguru", specifier = ">=0.7.0" },
+    { name = "loguru", specifier = ">=0.7.0,<1" },
     { name = "lxml", specifier = "~=6.1" },
     { name = "mako", specifier = ">=1.3.11" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = "~=1.5" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = "~=9.5" },
     { name = "mkdocs-minify-plugin", marker = "extra == 'docs'", specifier = ">=0.8.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.24.0" },
-    { name = "mlx-lm", marker = "sys_platform == 'darwin' and extra == 'mlx'", specifier = ">=0.0.19" },
+    { name = "mlx-lm", marker = "sys_platform == 'darwin' and extra == 'mlx'", specifier = ">=0.0.19,<1" },
     { name = "mutagen", specifier = "~=1.47" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = "~=1.8" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "~=1.8,!=1.20.2" },
     { name = "netcdf4", marker = "extra == 'scientific'", specifier = "~=1.6" },
     { name = "numpy", marker = "extra == 'dedup-text'", specifier = ">=1.24,<3" },
     { name = "numpy", marker = "extra == 'search'", specifier = ">=1.24,<3" },
@@ -1339,11 +1338,11 @@ requires-dist = [
     { name = "pillow", specifier = "~=12.2" },
     { name = "platformdirs", specifier = "~=4.9" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "~=3.6" },
-    { name = "psutil", specifier = "~=5.9" },
-    { name = "py7zr", specifier = ">=0.20.0" },
+    { name = "psutil", specifier = ">=6.1,<7" },
+    { name = "py7zr", specifier = ">=0.20.0,<1" },
     { name = "pydantic", specifier = "~=2.5" },
     { name = "pydantic-settings", specifier = "~=2.1" },
-    { name = "pydub", marker = "extra == 'media'", specifier = ">=0.25.0" },
+    { name = "pydub", marker = "extra == 'media'", specifier = ">=0.25.0,<1" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyinstaller", marker = "extra == 'build'", specifier = "~=6.0" },
     { name = "pymarkdownlnt", marker = "extra == 'dev'", specifier = ">=0.9.25" },
@@ -1360,23 +1359,22 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "~=3.5" },
     { name = "python-docx", specifier = "~=1.0" },
     { name = "python-dotenv", specifier = "~=1.0" },
-    { name = "python-pptx", specifier = ">=0.6.0" },
+    { name = "python-pptx", specifier = ">=0.6.0,<1" },
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "rank-bm25", marker = "extra == 'search'", specifier = ">=0.2.0" },
     { name = "rarfile", specifier = "~=4.1" },
     { name = "rich", specifier = "~=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
-    { name = "scenedetect", extras = ["opencv"], marker = "extra == 'media'", specifier = ">=0.6.0" },
+    { name = "scenedetect", extras = ["opencv"], marker = "extra == 'media'", specifier = ">=0.6.0,<1" },
     { name = "scikit-learn", marker = "extra == 'dedup-text'", specifier = ">=1.4,<1.9" },
     { name = "scikit-learn", marker = "extra == 'search'", specifier = ">=1.4,<1.9" },
     { name = "scipy", marker = "extra == 'scientific'", specifier = "~=1.11" },
     { name = "snowballstemmer", specifier = ">=2.2.0" },
     { name = "sqlalchemy", specifier = "~=2.0" },
-    { name = "striprtf", specifier = ">=0.0.26" },
+    { name = "striprtf", specifier = ">=0.0.26,<1" },
     { name = "tinytag", specifier = "~=2.2" },
     { name = "torch", marker = "extra == 'dedup-image'", specifier = "~=2.1" },
     { name = "torch", marker = "extra == 'media'", specifier = "~=2.1" },
-    { name = "tqdm", specifier = "~=4.66" },
     { name = "typer", extras = ["all"], specifier = "~=0.12" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = "~=6.0" },
     { name = "watchdog", specifier = "~=3.0" },
@@ -3175,16 +3173,17 @@ wheels = [
 
 [[package]]
 name = "psutil"
-version = "5.9.8"
+version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/c7/6dc0a455d111f68ee43f27793971cf03fe29b6ef972042549db29eec39a2/psutil-5.9.8.tar.gz", hash = "sha256:6be126e3225486dff286a8fb9a06246a5253f4c7c53b475ea5f5ac934e64194c", size = 503247, upload-time = "2024-01-19T20:47:09.517Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/5a/07871137bb752428aa4b659f910b399ba6f291156bdea939be3e96cae7cb/psutil-6.1.1.tar.gz", hash = "sha256:cf8496728c18f2d0b45198f06895be52f36611711746b7f30c464b422b50e2f5", size = 508502, upload-time = "2024-12-19T18:21:20.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/e3/07ae864a636d70a8a6f58da27cb1179192f1140d5d1da10886ade9405797/psutil-5.9.8-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:aee678c8720623dc456fa20659af736241f575d79429a0e5e9cf88ae0605cc81", size = 248702, upload-time = "2024-01-19T20:47:36.303Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/bd/28c5f553667116b2598b9cc55908ec435cb7f77a34f2bff3e3ca765b0f78/psutil-5.9.8-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8cb6403ce6d8e047495a701dc7c5bd788add903f8986d523e3e20b98b733e421", size = 285242, upload-time = "2024-01-19T20:47:39.65Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/4f/0e22aaa246f96d6ac87fe5ebb9c5a693fbe8877f537a1022527c47ca43c5/psutil-5.9.8-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d06016f7f8625a1825ba3732081d77c94589dca78b7a3fc072194851e88461a4", size = 288191, upload-time = "2024-01-19T20:47:43.078Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f5/2aa3a4acdc1e5940b59d421742356f133185667dd190b166dbcfcf5d7b43/psutil-5.9.8-cp37-abi3-win32.whl", hash = "sha256:bc56c2a1b0d15aa3eaa5a60c9f3f8e3e565303b465dbf57a1b730e7a2b9844e0", size = 251252, upload-time = "2024-01-19T20:47:52.88Z" },
-    { url = "https://files.pythonhosted.org/packages/93/52/3e39d26feae7df0aa0fd510b14012c3678b36ed068f7d78b8d8784d61f0e/psutil-5.9.8-cp37-abi3-win_amd64.whl", hash = "sha256:8db4c1b57507eef143a15a6884ca10f7c73876cdf5d51e713151c1236a0e68cf", size = 255090, upload-time = "2024-01-19T20:47:56.019Z" },
-    { url = "https://files.pythonhosted.org/packages/05/33/2d74d588408caedd065c2497bdb5ef83ce6082db01289a1e1147f6639802/psutil-5.9.8-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:d16bbddf0693323b8c6123dd804100241da461e41d6e332fb0ba6058f630f8c8", size = 249898, upload-time = "2024-01-19T20:47:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/61/99/ca79d302be46f7bdd8321089762dd4476ee725fce16fc2b2e1dbba8cac17/psutil-6.1.1-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc0ed7fe2231a444fc219b9c42d0376e0a9a1a72f16c5cfa0f68d19f1a0663e8", size = 247511, upload-time = "2024-12-19T18:21:45.163Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/6b/73dbde0dd38f3782905d4587049b9be64d76671042fdcaf60e2430c6796d/psutil-6.1.1-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:0bdd4eab935276290ad3cb718e9809412895ca6b5b334f5a9111ee6d9aff9377", size = 248985, upload-time = "2024-12-19T18:21:49.254Z" },
+    { url = "https://files.pythonhosted.org/packages/17/38/c319d31a1d3f88c5b79c68b3116c129e5133f1822157dd6da34043e32ed6/psutil-6.1.1-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b6e06c20c05fe95a3d7302d74e7097756d4ba1247975ad6905441ae1b5b66003", size = 284488, upload-time = "2024-12-19T18:21:51.638Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/39/0f88a830a1c8a3aba27fededc642da37613c57cbff143412e3536f89784f/psutil-6.1.1-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97f7cb9921fbec4904f522d972f0c0e1f4fabbdd4e0287813b21215074a0f160", size = 287477, upload-time = "2024-12-19T18:21:55.306Z" },
+    { url = "https://files.pythonhosted.org/packages/47/da/99f4345d4ddf2845cb5b5bd0d93d554e84542d116934fde07a0c50bd4e9f/psutil-6.1.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33431e84fee02bc84ea36d9e2c4a6d395d479c9dd9bba2376c1f6ee8f3a4e0b3", size = 289017, upload-time = "2024-12-19T18:21:57.875Z" },
+    { url = "https://files.pythonhosted.org/packages/38/53/bd755c2896f4461fd4f36fa6a6dcb66a88a9e4b9fd4e5b66a77cf9d4a584/psutil-6.1.1-cp37-abi3-win32.whl", hash = "sha256:eaa912e0b11848c4d9279a93d7e2783df352b082f40111e078388701fd479e53", size = 250602, upload-time = "2024-12-19T18:22:08.808Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d7/7831438e6c3ebbfa6e01a927127a6cb42ad3ab844247f3c5b96bea25d73d/psutil-6.1.1-cp37-abi3-win_amd64.whl", hash = "sha256:f35cfccb065fff93529d2afb4a2e89e363fe63ca1e4a5da22b603a85833c2649", size = 254444, upload-time = "2024-12-19T18:22:11.335Z" },
 ]
 
 [[package]]
@@ -3219,10 +3218,9 @@ wheels = [
 
 [[package]]
 name = "py7zr"
-version = "1.1.0"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-zstd", marker = "python_full_version < '3.14'" },
     { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
     { name = "brotlicffi", marker = "platform_python_implementation == 'PyPy'" },
     { name = "inflate64" },
@@ -3231,11 +3229,12 @@ dependencies = [
     { name = "pybcj" },
     { name = "pycryptodomex" },
     { name = "pyppmd" },
+    { name = "pyzstd" },
     { name = "texttable" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/e6/01fb15361ca75ee5d01df6361825a49816a836c99980c5481da0e40c6877/py7zr-1.1.0.tar.gz", hash = "sha256:087b1a94861ad9eb4d21604f6aaa0a8986a7e00580abd79fedd6f82fecf0592c", size = 70855, upload-time = "2025-12-21T03:27:44.653Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/c3/0e05c711c16af0b9c47f3f77323303b338b9a871ba020d95d2b8dd6605ae/py7zr-0.22.0.tar.gz", hash = "sha256:c6c7aea5913535184003b73938490f9a4d8418598e533f9ca991d3b8e45a139e", size = 4992926, upload-time = "2024-08-08T13:10:01.514Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/9c/762284710ead9076eeecd55fb60509c19cd1f4bea811df5f3603725b44cb/py7zr-1.1.0-py3-none-any.whl", hash = "sha256:5921bc30fb72b5453aafe3b2183664c08ef508cde2655988d5e9bd6078353ef7", size = 71257, upload-time = "2025-12-21T03:27:42.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/59/dd1750002c0f46099281116f8165247bc62dc85edad41cdd26e7b26de19d/py7zr-0.22.0-py3-none-any.whl", hash = "sha256:993b951b313500697d71113da2681386589b7b74f12e48ba13cc12beca79d078", size = 67906, upload-time = "2024-08-08T13:09:58.092Z" },
 ]
 
 [[package]]
@@ -3687,60 +3686,32 @@ wheels = [
 
 [[package]]
 name = "pyppmd"
-version = "1.3.1"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/d7/803232913cab9163a1a97ecf2236cd7135903c46ac8d49613448d88e8759/pyppmd-1.3.1.tar.gz", hash = "sha256:ced527f08ade4408c1bfc5264e9f97ffac8d221c9d13eca4f35ec1ec0c7b6b2e", size = 1351815, upload-time = "2025-11-27T22:08:44.175Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/8e/06581a619ad31cd28fd897bd55aff2ea945d3d566969b8b3f682599e6dee/pyppmd-1.1.1.tar.gz", hash = "sha256:f1a812f1e7628f4c26d05de340b91b72165d7b62778c27d322b82ce2e8ff00cb", size = 1349281, upload-time = "2024-12-23T04:12:09.391Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/40/580b99818c9db3a09cbae8e3740f9b5127ef7fd7314daf009c487ab02eb6/pyppmd-1.3.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:fdf55aa6ee7aef492f6896464e7a5a528f8615bb9e435f55bc8dff226fcc8292", size = 77550, upload-time = "2025-11-27T22:07:37.839Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/a3/f7b4c49ef920f5b2c9812f8f54f48e01435433cb6b46ec82b1b4e740714d/pyppmd-1.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:aa820aac385ac4ee57160b26d92862c69d31c08f92272dbef05fe8e619cea8d1", size = 48000, upload-time = "2025-11-27T22:07:38.983Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/c3/30de6f7892e77b83350e55d54a6913420591cc2c5c4d2394c219a4c461ac/pyppmd-1.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e16593ba4ca0a85821ae698ef06847a52937662f5ce1b130c39cca2979a4e8cd", size = 48439, upload-time = "2025-11-27T22:07:40.428Z" },
-    { url = "https://files.pythonhosted.org/packages/39/22/33889cbe22a617c42df2199be54e9e1bf88393fd8643fe911eb9f982849c/pyppmd-1.3.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:486dde2294ff9b30465ab5bb0f213b20bd5ac0e4adf21be801a1ceb29aa75d9d", size = 141737, upload-time = "2025-11-27T22:07:41.641Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/f7/940ab2fd78caaef3a9e9833adb36e17b9d03016d8b45ae110cbb4bfc83d1/pyppmd-1.3.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89730cf026416ae2546c92738966ecf117c8176d52c229ad621a61c34643818b", size = 143643, upload-time = "2025-11-27T22:07:42.892Z" },
-    { url = "https://files.pythonhosted.org/packages/75/51/129ce02d2b28a4f6788bccfe6d0ae1defc45db10eb1c4e4389cde8994ec7/pyppmd-1.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e77f5a6770950d464b50da760d53e67bce308a3abc8e3bd51db620b3f8cf1fa8", size = 138625, upload-time = "2025-11-27T22:07:44.54Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/89/f8390d1a21951d3d4619c854a839f7b1431746997cd98b475f614a658305/pyppmd-1.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8e3bf8deef44f8e03612689a6067a4a3dd7e50d2ef00af4cf987c59b62ff3006", size = 141663, upload-time = "2025-11-27T22:07:45.814Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/3f/b58dd8875ebbb78436f87567547967bebdf3a5586f5f243c735fc4460843/pyppmd-1.3.1-cp311-cp311-win32.whl", hash = "sha256:a3509b3f881409ebc5522942438108c48a78f8df88bcf3f9d907b74131b9431c", size = 42014, upload-time = "2025-11-27T22:07:47.058Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/d3/5fe05bdccdd7af04461c25a3dc34799f48ad3e9a2bd591aaec9afbc1d10a/pyppmd-1.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:23b83799f33f9a24577f22e092b0feecda8cd1ea33871ad8610a58629874f7bc", size = 46862, upload-time = "2025-11-27T22:07:48.162Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/ba/6414cbe8407c23bacce906dad0599f155b2baf6082da104e64d7f1573717/pyppmd-1.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:234489036a1758670655d1ceafd4caeb93b858bd4c0ca39686837d38aef044c0", size = 45249, upload-time = "2025-11-27T22:07:49.261Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/89/696046e53c7aea98bb563aed3f15c3e2fa20c33e3d6c9de3c20992c586cc/pyppmd-1.3.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3faa58ab2ebe3b13ec23b1904639d687fb727270d2962fd2d239ca00fd6eb865", size = 77796, upload-time = "2025-11-27T22:07:50.362Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/c5/a708cdb58e76889bc65201eda12211486548ffe00ecddc5dfbdce6d4d252/pyppmd-1.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:27703f041ee96912a5410fd3ce31c5cde32f9323bd67f72f100bd960ee67bf13", size = 48185, upload-time = "2025-11-27T22:07:51.736Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/5d/f299535c18009addb866d89a7044f1086e4eecf50542e57ff5bb15840195/pyppmd-1.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e773d8353b36f7e7973a43526993fb276b98a97839cb5dc8f4e6465ad873f41a", size = 48496, upload-time = "2025-11-27T22:07:52.866Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/9d/4a59b73ea8e305f9192ee26ceb7c3d57e17ccb9bcca0e99ef335db29fcf7/pyppmd-1.3.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37b1883accf840cb0b711785d353f8548853a1401d381da007c0aec362f3ffac", size = 142620, upload-time = "2025-11-27T22:07:54.411Z" },
-    { url = "https://files.pythonhosted.org/packages/88/d7/fe32c2a4f8539365e6292aed25545830a5e718a510cdb4caddd6fd8d8056/pyppmd-1.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1bd6d179ad39b6191ca0cbe62fb9592f33f49277b4384ad7bc5eb0e6ca27ebee", size = 144306, upload-time = "2025-11-27T22:07:55.727Z" },
-    { url = "https://files.pythonhosted.org/packages/20/20/e3907cf263b58f4ed4c5315bc1ac91721c85332fd0d73a89e3e2752904ef/pyppmd-1.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:806cf8d33606e44bf5ff5786c57891f57993f1eef1c763da3c58ea97de3a13c8", size = 139522, upload-time = "2025-11-27T22:07:57.034Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/03/22d5f93251e481f23bf741dde7f59cfc3e315f60b32b63f215a2d7bb8944/pyppmd-1.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1826cbce9a2c944aa08df79310a7e6d4a61fd20636b6dff64a77ea4bc43da30f", size = 142340, upload-time = "2025-11-27T22:07:58.49Z" },
-    { url = "https://files.pythonhosted.org/packages/34/88/38d36c1394d5e331db9708dae08863c87c059bd5b6e43b20234be02a0503/pyppmd-1.3.1-cp312-cp312-win32.whl", hash = "sha256:d3ff96671319318d941dd34300d641745048e8a3251b077bddf98652d6ddc513", size = 42102, upload-time = "2025-11-27T22:08:00.124Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/29/1398c6f67dfb66367babeed2980caee837d0a488705e3dff7ff159e017e7/pyppmd-1.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:c8c1ad39e7ebde71bf5a54cf61f489bf4790f1dd0beb70dc2e8f5ad3329d7ca7", size = 46957, upload-time = "2025-11-27T22:08:01.587Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/41/ee3193c16472a5a1c5f1965abb8fa87a7ad455c39688e9a0c2d87d6a7027/pyppmd-1.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:391b2bf76d7dc45b343781754d0b734dcbf539b92667986a343f5488c4bf9ca0", size = 45214, upload-time = "2025-11-27T22:08:02.721Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/01/7cc3854b0e1304b90d2435e946db5e1c42e103adf840a68400002fc838b4/pyppmd-1.3.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4b4edb3e9619fd0bc39c1a07eb03e8731db833a93b23134f36c7ef581a94b37a", size = 77800, upload-time = "2025-11-27T22:08:03.856Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/02/caf6305224b9432ea7373670d101392f620c1ce741d6f95458b1fb9a16a4/pyppmd-1.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b8b5c813e462c91048b88e2adfbcc0c69f2c905f70097001d32066f86f675bd4", size = 48195, upload-time = "2025-11-27T22:08:05.323Z" },
-    { url = "https://files.pythonhosted.org/packages/45/82/8c5d3f0f738a3cf5c209d1471efda105a16417c0aaa91a2ad39efb3d4efb/pyppmd-1.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e8d372d9fac382183e0371cf0c2d736b494b1857a1befe98d563342b1205265b", size = 48482, upload-time = "2025-11-27T22:08:06.441Z" },
-    { url = "https://files.pythonhosted.org/packages/76/9c/09ab8b4f00473f210284dacf837cae8355ad900f3fd8fd98b2bba12de4fa/pyppmd-1.3.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b765ae21f7ed2f4ea8f32bfd9e3a4a8d738e73fc8f8dcddec9cbe2c898d60be", size = 142828, upload-time = "2025-11-27T22:08:07.611Z" },
-    { url = "https://files.pythonhosted.org/packages/64/fd/673d429df719affa1445611288aab6111c0bc87e51eb4677fe2421a1dd64/pyppmd-1.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd00522ddfcc292304577386b6c217758c0c10e1fb9ce7877ad7d3b7b821a808", size = 144502, upload-time = "2025-11-27T22:08:08.869Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/0f/64dad213f56eaf23210ac7d3a5dedb19ad8f186f8b8682f65e7d51d9fa4a/pyppmd-1.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3de62099ff2ca876c2d39bc547bcba6f7b878988663abd782a5bad4edac3bb44", size = 139718, upload-time = "2025-11-27T22:08:10.114Z" },
-    { url = "https://files.pythonhosted.org/packages/74/61/bd5dbe8d7374748687d48f0bc44e6b930470e09552b1bbc65ef899ab673e/pyppmd-1.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:011f845de195d60fe973a635a1f4be981b7d80f357a8acb1b2d83bdf5087c808", size = 142578, upload-time = "2025-11-27T22:08:11.388Z" },
-    { url = "https://files.pythonhosted.org/packages/42/ae/0af00a9b1cd59b6821eb182413033d5ddbe05dfcde7511e3a6b1a5b83f6d/pyppmd-1.3.1-cp313-cp313-win32.whl", hash = "sha256:7d61bd01f25289b6ae54832db4254602fb0c6d105f6e6bf0aee39b803b698b98", size = 42102, upload-time = "2025-11-27T22:08:13.297Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/6d/311d8faca142f39b4d158c94ed7eb237a197d41dd7eb67f53442a7904e04/pyppmd-1.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:df8d84ab72381058a964ba66e5e81ed52dbd0b5ad734a5ef8353452983506098", size = 46962, upload-time = "2025-11-27T22:08:14.759Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/42/24b59b6bb73a3fec96c7f81521d146c2ac89ffcb89cf9e848f62e0660381/pyppmd-1.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:124a04aab6936ba011f9ad57067798c7f052fdb1848b0cc4318606eea55475e6", size = 45209, upload-time = "2025-11-27T22:08:15.933Z" },
-    { url = "https://files.pythonhosted.org/packages/65/10/ac2a011af1c7c40b6482e60d85d267ac5923fb8794b51bfddbb56b04d1ec/pyppmd-1.3.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ea53f71ac16e113599b8441a9d8b6dcd71cfdf15cdb33ba5151810b8e656c5ec", size = 77897, upload-time = "2025-11-27T22:08:17.104Z" },
-    { url = "https://files.pythonhosted.org/packages/20/13/737f4dac06685865d23f51b7061dbe9373c7bcc60b5b6456cd08301bc807/pyppmd-1.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:985c8703b53e5f68fe17f653e96748d60b1f855676c852a6e67cd472eb853671", size = 48268, upload-time = "2025-11-27T22:08:18.263Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/d3/c50ebaee8b8a064fe9a534e98df5051e309efb705728aadff4e6893cd87f/pyppmd-1.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:33daa996ad5203c665c0b55aff6329817b2cb7fa95f2c33a2e83ed0121b400cb", size = 48521, upload-time = "2025-11-27T22:08:19.742Z" },
-    { url = "https://files.pythonhosted.org/packages/80/6c/4a97c0a0ab7640aeddde4843cb6381b80ecb71fe2c6c48b9032d60586b11/pyppmd-1.3.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b49870c6d7194f6eb80f30335ca03596d153e02fcde2c222e4f1202ac25f7fcf", size = 142892, upload-time = "2025-11-27T22:08:20.972Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/22/744c32c7da3de171d9e62a1b2cb4104544ac778358565a3dbc06a2253324/pyppmd-1.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:385e92c97c42e8a6f0bfc0e4acfc6c074cb1ba3a2f650f292696dd9f19e2e603", size = 144550, upload-time = "2025-11-27T22:08:22.594Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/18/84af6808e0754923062122d3ee9f0532050f1612069d558bb5d53978e67a/pyppmd-1.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:017a1e2903f1c3147a1046db486990d401e8a25eb52c320b1fc2fb3e7b83cbeb", size = 139850, upload-time = "2025-11-27T22:08:23.863Z" },
-    { url = "https://files.pythonhosted.org/packages/20/5e/dc6166ea7929d442625301289d99313a5b358e3cb2e927a6bd913047e8ee/pyppmd-1.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f2770a4b777c0c5236b3d9294b7bf4bc15538c95d45b2079eb8ebc1298e62e37", size = 142589, upload-time = "2025-11-27T22:08:25.228Z" },
-    { url = "https://files.pythonhosted.org/packages/77/92/adc6b12ddf11173a02fd631010f88ad4fe4c532363959638d5d53583a3d9/pyppmd-1.3.1-cp314-cp314-win32.whl", hash = "sha256:b9d54cd59ce97f2ba57be1da91b3d874d129faca21c9565d7afec111f942e6a1", size = 42761, upload-time = "2025-11-27T22:08:26.917Z" },
-    { url = "https://files.pythonhosted.org/packages/12/4c/5003a413d9f2743298a070df6713a75dedccc470e7adeeced5b43cad7418/pyppmd-1.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0e64247618cb150d2909beb0137da3084fef1d3479b4cc73b5b47fda7611abf9", size = 47806, upload-time = "2025-11-27T22:08:28.059Z" },
-    { url = "https://files.pythonhosted.org/packages/07/b7/db927e1df7fc3132cb57960f4ea23bf174c7e86ccec22857e6a35cccdae7/pyppmd-1.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:d354d6e551d2630b0ac98f27e3ad63e86cdcac9ce2115b5dfe46e2c9d3f4e82c", size = 46122, upload-time = "2025-11-27T22:08:29.191Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/5f/3150227624f374b06e331a7f67ae3383e796dd90973ee17ec3e35d30524c/pyppmd-1.3.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:2d77ed79662c32e2551748d59763cfe3dcd10855bf3495937e3d5e5917507818", size = 78876, upload-time = "2025-11-27T22:08:30.635Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/81/11a3bba62d1d92050f4dd86db810062b506ec76d20b6e00b4ab567ff15e4/pyppmd-1.3.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:6a1f92b94635c23d85270bb26db25cc0db544e436af86efc1cf58302d71d5af1", size = 48830, upload-time = "2025-11-27T22:08:32.087Z" },
-    { url = "https://files.pythonhosted.org/packages/24/47/e8f50cf89c689543d5a16c7be3df3c4afd43cbeb1a019b84ff9e82f13415/pyppmd-1.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:610f214f2405e27eb5a3dad7fa15f385cfc42141a01cda71995d9c1e0b09fab9", size = 48956, upload-time = "2025-11-27T22:08:33.567Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/0f/944b30679a8dea3ea95a66531ee30cb6feb5d011ec7fd6832069d9130bf3/pyppmd-1.3.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae81a14895498d9a23429d92114c98da478b74b8e33251527d7cff3e01c09de0", size = 152872, upload-time = "2025-11-27T22:08:35.098Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/87/1e48ea92994f4c72dc9b5520a6a386b21c524d3d2969c2c2a5c325929ad7/pyppmd-1.3.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d1683e6d1ba09e377e0ae02de3a518191a3d63ccdb0b6037c74e6ddf577b5644", size = 154210, upload-time = "2025-11-27T22:08:36.368Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/21/650911f98c4cb360442724bbdade27cb3679b0587ea77e73512693d2918d/pyppmd-1.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e4d74fa0f3531e9dadc56e0ace41bce82d3c0babed47b3f224101dc0dbde7287", size = 147636, upload-time = "2025-11-27T22:08:37.657Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/29/4f8cfc1dd67b04ced8c10669fa14c4e35a42cf4a84e1101793735a82d5f0/pyppmd-1.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f8d6375b18b9c79127fee0885cfd52e2e983edb67041464309426571d38dcd4", size = 150998, upload-time = "2025-11-27T22:08:38.951Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/da/dc9e5e10bc56056bd8c33e533517cb327752cbaf172688bba3c23f6b2318/pyppmd-1.3.1-cp314-cp314t-win32.whl", hash = "sha256:de87f7acd575fb07a4ff42d41bcc071570fe759a36f345f1f54f574ecfccfc5b", size = 43016, upload-time = "2025-11-27T22:08:40.234Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/a0/46dc15549ad2c0427a9825730e6bdf342045ad410543368afd4389a16f36/pyppmd-1.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:76e4800aa67292b4cc80058fd29b39e02a5dded721af9fe5654f356ef24307f4", size = 48636, upload-time = "2025-11-27T22:08:41.45Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/7b/7e9a83848de928c26f0ab3ee105c0da63a932a0804a94807205e6313e73a/pyppmd-1.3.1-cp314-cp314t-win_arm64.whl", hash = "sha256:e066cbf1d335fe20480cd8ecc10848ba78d99fe6d1e44ea00def48feaf46afdf", size = 46402, upload-time = "2025-11-27T22:08:42.804Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/e5/e4c891ade6fffa0cf9ead432f80a481d069c26a009e78b9f402fe25bad40/pyppmd-1.1.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:753c5297c91c059443caef33bccbffb10764221739d218046981638aeb9bc5f2", size = 76148, upload-time = "2024-12-23T04:10:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/7d/24d4b61c144e03c1bfaa272636e2b44678d7849b0fbe7c308d53f0926784/pyppmd-1.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9b5a73da09de480a94793c9064876af14a01be117de872737935ac447b7cde3c", size = 47102, upload-time = "2024-12-23T04:10:41.726Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/19/91fc02ef18ae67c8f4cd54a8b8722d3ce58746622adb80506bfc4a80df58/pyppmd-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:89c6febb7114dea02a061143d78d04751a945dfcadff77560e9a3d3c7583c24b", size = 47308, upload-time = "2024-12-23T04:10:43.168Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d8/7d4e7106e744c55af7ac7f21388170a6d3c23cbe7d7b9e1a65524f264e37/pyppmd-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0001e467c35e35e6076a8c32ed9074aa45833615ee16115de9282d5c0985a1d8", size = 138445, upload-time = "2024-12-23T04:10:46.303Z" },
+    { url = "https://files.pythonhosted.org/packages/91/1b/71e47e6dc117f088ab8e7fa3b7ff1dc8e1a6c96d0ffdb0010288c2c42ac6/pyppmd-1.1.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c76820db25596afc859336ba06c01c9be0ff326480beec9c699fd378a546a77f", size = 136543, upload-time = "2024-12-23T04:10:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/46/93/363f6299aa6ab4209e4f91bfa313748c535e348b88b9232957d6175ddda1/pyppmd-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b67f0a228f8c58750a21ba667c170ae957283e08fd580857f13cb686334e5b3e", size = 141274, upload-time = "2024-12-23T04:10:49.597Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/9a/9d52964af47c351f543c546cf0c21876e384c66029a1b3cb75aa71b4651c/pyppmd-1.1.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b18f24c14f0b0f1757a42c458ae7b6fd7aa0bce8147ac1016a9c134068c1ccc2", size = 141887, upload-time = "2024-12-23T04:10:53.218Z" },
+    { url = "https://files.pythonhosted.org/packages/90/22/09bb81e7a0c1512a6efb30c9ddb1b07e1ca7ff050e427fcce5e7aeedadfd/pyppmd-1.1.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c9e43729161cc3b6ad5b04b16bae7665d3c0cc803de047d8a979aa9232a4f94a", size = 136166, upload-time = "2024-12-23T04:10:54.864Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/bf/24162ac82a502a75ac1042617fa0c69350406c79332a1a033cd96cb28cf6/pyppmd-1.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fe057d254528b4eeebe2800baefde47d6af679bae184d3793c13a06f794df442", size = 145209, upload-time = "2024-12-23T04:10:56.599Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a5/1cfafa9eea4723bd6b11d0e34519c1947ab26aeb8c78de67dfdbf7e91de7/pyppmd-1.1.1-cp311-cp311-win32.whl", hash = "sha256:faa51240493a5c53c9b544c99722f70303eea702742bf90f3c3064144342da4a", size = 41805, upload-time = "2024-12-23T04:10:59.524Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/30/fd2fb7e431414b520dc3d1ced7158da04232203c0f18ed8768ecd6a1d939/pyppmd-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:62486f544d6957e1381147e3961eee647b7f4421795be4fb4f1e29d52aee6cb5", size = 46472, upload-time = "2024-12-23T04:11:01.123Z" },
+    { url = "https://files.pythonhosted.org/packages/46/a8/a1fdc1b53466e9a01b0d8a8689ae4024fffa6de20330fb0d6025d745cf0f/pyppmd-1.1.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:9877ef273e2c0efdec740855e28004a708ada9012e0db6673df4bb6eba3b05e0", size = 76238, upload-time = "2024-12-23T04:11:03.362Z" },
+    { url = "https://files.pythonhosted.org/packages/63/54/15a7feae1a258bc67fc2413f82a7f296da7efb076d922d939fe7ef87b537/pyppmd-1.1.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f816a5cbccceced80e15335389eeeaf1b56a605fb7eebe135b1c85bd161e288c", size = 47192, upload-time = "2024-12-23T04:11:04.649Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4f/b5d9086c3479639f1347bc04d6ed1b543a7f87212f68c38f30180cb28e35/pyppmd-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6bddabf8f2c6b991d15d6785e603d9d414ae4a791f131b1a729bb8a5d31133d1", size = 47309, upload-time = "2024-12-23T04:11:07.426Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/2dc8d61008ed5da459fbef13917582b78902867451cb3467d59ca86c945f/pyppmd-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:855bc2b0d19c3fead5815d72dbe350b4f765334336cbf8bcb504d46edc9e9dd2", size = 139378, upload-time = "2024-12-23T04:11:10.525Z" },
+    { url = "https://files.pythonhosted.org/packages/85/cf/9899ec2a5a9b10f42afecdd0635186f38731c100643d9b092f5b6d7f137c/pyppmd-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a95b11b3717c083b912f0879678ba72f301bbdb9b69efed46dbc5df682aa3ce7", size = 137565, upload-time = "2024-12-23T04:11:13.767Z" },
+    { url = "https://files.pythonhosted.org/packages/33/33/c67c41e681e171f9bbbf184eae8899e913845e8e6186cbdad62a3ddf231d/pyppmd-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38b645347b6ea217b0c58e8edac27473802868f152db520344ac8c7490981849", size = 142829, upload-time = "2024-12-23T04:11:15.378Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/c3/18e6f565cb1a3941640fd522a3f02f48e546c2996c7f0048608f35994a51/pyppmd-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f8f94b6222262def5b532f2b9716554ef249ad8411fd4da303596cc8c2e8eda1", size = 143080, upload-time = "2024-12-23T04:11:17.066Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ec/40625be3275bae8470136c98d2e63556537ba5cedb6c0a9fa8f90a541a46/pyppmd-1.1.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:1c0306f69ceddf385ef689ebd0218325b7e523c48333d87157b37393466cfa1e", size = 137254, upload-time = "2024-12-23T04:11:20.568Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f4/92366a1e893f0b04a4bbf1cbc8263d4b58f2ac2f53cee65b11d92d0253bf/pyppmd-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a4ba510457a56535522a660098399e3fa8722e4de55808d089c9d13435d87069", size = 146613, upload-time = "2024-12-23T04:11:22.278Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c2/50ffb30b7787aec4c0cb5a99eaab78d90b0c98e0006d34a22198f954084e/pyppmd-1.1.1-cp312-cp312-win32.whl", hash = "sha256:032f040a89fd8348109e8638f94311bd4c3c693fb4cad213ad06a37c203690b1", size = 41857, upload-time = "2024-12-23T04:11:23.671Z" },
+    { url = "https://files.pythonhosted.org/packages/77/94/03ff304086c5b0823bee966a5ae4915b5341dba8ed5e4c9f1b9532d9a9ff/pyppmd-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:2be8cbd13dd59fad1a0ad38062809e28596f3673b77a799dfe82b287986265ed", size = 46564, upload-time = "2024-12-23T04:11:26.379Z" },
 ]
 
 [[package]]
@@ -3896,17 +3867,16 @@ wheels = [
 
 [[package]]
 name = "python-pptx"
-version = "1.0.2"
+version = "0.6.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lxml" },
     { name = "pillow" },
-    { name = "typing-extensions" },
     { name = "xlsxwriter" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e7/aeaf794b2d440da609684494075e64cfada248026ecb265807d0668cdd00/python-pptx-0.6.23.tar.gz", hash = "sha256:587497ff28e779ab18dbb074f6d4052893c85dedc95ed75df319364f331fedee", size = 10083771, upload-time = "2023-11-02T21:35:31.525Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788, upload-time = "2024-08-07T17:33:28.192Z" },
+    { url = "https://files.pythonhosted.org/packages/72/49/6eee83072983473e9905ffddd5c2032b9a0ca4616425560d6d582287b467/python_pptx-0.6.23-py3-none-any.whl", hash = "sha256:dd0527194627a2b7cc05f3ba23ecaa2d9a0d5ac9b6193a28ed1b7a716f4217d4", size = 471575, upload-time = "2023-11-02T21:35:21.747Z" },
 ]
 
 [[package]]
@@ -4076,6 +4046,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "pyzstd"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-zstd", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/66/59fed71d0d2065e02974b40296f836a237c364c8bbe07295f2d0dc33c278/pyzstd-0.19.1.tar.gz", hash = "sha256:36723d3c915b3981de9198d0a2c82b2f5fe3eaa36e4d8d586937830a8afc7d72", size = 69531, upload-time = "2025-12-13T08:15:33.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/62/f55d1363512d1b1cc122af6ca5951008e42605b63675c7d6781affc7c475/pyzstd-0.19.1-py3-none-any.whl", hash = "sha256:267e2eb0de0291dfcb7ccfebc4ffe75b2f9d84e7007ac38844f6ccafc6dce081", size = 23779, upload-time = "2025-12-13T08:15:31.979Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Atomic landing of the **integration/pre-commit-ratchet** series — four mechanical guardrails distilled from the last quarter's PR-review-comment audit. Each catches a recurring finding that today only gets caught at code-review time, after CI has run and the diff has been pushed.

## Sub-PRs (all merged into integration)

| # | PR | Rule | Backlog | Mechanism |
|---|----|------|---------|-----------|
| A | [#213](https://github.com/curdriceaurora/fo-core/pull/213) | ruff `PT012` / `PT017` / `PT022` | 16 / 0 / 2 | `pyproject.toml` `extend-select` |
| B | [#214](https://github.com/curdriceaurora/fo-core/pull/214) | atomic-write-required (F3 / Epic B.atomic) | 29 (all marked) | `scripts/check_atomic_write.py` + `tests/ci/test_atomic_write_required.py` |
| C | [#217](https://github.com/curdriceaurora/fo-core/pull/217) | pytest.raises hygiene (T15 — no mock assertion after raise inside the block) | 0 (preventive) | `scripts/check_pytest_raises_hygiene.py` + `tests/ci/test_pytest_raises_hygiene.py` |
| D | [#218](https://github.com/curdriceaurora/fo-core/pull/218) | T3 narrow (no `assert <mock>.called` attribute form) | 14 (all converted) | `scripts/check_called_attribute_assertion.py` + `tests/ci/test_called_attribute_assertion.py` |

## What lands

### New rails (all AST-based after multiple review iterations)
- 3 detector scripts (`scripts/check_*.py`) — atomic-write, pytest.raises hygiene, T3-narrow `assert .called`
- 3 semantic-guardrail test files (`tests/ci/test_*.py`) — total **555 tests** in `tests/ci/`
- 4 new pre-commit hooks (`atomic-write-required`, `pytest-raises-hygiene`, `t3-no-bare-called-assertion`, plus the implicit ruff PT updates)
- 3 new ruff rules selected (`PT012`, `PT017`, `PT022`)

### Backlog cleanup (all behaviour-preserving)
- **5 sites** in `test_models_optional_providers.py` refactored to narrow `pytest.raises` to just the raising call
- **11 sites** marked `# noqa: PT012` with one-line reasons
- **29 sites** marked with `# atomic-write: ok — <reason>` across 7 reason categories — comments placed *above* the call to keep the diff-coverage gate clean
- **14 sites** of `assert <mock>.called` converted to the canonical `<mock>.assert_called()` method form (12 from initial PR-D + 2 more caught by the AST refactor in `tests/integration/test_fallback_no_ollama.py`)

### Code-quality fixes (added during review cycles)
- `src/integrations/obsidian.py` `send_file` — wraps file I/O in try/except + returns False on OSError (CR Major)
- `src/services/suggestion_feedback.py` — explicit `encoding="utf-8"` + try/except wrap with `logger.exception` + reraise (CR Major)
- `src/undo/durable_move.py` `_sweep_unlocked_body` — replaced in-place `Path.write_text` with `atomic_write_with` (CR Major)
- `src/history/export.py` (4 sites) + `src/services/analytics/analytics_service.py` (2 sites) — explicit `encoding="utf-8"` (CR Trivial)

### Documentation
- `.claude/rules/feature-generation-patterns.md` F3: opt-out marker taxonomy for atomic-write
- `.claude/rules/test-generation-patterns.md`: new T15 (mock-assert-after-raise), T3 narrow sub-rail section, rule-of-thumb appendix entries

## Out of scope (deferred — each tracked by an issue)

| Item | Reason | Tracked |
|------|--------|---------|
| BLE001 + PT011 + PT018 backlog (~260 sites) | Sprawling backlog; each deserves a focused PR with manual rationale audit | Will be opened as separate sub-PRs against a future `integration/ruff-backlog` branch |
| Path.resolve() RuntimeError guard | Tier 2 ratchet; G3 already covers user-facing CLI surface | [#216](https://github.com/curdriceaurora/fo-core/issues/216) |
| Legacy `PidFileManager.write_pid` atomic conversion | Back-compat method; F2-hardened path is `write_pid_record` | [#220](https://github.com/curdriceaurora/fo-core/issues/220) |
| T3-full payload-precise mock assertions in test_doctor (10 sites) | Tests verify control-flow; payload pinning would be brittle | [#221](https://github.com/curdriceaurora/fo-core/issues/221) |
| ~~T3-narrow AST refactor~~ | ~~Bypass bugs in PR-D's rail surfaced post-merge~~ | ~~[#222](https://github.com/curdriceaurora/fo-core/issues/222)~~ — **closed**, fix landed inline (commit a87dff73) |

## Review iterations on this PR

The PR went through **four rounds** of Codex / CodeRabbit review, all addressed:

**Round 1 (Codex r219 — initial):**
- `open()` regex bypass on nested parens (`open(Path(name).with_suffix('.json'), 'w')`) → fixed by AST refactor
- Forbidden patterns inside string literals false-flagged (`logger.debug("open(path, 'w')")`) → fixed by AST refactor

**Round 2 (CodeRabbit Major + Minor + Trivial — 5 threads):**
- Opt-out marker bypassable via string literal (`msg = "# atomic-write: ok"`) → tokenize-based comment-only collector
- Doc/message inconsistencies (window wording, mode list) → aligned
- Missing `encoding="utf-8"` in 6 export sites → applied

**Round 3 (Codex P2 — 2 more bypasses found post-CI-green):**
- Mode-set bypass on aliases like `"wt"`, `"at"`, `"w+b"` → replaced literal set with character-based `_mode_is_forbidden`
- pytest.raises rail didn't propagate reachability into nested blocks → recursive `_walk_unreachable_mock_assertions`

**Round 4 (Codex P2 + local review pass):**
- `Path("out.json").open("w")` method-call bypass → `_is_open_call` now matches both builtin Name and Attribute call shapes; `_extract_mode_string` handles the mode-at-args[0] semantics for method calls
- Multi-line `assert (\n    mock.called\n)` and `assert mock.called, "msg"` bypass → T3-narrow rail switched from regex to AST detection (closes #222 inline)
- Local-review extras: `Annotated[Path, ...]` recognised by G3 CLI-path-validation rail; validator targets via keyword args; sorted output for stable diffs across all rails

All 21+ review threads on this PR have been replied to and resolved.

## Verification

- Final commit `a87dff73`
- 555 tests pass under `pytest tests/ci/`
- Local pre-commit-validation green across every push
- Integration suite locally: 7282 passed, 3 skipped, 90% line+branch coverage (gate is 71.9%)

## Test plan

- [x] All 4 sub-PRs CI green
- [x] Integration branch synced; rebases applied cleanly
- [x] Pre-commit validation green on every push
- [x] Integration test suite green (90% coverage > 71.9% floor)
- [x] All 21+ Codex / CodeRabbit threads resolved with replies (4 review rounds)
- [x] All actionable findings landed as fixes; remaining deferrals each have a tracking issue
- [x] No outstanding bypass / coverage / lint / type / format issues locally
- [x] Issue #222 (T3-narrow AST refactor) closed — fix landed inline in commit a87dff73
- [ ] CI green on the final commit (`a87dff73`)
- [ ] Squash-merge into main (single atomic landing per integration-branch convention)

## Related

- [#215](https://github.com/curdriceaurora/fo-core/pull/215) — Python 3.9 stale-refs cleanup (landed separately on main earlier today)
- [#216](https://github.com/curdriceaurora/fo-core/issues/216) — deferred PR-E follow-up
- [#220](https://github.com/curdriceaurora/fo-core/issues/220) — deferred PID-file atomic conversion
- [#221](https://github.com/curdriceaurora/fo-core/issues/221) — deferred T3-full payload-precision
- ~~[#222](https://github.com/curdriceaurora/fo-core/issues/222)~~ — **closed**, AST refactor landed inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated enforcement of atomic write patterns for persistent data changes
  * Added pytest-specific linting rules for improved test reliability
  * Implemented pre-commit hooks to catch common test hygiene issues and unsafe file operations
  * Updated test assertions to follow best practices for mock verification
  * Improved error handling in file export operations
  * Enhanced documentation through inline comments for safer patterns

* **Tests**
  * Added comprehensive test suites validating new code quality checks
  * Updated existing tests to follow modern assertion patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->