### PR TITLE
Clarify out-of-diff thread handling in PR review protocol

### DIFF
--- a/.claude/rules/pr-review-response-protocol.md
+++ b/.claude/rules/pr-review-response-protocol.md
@@ -37,6 +37,17 @@ Save complete output to file for reference.
 6. **Scope is frozen at this point**: If new comments arrive while you're fixing, complete the current batch and treat new findings as a separate PR review cycle
 7. Example: "Found 5 issues: #1 (thread-ID-1) mock mismatch, #2 (thread-ID-2) weak assertion..."
 
+### 1C: Identify Out-of-Diff Threads
+
+After extracting all threads, cross-reference each thread's `path` against the PR's file list (from `get_files`). Any thread whose `path` is **not** in that set is an **out-of-diff thread** — it is anchored to a file the PR did not change.
+
+Out-of-diff threads are commonly `is_outdated=True` (file was in an intermediate commit then removed), but they are NOT automatically dismissed. For each out-of-diff thread, explicitly decide:
+
+- **SKIP** — the concern is addressed elsewhere in this PR's diff (e.g., the fix landed in a different file). Reply to explain.
+- **DEFER-to-issue** — the concern applies to the unchanged file in its current state. Create a GitHub issue, reply with the link. The file will need a follow-up PR.
+
+Do not assume `is_outdated=True` means the finding is irrelevant — the underlying code concern may still be valid in the current file, even if the diff position no longer exists.
+
 ---
 
 ## Step 2: Verify Each Finding Against Current Code
@@ -66,6 +77,12 @@ For each comment, decide what action to take using this decision matrix:
 - Create GitHub issue with exact details from reviewer's comment
 - Reply to reviewer: "Valid point, created issue #XXX for this"
 - Don't include in current PR
+
+**OUT-OF-DIFF** (special case, from Step 1C)
+- Thread `path` is not in the PR's file list
+- Sub-cases:
+  - Concern addressed elsewhere in this PR's diff → SKIP (reply explaining where)
+  - Concern still applies to the unchanged file → DEFER-to-issue (create issue + reply)
 
 ### Verification Process
 

--- a/tests/integration/test_cli_copilot.py
+++ b/tests/integration/test_cli_copilot.py
@@ -1,8 +1,5 @@
 """Integration tests for cli/copilot.py.
 
-Coverage target: copilot.py = 100% (per
-``scripts/coverage/integration_module_floor_baseline.json``).
-
 Originally part of ``test_cli_dedupe_removal_copilot.py``; that file was
 removed in PR #205 alongside the legacy ``cli/dedupe_removal.py`` module.
 The copilot tests are independent — they exercise ``cli/copilot.py`` via


### PR DESCRIPTION
## Description

This change enhances the PR review response protocol documentation to explicitly address how to handle review threads anchored to files outside the PR's diff (out-of-diff threads). It adds a new section (1C) that clarifies the decision-making process for such threads and updates the verification decision matrix to include this special case.

The changes also remove an outdated coverage target comment from the integration test file that referenced a removed baseline file.

## Type of change

- [x] Documentation update
- [x] Clarification of existing process (no functional change)

## Motivation

Out-of-diff threads (where `path` is not in the PR's file list) require explicit handling to avoid either dismissing valid concerns or missing opportunities to address them within the current PR. This change:

1. Defines what constitutes an out-of-diff thread
2. Clarifies that `is_outdated=True` does not automatically mean the finding is irrelevant
3. Provides two explicit decision paths: SKIP (if addressed elsewhere in the diff) or DEFER-to-issue (if the concern still applies to the unchanged file)
4. Removes stale documentation reference in test file

## How Has This Been Tested?

N/A — This is a documentation and comment cleanup change with no functional code modifications.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

https://claude.ai/code/session_012srRMVEFhjv6JwwCSrYkMj