### PR TITLE
Fix: Resolve Matrix CI Failures (CI Full extras-canary collision)

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -42,16 +42,19 @@ jobs:
             pip install -e ".[dev,search]"
             pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
       - name: Run full test suite
-        # tests/extras/ is the canary suite for ci-extras.yml; those tests use
-        # hard imports (cv2, torch, imagededup) and intentionally fail — not skip —
-        # when the corresponding extra is absent. CI Full installs only [dev,search],
-        # so collecting tests/extras/ here produces ModuleNotFoundError at setup.
-        # Each extra is exercised by ci-extras.yml with the right install.
+        # tests/extras/ contains canary suites for ci-extras.yml.  Most hard-import
+        # optional deps (cv2, torch, imagededup, ezdxf, h5py) that aren't installed
+        # by [dev,search] and would fail at collection.  The exception is
+        # test_extras_dedup_text.py: its deps (numpy, scikit-learn) ARE provided by
+        # [dev,search], so we run it here for broader matrix coverage.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pytest tests/ \
-            --ignore=tests/extras \
+            --ignore=tests/extras/test_extras_cad.py \
+            --ignore=tests/extras/test_extras_dedup_image.py \
+            --ignore=tests/extras/test_extras_media.py \
+            --ignore=tests/extras/test_extras_scientific.py \
             -m "not benchmark and not e2e" \
             --strict-markers \
             -n auto \
@@ -123,9 +126,9 @@ jobs:
           command: pip install -e ".[dev,search]"
       - name: Run tests
         # CI Full's cross-platform contract: validate the portable ci/smoke subset on macOS.
-        # tests/extras/ is owned by ci-extras.yml; its smoke canaries hard-import optional deps
-        # (cv2, torch, imagededup) that aren't installed in [dev,search], so they collide with -m "smoke".
-        run: pytest tests/ --ignore=tests/extras --strict-markers --timeout=30 -n=auto --dist=loadgroup --override-ini="addopts=" -m "ci or smoke"
+        # Ignore extras whose deps (cv2, torch, imagededup, ezdxf, h5py) aren't in [dev,search].
+        # test_extras_dedup_text.py is intentionally kept: sklearn/numpy are in [dev,search].
+        run: pytest tests/ --ignore=tests/extras/test_extras_cad.py --ignore=tests/extras/test_extras_dedup_image.py --ignore=tests/extras/test_extras_media.py --ignore=tests/extras/test_extras_scientific.py --strict-markers --timeout=30 -n=auto --dist=loadgroup --override-ini="addopts=" -m "ci or smoke"
 
   test-windows:
     name: Test Windows (Python 3.12)
@@ -158,6 +161,6 @@ jobs:
         # ProactorEventLoop IOCP teardown race: fixed in tests/conftest.py via
         # SelectorEventLoop on win32 (see ensure_default_event_loop fixture).
         # The 20-minute job timeout provides a sufficient hard cap.
-        # tests/extras/ is owned by ci-extras.yml; its smoke canaries hard-import optional deps
-        # (cv2, torch, imagededup) that aren't installed in [dev,search], so they collide with -m "smoke".
-        run: pytest tests/ --ignore=tests/extras --strict-markers --override-ini="addopts=" -m "ci or smoke"
+        # Ignore extras whose deps (cv2, torch, imagededup, ezdxf, h5py) aren't in [dev,search].
+        # test_extras_dedup_text.py is intentionally kept: sklearn/numpy are in [dev,search].
+        run: pytest tests/ --ignore=tests/extras/test_extras_cad.py --ignore=tests/extras/test_extras_dedup_image.py --ignore=tests/extras/test_extras_media.py --ignore=tests/extras/test_extras_scientific.py --strict-markers --override-ini="addopts=" -m "ci or smoke"

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -42,10 +42,16 @@ jobs:
             pip install -e ".[dev,search]"
             pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
       - name: Run full test suite
+        # tests/extras/ is the canary suite for ci-extras.yml; those tests use
+        # hard imports (cv2, torch, imagededup) and intentionally fail — not skip —
+        # when the corresponding extra is absent. CI Full installs only [dev,search],
+        # so collecting tests/extras/ here produces ModuleNotFoundError at setup.
+        # Each extra is exercised by ci-extras.yml with the right install.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pytest tests/ \
+            --ignore=tests/extras \
             -m "not benchmark and not e2e" \
             --strict-markers \
             -n auto \
@@ -117,7 +123,9 @@ jobs:
           command: pip install -e ".[dev,search]"
       - name: Run tests
         # CI Full's cross-platform contract: validate the portable ci/smoke subset on macOS.
-        run: pytest tests/ --strict-markers --timeout=30 -n=auto --dist=loadgroup --override-ini="addopts=" -m "ci or smoke"
+        # tests/extras/ is owned by ci-extras.yml; its smoke canaries hard-import optional deps
+        # (cv2, torch, imagededup) that aren't installed in [dev,search], so they collide with -m "smoke".
+        run: pytest tests/ --ignore=tests/extras --strict-markers --timeout=30 -n=auto --dist=loadgroup --override-ini="addopts=" -m "ci or smoke"
 
   test-windows:
     name: Test Windows (Python 3.12)
@@ -150,4 +158,6 @@ jobs:
         # ProactorEventLoop IOCP teardown race: fixed in tests/conftest.py via
         # SelectorEventLoop on win32 (see ensure_default_event_loop fixture).
         # The 20-minute job timeout provides a sufficient hard cap.
-        run: pytest tests/ --strict-markers --override-ini="addopts=" -m "ci or smoke"
+        # tests/extras/ is owned by ci-extras.yml; its smoke canaries hard-import optional deps
+        # (cv2, torch, imagededup) that aren't installed in [dev,search], so they collide with -m "smoke".
+        run: pytest tests/ --ignore=tests/extras --strict-markers --override-ini="addopts=" -m "ci or smoke"


### PR DESCRIPTION
## Summary

CI Full Matrix #27 ([run](https://github.com/curdriceaurora/fo-core/actions/runs/24981266122)) failed across **all 4 matrix jobs** with the same root cause:

| Job | Conclusion | Failure |
|---|---|---|
| Test Linux (py3.11) | ❌ failed | `ModuleNotFoundError: cv2 / torch / imagededup` at setup |
| Test Linux (py3.12) | ❌ failed | same |
| Test macOS (Python 3.12) | ❌ failed | same |
| Test Windows (Python 3.12) | ❌ failed | same |

## Root Cause

`tests/extras/test_extras_media.py` and `tests/extras/test_extras_dedup_image.py` are **smoke canaries** for the `[media]` and `[dedup-image]` extras. They are marked `pytest.mark.smoke` and use **hard imports** (`import cv2`, `import torch`, `import imagededup`) — by design. The comment in each file states:

> Hard imports — missing package means the extra is broken, not skippable.

These canaries are owned by **`ci-extras.yml`**, which installs each extra individually and runs the matching test file directly via `pytest "$TEST_FILE"`.

`ci-full.yml`, however, installs only `[dev,search]` and runs:
- Linux: `-m "not benchmark and not e2e"` (matches every non-bench, non-e2e test → including smoke)
- macOS/Windows: `-m "ci or smoke"` (matches the canaries)

So pytest collects `tests/extras/test_extras_media.py` and `tests/extras/test_extras_dedup_image.py`, and the `_require_media` / `_require_dedup_image` autouse fixtures explode at setup with `ModuleNotFoundError` because cv2/torch/imagededup aren't installed in `[dev,search]`.

The 6 failing tests:
- `tests/extras/test_extras_media.py::test_opencv_read_write_cycle` — `No module named 'cv2'`
- `tests/extras/test_extras_media.py::test_pydub_reads_wav` — `No module named 'cv2'`
- `tests/extras/test_extras_media.py::test_faster_whisper_importable` — `No module named 'cv2'`
- `tests/extras/test_extras_dedup_image.py::test_dedup_text_stack_available` — `No module named 'torch'`
- `tests/extras/test_extras_dedup_image.py::test_image_deduplicator_importable` — `No module named 'torch'`
- `tests/extras/test_extras_dedup_image.py::test_imagededup_importable` — `No module named 'torch'`

## Fix

Add `--ignore=tests/extras` to all three pytest invocations in `.github/workflows/ci-full.yml`. Each gets an inline comment explaining the exclusion.

This is the right boundary because:
1. `ci-extras.yml` exercises every extra with the correct install — no coverage is lost
2. `ci-extras.yml` references each test file by explicit `$TEST_FILE` path, so it isn't affected by the ignore
3. The hard-import design of the canaries is intentional; we don't want to weaken them by adding `pytest.importorskip`
4. Scoped to a single workflow file — no source/test code changed

## Trade-offs

None considered material. The alternative — switching the canaries to `pytest.importorskip` — would silently turn a broken extra into a skipped test in `ci-extras.yml`, which is the opposite of what the maintainer wanted (failure mode is by design).

## Verification

Reproduced the failure locally with the same pytest invocation, then validated each matrix variant after the fix:

| Matrix variant | Before | After |
|---|---|---|
| Linux full (`-m "not benchmark and not e2e"`, `-n auto`, `--dist=loadgroup`) | 6 errors at setup | 16309 passed, 73 skipped |
| macOS (`-m "ci or smoke"`, `-n=auto`, `--dist=loadgroup`) | 6 errors at setup | 4053 passed, 1 skipped |
| Windows (`-m "ci or smoke"`, no xdist) | 6 errors at setup | 4053 passed, 1 skipped |

Workflow YAML validated with `yaml.safe_load`.

## Impacted Areas

- `.github/workflows/ci-full.yml` only (12 insertions, 2 deletions)
- No source changes
- No test changes
- `ci-extras.yml` unaffected

## Test Plan

- [ ] CI Full Matrix run (workflow_dispatch) succeeds on all 4 matrix jobs after merge
- [ ] Daily scheduled CI Full Matrix run on 2026-04-28 succeeds
- [ ] `ci-extras.yml` continues to pass (no behavioural change)

## Links

- Failing run: https://github.com/curdriceaurora/fo-core/actions/runs/24981266122
- Related workflows: `.github/workflows/ci-full.yml`, `.github/workflows/ci-extras.yml`


---
_Generated by [Claude Code](https://claude.ai/code/session_013TWhDyMsnYUw7y8V8eFnVW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to improve test execution efficiency and prevent potential dependency-related failures during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->