### PR TITLE
docs(release): beta-criteria + 5 step plans for alpha→beta path

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ pytest
 ruff check src/
 ```
 
+## Releases
+
+Currently `2.0.0-alpha.3`. The criteria for promoting to beta and the contract
+with public pre-release testers are documented in
+[docs/release/beta-criteria.md](docs/release/beta-criteria.md).
+
 ## License
 
 MIT OR Apache-2.0

--- a/docs/release/beta-criteria.md
+++ b/docs/release/beta-criteria.md
@@ -1,0 +1,138 @@
+# Beta Criteria
+
+This document defines what "beta" means for fo-core, the criteria for entering
+beta, and the contract between the project and public pre-release testers.
+
+## 1. What "beta" means here
+
+fo-core's beta is a low-ceremony label. The transition consists of two
+mechanical changes: bumping the PyPI classifier from `Development Status :: 3 -
+Alpha` to `Development Status :: 4 - Beta` (in `pyproject.toml`), and opening
+the auto-updater's public pre-release channel (`fo update --pre-release`,
+already wired in `src/cli/update.py`).
+
+Beta is **not** a feature freeze. Development continues normally, and new
+commands, flags, dependencies, or methodologies may land in any beta point
+release. Read the changelog before upgrading.
+
+Beta is **not** time-boxed. `4 - Beta` is the steady state until the maintainer
+decides otherwise. There is no committed timeline for bumping to
+`5 - Production/Stable`; see §5.
+
+The single guarantee that beta adds beyond alpha is the schema-compatibility
+contract in §3.
+
+## 2. Entry checklist
+
+These items must all be true to bump the classifier from `3 - Alpha` to
+`4 - Beta` and cut `2.0.0-beta.1`.
+
+- [ ] **Audio works end-to-end.** `AudioModel.generate()` (currently raises
+      `NotImplementedError` at `src/models/audio_model.py:53`) is wired to the
+      existing transcriber code. `fo benchmark --suite audio` succeeds on a
+      sample audio file with the `[media]` extra installed. The `[media]` extra
+      description in `pyproject.toml` and the README's Optional Feature Packs
+      table accurately describe what ships.
+- [ ] **Integration coverage floors.** Global integration coverage ≥ 75%
+      (currently 71.9%). Per-module floor ≥ 70% on every module currently
+      below it in
+      `scripts/coverage/integration_module_floor_baseline.json`. The nine
+      modules below 70% as of this writing are: `services/search/__init__.py`
+      (38%), `utils/epub_enhanced.py` (55%), `daemon/service.py` (57%),
+      `services/deduplication/__init__.py` (60%),
+      `services/intelligence/profile_migrator.py` (60%),
+      `methodologies/johnny_decimal/adapters.py` (67%),
+      `services/intelligence/profile_merger.py` (67%),
+      `core/hardware_profile.py` (68%),
+      `methodologies/johnny_decimal/numbering.py` (68%). Search and daemon are
+      the highest-risk and the tallest hills.
+- [ ] **Daemon smoke test in CI** exercising `start → watch → stop → status`
+      and recovery after `SIGTERM`. The test runs in the integration job and
+      blocks merge on failure.
+- [ ] **`--debug` flag wired** in `src/cli/main.py`. The flag enables full
+      loguru handlers and surfaces tracebacks (currently swallowed by the
+      global error handler that re-emits as `[red]Error: {message}[/red]`).
+      The flag is documented in `docs/troubleshooting.md`.
+- [ ] **Doc-honesty pass.** Every documented command, extra, and flag exists
+      and works as described. No `NotImplementedError` is reachable from a
+      documented surface. README, `docs/cli-reference.md`, and
+      `docs/USER_GUIDE.md` all match what the code does.
+- [ ] **Schema-stability test** in CI that writes a config with one
+      `AppConfig` version, reads it back with another, and asserts equality.
+      Parameterized over the last alpha and a synthetic future beta to exercise
+      both the alpha → beta boundary and the beta.X → beta.Y guarantee in §3.
+      `AppConfig` stays at version `1.0` for the duration of beta.
+- [ ] **Bug-report template exists** at `.github/ISSUE_TEMPLATE/beta-bug.md`,
+      requesting `fo --debug <command>` output, the `fo doctor` summary,
+      OS/version, and reproduction steps.
+
+## 3. The one stable promise: frozen schema across beta.X → beta.Y
+
+Any config file written by `2.0.0-beta.X` reads cleanly under
+`2.0.0-beta.Y` for all `X`, `Y` in the beta line, with no manual migration.
+
+The `AppConfig` schema version stays at `1.0` for the duration of beta. New
+optional fields may be added (with sensible defaults), but no existing field is
+renamed, retyped, or removed during beta. A round-trip test in CI guards this
+promise.
+
+The schema may bump after the beta line ends. That decision is out of scope
+for this document.
+
+This is the only beta-line compatibility guarantee. Everything else (CLI flags,
+dependency versions, default models, methodology behavior) may change between
+point releases.
+
+## 4. Tester contract
+
+### Opting in
+
+```bash
+fo update --pre-release   # switch your update channel to the beta line
+fo update check           # the auto-updater will now offer beta releases
+```
+
+Once opted in, `fo update install` will pull the latest beta point release.
+
+### Rolling back
+
+```bash
+pip install 'fo-core==2.0.0-alpha.3'   # or whatever stable version you prefer
+fo update --no-pre-release             # leave the pre-release channel
+```
+
+Because the schema is frozen across the beta line (§3), rolling back to alpha
+may require deleting your config if you started fresh on beta. Rolling between
+beta point releases is always safe.
+
+### Filing bugs
+
+Open an issue using the **Beta bug** template at GitHub Issues. Every report
+must include:
+
+- Output of `fo --debug <the failing command>` (full traceback, not just the
+  red error line).
+- Output of `fo doctor` (Ollama connection + dependency check).
+- OS, Python version, fo-core version (`fo version`).
+- Minimum reproduction steps.
+
+Reports without `--debug` output will usually be asked to re-run with the flag
+before triage proceeds.
+
+### Expectations
+
+- Beta point releases may add commands, flags, dependencies, or change
+  defaults. Read the changelog before upgrading.
+- The schema promise in §3 is the only compatibility guarantee.
+- There is no SLA on bug response time. fo-core is maintained by a small
+  team; beta participation is appreciated, not contractually owed.
+
+## 5. Explicit non-promise about GA
+
+There is no committed timeline for bumping `4 - Beta` to
+`5 - Production/Stable`. The maintainer will make that call when warranted —
+likely driven by a sustained absence of critical bug reports against current
+beta releases, but no specific gates are pre-committed.
+
+Public pre-release testers should not assume GA is imminent or planned for any
+particular window. Treat beta as the project's current steady state.

--- a/docs/release/beta-criteria.md
+++ b/docs/release/beta-criteria.md
@@ -7,9 +7,10 @@ beta, and the contract between the project and public pre-release testers.
 
 fo-core's beta is a low-ceremony label. The transition consists of two
 mechanical changes: bumping the PyPI classifier from `Development Status :: 3 -
-Alpha` to `Development Status :: 4 - Beta` (in `pyproject.toml`), and opening
-the auto-updater's public pre-release channel (`fo update --pre-release`,
-already wired in `src/cli/update.py`).
+Alpha` to `Development Status :: 4 - Beta` (in `pyproject.toml`), and tagging
+the first release on the auto-updater's pre-release surface (the `--pre` flag
+on `fo update check` / `fo update install`, already wired in
+`src/cli/update.py`).
 
 Beta is **not** a feature freeze. Development continues normally, and new
 commands, flags, dependencies, or methodologies may land in any beta point
@@ -27,12 +28,12 @@ contract in §3.
 These items must all be true to bump the classifier from `3 - Alpha` to
 `4 - Beta` and cut `2.0.0-beta.1`.
 
-- [ ] **Audio works end-to-end.** `AudioModel.generate()` (currently raises
-      `NotImplementedError` at `src/models/audio_model.py:53`) is wired to the
-      existing transcriber code. `fo benchmark --suite audio` succeeds on a
-      sample audio file with the `[media]` extra installed. The `[media]` extra
-      description in `pyproject.toml` and the README's Optional Feature Packs
-      table accurately describe what ships.
+- [ ] **Audio works end-to-end.** `AudioModel.generate()` in
+      `src/models/audio_model.py` (currently raises `NotImplementedError`) is
+      wired to the existing transcriber code. `fo benchmark --suite audio`
+      succeeds on a sample audio file with the `[media]` extra installed. The
+      `[media]` extra description in `pyproject.toml` and the README's
+      Optional Feature Packs table accurately describe what ships.
 - [ ] **Integration coverage floors.** Global integration coverage ≥ 75%
       (currently 71.9%). Per-module floor ≥ 70% on every module currently
       below it in
@@ -57,11 +58,15 @@ These items must all be true to bump the classifier from `3 - Alpha` to
       and works as described. No `NotImplementedError` is reachable from a
       documented surface. README, `docs/cli-reference.md`, and
       `docs/USER_GUIDE.md` all match what the code does.
-- [ ] **Schema-stability test** in CI that writes a config with one
-      `AppConfig` version, reads it back with another, and asserts equality.
-      Parameterized over the last alpha and a synthetic future beta to exercise
-      both the alpha → beta boundary and the beta.X → beta.Y guarantee in §3.
-      `AppConfig` stays at version `1.0` for the duration of beta.
+- [ ] **Schema-stability test suite** in CI covering both the alpha → beta
+      boundary and the beta.X → beta.Y guarantee in §3, including
+      synthetic future-version handling. The plan in
+      `docs/superpowers/plans/2026-04-27-config-schema-stability-test-2c.md`
+      implements this as three CI tests
+      (`test_save_load_round_trip_at_current_version`,
+      `test_synthetic_future_version_preserves_known_fields`,
+      `test_future_version_loads_best_effort_with_warning`). `AppConfig` stays
+      at version `1.0` for the duration of beta.
 - [ ] **Bug-report template exists** at `.github/ISSUE_TEMPLATE/beta-bug.md`,
       requesting `fo --debug <command>` output, the `fo doctor` summary,
       OS/version, and reproduction steps.
@@ -87,19 +92,21 @@ point releases.
 
 ### Opting in
 
+The auto-updater surfaces pre-release versions when you pass the `--pre` flag.
+There is no persistent channel state — the flag applies per-invocation:
+
 ```bash
-fo update --pre-release   # switch your update channel to the beta line
-fo update check           # the auto-updater will now offer beta releases
+fo update check --pre      # see the latest pre-release if any
+fo update install --pre    # download and install it
 ```
 
-Once opted in, `fo update install` will pull the latest beta point release.
-
-### Rolling back
+To stay on stable: just don't pass `--pre`. To pin a specific older version:
 
 ```bash
 pip install 'fo-core==2.0.0-alpha.3'   # or whatever stable version you prefer
-fo update --no-pre-release             # leave the pre-release channel
 ```
+
+### Rolling back
 
 Because the schema is frozen across the beta line (§3), rolling back to alpha
 may require deleting your config if you started fresh on beta. Rolling between

--- a/docs/release/beta-criteria.md
+++ b/docs/release/beta-criteria.md
@@ -30,23 +30,31 @@ These items must all be true to bump the classifier from `3 - Alpha` to
 
 - [ ] **Audio works end-to-end.** `AudioModel.generate()` in
       `src/models/audio_model.py` (currently raises `NotImplementedError`) is
-      wired to the existing transcriber code. `fo benchmark --suite audio`
+      wired to the existing transcriber code. `fo benchmark run --suite audio`
       succeeds on a sample audio file with the `[media]` extra installed. The
       `[media]` extra description in `pyproject.toml` and the README's
       Optional Feature Packs table accurately describe what ships.
-- [ ] **Integration coverage floors.** Global integration coverage ≥ 75%
-      (currently 71.9%). Per-module floor ≥ 70% on every module currently
-      below it in
-      `scripts/coverage/integration_module_floor_baseline.json`. The nine
-      modules below 70% as of this writing are: `services/search/__init__.py`
-      (38%), `utils/epub_enhanced.py` (55%), `daemon/service.py` (57%),
-      `services/deduplication/__init__.py` (60%),
-      `services/intelligence/profile_migrator.py` (60%),
-      `methodologies/johnny_decimal/adapters.py` (67%),
-      `services/intelligence/profile_merger.py` (67%),
-      `core/hardware_profile.py` (68%),
-      `methodologies/johnny_decimal/numbering.py` (68%). Search and daemon are
-      the highest-risk and the tallest hills.
+- [ ] **Integration coverage floors.** This is a **target floor** that must
+      be reached before the classifier flips, not a value already enforced.
+      Currently the project enforces a global floor of **71.9%** via
+      `policy.new_module_min_percent` in
+      `scripts/coverage/integration_module_floor_baseline.json` (line 10).
+      Beta entry requires ratcheting that to ≥ 75% globally and ≥ 70%
+      per-module on every module currently below it. As of the
+      2026-04-23 baseline (`scripts/coverage/integration_module_floor_baseline.json`),
+      the nine modules below 70% are:
+      `src/services/search/__init__.py` (38.0%, baseline line 260),
+      `src/utils/epub_enhanced.py` (55.0%, line 291),
+      `src/daemon/service.py` (57.0%, line 69),
+      `src/services/deduplication/__init__.py` (60.0%, line 225),
+      `src/services/intelligence/profile_migrator.py` (60.0%, line 255),
+      `src/methodologies/johnny_decimal/adapters.py` (67.0%, line 108),
+      `src/services/intelligence/profile_merger.py` (67.0%, line 254),
+      `src/core/hardware_profile.py` (68.0%, line 59),
+      `src/methodologies/johnny_decimal/numbering.py` (68.0%, line 113).
+      Search and daemon are the highest-risk and the tallest hills. The
+      Step 4 plan in `docs/superpowers/plans/2026-04-27-integration-coverage-lift-step-4.md`
+      executes the lift.
 - [ ] **Daemon smoke test in CI** exercising `start → watch → stop → status`
       and recovery after `SIGTERM`. The test runs in the integration job and
       blocks merge on failure.

--- a/docs/superpowers/plans/2026-04-27-audio-model-wiring-2a.md
+++ b/docs/superpowers/plans/2026-04-27-audio-model-wiring-2a.md
@@ -341,7 +341,11 @@ class TestAudioModelGenerate:
         model.initialize()
 
         fake_audio = tmp_path / "sample.wav"
-        fake_audio.touch()  # transcriber is mocked; existence check still runs
+        # No need to actually create the file: patching
+        # `model._transcriber.transcribe` replaces AudioTranscriber.transcribe
+        # entirely, including its `audio_path.exists()` check at
+        # src/services/audio/transcriber.py:212. We pass the path through to
+        # verify generate() forwards it correctly.
 
         fake_result = MagicMock()
         fake_result.text = "hello world"

--- a/docs/superpowers/plans/2026-04-27-audio-model-wiring-2a.md
+++ b/docs/superpowers/plans/2026-04-27-audio-model-wiring-2a.md
@@ -1,0 +1,992 @@
+# AudioModel Wiring + Benchmark Smoke (Step 2A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire `AudioModel.generate()` (currently `NotImplementedError`) to the existing `services.audio.transcriber.AudioTranscriber`, and add an opt-in transcription smoke pass to `fo benchmark --suite audio` so the `[media]` extra delivers what its README description claims.
+
+**Architecture:** `AudioModel` becomes a thin adapter over `services.audio.transcriber.AudioTranscriber`. The transcriber is instantiated in `AudioModel.__init__` (cheap — model weights load lazily on first `transcribe()`). `generate(prompt)` treats `prompt` as the audio file path, calls `transcriber.transcribe(path)`, and returns `result.text`. Lifecycle hooks (`_enter_generate` / `_exit_generate`) come from `BaseModel`. Benchmark gains a `--transcribe-smoke` flag that transcribes exactly one candidate file (smallest first) so the smoke test cost is bounded.
+
+**Tech Stack:** Python 3.11+, `faster-whisper` (via `[media]` extra), pytest, Typer CLI, dataclasses. No new dependencies.
+
+**Out of scope:** consolidating `models.audio_transcriber` (the unused duplicate) and `services.audio.transcriber` — that's follow-up cleanup. Wiring transcription into `fo organize` is Step 2B (separate plan).
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/models/audio_model.py` | Modify | Replace stub: instantiate transcriber, route `generate()`, unload in `cleanup()` |
+| `tests/test_audio_model.py` | Rewrite | Replace placeholder skip-tests with real unit tests (mock the transcriber) |
+| `tests/integration/test_audio_model_integration.py` | Create | End-to-end test with a generated WAV file, skipped if `faster-whisper` absent |
+| `src/cli/benchmark.py` | Modify | Add `--transcribe-smoke` flag; extend `_run_audio_suite` and `_SuiteIterationOutcome` |
+| `tests/cli/test_benchmark_audio_transcribe.py` | Create | Test that `--transcribe-smoke` invokes transcription on exactly one file |
+| `README.md` | Modify | Soften `[media]` row to match what's actually wired |
+| `pyproject.toml` | Modify | Update inline comment for `[media]` extra to match new behavior |
+
+---
+
+## Conventions for this plan
+
+- All `pytest` invocations run from repo root: `pytest <args>` (the project pre-commit-validation script handles env).
+- Commits use the project's `<type>(<scope>): <subject>` format (per `.claude/rules/development-guidelines.md`).
+- After each commit, the `pre-commit` hook will run automatically — if it fails, fix violations and create a NEW commit (never `--amend` per CLAUDE.md guidance).
+- Tests use `pytest.MonkeyPatch` for env, never `os.environ` mutation.
+- No hardcoded `/tmp/` paths — always `tmp_path`.
+
+---
+
+## Task 1: AudioModel.__init__ holds an AudioTranscriber instance
+
+**Files:**
+- Modify: `src/models/audio_model.py:21-33`
+- Test: `tests/test_audio_model.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the contents of `tests/test_audio_model.py` (the file currently only contains placeholder skip-tests) with the new test class header plus this first test:
+
+```python
+"""Unit tests for AudioModel — wires services.audio.transcriber."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models.audio_model import AudioModel
+from models.base import ModelConfig, ModelType
+
+
+@pytest.mark.unit
+class TestAudioModelInit:
+    def test_init_creates_transcriber_attribute(self) -> None:
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        assert model._transcriber is not None
+        assert hasattr(model._transcriber, "transcribe")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/test_audio_model.py::TestAudioModelInit::test_init_creates_transcriber_attribute -v
+```
+
+Expected: FAIL — `AttributeError: 'AudioModel' object has no attribute '_transcriber'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/models/audio_model.py`, replace lines 1-33 (header through `__init__`) with:
+
+```python
+"""Audio model — wraps services.audio.transcriber for the BaseModel interface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from models.base import BaseModel, ModelConfig, ModelType
+from services.audio.transcriber import (
+    AudioTranscriber,
+    ModelSize,
+    TranscriptionOptions,
+)
+
+
+def _resolve_model_size(name: str) -> ModelSize:
+    """Map a `ModelConfig.name` to a faster-whisper `ModelSize`.
+
+    Accepts forms like "base", "whisper-base", "Whisper_Large-V3". Falls back
+    to `ModelSize.BASE` for unknown names — keeps the call live rather than
+    crashing on a config typo.
+    """
+    normalized = name.lower().replace("whisper-", "").replace("_", "-")
+    for size in ModelSize:
+        if size.value == normalized:
+            return size
+    return ModelSize.BASE
+
+
+class AudioModel(BaseModel):
+    """Audio transcription model backed by faster-whisper."""
+
+    def __init__(self, config: ModelConfig):
+        if config.model_type != ModelType.AUDIO:
+            raise ValueError(f"Expected AUDIO model type, got {config.model_type}")
+        super().__init__(config)
+        self._transcriber = AudioTranscriber(
+            model_size=_resolve_model_size(config.name),
+            device=config.device.value if config.device else "auto",
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pytest tests/test_audio_model.py::TestAudioModelInit::test_init_creates_transcriber_attribute -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/audio_model.py tests/test_audio_model.py
+git commit -m "$(cat <<'EOF'
+feat(audio_model): instantiate AudioTranscriber in __init__
+
+First step of wiring AudioModel to the existing
+services.audio.transcriber. Subsequent commits add the generate(),
+initialize(), and cleanup() bridges.
+EOF
+)"
+```
+
+---
+
+## Task 2: ModelConfig.name resolves to a valid Whisper size
+
+**Files:**
+- Modify: `src/models/audio_model.py` (the `_resolve_model_size` helper added in Task 1)
+- Test: `tests/test_audio_model.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audio_model.py`:
+
+```python
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "name,expected_value",
+    [
+        ("base", "base"),
+        ("whisper-base", "base"),
+        ("tiny", "tiny"),
+        ("Whisper-Large-V3", "large-v3"),
+        ("nonsense-model-name", "base"),  # falls back
+    ],
+)
+def test_resolve_model_size_maps_to_valid_size(
+    name: str, expected_value: str
+) -> None:
+    from models.audio_model import _resolve_model_size
+
+    assert _resolve_model_size(name).value == expected_value
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+```bash
+pytest tests/test_audio_model.py::test_resolve_model_size_maps_to_valid_size -v
+```
+
+Expected: PASS (the helper was already implemented in Task 1; this is an explicit test pinning its contract).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_audio_model.py
+git commit -m "test(audio_model): pin _resolve_model_size mapping contract"
+```
+
+---
+
+## Task 3: Update get_default_config to use a faster-whisper-compatible name
+
+**Files:**
+- Modify: `src/models/audio_model.py` (the `get_default_config` static method, currently at lines 61-79 in the original file)
+- Test: `tests/test_audio_model.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audio_model.py`:
+
+```python
+@pytest.mark.unit
+def test_default_config_resolves_to_valid_model_size() -> None:
+    from models.audio_model import AudioModel, _resolve_model_size
+
+    config = AudioModel.get_default_config()
+    size = _resolve_model_size(config.name)
+    # Must be one of the real ModelSize values (not the silent fallback)
+    assert size.value == config.name or size.value == config.name.replace("whisper-", "")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/test_audio_model.py::test_default_config_resolves_to_valid_model_size -v
+```
+
+Expected: FAIL — current default name is `"distil-whisper-large-v3"` which is not a `ModelSize` value (it falls back to `BASE`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/models/audio_model.py`, replace the existing `get_default_config` block with:
+
+```python
+    @staticmethod
+    def get_default_config(model_name: str = "base") -> ModelConfig:
+        """Get default configuration for audio model.
+
+        Default is faster-whisper "base" (~150 MB, multilingual). Override
+        via `model_name` for "tiny", "small", "large-v3", etc.
+        """
+        return ModelConfig(
+            name=model_name,
+            model_type=ModelType.AUDIO,
+            framework="faster-whisper",
+            temperature=0.0,
+            max_tokens=1000,
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pytest tests/test_audio_model.py::test_default_config_resolves_to_valid_model_size -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/audio_model.py tests/test_audio_model.py
+git commit -m "fix(audio_model): default get_default_config to whisper 'base'"
+```
+
+---
+
+## Task 4: AudioModel.initialize() sets _initialized through BaseModel
+
+**Files:**
+- Modify: `src/models/audio_model.py` (replace the placeholder `initialize`)
+- Test: `tests/test_audio_model.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audio_model.py`:
+
+```python
+@pytest.mark.unit
+class TestAudioModelLifecycle:
+    def test_initialize_sets_initialized_flag(self) -> None:
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        assert model.is_initialized is False
+        model.initialize()
+        assert model.is_initialized is True
+```
+
+- [ ] **Step 2: Run test to verify the current behavior**
+
+```bash
+pytest tests/test_audio_model.py::TestAudioModelLifecycle::test_initialize_sets_initialized_flag -v
+```
+
+Expected outcome depends on the file at this point: the original `initialize` calls `super().initialize()` already (via `super().initialize()` on line 38), so this test may already PASS. Either way, capture the current state before editing.
+
+- [ ] **Step 3: Replace the `initialize` method**
+
+In `src/models/audio_model.py`, replace the existing `initialize` method (originally at lines 35-38) with:
+
+```python
+    def initialize(self) -> None:
+        """Initialize the model. Whisper weights load lazily on first generate()."""
+        super().initialize()
+```
+
+(Drops the misleading "not fully implemented" warning. The transcriber is already created in `__init__`; weight loading defers until first `transcribe()` call inside the underlying `AudioTranscriber`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pytest tests/test_audio_model.py::TestAudioModelLifecycle::test_initialize_sets_initialized_flag -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/audio_model.py tests/test_audio_model.py
+git commit -m "refactor(audio_model): drop 'not implemented' warning from initialize()"
+```
+
+---
+
+## Task 5: AudioModel.generate() returns transcribed text
+
+**Files:**
+- Modify: `src/models/audio_model.py` (replace `generate` method body)
+- Test: `tests/test_audio_model.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audio_model.py`:
+
+```python
+@pytest.mark.unit
+class TestAudioModelGenerate:
+    def test_generate_returns_transcription_text(self, tmp_path: Path) -> None:
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        model.initialize()
+
+        fake_audio = tmp_path / "sample.wav"
+        fake_audio.touch()  # transcriber is mocked; existence check still runs
+
+        fake_result = MagicMock()
+        fake_result.text = "hello world"
+        with patch.object(
+            model._transcriber, "transcribe", return_value=fake_result
+        ) as mock_transcribe:
+            output = model.generate(str(fake_audio))
+
+        assert output == "hello world"
+        mock_transcribe.assert_called_once()
+        # First positional arg is the audio path
+        called_path = mock_transcribe.call_args.args[0]
+        assert Path(called_path) == fake_audio
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/test_audio_model.py::TestAudioModelGenerate::test_generate_returns_transcription_text -v
+```
+
+Expected: FAIL — `NotImplementedError: Audio processing will be implemented in Phase 3`.
+
+- [ ] **Step 3: Replace the `generate` method**
+
+In `src/models/audio_model.py`, replace the existing `generate` method (originally at lines 40-53, currently raising NotImplementedError) with:
+
+```python
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        """Transcribe an audio file.
+
+        Args:
+            prompt: Path to the audio file (treated as a filesystem path).
+            **kwargs: Reserved for future per-call options. Currently ignored.
+
+        Returns:
+            Transcribed text. May be the empty string for silent or
+            unintelligible audio.
+
+        Raises:
+            FileNotFoundError: If `prompt` does not name an existing file.
+            ImportError: If the `[media]` extra is not installed
+                (faster-whisper missing).
+            RuntimeError: If the model is shutting down or not initialized.
+        """
+        self._enter_generate()
+        try:
+            options = TranscriptionOptions()
+            result = self._transcriber.transcribe(Path(prompt), options=options)
+            return result.text
+        finally:
+            self._exit_generate()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pytest tests/test_audio_model.py::TestAudioModelGenerate::test_generate_returns_transcription_text -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/audio_model.py tests/test_audio_model.py
+git commit -m "feat(audio_model): wire generate() to AudioTranscriber.transcribe()"
+```
+
+---
+
+## Task 6: generate() lifecycle errors propagate correctly
+
+**Files:**
+- Test only: `tests/test_audio_model.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audio_model.py`:
+
+```python
+@pytest.mark.unit
+class TestAudioModelGenerateErrors:
+    def test_generate_before_initialize_raises_runtime_error(
+        self, tmp_path: Path
+    ) -> None:
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        # Note: not calling initialize()
+        fake_audio = tmp_path / "sample.wav"
+        fake_audio.touch()
+        with pytest.raises(RuntimeError, match="not initialized"):
+            model.generate(str(fake_audio))
+
+    def test_generate_after_shutdown_raises_runtime_error(
+        self, tmp_path: Path
+    ) -> None:
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        model.initialize()
+        model.safe_cleanup()  # marks _shutting_down
+        fake_audio = tmp_path / "sample.wav"
+        fake_audio.touch()
+        with pytest.raises(RuntimeError, match="shutting down"):
+            model.generate(str(fake_audio))
+
+    def test_generate_propagates_filenotfound(self, tmp_path: Path) -> None:
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        model.initialize()
+        missing = tmp_path / "does-not-exist.wav"
+        with pytest.raises(FileNotFoundError):
+            model.generate(str(missing))
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+```bash
+pytest tests/test_audio_model.py::TestAudioModelGenerateErrors -v
+```
+
+Expected: PASS — `_enter_generate()` and `AudioTranscriber.transcribe()` already raise these errors per `src/models/base.py:198-208` and `src/services/audio/transcriber.py:211-213`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_audio_model.py
+git commit -m "test(audio_model): pin generate() lifecycle and FileNotFoundError contracts"
+```
+
+---
+
+## Task 7: AudioModel.cleanup() unloads the Whisper model
+
+**Files:**
+- Modify: `src/models/audio_model.py` (replace `cleanup`)
+- Test: `tests/test_audio_model.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_audio_model.py`:
+
+```python
+    def test_cleanup_unloads_transcriber(self) -> None:
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        model.initialize()
+        with patch.object(model._transcriber, "unload_model") as mock_unload:
+            model.cleanup()
+        mock_unload.assert_called_once()
+        assert model.is_initialized is False
+```
+
+(Append inside `TestAudioModelLifecycle`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest tests/test_audio_model.py::TestAudioModelLifecycle::test_cleanup_unloads_transcriber -v
+```
+
+Expected: FAIL — current `cleanup()` only flips `_initialized`; the transcriber's model is never released.
+
+- [ ] **Step 3: Replace the `cleanup` method**
+
+In `src/models/audio_model.py`, replace the existing `cleanup` method (originally at lines 55-59) with:
+
+```python
+    def cleanup(self) -> None:
+        """Cleanup model resources. Unloads the underlying Whisper model."""
+        logger.debug("Cleaning up audio model")
+        with self._lifecycle_lock:
+            self._transcriber.unload_model()
+            self._initialized = False
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pytest tests/test_audio_model.py::TestAudioModelLifecycle::test_cleanup_unloads_transcriber -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole test_audio_model.py file**
+
+```bash
+pytest tests/test_audio_model.py -v
+```
+
+Expected: all tests PASS. No regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/models/audio_model.py tests/test_audio_model.py
+git commit -m "feat(audio_model): cleanup() unloads underlying Whisper model"
+```
+
+---
+
+## Task 8: Integration test — AudioModel.generate() against real audio
+
+**Files:**
+- Create: `tests/integration/test_audio_model_integration.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/integration/test_audio_model_integration.py`:
+
+```python
+"""Integration tests for AudioModel — end-to-end with faster-whisper.
+
+Skipped automatically when the [media] extra is not installed.
+"""
+
+from __future__ import annotations
+
+import struct
+import wave
+from pathlib import Path
+
+import pytest
+
+from models.audio_model import AudioModel
+from models.base import ModelConfig, ModelType
+
+
+def _generate_silence_wav(path: Path, seconds: float = 1.0) -> None:
+    """Write a mono 16-bit 16kHz silent WAV file at `path`."""
+    sample_rate = 16000
+    n_frames = int(seconds * sample_rate)
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        # 16-bit signed silence = b"\x00\x00" per sample
+        w.writeframes(struct.pack("<h", 0) * n_frames)
+
+
+@pytest.mark.integration
+class TestAudioModelEndToEnd:
+    @pytest.fixture(autouse=True)
+    def _require_faster_whisper(self) -> None:
+        pytest.importorskip("faster_whisper")
+
+    def test_generate_returns_string_for_silent_wav(self, tmp_path: Path) -> None:
+        audio_path = tmp_path / "silence.wav"
+        _generate_silence_wav(audio_path, seconds=1.0)
+
+        config = ModelConfig(name="tiny", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        model.initialize()
+        try:
+            output = model.generate(str(audio_path))
+        finally:
+            model.safe_cleanup()
+
+        assert isinstance(output, str)
+        # Silence may transcribe to empty or to a short artifact; both are valid.
+        # The contract we're proving: pipeline runs end-to-end without crashing.
+        assert len(output) <= 200  # sanity: not a huge garbage dump
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+pytest tests/integration/test_audio_model_integration.py -v
+```
+
+Expected: PASS if `faster-whisper` is installed (it is in the dev environment per `[media]`). Skipped if not. First run will download the "tiny" model (~39 MB) — subsequent runs use the cached download.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_audio_model_integration.py
+git commit -m "test(audio_model): integration test with generated silent WAV"
+```
+
+---
+
+## Task 9: Add `--transcribe-smoke` flag to fo benchmark
+
+**Files:**
+- Modify: `src/cli/benchmark.py` (add CLI flag, extend outcome dataclass, modify `_run_audio_suite`, add `functools.partial` dispatch in `run()`)
+
+**Architecture note** (verified by reading the file): The benchmark CLI is `benchmark_app` (a `typer.Typer` instance) with one `run` subcommand at line 947. Suite runners live in `_SUITE_RUNNERS` (line 712) and are dispatched via `runner(files)` at line 801 — the signature is fixed `Callable[[list[Path]], _SuiteIterationOutcome]`. To thread `transcribe_smoke` through without changing every runner's signature, we use `functools.partial` in `run()` to pre-bind the flag to the audio runner only.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/cli/test_benchmark_audio_transcribe.py`:
+
+```python
+"""Test that fo benchmark run --transcribe-smoke exercises AudioModel.generate()."""
+
+from __future__ import annotations
+
+import struct
+import wave
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from cli.benchmark import benchmark_app
+
+
+def _generate_silence_wav(path: Path, seconds: float = 0.5) -> None:
+    sample_rate = 16000
+    n_frames = int(seconds * sample_rate)
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        w.writeframes(struct.pack("<h", 0) * n_frames)
+
+
+@pytest.mark.integration
+class TestBenchmarkTranscribeSmoke:
+    def test_transcribe_smoke_invokes_audio_model_once(
+        self, tmp_path: Path
+    ) -> None:
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir()
+        _generate_silence_wav(audio_dir / "a.wav")
+        _generate_silence_wav(audio_dir / "b.wav")
+
+        runner = CliRunner()
+        with patch("cli.benchmark.AudioModel") as mock_model_cls:
+            instance = mock_model_cls.return_value
+            instance.generate.return_value = ""
+            result = runner.invoke(
+                benchmark_app,
+                [
+                    "run",
+                    str(audio_dir),
+                    "--suite", "audio",
+                    "--transcribe-smoke",
+                    "--iterations", "1",
+                    "--warmup", "0",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # Smoke: exactly one transcription regardless of candidate count
+        assert instance.generate.call_count == 1
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+pytest tests/cli/test_benchmark_audio_transcribe.py -v
+```
+
+Expected: FAIL — `--transcribe-smoke` flag does not exist.
+
+- [ ] **Step 3: Modify `_SuiteIterationOutcome`**
+
+In `src/cli/benchmark.py`, find the `_SuiteIterationOutcome` dataclass (search for `class _SuiteIterationOutcome`) and add a new field:
+
+```python
+@dataclass
+class _SuiteIterationOutcome:
+    processed_count: int
+    used_synthetic_audio_metadata: bool = False
+    transcription_smoke_passed: bool = False  # NEW: set True when --transcribe-smoke completes
+```
+
+(Preserve all existing fields; add the new one at the end with a default so existing call sites that construct `_SuiteIterationOutcome(processed_count=...)` keep working.)
+
+- [ ] **Step 4: Add the imports for `functools.partial` and AudioModel**
+
+Add to the top of `src/cli/benchmark.py`, in the existing imports block (next to the other `from models...` imports if any, or just after `import typer`):
+
+```python
+import functools
+
+from models.audio_model import AudioModel
+from models.base import ModelConfig, ModelType
+```
+
+(If `import functools` is already present, don't duplicate it.)
+
+- [ ] **Step 5: Add the `--transcribe-smoke` option to the `run` command**
+
+In `src/cli/benchmark.py`, locate the `run` function decorated with `@benchmark_app.command()` at line ~946. Add a new option parameter to its signature (place after `--compare`, before the `) -> None:` close):
+
+```python
+    transcribe_smoke: bool = typer.Option(
+        False,
+        "--transcribe-smoke",
+        help=(
+            "Run AudioModel.generate() on one candidate file as an end-to-end "
+            "smoke test. Only meaningful with --suite audio. Requires [media] "
+            "extra. Off by default to keep benchmark runs fast."
+        ),
+    ),
+```
+
+- [ ] **Step 6: Bind `transcribe_smoke` to the audio runner via `functools.partial`**
+
+In the `run` function body, locate the block (around line 1017-1022) that reads `runner = suite_spec["run"]`. Immediately after that line, add:
+
+```python
+    runner = suite_spec["run"]
+    classifier = suite_spec["classify"]
+    if suite == "audio" and transcribe_smoke:
+        runner = functools.partial(_run_audio_suite, transcribe_smoke=True)
+```
+
+- [ ] **Step 7: Extend `_run_audio_suite` to perform the smoke pass**
+
+Replace the entire `_run_audio_suite` function (currently lines 500-525) with:
+
+```python
+def _run_audio_suite(
+    files: list[Path],
+    transcribe_smoke: bool = False,
+) -> _SuiteIterationOutcome:
+    """Benchmark audio metadata + classification path.
+
+    With `transcribe_smoke=True`, additionally runs AudioModel.generate() on
+    the first candidate file to prove end-to-end transcription works. Counted
+    as a single smoke pass; not a per-file benchmark.
+    """
+    candidates = _suite_candidates(files, _AUDIO_EXTENSIONS, fallback_to_all=False)
+    if not candidates:
+        typer.echo("Warning: no audio files found; falling back to IO-only benchmark.", err=True)
+        return _run_io_suite(files)
+
+    from services.audio.classifier import AudioClassifier
+    from services.audio.metadata_extractor import AudioMetadataExtractor
+
+    extractor = AudioMetadataExtractor(use_fallback=True)
+    classifier = AudioClassifier()
+    used_synthetic_metadata = False
+    for file_path in candidates:
+        try:
+            metadata = extractor.extract(file_path)
+        except ImportError:
+            used_synthetic_metadata = True
+            metadata = _synthesized_audio_metadata(file_path)
+        except Exception as exc:
+            raise RuntimeError(f"Audio benchmark runner failed for {file_path}: {exc}") from exc
+        _ = classifier.classify(metadata)
+
+    transcription_smoke_passed = False
+    if transcribe_smoke:
+        try:
+            config = ModelConfig(name="tiny", model_type=ModelType.AUDIO)
+            model = AudioModel(config)
+            model.initialize()
+            try:
+                _ = model.generate(str(candidates[0]))
+                transcription_smoke_passed = True
+            finally:
+                model.safe_cleanup()
+        except ImportError as exc:
+            typer.echo(
+                f"Warning: --transcribe-smoke requires [media] extra: {exc}",
+                err=True,
+            )
+
+    return _SuiteIterationOutcome(
+        processed_count=len(candidates),
+        used_synthetic_audio_metadata=used_synthetic_metadata,
+        transcription_smoke_passed=transcription_smoke_passed,
+    )
+```
+
+- [ ] **Step 8: Run the test to verify it passes**
+
+```bash
+pytest tests/cli/test_benchmark_audio_transcribe.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Run the full benchmark test surface to catch regressions**
+
+```bash
+pytest tests/cli/ -k benchmark -v
+```
+
+Expected: all PASS. Pay attention to any test asserting the exact set of fields on `_SuiteIterationOutcome` — adding a defaulted field is backward-compatible at the constructor level but a strict-equality assertion on the whole dataclass would break.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/cli/benchmark.py tests/cli/test_benchmark_audio_transcribe.py
+git commit -m "$(cat <<'EOF'
+feat(benchmark): add --transcribe-smoke flag for fo benchmark --suite audio
+
+Runs AudioModel.generate() on one candidate file when the flag is set.
+Off by default to keep default benchmark runs fast. Required for the
+beta entry checklist (docs/release/beta-criteria.md §2).
+EOF
+)"
+```
+
+---
+
+## Task 10: Honesty pass on README and pyproject [media] description
+
+**Files:**
+- Modify: `README.md` (the Optional Feature Packs table row for "Media")
+- Modify: `pyproject.toml` (inline comment for the `media` extra)
+
+- [ ] **Step 1: Read the current claims**
+
+```bash
+grep -A 1 "\[media\]" README.md
+grep -B 1 -A 5 "^media = \[" pyproject.toml
+```
+
+- [ ] **Step 2: Update README**
+
+In `README.md`, change the Media row of the Optional Feature Packs table from:
+
+```markdown
+| Media | `pip install -e ".[media]"` | Audio transcription + video scene detection |
+```
+
+to:
+
+```markdown
+| Media | `pip install -e ".[media]"` | Audio transcription (faster-whisper) + video scene detection. Exercise via `fo benchmark --suite audio --transcribe-smoke`. |
+```
+
+- [ ] **Step 3: Update pyproject.toml**
+
+In `pyproject.toml`, locate the comment immediately above `media = [...]` and update it to reflect the actual surface. Example (adjust to match the existing comment style):
+
+```toml
+# Optional: audio transcription (faster-whisper) and video scene detection.
+# Audio is exposed via the AudioModel class and exercised by
+# `fo benchmark --suite audio --transcribe-smoke`. Video scene detection
+# is invoked by services/video/scene_detector.py callers.
+media = [
+    "faster-whisper~=1.0",
+    "torch~=2.1",
+    "pydub>=0.25.0,<1",
+    "opencv-python~=4.8",
+    "scenedetect[opencv]>=0.6.0,<1",
+]
+```
+
+- [ ] **Step 4: Lint the markdown**
+
+```bash
+pymarkdown -c .pymarkdown.json scan README.md
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md pyproject.toml
+git commit -m "docs: tighten [media] extra description to match wired surface"
+```
+
+---
+
+## Task 11: Full test suite + pre-commit validation
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the unit and CI test marker subsets**
+
+```bash
+pytest -m "ci" -v
+pytest -m "unit" tests/test_audio_model.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Run the integration tests for audio**
+
+```bash
+pytest -m "integration" tests/integration/test_audio_model_integration.py tests/cli/test_benchmark_audio_transcribe.py -v
+```
+
+Expected: PASS (or SKIP if `faster-whisper` not installed in the running env — the autouse `_require_faster_whisper` fixture handles that).
+
+- [ ] **Step 3: Run pre-commit validation**
+
+```bash
+bash .claude/scripts/pre-commit-validation.sh
+```
+
+Expected: ✓ all checks pass.
+
+- [ ] **Step 4: Run code review**
+
+Invoke the project's code-review skill (`/code-reviewer`) on the diff. Address any APPLY findings; reply to SKIP findings; defer DEFER findings to follow-up issues. See `.claude/rules/pr-review-response-protocol.md`.
+
+- [ ] **Step 5: Push branch and open PR**
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "feat(audio_model): wire generate() to faster-whisper + benchmark smoke" --body "$(cat <<'EOF'
+## Summary
+
+Closes Step 2A of the alpha → beta path documented in
+[docs/release/beta-criteria.md](docs/release/beta-criteria.md).
+
+- `AudioModel.generate()` now wraps `services.audio.transcriber.AudioTranscriber`
+  instead of raising `NotImplementedError`.
+- `fo benchmark --suite audio --transcribe-smoke` runs an end-to-end
+  transcription smoke pass on one candidate file. Default benchmark runs
+  remain fast.
+- README and pyproject's `[media]` description updated to match wired surface.
+
+## Test plan
+
+- [ ] `pytest tests/test_audio_model.py -v` — all unit tests pass
+- [ ] `pytest tests/integration/test_audio_model_integration.py -v` —
+      end-to-end test with generated silent WAV passes
+- [ ] `pytest tests/cli/test_benchmark_audio_transcribe.py -v` —
+      smoke flag invokes `AudioModel.generate` exactly once
+- [ ] Manual: `fo benchmark --suite audio --transcribe-smoke --input <dir>` on
+      a directory with two audio files; output reports `transcription_smoke_passed=True`
+EOF
+)"
+```
+
+- [ ] **Step 6: Monitor CI**
+
+Per `.claude/rules/pr-monitoring-protocol.md`, monitor PR until merge. Re-arm CI monitor on every push.
+
+---
+
+## Verification checklist (rolls up the entry-checklist row in beta-criteria.md)
+
+After this plan executes and merges:
+
+- `AudioModel.generate()` returns transcribed text for a real audio file. Confirmed by `tests/integration/test_audio_model_integration.py`.
+- `fo benchmark --suite audio --transcribe-smoke` succeeds end-to-end on a sample file with `[media]` installed. Confirmed by `tests/cli/test_benchmark_audio_transcribe.py` and a manual run.
+- README and `pyproject.toml` describe what actually ships. Confirmed by Task 10.
+- No reachable `NotImplementedError` from a documented surface. Confirmed: `grep -rn "NotImplementedError" src/models/audio_model.py` returns no matches after Task 5.
+
+This satisfies the first row of the §2 entry checklist in
+[docs/release/beta-criteria.md](docs/release/beta-criteria.md). The remaining
+rows (coverage floors, daemon smoke test, `--debug` flag, doc-honesty pass,
+schema-stability test, bug-report template) are addressed by later steps in
+the master plan.

--- a/docs/superpowers/plans/2026-04-27-audio-model-wiring-2a.md
+++ b/docs/superpowers/plans/2026-04-27-audio-model-wiring-2a.md
@@ -948,7 +948,7 @@ gh pr create --title "feat(audio_model): wire generate() to faster-whisper + ben
 ## Summary
 
 Closes Step 2A of the alpha → beta path documented in
-[docs/release/beta-criteria.md](docs/release/beta-criteria.md).
+`docs/release/beta-criteria.md`.
 
 - `AudioModel.generate()` now wraps `services.audio.transcriber.AudioTranscriber`
   instead of raising `NotImplementedError`.
@@ -986,7 +986,7 @@ After this plan executes and merges:
 - No reachable `NotImplementedError` from a documented surface. Confirmed: `grep -rn "NotImplementedError" src/models/audio_model.py` returns no matches after Task 5.
 
 This satisfies the first row of the §2 entry checklist in
-[docs/release/beta-criteria.md](docs/release/beta-criteria.md). The remaining
+[docs/release/beta-criteria.md](../../release/beta-criteria.md). The remaining
 rows (coverage floors, daemon smoke test, `--debug` flag, doc-honesty pass,
 schema-stability test, bug-report template) are addressed by later steps in
 the master plan.

--- a/docs/superpowers/plans/2026-04-27-audio-model-wiring-2a.md
+++ b/docs/superpowers/plans/2026-04-27-audio-model-wiring-2a.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Wire `AudioModel.generate()` (currently `NotImplementedError`) to the existing `services.audio.transcriber.AudioTranscriber`, and add an opt-in transcription smoke pass to `fo benchmark --suite audio` so the `[media]` extra delivers what its README description claims.
+**Goal:** Wire `AudioModel.generate()` (currently `NotImplementedError`) to the existing `services.audio.transcriber.AudioTranscriber`, and add an opt-in transcription smoke pass to `fo benchmark run --suite audio` so the `[media]` extra delivers what its README description claims.
 
 **Architecture:** `AudioModel` becomes a thin adapter over `services.audio.transcriber.AudioTranscriber`. The transcriber is instantiated in `AudioModel.__init__` (cheap — model weights load lazily on first `transcribe()`). `generate(prompt)` treats `prompt` as the audio file path, calls `transcriber.transcribe(path)`, and returns `result.text`. Lifecycle hooks (`_enter_generate` / `_exit_generate`) come from `BaseModel`. Benchmark gains a `--transcribe-smoke` flag that transcribes exactly one candidate file (smallest first) so the smoke test cost is bounded.
 
@@ -838,7 +838,7 @@ Expected: all PASS. Pay attention to any test asserting the exact set of fields 
 ```bash
 git add src/cli/benchmark.py tests/cli/test_benchmark_audio_transcribe.py
 git commit -m "$(cat <<'EOF'
-feat(benchmark): add --transcribe-smoke flag for fo benchmark --suite audio
+feat(benchmark): add --transcribe-smoke flag for fo benchmark run --suite audio
 
 Runs AudioModel.generate() on one candidate file when the flag is set.
 Off by default to keep default benchmark runs fast. Required for the
@@ -873,7 +873,7 @@ In `README.md`, change the Media row of the Optional Feature Packs table from:
 to:
 
 ```markdown
-| Media | `pip install -e ".[media]"` | Audio transcription (faster-whisper) + video scene detection. Exercise via `fo benchmark --suite audio --transcribe-smoke`. |
+| Media | `pip install -e ".[media]"` | Audio transcription (faster-whisper) + video scene detection. Exercise via `fo benchmark run --suite audio --transcribe-smoke`. |
 ```
 
 - [ ] **Step 3: Update pyproject.toml**
@@ -883,7 +883,7 @@ In `pyproject.toml`, locate the comment immediately above `media = [...]` and up
 ```toml
 # Optional: audio transcription (faster-whisper) and video scene detection.
 # Audio is exposed via the AudioModel class and exercised by
-# `fo benchmark --suite audio --transcribe-smoke`. Video scene detection
+# `fo benchmark run --suite audio --transcribe-smoke`. Video scene detection
 # is invoked by services/video/scene_detector.py callers.
 media = [
     "faster-whisper~=1.0",
@@ -956,7 +956,7 @@ Closes Step 2A of the alpha → beta path documented in
 
 - `AudioModel.generate()` now wraps `services.audio.transcriber.AudioTranscriber`
   instead of raising `NotImplementedError`.
-- `fo benchmark --suite audio --transcribe-smoke` runs an end-to-end
+- `fo benchmark run --suite audio --transcribe-smoke` runs an end-to-end
   transcription smoke pass on one candidate file. Default benchmark runs
   remain fast.
 - README and pyproject's `[media]` description updated to match wired surface.
@@ -968,7 +968,7 @@ Closes Step 2A of the alpha → beta path documented in
       end-to-end test with generated silent WAV passes
 - [ ] `pytest tests/cli/test_benchmark_audio_transcribe.py -v` —
       smoke flag invokes `AudioModel.generate` exactly once
-- [ ] Manual: `fo benchmark --suite audio --transcribe-smoke --input <dir>` on
+- [ ] Manual: `fo benchmark run --suite audio --transcribe-smoke --input <dir>` on
       a directory with two audio files; output reports `transcription_smoke_passed=True`
 EOF
 )"
@@ -985,7 +985,7 @@ Per `.claude/rules/pr-monitoring-protocol.md`, monitor PR until merge. Re-arm CI
 After this plan executes and merges:
 
 - `AudioModel.generate()` returns transcribed text for a real audio file. Confirmed by `tests/integration/test_audio_model_integration.py`.
-- `fo benchmark --suite audio --transcribe-smoke` succeeds end-to-end on a sample file with `[media]` installed. Confirmed by `tests/cli/test_benchmark_audio_transcribe.py` and a manual run.
+- `fo benchmark run --suite audio --transcribe-smoke` succeeds end-to-end on a sample file with `[media]` installed. Confirmed by `tests/cli/test_benchmark_audio_transcribe.py` and a manual run.
 - README and `pyproject.toml` describe what actually ships. Confirmed by Task 10.
 - No reachable `NotImplementedError` from a documented surface. Confirmed: `grep -rn "NotImplementedError" src/models/audio_model.py` returns no matches after Task 5.
 

--- a/docs/superpowers/plans/2026-04-27-classifier-bump-step-5.md
+++ b/docs/superpowers/plans/2026-04-27-classifier-bump-step-5.md
@@ -252,7 +252,7 @@ schema-frozen promise, and the rollback path.
 
 - Audio transcription is wired end-to-end. `fo organize --transcribe-audio`
   uses faster-whisper to categorize audio files by transcript content;
-  `fo benchmark --suite audio --transcribe-smoke` exercises the full path.
+  `fo benchmark run --suite audio --transcribe-smoke` exercises the full path.
 - Global `--debug` flag surfaces tracebacks for bug reports.
 - First-run setup gate now consistently blocks all non-allowlisted commands.
 - Config validation errors include valid-values lists and "did you mean"
@@ -424,7 +424,9 @@ Per the project's communication conventions (which I don't presume — leave thi
 
 After this plan executes:
 
-- `pip show fo-core | grep Status` reports `Status: 4 - Beta`.
+- `pip show --verbose fo-core | grep "Development Status"` reports
+  `Development Status :: 4 - Beta`. (Plain `pip show` does not include
+  classifiers in its output; the `--verbose` flag is required.)
 - `fo --version` reports `2.0.0-beta.1`.
 - `fo update check --pre` finds the new pre-release.
 - The Beta bug-report template appears in the issue creation flow.

--- a/docs/superpowers/plans/2026-04-27-classifier-bump-step-5.md
+++ b/docs/superpowers/plans/2026-04-27-classifier-bump-step-5.md
@@ -245,9 +245,8 @@ First public-pre-release beta. The PyPI classifier moves from
 `3 - Alpha` to `4 - Beta` and the auto-updater's pre-release channel is
 open: opt in with `fo update --pre-release`.
 
-See [docs/release/beta-criteria.md](docs/release/beta-criteria.md) for the
-full beta-tester contract, the schema-frozen promise, and the rollback
-path.
+See `docs/release/beta-criteria.md` for the full beta-tester contract, the
+schema-frozen promise, and the rollback path.
 
 ### What's new since 2.0.0-alpha.3
 
@@ -289,21 +288,24 @@ fo update --no-pre-release
 
 Change `README.md` (the "Releases" section near the bottom) from:
 
-```markdown
-Currently `2.0.0-alpha.3`. The criteria for promoting to beta and the contract
-with public pre-release testers are documented in
-[docs/release/beta-criteria.md](docs/release/beta-criteria.md).
-```
+From:
 
-to:
+> Currently `2.0.0-alpha.3`. The criteria for promoting to beta and the
+> contract with public pre-release testers are documented in
+> `[docs/release/beta-criteria.md](docs/release/beta-criteria.md)`.
 
-```markdown
-Currently `2.0.0-beta.1`. The auto-updater's public pre-release channel is open
-— opt in with `fo update --pre-release`. See
-[docs/release/beta-criteria.md](docs/release/beta-criteria.md) for the
-beta-tester contract, the schema-frozen compatibility promise, and the
-rollback path.
-```
+To:
+
+> Currently `2.0.0-beta.1`. The auto-updater's public pre-release channel is
+> open — opt in with `fo update --pre-release`. See
+> `[docs/release/beta-criteria.md](docs/release/beta-criteria.md)` for the
+> beta-tester contract, the schema-frozen compatibility promise, and the
+> rollback path.
+
+(The `[text](url)` markdown-link syntax above is shown inside backticks so
+the plan's own link checker doesn't try to resolve it from this file's
+directory; when you edit `README.md`, drop the surrounding backticks so the
+syntax becomes a real clickable link.)
 
 - [ ] **Step 5: Fix README CLI command list to match actual surface**
 

--- a/docs/superpowers/plans/2026-04-27-classifier-bump-step-5.md
+++ b/docs/superpowers/plans/2026-04-27-classifier-bump-step-5.md
@@ -1,0 +1,432 @@
+# Classifier Bump to Beta (Step 5) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bump fo-core from `2.0.0-alpha.3` / `Development Status :: 3 - Alpha` to `2.0.0-beta.1` / `Development Status :: 4 - Beta`. Open the public pre-release channel. Add the Beta bug-report template. Cut the release.
+
+**Prerequisites:** Steps 1–4 must merge first. This plan validates that every entry-checklist row in `docs/release/beta-criteria.md` §2 is closed before flipping the classifier.
+
+**Architecture:** Three changes — a version bump in `pyproject.toml`, a CHANGELOG entry summarizing what beta promises, and a new GitHub Issue Template. Plus a release run that produces the `2.0.0-beta.1` tag and PyPI artifact.
+
+**Tech Stack:** `pyproject.toml`, GitHub release workflow (existing), `gh release create`.
+
+**Out of scope:** Renaming `2.0.0-alpha.X` releases. Restructuring the changelog. Anything that the beta-criteria doc explicitly defers.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `pyproject.toml` | Modify | Bump `version` and `Development Status` classifier |
+| `CHANGELOG.md` | Modify | Add a `## [2.0.0-beta.1]` section summarizing the beta-readiness work |
+| `.github/ISSUE_TEMPLATE/beta-bug.md` | Create | Beta-specific bug template requiring `--debug` output and `fo doctor` summary |
+| `README.md` | Modify | Update the Releases section to reflect beta status |
+| `tests/ci/test_release_metadata.py` | Create | Guard test asserting version + classifier match each other |
+
+Plan conventions: see [2A plan](2026-04-27-audio-model-wiring-2a.md) "Conventions for this plan" section.
+
+---
+
+## Task 1: Pre-bump audit — verify every entry-checklist row is closed
+
+This task ships no code. It's a hard gate before any version bump.
+
+**Files:** none (audit only)
+
+- [ ] **Step 1: Walk the §2 entry checklist**
+
+Open `docs/release/beta-criteria.md` and tick each row:
+
+- [ ] **Audio works end-to-end.** Verify: `pytest tests/integration/test_audio_model_integration.py tests/integration/test_organize_audio_e2e.py -v` passes. `grep "NotImplementedError" src/models/audio_model.py` returns no matches. README and `pyproject.toml` `[media]` description match the wired surface.
+
+- [ ] **Integration coverage floors.** Verify: `bash .claude/scripts/measure-integration-coverage.sh` reports global ≥ 75%, and `scripts/coverage/integration_module_floor_baseline.json` shows ≥ 70% for every module previously below.
+
+- [ ] **Daemon smoke test in CI.** Verify: `tests/integration/test_daemon_smoke.py` exists and is green in the latest `test-integration` CI run on main.
+
+- [ ] **`--debug` flag wired.** Verify: `fo --debug version` runs without error; an intentional failure (`fo --debug organize /nonexistent /nonexistent`) prints a Rich traceback. Documented in `docs/troubleshooting.md`.
+
+- [ ] **Doc-honesty pass.** Verify: every command in `docs/cli-reference.md` is registered in `src/cli/main.py`. Every extra in the README's Optional Feature Packs table maps to a real `pyproject.toml` extra. `grep -rn "NotImplementedError" src/` from any documented entry point returns no matches.
+
+- [ ] **Schema-stability test.** Verify: `pytest tests/integration/test_config_schema_stability.py -v` passes; the test runs in the `ci` marker subset (every PR).
+
+- [ ] **Bug-report template exists.** Will be true after Task 4 of this plan.
+
+- [ ] **Step 2: If any row fails, STOP**
+
+Do not proceed to the bump. File the gap as a tracked issue, close it via the relevant earlier step's plan, then return to this audit.
+
+- [ ] **Step 3: If all rows pass, capture evidence**
+
+Save the output of:
+
+```bash
+bash .claude/scripts/measure-integration-coverage.sh > /tmp/beta-cov-final.txt
+pytest -m "ci" -v > /tmp/beta-ci-final.txt
+fo --debug version > /tmp/beta-debug-evidence.txt 2>&1
+```
+
+These outputs go into the PR body for the bump.
+
+---
+
+## Task 2: Add the Beta bug-report template
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/beta-bug.md`
+
+- [ ] **Step 1: Write the template**
+
+````markdown
+---
+name: Beta bug
+about: Report a bug in a 2.0.0-beta.X release
+title: "[BETA] "
+labels: bug, beta
+assignees: ""
+---
+
+<!--
+Thanks for testing the fo-core beta channel!
+Filing a bug here helps us decide when this build is ready to graduate to GA.
+-->
+
+## What happened
+
+<!-- One-line description of the bug. -->
+
+## fo --debug output
+
+<!--
+REQUIRED. Re-run your failing command with --debug and paste the FULL output
+below (red error line + traceback). Without this, triage usually has to ask
+you to re-run.
+-->
+
+```text
+$ fo --debug <your command>
+<paste output here>
+```
+
+## fo doctor output
+
+<!-- REQUIRED. Output of `fo doctor`. -->
+
+```text
+$ fo doctor
+<paste output here>
+```
+
+## Environment
+
+- OS:
+- Python version (`python --version`):
+- fo-core version (`fo version`):
+- How installed (`pip install fo-core`, `pip install -e .`, etc.):
+- Optional extras installed (`pip show fo-core`):
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What did you think would happen? -->
+
+## Actual behavior
+
+<!-- What happened instead? -->
+````
+
+- [ ] **Step 2: Lint markdown**
+
+```bash
+pymarkdown -c .pymarkdown.json scan .github/ISSUE_TEMPLATE/beta-bug.md
+```
+
+(If the project's pymarkdown config excludes `.github/`, this step is a no-op.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/beta-bug.md
+git commit -m "feat(github): beta bug-report template requiring --debug output"
+```
+
+---
+
+## Task 3: Add a release-metadata sanity test
+
+**Files:**
+- Create: `tests/ci/test_release_metadata.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+"""Guard: version string and Development Status classifier must agree."""
+from __future__ import annotations
+import re
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.ci
+def test_version_and_classifier_agree() -> None:
+    root = Path(__file__).resolve().parents[2]
+    pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+
+    version_match = re.search(r'^version = "([^"]+)"', pyproject, re.MULTILINE)
+    assert version_match, "Could not find version line in pyproject.toml"
+    version = version_match.group(1)
+
+    expected_classifier_substring = (
+        "Development Status :: 4 - Beta" if "beta" in version
+        else "Development Status :: 3 - Alpha" if "alpha" in version
+        else "Development Status :: 5 - Production/Stable"
+    )
+
+    assert expected_classifier_substring in pyproject, (
+        f"Version {version!r} implies classifier {expected_classifier_substring!r}, "
+        f"but it was not found in pyproject.toml. Update the classifier."
+    )
+```
+
+- [ ] **Step 2: Run BEFORE the version bump**
+
+```bash
+pytest tests/ci/test_release_metadata.py -v
+```
+
+Expected (pre-bump): PASS — current version `2.0.0-alpha.3` matches `3 - Alpha`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/ci/test_release_metadata.py
+git commit -m "test(ci): pin version <-> Development Status classifier agreement"
+```
+
+---
+
+## Task 4: The bump itself
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `CHANGELOG.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Bump version in pyproject.toml**
+
+Change `pyproject.toml:7`:
+
+```toml
+version = "2.0.0-beta.1"
+```
+
+- [ ] **Step 2: Bump classifier in pyproject.toml**
+
+Change `pyproject.toml:17`:
+
+```toml
+    "Development Status :: 4 - Beta",
+```
+
+- [ ] **Step 3: Add CHANGELOG section**
+
+Insert at the top of `CHANGELOG.md` (above the existing alpha entries):
+
+````markdown
+## [2.0.0-beta.1] — YYYY-MM-DD
+
+First public-pre-release beta. The PyPI classifier moves from
+`3 - Alpha` to `4 - Beta` and the auto-updater's pre-release channel is
+open: opt in with `fo update --pre-release`.
+
+See [docs/release/beta-criteria.md](docs/release/beta-criteria.md) for the
+full beta-tester contract, the schema-frozen promise, and the rollback
+path.
+
+### What's new since 2.0.0-alpha.3
+
+- Audio transcription is wired end-to-end. `fo organize --transcribe-audio`
+  uses faster-whisper to categorize audio files by transcript content;
+  `fo benchmark --suite audio --transcribe-smoke` exercises the full path.
+- Global `--debug` flag surfaces tracebacks for bug reports.
+- First-run setup gate now consistently blocks all non-allowlisted commands.
+- Config validation errors include valid-values lists and "did you mean"
+  suggestions.
+- Integration coverage lifted to ≥ 75% global; per-module floor at ≥ 70%
+  on every module.
+- Daemon smoke test guards start/watch/stop/status/SIGTERM in CI.
+
+### Compatibility
+
+- Schema is frozen at version 1.0 across the entire 2.0.0-beta.X line.
+- Configs written by 2.0.0-alpha.3 read cleanly under 2.0.0-beta.1.
+- See `docs/release/beta-criteria.md` §3 for the precise compat contract.
+
+### How to opt in
+
+```bash
+fo update --pre-release
+fo update install
+```
+
+### How to roll back to alpha
+
+```bash
+pip install 'fo-core==2.0.0-alpha.3'
+fo update --no-pre-release
+```
+````
+
+(Replace `YYYY-MM-DD` with the actual release date when running this task.)
+
+- [ ] **Step 4: Update README Releases section**
+
+Change `README.md` (the "Releases" section near the bottom) from:
+
+```markdown
+Currently `2.0.0-alpha.3`. The criteria for promoting to beta and the contract
+with public pre-release testers are documented in
+[docs/release/beta-criteria.md](docs/release/beta-criteria.md).
+```
+
+to:
+
+```markdown
+Currently `2.0.0-beta.1`. The auto-updater's public pre-release channel is open
+— opt in with `fo update --pre-release`. See
+[docs/release/beta-criteria.md](docs/release/beta-criteria.md) for the
+beta-tester contract, the schema-frozen compatibility promise, and the
+rollback path.
+```
+
+- [ ] **Step 5: Fix README CLI command list to match actual surface**
+
+A pre-existing README inaccuracy (caught during the plan review pass): the
+"CLI Commands" table near the top of `README.md` describes `fo profile` as
+"Hardware profiling" — but `fo profile` is actually the Click-based
+configuration-profile management group registered lazily in
+`src/cli/main.py:314-324` (`_register_profile_command`), and the real
+hardware-detection command is `fo hardware-info` defined at
+`src/cli/main.py:154`. Fix both lines while we're already touching README
+for the version bump.
+
+In the `## CLI Commands` block, replace:
+
+```text
+fo profile                    Hardware profiling
+```
+
+with two lines (preserving the column alignment of the surrounding table):
+
+```text
+fo profile                    Configuration profile management
+fo hardware-info              Detect and display hardware capabilities
+```
+
+- [ ] **Step 6: Run the metadata sanity test**
+
+```bash
+pytest tests/ci/test_release_metadata.py -v
+```
+
+Expected: PASS — version `2.0.0-beta.1` now matches `4 - Beta`.
+
+- [ ] **Step 7: Run full pre-commit validation**
+
+```bash
+bash .claude/scripts/pre-commit-validation.sh
+pytest -m "ci" -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pyproject.toml CHANGELOG.md README.md
+git commit -m "$(cat <<'EOF'
+release: 2.0.0-beta.1 (Development Status 4 - Beta)
+
+Closes Step 5 of the alpha→beta path. Entry checklist in
+docs/release/beta-criteria.md §2 audited before this bump; evidence
+attached in the PR body.
+
+The schema is frozen at 1.0 across the beta line; alpha.3 configs
+read cleanly under beta.1. Public pre-release channel is open
+(`fo update --pre-release`).
+EOF
+)"
+```
+
+---
+
+## Task 5: PR + release
+
+- [ ] **Step 1: Push and open PR**
+
+Title: `release: 2.0.0-beta.1 (4 - Beta)`
+
+Body: include the audit evidence captured in Task 1 Step 3. Link to the beta-criteria doc and to each Step plan that contributed.
+
+- [ ] **Step 2: Wait for CI green**
+
+Per `.claude/rules/pr-monitoring-protocol.md`, monitor until merge.
+
+- [ ] **Step 3: Cut the GitHub release**
+
+After merge:
+
+```bash
+git fetch origin
+git checkout main
+git pull
+git tag -a 2.0.0-beta.1 -m "fo-core 2.0.0-beta.1 — first public beta"
+git push origin 2.0.0-beta.1
+
+gh release create 2.0.0-beta.1 \
+    --title "2.0.0-beta.1 — first public beta" \
+    --notes-from-tag \
+    --prerelease
+```
+
+The `--prerelease` flag is critical — it puts the release on the pre-release channel that `fo update --pre-release` consumes, NOT the stable channel.
+
+- [ ] **Step 4: Smoke-test the published release**
+
+In a fresh venv:
+
+```bash
+python -m venv /tmp/beta-smoke
+source /tmp/beta-smoke/bin/activate
+pip install --pre fo-core==2.0.0-beta.1
+fo --version  # should print 2.0.0-beta.1
+fo doctor
+```
+
+- [ ] **Step 5: Announce**
+
+Per the project's communication conventions (which I don't presume — leave this step for the maintainer to fill in: discussion forum post? README banner? Discord? Mailing list?). The doc honesty principle from beta-criteria.md applies: don't promise SLAs we don't have.
+
+---
+
+## Verification checklist
+
+After this plan executes:
+
+- `pip show fo-core | grep Status` reports `Status: 4 - Beta`.
+- `fo --version` reports `2.0.0-beta.1`.
+- `fo update --pre-release` then `fo update check` finds the new release.
+- The Beta bug-report template appears in the issue creation flow.
+- `tests/ci/test_release_metadata.py` is green (and will block any future bump that forgets to update the classifier).
+
+This closes the alpha→beta path. From here forward, development continues
+under the `4 - Beta` classifier with the schema-frozen promise from
+`docs/release/beta-criteria.md` §3 as the only beta-line compatibility
+guarantee. There is no committed timeline for `5 - Production/Stable` per
+beta-criteria.md §5.

--- a/docs/superpowers/plans/2026-04-27-classifier-bump-step-5.md
+++ b/docs/superpowers/plans/2026-04-27-classifier-bump-step-5.md
@@ -241,9 +241,9 @@ Insert at the top of `CHANGELOG.md` (above the existing alpha entries):
 ````markdown
 ## [2.0.0-beta.1] — YYYY-MM-DD
 
-First public-pre-release beta. The PyPI classifier moves from
-`3 - Alpha` to `4 - Beta` and the auto-updater's pre-release channel is
-open: opt in with `fo update --pre-release`.
+First public pre-release beta. The PyPI classifier moves from
+`3 - Alpha` to `4 - Beta` and the first release is tagged on the
+auto-updater's pre-release surface — see "How to opt in" below.
 
 See `docs/release/beta-criteria.md` for the full beta-tester contract, the
 schema-frozen promise, and the rollback path.
@@ -270,16 +270,19 @@ schema-frozen promise, and the rollback path.
 ### How to opt in
 
 ```bash
-fo update --pre-release
-fo update install
+fo update check --pre      # see the latest pre-release if any
+fo update install --pre    # download and install it
 ```
+
+There is no persistent channel state; the `--pre` flag applies per-invocation.
 
 ### How to roll back to alpha
 
 ```bash
 pip install 'fo-core==2.0.0-alpha.3'
-fo update --no-pre-release
 ```
+
+Drop the `--pre` flag on subsequent `fo update` calls to stay on stable.
 ````
 
 (Replace `YYYY-MM-DD` with the actual release date when running this task.)
@@ -296,8 +299,8 @@ From:
 
 To:
 
-> Currently `2.0.0-beta.1`. The auto-updater's public pre-release channel is
-> open — opt in with `fo update --pre-release`. See
+> Currently `2.0.0-beta.1`. Pre-release versions are surfaced to anyone who
+> passes `--pre` to `fo update check` / `fo update install`. See
 > `[docs/release/beta-criteria.md](docs/release/beta-criteria.md)` for the
 > beta-tester contract, the schema-frozen compatibility promise, and the
 > rollback path.
@@ -360,8 +363,8 @@ docs/release/beta-criteria.md §2 audited before this bump; evidence
 attached in the PR body.
 
 The schema is frozen at 1.0 across the beta line; alpha.3 configs
-read cleanly under beta.1. Public pre-release channel is open
-(`fo update --pre-release`).
+read cleanly under beta.1. Pre-release versions are surfaced via
+`fo update check --pre` / `fo update install --pre`.
 EOF
 )"
 ```
@@ -397,7 +400,7 @@ gh release create 2.0.0-beta.1 \
     --prerelease
 ```
 
-The `--prerelease` flag is critical — it puts the release on the pre-release channel that `fo update --pre-release` consumes, NOT the stable channel.
+`gh release create`'s `--prerelease` flag (one word, gh's spelling) is critical — it tags the GitHub Release as pre-release so `fo update check --pre` / `fo update install --pre` (the auto-updater's `--pre` flag, two words in `fo`'s spelling) surface it instead of the stable feed.
 
 - [ ] **Step 4: Smoke-test the published release**
 
@@ -423,7 +426,7 @@ After this plan executes:
 
 - `pip show fo-core | grep Status` reports `Status: 4 - Beta`.
 - `fo --version` reports `2.0.0-beta.1`.
-- `fo update --pre-release` then `fo update check` finds the new release.
+- `fo update check --pre` finds the new pre-release.
 - The Beta bug-report template appears in the issue creation flow.
 - `tests/ci/test_release_metadata.py` is green (and will block any future bump that forgets to update the classifier).
 

--- a/docs/superpowers/plans/2026-04-27-cli-ux-gaps-step-3.md
+++ b/docs/superpowers/plans/2026-04-27-cli-ux-gaps-step-3.md
@@ -521,16 +521,36 @@ def test_config_edit_invalid_device_includes_valid_values(
 
 - [ ] **Step 4: Replace bare validation messages with the helper**
 
-For each match found in step 1, swap from a bare error to:
+`config_cli.py` already defines authoritative validation sets at the top of the
+file — verified via `grep -n "_VALID_DEVICES\|_VALID_METHODOLOGIES" src/cli/config_cli.py`:
+
+```python
+# src/cli/config_cli.py:62-63 (existing constants — do not duplicate)
+_VALID_DEVICES = {"auto", "cpu", "cuda", "mps", "metal"}
+_VALID_METHODOLOGIES = {"none", "para", "jd"}
+```
+
+For each validation site found in step 1, swap from a bare error to a call
+that pulls from those constants directly (so a future addition of `"rocm"`
+to `_VALID_DEVICES` propagates to the error message automatically without a
+separate edit):
 
 ```python
 from utils.cli_errors import format_validation_error
 ...
-console.print(f"[red]{format_validation_error(field='device', value=device, valid_values=['auto', 'cpu', 'cuda', 'mps'])}[/red]")
+console.print(
+    f"[red]{format_validation_error(field='device', value=device, valid_values=sorted(_VALID_DEVICES))}[/red]"
+)
 raise typer.Exit(code=1)
 ```
 
-Repeat for `methodology` (`['none', 'para', 'jd']`), `framework` (`['ollama', 'llama_cpp', 'mlx', 'openai', 'claude']`), and any other enum-shaped fields validated in config_cli.
+For `methodology`, use `sorted(_VALID_METHODOLOGIES)` similarly. If you find a
+`framework` validation site that needs the same treatment but no
+`_VALID_FRAMEWORKS` constant exists yet, define it next to the others
+(`_VALID_FRAMEWORKS = {"ollama", "llama_cpp", "mlx", "openai", "claude"}`)
+in the same commit so all three follow the same pattern. **Never inline
+literal lists in the error-message call** — that's the anti-pattern this
+fix is closing.
 
 - [ ] **Step 5: Run — expected pass**
 

--- a/docs/superpowers/plans/2026-04-27-cli-ux-gaps-step-3.md
+++ b/docs/superpowers/plans/2026-04-27-cli-ux-gaps-step-3.md
@@ -1,0 +1,621 @@
+# CLI UX Gaps (Step 3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the three CLI-surface UX gaps that make beta tester bug reports hard to triage: (a) no `--debug` flag and stack traces are swallowed; (b) the `setup_completed` first-run gate only protects `fo organize` and `fo preview`; (c) config validation errors lack hints. Together these turn "something failed" into actionable reports.
+
+**Architecture:** All three changes target `src/cli/main.py:62-88` (the global Typer callback) and adjacent CLI files. `--debug` is a new global flag added to `main_callback`. The setup gate is promoted to a callback-level check that runs for every subcommand except a configurable allowlist (`setup`, `version`, `doctor`, `update`, `recover`, `config`). Config validation hints come from extending `cli/config_cli.py`'s error paths with "valid values" lists.
+
+**Tech Stack:** Typer, loguru, existing `cli.state.CLIState`, existing `_check_setup_completed` from `src/cli/organize.py:17`.
+
+**Out of scope:** Remote crash reporting (Sentry-style telemetry) — we surface the traceback locally via `--debug`, but don't ship it anywhere. Migrating away from `print(f"[red]Error: {exc}[/red]")` to a unified exception handler — that's a larger refactor; this plan adds `--debug` alongside the existing pattern without ripping it out.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/cli/state.py` | Modify | Add `debug: bool` to `CLIState` |
+| `src/cli/main.py` | Modify | Add `--debug` global flag; install loguru handler when set; promote setup gate to callback |
+| `src/cli/organize.py` | Modify | Drop the now-redundant inline `_check_setup_completed()` calls (logic moved to callback) |
+| `src/cli/config_cli.py` | Modify | Replace bare validation errors with hint-rich messages |
+| `src/utils/cli_errors.py` | Create | Helper `format_validation_error(field, value, valid_values)` returning a styled string |
+| `tests/cli/test_debug_flag.py` | Create | Tests for `--debug` enabling traceback output |
+| `tests/cli/test_setup_gate.py` | Create | Tests for the global setup gate covering allowlisted and non-allowlisted commands |
+| `tests/cli/test_config_validation_hints.py` | Create | Tests for config error message format |
+| `docs/troubleshooting.md` | Modify | Document `--debug` and link from beta-bug template |
+
+Plan conventions: see [2A plan](2026-04-27-audio-model-wiring-2a.md) "Conventions for this plan" section.
+
+---
+
+## Group A: --debug flag
+
+### Task A1: Add `debug: bool` to CLIState
+
+**Files:**
+- Modify: `src/cli/state.py`
+- Test: `tests/cli/test_debug_flag.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/cli/test_debug_flag.py`:
+
+```python
+"""Tests for the global --debug flag."""
+from __future__ import annotations
+import pytest
+from cli.state import CLIState
+
+
+@pytest.mark.unit
+def test_cli_state_has_debug_field() -> None:
+    state = CLIState(verbose=False, dry_run=False, json_output=False, yes=False, no_interactive=False, debug=True)
+    assert state.debug is True
+
+
+@pytest.mark.unit
+def test_cli_state_debug_defaults_false() -> None:
+    state = CLIState(verbose=False, dry_run=False, json_output=False, yes=False, no_interactive=False)
+    assert state.debug is False
+```
+
+- [ ] **Step 2: Run — expected failure**
+
+```bash
+pytest tests/cli/test_debug_flag.py -v
+```
+
+- [ ] **Step 3: Add `debug: bool = False` to CLIState**
+
+Open `src/cli/state.py`, find the `CLIState` dataclass, add `debug: bool = False` as a new field after `no_interactive`.
+
+- [ ] **Step 4: Run — expected pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/state.py tests/cli/test_debug_flag.py
+git commit -m "feat(cli): add debug field to CLIState"
+```
+
+---
+
+### Task A2: Wire `--debug` flag into main_callback
+
+**Files:**
+- Modify: `src/cli/main.py:62-88`
+- Test: `tests/cli/test_debug_flag.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/cli/test_debug_flag.py`:
+
+```python
+@pytest.mark.unit
+def test_debug_flag_sets_state_and_installs_loguru_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When --debug is passed, the loguru stderr handler is installed at DEBUG."""
+    from typer.testing import CliRunner
+    from cli.main import app
+
+    captured_levels: list[str] = []
+
+    def _fake_add(sink, **kwargs):  # type: ignore[no-untyped-def]
+        captured_levels.append(kwargs.get("level", ""))
+        return 1  # handler id
+
+    monkeypatch.setattr("loguru.logger.add", _fake_add)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--debug", "version"])
+    assert result.exit_code == 0
+    assert "DEBUG" in captured_levels
+
+
+@pytest.mark.unit
+def test_no_debug_flag_does_not_install_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from typer.testing import CliRunner
+    from cli.main import app
+
+    captured_levels: list[str] = []
+    monkeypatch.setattr(
+        "loguru.logger.add",
+        lambda sink, **kwargs: captured_levels.append(kwargs.get("level", "")) or 1,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    # No DEBUG-level handler installed by us (loguru may have a default; we
+    # only assert that --debug, when absent, does not install ours)
+    assert "DEBUG" not in captured_levels
+```
+
+- [ ] **Step 2: Run — expected failure**
+
+- [ ] **Step 3: Add the `--debug` option to `main_callback`**
+
+In `src/cli/main.py`, modify `main_callback` to accept a new option:
+
+```python
+    debug: bool = typer.Option(
+        False,
+        "--debug",
+        help=(
+            "Enable verbose logging and surface tracebacks on errors. "
+            "Required for filing useful beta bug reports."
+        ),
+    ),
+```
+
+In the function body, before `ctx.obj = CLIState(...)`:
+
+```python
+    if debug:
+        import sys
+        from loguru import logger as _loguru_logger
+        _loguru_logger.add(sys.stderr, level="DEBUG", backtrace=True, diagnose=True)
+```
+
+And include `debug=debug` in the `CLIState(...)` constructor.
+
+- [ ] **Step 4: Run — expected pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/main.py tests/cli/test_debug_flag.py
+git commit -m "feat(cli): add --debug flag, install loguru DEBUG handler when set"
+```
+
+---
+
+### Task A3: Surface tracebacks via `--debug` in CLI error handlers
+
+**Files:**
+- Modify: `src/cli/organize.py:146-148` (and similar `except Exception as exc` blocks elsewhere — grep first)
+
+- [ ] **Step 1: Find all `except Exception as exc:` followed by `console.print(f"[red]Error..."` patterns**
+
+```bash
+grep -rn -B 0 -A 3 "except Exception as exc:" src/cli/
+```
+
+For each match, plan to surface the traceback when `_get_state().debug` is true.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `tests/cli/test_debug_flag.py`:
+
+```python
+@pytest.mark.unit
+def test_debug_surfaces_traceback_on_organize_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from typer.testing import CliRunner
+    from cli.main import app
+
+    monkeypatch.setattr("cli.organize._check_setup_completed", lambda: True)
+
+    def _boom(*a, **kw):
+        raise RuntimeError("boom-from-test")
+
+    monkeypatch.setattr("core.organizer.FileOrganizer.organize", _boom)
+
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    out_dir = tmp_path / "out"
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--debug", "organize", str(in_dir), str(out_dir)])
+
+    assert result.exit_code == 1
+    # Without --debug we'd see only "[red]Error: boom-from-test[/red]"
+    # With --debug we expect the traceback to be surfaced (file:line refs)
+    assert "boom-from-test" in result.output
+    assert "Traceback" in result.output or ".py" in result.output
+```
+
+- [ ] **Step 3: Run — expected failure**
+
+- [ ] **Step 4: Update each error handler to surface tracebacks when debug is on**
+
+Replace patterns like:
+
+```python
+    except Exception as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+```
+
+with:
+
+```python
+    except Exception as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        if _get_state().debug:
+            console.print_exception(show_locals=False)
+        raise typer.Exit(code=1) from exc
+```
+
+(Rich's `Console.print_exception` emits the formatted traceback. Grep for every match and apply consistently.)
+
+- [ ] **Step 5: Run — expected pass**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/ tests/cli/test_debug_flag.py
+git commit -m "feat(cli): surface tracebacks via console.print_exception when --debug"
+```
+
+---
+
+## Group B: Setup gate covers all entry commands
+
+### Task B1: Identify allowlist of commands that don't need setup
+
+**Files:**
+- Read only: `src/cli/main.py`
+
+- [ ] **Step 1: Decide the allowlist**
+
+Commands that MUST work pre-setup (they're either bootstrap or read-only diagnostics):
+
+- `setup` — the wizard itself
+- `version`, `--version` — version reporting
+- `doctor` — diagnostic
+- `update` (and subcommands) — updater
+- `recover` — emergency recovery
+- `config` — viewing/editing config (the wizard isn't the only way)
+- `hardware-info` — hardware detection diagnostic
+
+Everything else (`organize`, `preview`, `search`, `analyze`, `dedupe`, `suggest`, `autotag`, `copilot`, `daemon`, `rules`, `model`, `analytics`, `undo`, `redo`, `history`, `benchmark`, `profile`) requires setup.
+
+- [ ] **Step 2: Capture the list as a constant**
+
+This is a code-only step in the next task; this step is just confirming the list before writing code.
+
+---
+
+### Task B2: Promote setup gate to global callback
+
+**Files:**
+- Modify: `src/cli/main.py:62-132` (the `main_callback`)
+- Modify: `src/cli/organize.py:115,187` — remove the now-redundant `_check_setup_completed()` calls
+- Test: `tests/cli/test_setup_gate.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/cli/test_setup_gate.py`:
+
+```python
+"""Test that the setup gate runs for all commands except an allowlist."""
+from __future__ import annotations
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from cli.main import app
+
+
+@pytest.fixture
+def fresh_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Force a config dir where setup_completed is False."""
+    monkeypatch.setattr("config.manager.DEFAULT_CONFIG_DIR", tmp_path)
+    return tmp_path
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("cmd", ["organize", "search", "analyze", "dedupe"])
+def test_unsetup_blocks_command(cmd: str, fresh_config: Path) -> None:
+    runner = CliRunner()
+    # Use placeholder args; gate runs before arg parsing for the command
+    result = runner.invoke(app, [cmd, "--help"])  # --help should still work
+    # Gate should NOT block --help, but should block actual invocation
+    assert result.exit_code == 0  # --help bypasses gate
+
+    # Now invoke without --help: should hit the gate
+    if cmd in ("organize",):
+        result = runner.invoke(app, [cmd, "/nonexistent", "/nonexistent"])
+        assert "First-time setup required" in result.output
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("cmd", ["setup", "version", "doctor", "update", "config"])
+def test_allowlisted_commands_bypass_gate(cmd: str, fresh_config: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, [cmd, "--help"])
+    assert result.exit_code == 0
+    assert "First-time setup required" not in result.output
+```
+
+- [ ] **Step 2: Run — expected mixed (some pass with current behavior; the global gate test fails)**
+
+- [ ] **Step 3: Add allowlist constant in `src/cli/main.py`**
+
+After the existing imports, before `main_callback`:
+
+```python
+_SETUP_GATE_ALLOWLIST: frozenset[str] = frozenset({
+    "setup",
+    "version",
+    "doctor",
+    "update",
+    "recover",
+    "config",
+    "hardware-info",
+})
+"""Commands that work pre-setup. Adding to this list relaxes the gate
+for that command — verify it doesn't write or organize files first."""
+```
+
+- [ ] **Step 4: Add gate logic in `main_callback`**
+
+After the existing `set_flags(...)` line, before the function returns:
+
+```python
+    if (
+        ctx.invoked_subcommand
+        and ctx.invoked_subcommand not in _SETUP_GATE_ALLOWLIST
+    ):
+        from cli.organize import _check_setup_completed
+        _check_setup_completed()
+```
+
+- [ ] **Step 5: Remove the redundant inline calls in `src/cli/organize.py`**
+
+Remove `_check_setup_completed()` from both `organize` (line 115) and `preview` (line 187) — the global gate now covers them.
+
+- [ ] **Step 6: Run — expected pass**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cli/main.py src/cli/organize.py tests/cli/test_setup_gate.py
+git commit -m "feat(cli): global setup gate via main_callback with allowlist"
+```
+
+---
+
+## Group C: Config validation hints
+
+### Task C1: Helper for hint-rich validation errors
+
+**Files:**
+- Create: `src/utils/cli_errors.py`
+- Test: `tests/utils/test_cli_errors.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/utils/test_cli_errors.py`:
+
+```python
+"""Tests for the CLI validation-error formatter."""
+from __future__ import annotations
+import pytest
+
+
+@pytest.mark.unit
+def test_format_validation_error_lists_valid_values() -> None:
+    from utils.cli_errors import format_validation_error
+
+    msg = format_validation_error(
+        field="device",
+        value="unknown",
+        valid_values=["auto", "cpu", "cuda", "mps"],
+    )
+    assert "device" in msg
+    assert "unknown" in msg
+    assert "auto, cpu, cuda, mps" in msg
+
+
+@pytest.mark.unit
+def test_format_validation_error_suggests_close_match() -> None:
+    from utils.cli_errors import format_validation_error
+
+    msg = format_validation_error(
+        field="device",
+        value="cdua",  # typo for "cuda"
+        valid_values=["auto", "cpu", "cuda", "mps"],
+    )
+    assert "did you mean" in msg.lower()
+    assert "cuda" in msg
+```
+
+- [ ] **Step 2: Run — expected failure**
+
+- [ ] **Step 3: Implement the helper**
+
+Create `src/utils/cli_errors.py`:
+
+```python
+"""Helpers for hint-rich CLI validation errors."""
+
+from __future__ import annotations
+
+import difflib
+from collections.abc import Iterable
+
+
+def format_validation_error(
+    *,
+    field: str,
+    value: object,
+    valid_values: Iterable[str],
+) -> str:
+    """Format a validation error with valid-values list and 'did you mean'."""
+    valid = list(valid_values)
+    base = (
+        f"Invalid value {value!r} for {field}. "
+        f"Valid values: {', '.join(valid)}."
+    )
+    if isinstance(value, str):
+        close = difflib.get_close_matches(value, valid, n=1, cutoff=0.6)
+        if close:
+            base += f" Did you mean {close[0]!r}?"
+    return base
+```
+
+- [ ] **Step 4: Run — expected pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/cli_errors.py tests/utils/test_cli_errors.py
+git commit -m "feat(utils): hint-rich validation-error formatter"
+```
+
+---
+
+### Task C2: Use the helper in config_cli error paths
+
+**Files:**
+- Modify: `src/cli/config_cli.py`
+- Test: `tests/cli/test_config_validation_hints.py`
+
+- [ ] **Step 1: Locate validation paths in config_cli**
+
+```bash
+grep -n "Invalid\|must be one of\|raise typer\|raise ValueError" src/cli/config_cli.py | head -20
+```
+
+Capture the spots where the user-facing message is emitted.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/cli/test_config_validation_hints.py`:
+
+```python
+"""Test that config edit errors include valid-values hints."""
+from __future__ import annotations
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from cli.main import app
+
+
+@pytest.mark.unit
+def test_config_edit_invalid_device_includes_valid_values(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("config.manager.DEFAULT_CONFIG_DIR", tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(app, ["config", "edit", "--device", "cdua"])
+    assert result.exit_code != 0
+    assert "auto" in result.output
+    assert "cuda" in result.output
+    assert "did you mean" in result.output.lower()
+```
+
+- [ ] **Step 3: Run — expected failure**
+
+- [ ] **Step 4: Replace bare validation messages with the helper**
+
+For each match found in step 1, swap from a bare error to:
+
+```python
+from utils.cli_errors import format_validation_error
+...
+console.print(f"[red]{format_validation_error(field='device', value=device, valid_values=['auto', 'cpu', 'cuda', 'mps'])}[/red]")
+raise typer.Exit(code=1)
+```
+
+Repeat for `methodology` (`['none', 'para', 'jd']`), `framework` (`['ollama', 'llama_cpp', 'mlx', 'openai', 'claude']`), and any other enum-shaped fields validated in config_cli.
+
+- [ ] **Step 5: Run — expected pass**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/config_cli.py tests/cli/test_config_validation_hints.py
+git commit -m "feat(config_cli): hint-rich errors with valid-values + did-you-mean"
+```
+
+---
+
+## Task D: Document --debug in troubleshooting
+
+**Files:**
+- Modify: `docs/troubleshooting.md`
+
+- [ ] **Step 1: Append a "Filing a bug report" section**
+
+````markdown
+## Filing a bug report
+
+If you hit an error, the most useful thing you can attach to a bug report is
+the output with `--debug` enabled:
+
+```bash
+fo --debug <your command and args>
+```
+
+`--debug` enables verbose logging and surfaces the full traceback when an
+error occurs. Without it, the CLI prints only the error summary, which is
+often not enough for triage.
+
+Your bug report should include:
+
+- The full output of `fo --debug <command>` (use the [Beta bug
+  template](https://github.com/curdriceaurora/fo-core/issues/new?template=beta-bug.md))
+- Output of `fo doctor` (Ollama + dependency check)
+- Your OS, Python version, and `fo version`
+- Minimal reproduction steps
+````
+
+- [ ] **Step 2: Lint**
+
+```bash
+pymarkdown -c .pymarkdown.json scan docs/troubleshooting.md
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/troubleshooting.md
+git commit -m "docs(troubleshooting): document --debug for bug reports"
+```
+
+---
+
+## Task E: Pre-commit + CI + PR
+
+- [ ] **Step 1: Validation**
+
+```bash
+bash .claude/scripts/pre-commit-validation.sh
+pytest -m "ci" -v
+pytest -m "unit" tests/cli/test_debug_flag.py tests/cli/test_setup_gate.py tests/cli/test_config_validation_hints.py tests/utils/test_cli_errors.py -v
+```
+
+- [ ] **Step 2: Code review** via `/code-reviewer`. Focus areas:
+  - `--debug` interaction with `--verbose` (both can be set; --debug strictly wider)
+  - Setup gate allowlist completeness — every other CLI command must be on the gated path
+  - `format_validation_error` doesn't leak secrets if `value` is a credential (it shouldn't be — config_cli doesn't validate api_keys with this helper)
+
+- [ ] **Step 3: Push and open PR**
+
+Title: `feat(cli): --debug flag, global setup gate, hint-rich config errors`
+
+Body should reference §2 of `docs/release/beta-criteria.md` (closes the `--debug flag wired`, the implicit "first-run gate consistent" UX requirement, and contributes to the doc-honesty pass).
+
+---
+
+## Verification checklist
+
+- `fo --debug organize <bad-args>` produces a Rich-formatted traceback in addition to the red error line.
+- `fo organize <args>` without prior `fo setup` shows the yellow "First-time setup required" panel (not a stack trace).
+- `fo search <query>` without prior `fo setup` shows the same panel (the gate is no longer organize-only).
+- `fo config edit --device cdua` produces an error message listing valid values AND suggesting `cuda`.
+- `docs/troubleshooting.md` has a "Filing a bug report" section pointing at `--debug`.
+- All three §2 entry-checklist rows for UX (`--debug flag wired`, the doc-honesty pass for troubleshooting, `setup_completed` consistency) advance toward done. The bug-report template lands in Step 5.

--- a/docs/superpowers/plans/2026-04-27-config-schema-stability-test-2c.md
+++ b/docs/superpowers/plans/2026-04-27-config-schema-stability-test-2c.md
@@ -83,17 +83,16 @@ def _make_realistic_config() -> AppConfig:
 @pytest.mark.integration
 class TestConfigRoundTrip:
     def test_save_load_round_trip_at_current_version(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path
     ) -> None:
-        # Point ConfigManager at a tmp dir so we don't touch the real ~/.config/fo
-        monkeypatch.setattr("config.manager.DEFAULT_CONFIG_DIR", tmp_path)
-
+        # Inject config_dir explicitly so the test is isolated from
+        # DEFAULT_CONFIG_DIR and the FO_CONFIG env var (which would
+        # otherwise take precedence per src/config/manager.py:62-65).
         original = _make_realistic_config()
-        manager = ConfigManager()
-        manager.save(original)
+        ConfigManager(config_dir=tmp_path).save(original)
 
-        # Read back via the public API
-        roundtripped = ConfigManager().load()
+        # Read back via a fresh manager pointing at the same tmp dir
+        roundtripped = ConfigManager(config_dir=tmp_path).load()
 
         # The round-tripped config must equal the original on every field
         assert asdict(roundtripped) == asdict(original)
@@ -143,18 +142,18 @@ class TestConfigCrossVersionRoundTrip:
         """
         from config.migrations import MIGRATIONS, Migration
 
-        monkeypatch.setattr("config.manager.DEFAULT_CONFIG_DIR", tmp_path)
-
-        # Save with the current binary
+        # Save with the current binary, injecting config_dir explicitly so the
+        # test is isolated from DEFAULT_CONFIG_DIR and the FO_CONFIG env var.
         original = _make_realistic_config()
-        ConfigManager().save(original)
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.save(original)
 
         # Mutate the file's version to a synthetic past version, register a
         # no-op migration to current. This simulates a future beta whose
         # binary knows how to migrate from "0.9" to "1.0" — except for us
         # the migration is identity, proving "no fields dropped" when the
         # only schema delta is "version bumped".
-        config_file = tmp_path / "config.yaml"
+        config_file = manager.config_path
         with config_file.open("r") as f:
             data = yaml.safe_load(f)
         data["version"] = "0.9"
@@ -171,7 +170,7 @@ class TestConfigCrossVersionRoundTrip:
             Migration(to_version=CURRENT_SCHEMA_VERSION, transform=_identity_migration),
         )
 
-        loaded = ConfigManager().load()
+        loaded = ConfigManager(config_dir=tmp_path).load()
 
         # Every field except `version` round-trips identically. `version`
         # is updated to current after the migration (correct behavior).
@@ -215,7 +214,6 @@ Append:
     def test_future_version_loads_best_effort_with_warning(
         self,
         tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """If a user opts back into alpha after running beta, the alpha binary
@@ -223,12 +221,11 @@ Append:
         best-effort with a WARNING. This test pins that contract."""
         import logging
 
-        monkeypatch.setattr("config.manager.DEFAULT_CONFIG_DIR", tmp_path)
-
         original = _make_realistic_config()
-        ConfigManager().save(original)
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.save(original)
 
-        config_file = tmp_path / "config.yaml"
+        config_file = manager.config_path
         with config_file.open("r") as f:
             data = yaml.safe_load(f)
         data["version"] = "99.0"  # synthetic future
@@ -236,7 +233,7 @@ Append:
             yaml.safe_dump(data, f)
 
         with caplog.at_level(logging.WARNING):
-            loaded = ConfigManager().load()
+            loaded = ConfigManager(config_dir=tmp_path).load()
 
         # Loaded best-effort: known fields preserved
         assert loaded.profile_name == original.profile_name

--- a/docs/superpowers/plans/2026-04-27-config-schema-stability-test-2c.md
+++ b/docs/superpowers/plans/2026-04-27-config-schema-stability-test-2c.md
@@ -1,0 +1,301 @@
+# Config Schema Stability Test (Step 2C) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a CI-blocking test that proves the schema-frozen promise from `docs/release/beta-criteria.md` §3 actually holds — a config written by one `AppConfig` version reads cleanly under another, with no manual migration required.
+
+**Architecture:** The test parameterizes over (a) the current `CURRENT_SCHEMA_VERSION` (alpha→beta boundary today, where the schema does not change) and (b) a synthetic future bump that exercises the migration walker even when no real migration is registered. The test writes a fully-populated `AppConfig` to a YAML file via `ConfigManager.save`, mutates the version in the file to the source version, then loads via `ConfigManager.load` and asserts equality on the round-tripped object. Lives under `@pytest.mark.ci` so it runs on every PR.
+
+**Tech Stack:** pytest, dataclasses, PyYAML (already a dep). No new dependencies.
+
+**Out of scope:** Adding actual migrations (none are needed during the beta line per §3). Schema versioning UX in `fo config show`. Integration with on-disk fixture files from prior versions.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `tests/integration/test_config_schema_stability.py` | Create | The schema-stability test — round-trips configs across version boundaries |
+| `pyproject.toml` (`tool.pytest.ini_options`) | No change needed | The `ci` marker is already defined |
+
+Plan conventions: see [2A plan](2026-04-27-audio-model-wiring-2a.md) "Conventions for this plan" section.
+
+---
+
+## Task 1: Round-trip an AppConfig with no version change
+
+**Files:**
+- Create: `tests/integration/test_config_schema_stability.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/integration/test_config_schema_stability.py`:
+
+```python
+"""Schema-stability tests guarding the beta-line config-compat promise.
+
+Beta-criteria §3: any config written by 2.0.0-beta.X reads cleanly under
+2.0.0-beta.Y for all X, Y. The AppConfig schema stays at version 1.0 for
+the duration of beta. These tests prove the round-trip is lossless.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+import yaml
+
+from config.manager import ConfigManager
+from config.schema import CURRENT_SCHEMA_VERSION, AppConfig, ModelPreset, UpdateSettings
+
+
+def _make_realistic_config() -> AppConfig:
+    """Build an AppConfig populated like a real user config — non-default
+    values across the surface so the round-trip can detect dropped fields."""
+    return AppConfig(
+        profile_name="beta-tester",
+        version=CURRENT_SCHEMA_VERSION,
+        default_methodology="para",
+        setup_completed=True,
+        models=ModelPreset(
+            text_model="qwen2.5:7b",
+            vision_model="qwen2.5vl:14b",
+            temperature=0.3,
+            max_tokens=4096,
+            device="mps",
+            framework="ollama",
+        ),
+        updates=UpdateSettings(
+            check_on_startup=True,
+            interval_hours=12,
+            include_prereleases=True,
+            repo="curdriceaurora/fo-core",
+        ),
+        watcher={"enabled": True, "interval_seconds": 30},
+        para={"areas_root": "Areas", "projects_root": "Projects"},
+    )
+
+
+@pytest.mark.ci
+@pytest.mark.integration
+class TestConfigRoundTrip:
+    def test_save_load_round_trip_at_current_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Point ConfigManager at a tmp dir so we don't touch the real ~/.config/fo
+        monkeypatch.setattr("config.manager.DEFAULT_CONFIG_DIR", tmp_path)
+
+        original = _make_realistic_config()
+        manager = ConfigManager()
+        manager.save(original)
+
+        # Read back via the public API
+        roundtripped = ConfigManager().load()
+
+        # The round-tripped config must equal the original on every field
+        assert asdict(roundtripped) == asdict(original)
+```
+
+- [ ] **Step 2: Run the test to verify it passes (or surfaces a real bug)**
+
+```bash
+pytest tests/integration/test_config_schema_stability.py::TestConfigRoundTrip::test_save_load_round_trip_at_current_version -v
+```
+
+Expected: PASS. If it FAILS, the failure surfaces a real schema-stability bug — investigate before committing the test (which field dropped? did a default override an explicit value?).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_config_schema_stability.py
+git commit -m "test(config): round-trip AppConfig at current schema version"
+```
+
+---
+
+## Task 2: Round-trip across a synthetic version bump (exercises migration walker)
+
+**Files:**
+- Modify: `tests/integration/test_config_schema_stability.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/integration/test_config_schema_stability.py`:
+
+```python
+@pytest.mark.ci
+@pytest.mark.integration
+class TestConfigCrossVersionRoundTrip:
+    def test_synthetic_future_version_preserves_known_fields(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Write a config tagged at a synthetic future version, ensure load()
+        preserves all fields the current binary knows about.
+
+        We don't register an actual migration — beta promises the schema does
+        not change across the line — but we DO promise that adding fields in
+        the future won't drop existing fields. This test exercises that path
+        using a registry monkeypatch, simulating what a future migration
+        landing in beta.5 (say) would do during a beta.4 → beta.5 read.
+        """
+        from config.migrations import MIGRATIONS, Migration
+
+        monkeypatch.setattr("config.manager.DEFAULT_CONFIG_DIR", tmp_path)
+
+        # Save with the current binary
+        original = _make_realistic_config()
+        ConfigManager().save(original)
+
+        # Mutate the file's version to a synthetic past version, register a
+        # no-op migration to current. This simulates a future beta whose
+        # binary knows how to migrate from "0.9" to "1.0" — except for us
+        # the migration is identity, proving "no fields dropped" when the
+        # only schema delta is "version bumped".
+        config_file = tmp_path / "config.yaml"
+        with config_file.open("r") as f:
+            data = yaml.safe_load(f)
+        data["version"] = "0.9"
+        with config_file.open("w") as f:
+            yaml.safe_dump(data, f)
+
+        def _identity_migration(d: dict[str, object]) -> dict[str, object]:
+            d["version"] = CURRENT_SCHEMA_VERSION
+            return d
+
+        monkeypatch.setitem(
+            MIGRATIONS,
+            "0.9",
+            Migration(to_version=CURRENT_SCHEMA_VERSION, transform=_identity_migration),
+        )
+
+        loaded = ConfigManager().load()
+
+        # Every field except `version` round-trips identically. `version`
+        # is updated to current after the migration (correct behavior).
+        assert loaded.version == CURRENT_SCHEMA_VERSION
+        assert loaded.profile_name == original.profile_name
+        assert loaded.default_methodology == original.default_methodology
+        assert loaded.setup_completed == original.setup_completed
+        assert asdict(loaded.models) == asdict(original.models)
+        assert asdict(loaded.updates) == asdict(original.updates)
+        assert loaded.watcher == original.watcher
+        assert loaded.para == original.para
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+pytest tests/integration/test_config_schema_stability.py::TestConfigCrossVersionRoundTrip -v
+```
+
+Expected: PASS — migration walker should run the no-op transform and produce a config equal to the original.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_config_schema_stability.py
+git commit -m "test(config): round-trip across synthetic version bump via migration walker"
+```
+
+---
+
+## Task 3: Future-version handling — config newer than binary loads best-effort
+
+**Files:**
+- Modify: `tests/integration/test_config_schema_stability.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```python
+    def test_future_version_loads_best_effort_with_warning(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """If a user opts back into alpha after running beta, the alpha binary
+        sees a future-version config. Per migrations.py the load proceeds
+        best-effort with a WARNING. This test pins that contract."""
+        import logging
+
+        monkeypatch.setattr("config.manager.DEFAULT_CONFIG_DIR", tmp_path)
+
+        original = _make_realistic_config()
+        ConfigManager().save(original)
+
+        config_file = tmp_path / "config.yaml"
+        with config_file.open("r") as f:
+            data = yaml.safe_load(f)
+        data["version"] = "99.0"  # synthetic future
+        with config_file.open("w") as f:
+            yaml.safe_dump(data, f)
+
+        with caplog.at_level(logging.WARNING):
+            loaded = ConfigManager().load()
+
+        # Loaded best-effort: known fields preserved
+        assert loaded.profile_name == original.profile_name
+        assert loaded.setup_completed == original.setup_completed
+        # And a warning was emitted naming the offending version
+        assert any("99.0" in rec.message for rec in caplog.records), (
+            "Expected a WARNING naming the future version; got: "
+            f"{[r.message for r in caplog.records]}"
+        )
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+pytest tests/integration/test_config_schema_stability.py::TestConfigCrossVersionRoundTrip::test_future_version_loads_best_effort_with_warning -v
+```
+
+Expected: PASS, given the existing migration-walker behavior in `src/config/migrations.py:170-184`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_config_schema_stability.py
+git commit -m "test(config): future-version configs load best-effort with WARNING"
+```
+
+---
+
+## Task 4: Pre-commit + CI verification
+
+- [ ] **Step 1: Run pre-commit validation**
+
+```bash
+bash .claude/scripts/pre-commit-validation.sh
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Confirm the test runs in the `ci` marker subset**
+
+```bash
+pytest -m "ci" tests/integration/test_config_schema_stability.py -v
+```
+
+Expected: all three test methods run and PASS. They will then run on every PR via the `test` job in `.github/workflows/ci.yml`.
+
+- [ ] **Step 3: Push branch and open PR**
+
+Title: `test(config): schema-stability round-trip suite for beta line`
+
+Body should reference §3 of `docs/release/beta-criteria.md` and call out that this is the guard for the frozen-schema promise.
+
+---
+
+## Verification checklist
+
+After this plan executes:
+
+- The `ci` marker subset includes three new tests proving (a) round-trip at current version is lossless, (b) round-trip across a synthetic version bump preserves all fields, (c) future-version configs load best-effort with a logged WARNING.
+- Any future PR that breaks the schema-stability promise fails the `ci` job.
+
+This satisfies the "Schema-stability test in CI" row of beta-criteria.md §2.

--- a/docs/superpowers/plans/2026-04-27-integration-coverage-lift-step-4.md
+++ b/docs/superpowers/plans/2026-04-27-integration-coverage-lift-step-4.md
@@ -27,19 +27,29 @@ Plan conventions: see [2A plan](2026-04-27-audio-model-wiring-2a.md) "Convention
 
 ## The 9 modules and their groups
 
+Module paths use the `src/` prefix to match the keys in
+`scripts/coverage/integration_module_floor_baseline.json`. The "Current"
+column quotes the value recorded in that file as of the writing of this plan
+(2026-04-23 baseline); the "Target" column is this plan's proposed ratchet
+floor — these values are not yet present in the baseline.
+
 | Group | Module | Current | Target |
 |---|---|---|---|
-| **G1 Search** | `services/search/__init__.py` | 38% | 70% |
-| **G2 Daemon** | `daemon/service.py` | 57% | 70% |
-| **G3 Dedup/Intelligence** | `services/deduplication/__init__.py` | 60% | 70% |
-| | `services/intelligence/profile_migrator.py` | 60% | 70% |
-| | `services/intelligence/profile_merger.py` | 67% | 70% |
-| **G4 Methodology (JD)** | `methodologies/johnny_decimal/adapters.py` | 67% | 70% |
-| | `methodologies/johnny_decimal/numbering.py` | 68% | 70% |
-| **G5 Misc** | `core/hardware_profile.py` | 68% | 70% |
-| | `utils/epub_enhanced.py` | 55% | 70% |
+| **G1 Search** | `src/services/search/__init__.py` | 38% | 70% |
+| **G2 Daemon** | `src/daemon/service.py` | 57% | 70% |
+| **G3 Dedup/Intelligence** | `src/services/deduplication/__init__.py` | 60% | 70% |
+| | `src/services/intelligence/profile_migrator.py` | 60% | 70% |
+| | `src/services/intelligence/profile_merger.py` | 67% | 70% |
+| **G4 Methodology (JD)** | `src/methodologies/johnny_decimal/adapters.py` | 67% | 70% |
+| | `src/methodologies/johnny_decimal/numbering.py` | 68% | 70% |
+| **G5 Misc** | `src/core/hardware_profile.py` | 68% | 70% |
+| | `src/utils/epub_enhanced.py` | 55% | 70% |
 
 Each group is a separate PR. Within a group, modules share test fixtures.
+
+The global integration floor is currently set by `policy.new_module_min_percent`
+in the same baseline file (71.9% as of writing); the proposed ≥75% target also
+becomes a ratchet rather than a value already enforced.
 
 ---
 

--- a/docs/superpowers/plans/2026-04-27-integration-coverage-lift-step-4.md
+++ b/docs/superpowers/plans/2026-04-27-integration-coverage-lift-step-4.md
@@ -1,0 +1,332 @@
+# Integration Coverage Lift (Step 4) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lift integration coverage on the 9 modules currently below 70% to ≥70% per-module, and lift global integration coverage from 71.9% to ≥75%. This satisfies the "Integration coverage floors" row of `docs/release/beta-criteria.md` §2 and is the largest single workstream on the path to beta.
+
+**Architecture:** Integration tests in this project run via the `test-integration` CI job (full suite, real dependencies, no mocks for the system under test). Per-module floors are tracked in `scripts/coverage/integration_module_floor_baseline.json` — the file is the source of truth and is checked in CI. To raise a floor, you write tests that cover the gap, then bump the entry in the baseline file in the same PR. The baseline file refuses to drop floors silently — that's by design.
+
+**Approach:** Each module is its own workstream and likely its own PR. The plan groups them by domain so tests share fixtures naturally. Within each group, tasks follow the same TDD shape: read the module, identify the uncovered branches via `pytest --cov=<module> --cov-report=term-missing`, write tests for the highest-value missing lines, ratchet the floor, commit.
+
+**Tech Stack:** pytest, pytest-cov, existing integration fixtures, real system dependencies (no faster-whisper-style optional skips except where the module itself is gated).
+
+**Out of scope:** Refactoring untested modules to be more testable — if a function is untestable as written, surface that to the user rather than rewriting it under coverage pressure. Lifting modules already above 70% (orthogonal). Branch coverage targets — the baseline tracks line coverage; branch coverage is a follow-up.
+
+---
+
+## File Structure
+
+| File / Group | Action | Per-module target |
+|---|---|---|
+| `scripts/coverage/integration_module_floor_baseline.json` | Modify (ratchet) | Bump 9 entries to ≥70%; bump global floor to 75% |
+| Per-module test files (see groups below) | Create / extend | Add tests covering the highest-value uncovered branches |
+
+Plan conventions: see [2A plan](2026-04-27-audio-model-wiring-2a.md) "Conventions for this plan" section.
+
+---
+
+## The 9 modules and their groups
+
+| Group | Module | Current | Target |
+|---|---|---|---|
+| **G1 Search** | `services/search/__init__.py` | 38% | 70% |
+| **G2 Daemon** | `daemon/service.py` | 57% | 70% |
+| **G3 Dedup/Intelligence** | `services/deduplication/__init__.py` | 60% | 70% |
+| | `services/intelligence/profile_migrator.py` | 60% | 70% |
+| | `services/intelligence/profile_merger.py` | 67% | 70% |
+| **G4 Methodology (JD)** | `methodologies/johnny_decimal/adapters.py` | 67% | 70% |
+| | `methodologies/johnny_decimal/numbering.py` | 68% | 70% |
+| **G5 Misc** | `core/hardware_profile.py` | 68% | 70% |
+| | `utils/epub_enhanced.py` | 55% | 70% |
+
+Each group is a separate PR. Within a group, modules share test fixtures.
+
+---
+
+## The Group Workflow Template (apply to each of G1–G5)
+
+### Step 1: Identify the gap
+
+```bash
+pytest -m integration --cov=src/<group_path> --cov-report=term-missing tests/integration/ -v 2>&1 | tee /tmp/cov-<group>.log
+grep -A 50 "<module_path>" /tmp/cov-<group>.log | head -60
+```
+
+Pay attention to the `Missing` column — it lists the uncovered line numbers. Focus on:
+
+1. **Error paths** that exception-tested code skips (caught exceptions whose handlers aren't exercised).
+2. **Boundary conditions** in `if/elif/else` chains where one arm is unreached.
+3. **Public API entry points** that don't have a happy-path integration test.
+
+Skip:
+
+- Defensive branches genuinely unreachable (mark with `# pragma: no cover` only if you can't test them — see T11 in `.claude/rules/test-generation-patterns.md`).
+- Logging-only branches.
+- Platform-conditional code already in `known_local_drift` in the baseline file.
+
+### Step 2: Write tests targeting the missing lines
+
+Follow `.claude/rules/test-generation-patterns.md` strictly:
+
+- T1: Concrete value assertions, no sole `isinstance` checks.
+- T2: After a mutating call, verify state.
+- T3: Mock assertions with payloads, not just `call_count`.
+- T9: No `assert len(x) >= 0` tautologies.
+- T10: For predicates, add a negative case that has the same surface shape but different context.
+
+Tests go in `tests/integration/test_<module_name>_*.py`. Follow naming conventions of existing integration tests in the same directory.
+
+### Step 3: Re-measure
+
+```bash
+bash .claude/scripts/measure-integration-coverage.sh
+```
+
+Per `.claude/rules/ci-generation-patterns.md` C7, **always** use this script — never measure off a dirty `.coverage` file.
+
+Confirm the module's coverage is ≥ the new target. Confirm global coverage hasn't regressed elsewhere.
+
+### Step 4: Ratchet the baseline
+
+Edit `scripts/coverage/integration_module_floor_baseline.json`. Find the entry for the module and update its value to the new measured floor (rounded down to the nearest whole percent — give CI 0.5 pp tolerance per the `policy.tolerance_percent` field).
+
+If the global integration floor in `.github/workflows/ci.yml` (currently `71.9%`) needs bumping for this PR, do it in the same PR.
+
+### Step 5: Commit + PR
+
+```bash
+git add tests/integration/<new_files> scripts/coverage/integration_module_floor_baseline.json
+git commit -m "test(<module>): lift integration coverage to <new>%"
+```
+
+PR title: `test(coverage): lift <group> integration coverage to ≥70%`
+
+---
+
+## Group G1: Search (single module, biggest lift)
+
+**Module:** `src/services/search/__init__.py`  
+**Current:** 38%  
+**Target:** 70%
+
+### G1 — Task 1: Map the uncovered surface
+
+- [ ] **Step 1: Run coverage on the search package**
+
+```bash
+pytest -m integration --cov=src/services/search --cov-report=term-missing tests/integration/test_*search* -v 2>&1 | head -100
+```
+
+- [ ] **Step 2: Read `src/services/search/__init__.py`** and note the public functions/classes. Map each missing line range to a function. Capture in scratch notes.
+
+- [ ] **Step 3: Cross-reference with `.claude/rules/search-generation-patterns.md` S1–S6** — every `rglob`, every cache write, every result-formatting path is a candidate for testing.
+
+### G1 — Task 2: Write tests for symlink filtering (S1)
+
+The S1 anti-pattern says symlinks must be filtered. Verify the search corpus collector does this and add a test if missing.
+
+- [ ] **Step 1: Test**
+
+```python
+@pytest.mark.integration
+def test_search_skips_symlinked_paths(tmp_path: Path) -> None:
+    """S1: symlinks pointing outside the search root must not be indexed."""
+    from services.search import SearchService  # adjust import as needed
+
+    target = tmp_path / "outside_secret.txt"
+    target.write_text("CLASSIFIED")
+    inside = tmp_path / "corpus"
+    inside.mkdir()
+    (inside / "link.txt").symlink_to(target)
+
+    svc = SearchService(root=inside)
+    results = svc.search("CLASSIFIED")
+    assert all("link.txt" not in str(r) for r in results)
+```
+
+- [ ] **Step 2: If the test fails because the search service does follow symlinks**, that's a real S1 finding. Fix it in `src/services/search/__init__.py` per the S1 pattern (skip `is_symlink()` candidates) before shipping the coverage lift.
+
+- [ ] **Step 3: Repeat the same shape for hidden files (S2), absolute-path exposure (S4), and PII-in-debug-output (S5)**. Each finding either:
+  - Already-implemented → test passes → coverage rises
+  - Real bug → fix it before shipping the coverage lift
+
+### G1 — Task 3: Cover error paths
+
+- [ ] **Step 1**: Identify each `except` clause in the module and verify there's a test that triggers it. If not, write one.
+
+- [ ] **Step 2**: Identify each `if/elif/else` whose branches aren't all covered; add tests until each branch is reached.
+
+### G1 — Task 4: Re-measure, ratchet, commit, PR
+
+Follow the Group Workflow Template Steps 3–5.
+
+---
+
+## Group G2: Daemon
+
+**Module:** `src/daemon/service.py`  
+**Current:** 57%  
+**Target:** 70%
+
+### G2 — Task 1: Map uncovered surface
+
+- [ ] **Step 1**: `pytest -m integration --cov=src/daemon/service --cov-report=term-missing tests/integration/test_*daemon* -v`
+
+- [ ] **Step 2**: Read `src/daemon/service.py`. Daemon failure modes that integration tests usually skip:
+  - Signal handling (SIGTERM, SIGHUP)
+  - PID file lifecycle (creation, stale-PID cleanup, lock acquisition failure)
+  - Watcher restart on crash
+  - Graceful shutdown with in-flight events
+
+### G2 — Task 2: Daemon smoke test (also satisfies a separate beta-criteria bullet)
+
+- [ ] **Step 1**: Write `tests/integration/test_daemon_smoke.py` covering start → watch → stop → status → recovery-after-SIGTERM. This test ALSO satisfies the "Daemon smoke test in CI" row of beta-criteria.md §2.
+
+```python
+@pytest.mark.integration
+class TestDaemonSmoke:
+    def test_start_watch_stop_status_cycle(self, tmp_path: Path) -> None:
+        # Use subprocess.Popen to launch `fo daemon start --watch <tmp_path>`
+        # then `fo daemon status` should show running, then `fo daemon stop`
+        # cleanly terminates. Drop a file in tmp_path mid-cycle to verify
+        # the watcher is live.
+        ...
+```
+
+(Pin the exact subprocess shape to whatever the existing test infrastructure supports; if no precedent, use `subprocess.Popen` with a timeout and assert exit codes + output contains "running" / "stopped".)
+
+- [ ] **Step 2**: Test signal handling — send SIGTERM to a started daemon and assert PID file cleanup.
+
+### G2 — Task 3: Re-measure, ratchet, commit, PR
+
+Follow the template.
+
+---
+
+## Group G3: Dedup + Intelligence
+
+**Modules:**
+
+- `src/services/deduplication/__init__.py` (60% → 70%)
+- `src/services/intelligence/profile_migrator.py` (60% → 70%)
+- `src/services/intelligence/profile_merger.py` (67% → 70%)
+
+These three share the "user profile / preference data" domain and naturally test together.
+
+### G3 — Task 1: Profile migrator coverage
+
+- [ ] Coverage map: `pytest -m integration --cov=src/services/intelligence/profile_migrator --cov-report=term-missing -v`
+
+- [ ] Likely gaps: corrupted-profile recovery, version-mismatch fallback, partial-migration failure.
+
+- [ ] Write tests with `tmp_path` profile files in known-bad shapes (truncated JSON, missing fields, version too new). Assert the migrator either fixes them or fails loudly with a useful error.
+
+### G3 — Task 2: Profile merger coverage
+
+- [ ] Coverage map.
+
+- [ ] Likely gaps: conflict resolution between two profiles disagreeing on a key. Write tests with explicit conflict pairs.
+
+### G3 — Task 3: Deduplication package coverage
+
+- [ ] Coverage map for `src/services/deduplication/__init__.py`.
+
+- [ ] Likely gaps: ImportError handling for optional `imagededup` dep (`known_local_drift` notes this), threshold edge cases (exact 1.0 similarity, 0.0 similarity), empty-corpus path.
+
+### G3 — Task 4: Re-measure, ratchet, commit, PR
+
+Single PR for all three modules — they share fixtures.
+
+---
+
+## Group G4: Johnny Decimal Methodology
+
+**Modules:**
+
+- `src/methodologies/johnny_decimal/adapters.py` (67% → 70%)
+- `src/methodologies/johnny_decimal/numbering.py` (68% → 70%)
+
+Smallest lift; can be one PR.
+
+### G4 — Task 1: Numbering edge cases
+
+- [ ] Coverage map.
+
+- [ ] Gaps likely in: invalid number parsing, area/category boundary (e.g. `00.00` vs `99.99`), overflow when generating next number in a full category.
+
+- [ ] Write tests for each parse-and-roundtrip path with adversarial inputs (empty string, extra dots, non-ASCII digits).
+
+### G4 — Task 2: Adapter coverage
+
+- [ ] Coverage map.
+
+- [ ] Gaps likely in: format conversion errors (PARA → JD with no matching area), empty methodology config, fallback paths.
+
+### G4 — Task 3: Re-measure, ratchet, commit, PR
+
+---
+
+## Group G5: Hardware profile + EPUB
+
+**Modules:**
+
+- `src/core/hardware_profile.py` (68% → 70%)
+- `src/utils/epub_enhanced.py` (55% → 70%)
+
+Different domains; can be one PR (small) or split.
+
+### G5 — Task 1: Hardware profile fallback paths
+
+- [ ] Coverage map.
+
+- [ ] Gaps likely in: GPU detection on machines without CUDA/MPS (CI Linux runners), the `fo hardware-info` JSON path, invalid `device` strings.
+
+- [ ] Tests should mock `torch` import outcomes via `monkeypatch.setitem(sys.modules, ...)` (use `patch.dict` per `xdist-safe-patterns.md` Pattern 2 — atomic restore).
+
+### G5 — Task 2: EPUB enhanced extraction
+
+- [ ] Coverage map.
+
+- [ ] Gaps likely in: malformed EPUB recovery, missing TOC, encrypted EPUB rejection.
+
+- [ ] Use small synthetic EPUB fixtures (or `pytest.importorskip("ebooklib")` + build one in-memory).
+
+### G5 — Task 3: Re-measure, ratchet, commit, PR
+
+---
+
+## Final task: bump global integration floor
+
+After all five groups have merged and the per-module floors are at ≥70%:
+
+- [ ] **Step 1: Re-measure global coverage**
+
+```bash
+bash .claude/scripts/measure-integration-coverage.sh
+```
+
+- [ ] **Step 2: If global TOTAL is ≥75%**, bump the gate in `.github/workflows/ci.yml` (the `--cov-fail-under` value in the `test-integration` job, currently 71.9%) to the new measured floor minus 0.5 pp tolerance.
+
+- [ ] **Step 3: Update `scripts/coverage/integration_module_floor_baseline.json`** `policy.new_module_min_percent` if you want new-module floor raised correspondingly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml scripts/coverage/integration_module_floor_baseline.json
+git commit -m "ci: lift integration coverage gate to 75% (closes Step 4 of beta path)"
+```
+
+PR title: `ci: lift integration coverage gate to 75% (Step 4 closeout)`
+
+---
+
+## Verification checklist (rolls up the §2 entry-checklist row)
+
+After this plan executes:
+
+- All 9 modules previously below 70% are at ≥70% per the baseline file.
+- Global integration coverage gate is at ≥75%.
+- Daemon smoke test exists in CI exercising start → watch → stop → status → SIGTERM (also satisfies the separate daemon-smoke-test row of beta-criteria.md §2).
+- No silent floor regressions — every floor change is visible in the baseline file diff.
+
+This is the largest single Step in the alpha→beta path. Expect 5+ PRs over multiple weeks.

--- a/docs/superpowers/plans/2026-04-27-integration-coverage-lift-step-4.md
+++ b/docs/superpowers/plans/2026-04-27-integration-coverage-lift-step-4.md
@@ -196,7 +196,7 @@ Follow the Group Workflow Template Steps 3–5.
 @pytest.mark.integration
 class TestDaemonSmoke:
     def test_start_watch_stop_status_cycle(self, tmp_path: Path) -> None:
-        # Use subprocess.Popen to launch `fo daemon start --watch <tmp_path>`
+        # Use subprocess.Popen to launch `fo daemon start --watch-dir <tmp_path>`
         # then `fo daemon status` should show running, then `fo daemon stop`
         # cleanly terminates. Drop a file in tmp_path mid-cycle to verify
         # the watcher is live.

--- a/docs/superpowers/plans/2026-04-27-integration-coverage-lift-step-4.md
+++ b/docs/superpowers/plans/2026-04-27-integration-coverage-lift-step-4.md
@@ -105,8 +105,8 @@ PR title: `test(coverage): lift <group> integration coverage to ≥70%`
 
 ## Group G1: Search (single module, biggest lift)
 
-**Module:** `src/services/search/__init__.py`  
-**Current:** 38%  
+**Module:** `src/services/search/__init__.py`
+**Current:** 38%
 **Target:** 70%
 
 ### G1 — Task 1: Map the uncovered surface
@@ -164,8 +164,8 @@ Follow the Group Workflow Template Steps 3–5.
 
 ## Group G2: Daemon
 
-**Module:** `src/daemon/service.py`  
-**Current:** 57%  
+**Module:** `src/daemon/service.py`
+**Current:** 57%
 **Target:** 70%
 
 ### G2 — Task 1: Map uncovered surface

--- a/docs/superpowers/plans/2026-04-27-organize-audio-transcription-2b.md
+++ b/docs/superpowers/plans/2026-04-27-organize-audio-transcription-2b.md
@@ -1,0 +1,644 @@
+# Organize Audio Transcription (Step 2B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `fo organize` use audio transcription for content-aware categorization when the `[media]` extra is installed, so dropping `~/podcast-archive` into `fo organize` produces transcript-tagged folders rather than just metadata-tagged folders.
+
+**Depends on:** [Step 2A](2026-04-27-audio-model-wiring-2a.md) must merge first — this plan calls `AudioModel.generate()`.
+
+**Architecture:** `FileOrganizer._process_audio_files` (`src/core/organizer.py:528-530`) currently only extracts metadata. We add an opt-in transcription pass: when `[media]` is installed and the new `--transcribe-audio` flag is set, transcribe each audio file (with a configurable max duration cap), pass the transcript to the existing text-categorization path so audio gets organized like text content. When `[media]` is not installed, transcription is silently skipped and the existing metadata-only behavior is preserved (graceful degrade — beta testers without `[media]` still get a working `fo organize`).
+
+**Performance budget:** Transcription is the expensive operation. We default `--transcribe-audio` to OFF and document the tradeoff. When enabled, we cap per-file transcription at 10 minutes of audio (Whisper "tiny" model is roughly 5-10× realtime on CPU, so a 10-min clip is 1-2 minutes of CPU work). Files exceeding the cap fall back to metadata-only categorization with a warning.
+
+**Tech Stack:** Existing `services.audio.transcriber.AudioTranscriber` (via `AudioModel`), `services.audio.metadata_extractor` for the fallback path, `core.dispatcher.process_audio_files` for the integration point.
+
+**Out of scope:** Caching transcripts to disk (re-running `fo organize` re-transcribes — that's a separate optimization PR). Per-language model selection. Speaker diarization. Subtitle file parallel-tracks.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/core/dispatcher.py` | Modify | Extend `process_audio_files` to optionally accept a transcriber + duration cap |
+| `src/core/organizer.py` | Modify | Thread `--transcribe-audio` flag from CLI through `__init__` to `_process_audio_files` |
+| `src/cli/organize.py` | Modify | Add `--transcribe-audio` and `--max-transcribe-seconds` flags to `organize` and `preview` |
+| `tests/test_organizer_audio_transcription.py` | Create | Unit tests with mocked transcriber: enabled vs disabled, duration cap, missing extra |
+| `tests/integration/test_organize_audio_e2e.py` | Create | Integration test: real WAV file + real transcriber, organizer produces a transcript-derived category |
+| `docs/USER_GUIDE.md` | Modify | Document the `--transcribe-audio` flag and its performance tradeoff |
+| `README.md` | Modify | Update the Optional Feature Packs `[media]` row to mention `--transcribe-audio` |
+
+Plan conventions: see [2A plan](2026-04-27-audio-model-wiring-2a.md) "Conventions for this plan" section.
+
+---
+
+## Task 1: Read the current dispatcher.process_audio_files signature
+
+**Files:**
+- Read only: `src/core/dispatcher.py`
+
+- [ ] **Step 1: Find and read the function**
+
+```bash
+grep -n "def process_audio_files" src/core/dispatcher.py
+```
+
+Then read 30 lines around that match. Capture:
+
+- Current signature (parameters, return type)
+- How it constructs `ProcessedFile` objects today
+- Whether it already considers a transcript field on `ProcessedFile`
+
+Note the line numbers; subsequent tasks reference them.
+
+---
+
+## Task 2: Extend `ProcessedFile` to optionally carry a transcript
+
+**Files:**
+- Read: `src/core/types.py` (or wherever `ProcessedFile` is defined — `grep -rn "class ProcessedFile" src/`)
+- Modify: that file
+
+- [ ] **Step 1: Locate `ProcessedFile`**
+
+```bash
+grep -rn "class ProcessedFile" src/
+```
+
+- [ ] **Step 2: Write a failing test**
+
+Create `tests/test_processed_file_transcript_field.py`:
+
+```python
+"""Test that ProcessedFile carries an optional transcript field."""
+from __future__ import annotations
+from pathlib import Path
+import pytest
+
+
+@pytest.mark.unit
+def test_processed_file_has_optional_transcript_field() -> None:
+    from core.types import ProcessedFile  # adjust if located elsewhere
+
+    pf = ProcessedFile(
+        path=Path("/tmp/x.mp3"),
+        category="music",
+        transcript=None,  # NEW field
+    )
+    assert pf.transcript is None
+
+    pf2 = ProcessedFile(
+        path=Path("/tmp/podcast.mp3"),
+        category="news",
+        transcript="Hello and welcome to the news",
+    )
+    assert pf2.transcript == "Hello and welcome to the news"
+```
+
+- [ ] **Step 3: Run — expected failure if `transcript` does not exist**
+
+```bash
+pytest tests/test_processed_file_transcript_field.py -v
+```
+
+Expected: FAIL.
+
+- [ ] **Step 4: Add `transcript: str | None = None` to `ProcessedFile`**
+
+Edit the dataclass to add `transcript: str | None = None` as the last field. Other consumers continue to work because the field has a default.
+
+- [ ] **Step 5: Run — expected pass**
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/types.py tests/test_processed_file_transcript_field.py
+git commit -m "feat(types): add optional transcript field to ProcessedFile"
+```
+
+---
+
+## Task 3: Extend dispatcher.process_audio_files to optionally transcribe
+
+**Files:**
+- Modify: `src/core/dispatcher.py`
+- Test: `tests/test_organizer_audio_transcription.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_organizer_audio_transcription.py`:
+
+```python
+"""Unit tests for audio transcription in the organize path."""
+from __future__ import annotations
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.dispatcher import process_audio_files
+
+
+@pytest.mark.unit
+class TestDispatcherTranscribe:
+    def test_no_transcriber_means_no_transcript_attached(
+        self, tmp_path: Path
+    ) -> None:
+        audio = tmp_path / "a.mp3"
+        audio.touch()
+        results = process_audio_files(
+            [audio],
+            extractor_cls=MagicMock(),
+            transcriber=None,
+        )
+        assert all(getattr(r, "transcript", None) is None for r in results)
+
+    def test_transcriber_attaches_transcript(self, tmp_path: Path) -> None:
+        audio = tmp_path / "a.mp3"
+        audio.touch()
+        fake_transcriber = MagicMock()
+        fake_transcriber.generate.return_value = "hello world"
+        # extractor returns minimal valid metadata
+        extractor_cls = MagicMock()
+        extractor_cls.return_value.extract.return_value = MagicMock(duration=5.0)
+
+        results = process_audio_files(
+            [audio],
+            extractor_cls=extractor_cls,
+            transcriber=fake_transcriber,
+            max_transcribe_seconds=600,
+        )
+        assert any(r.transcript == "hello world" for r in results)
+        fake_transcriber.generate.assert_called_once_with(str(audio))
+
+    def test_transcribe_respects_duration_cap(self, tmp_path: Path) -> None:
+        audio = tmp_path / "long.mp3"
+        audio.touch()
+        fake_transcriber = MagicMock()
+        extractor_cls = MagicMock()
+        # 20-minute file, cap at 10 minutes -> skip transcription
+        extractor_cls.return_value.extract.return_value = MagicMock(duration=1200.0)
+
+        results = process_audio_files(
+            [audio],
+            extractor_cls=extractor_cls,
+            transcriber=fake_transcriber,
+            max_transcribe_seconds=600,
+        )
+        fake_transcriber.generate.assert_not_called()
+        assert all(getattr(r, "transcript", None) is None for r in results)
+```
+
+- [ ] **Step 2: Run — expected failure (signature does not yet accept `transcriber`)**
+
+- [ ] **Step 3: Modify `process_audio_files` signature and body**
+
+Edit `src/core/dispatcher.py:process_audio_files` to accept new keyword-only parameters:
+
+```python
+def process_audio_files(
+    files: list[Path],
+    *,
+    extractor_cls: type,
+    transcriber: object | None = None,
+    max_transcribe_seconds: float | None = None,
+) -> list[ProcessedFile]:
+    """Extract metadata; optionally transcribe when within duration cap."""
+    extractor = extractor_cls(use_fallback=True)
+    results: list[ProcessedFile] = []
+    for file_path in files:
+        try:
+            metadata = extractor.extract(file_path)
+        except (OSError, ImportError) as exc:
+            logger.warning("audio metadata failed for %s: %s", file_path, exc)
+            continue
+
+        transcript: str | None = None
+        if transcriber is not None and (
+            max_transcribe_seconds is None
+            or getattr(metadata, "duration", float("inf")) <= max_transcribe_seconds
+        ):
+            try:
+                transcript = transcriber.generate(str(file_path))
+            except (FileNotFoundError, RuntimeError, ImportError) as exc:
+                logger.warning("transcription failed for %s: %s", file_path, exc)
+                transcript = None
+
+        results.append(
+            ProcessedFile(
+                path=file_path,
+                category=_category_from_audio(metadata, transcript=transcript),
+                transcript=transcript,
+            )
+        )
+    return results
+```
+
+(Add `_category_from_audio` as a helper that uses transcript if non-empty, else falls back to the existing metadata-only categorization.)
+
+- [ ] **Step 4: Run — expected pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/dispatcher.py tests/test_organizer_audio_transcription.py
+git commit -m "feat(dispatcher): optional transcription pass for audio files"
+```
+
+---
+
+## Task 4: FileOrganizer accepts a transcribe_audio flag
+
+**Files:**
+- Modify: `src/core/organizer.py:83` (`__init__`) and `src/core/organizer.py:528` (`_process_audio_files`)
+- Test: `tests/test_organizer_audio_transcription.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_organizer_audio_transcription.py`:
+
+```python
+@pytest.mark.unit
+class TestFileOrganizerTranscribeFlag:
+    def test_transcribe_audio_flag_threads_transcriber_to_dispatcher(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.organizer import FileOrganizer
+        captured = {}
+
+        def _spy(files, *, extractor_cls, transcriber=None, max_transcribe_seconds=None):
+            captured["transcriber"] = transcriber
+            captured["max_seconds"] = max_transcribe_seconds
+            return []
+
+        monkeypatch.setattr("core.organizer.dispatcher.process_audio_files", _spy)
+
+        organizer = FileOrganizer(
+            dry_run=True,
+            transcribe_audio=True,
+            max_transcribe_seconds=300,
+        )
+        organizer._process_audio_files([tmp_path / "x.mp3"])
+
+        assert captured["transcriber"] is not None
+        assert captured["max_seconds"] == 300
+
+    def test_transcribe_audio_disabled_passes_no_transcriber(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from core.organizer import FileOrganizer
+        captured = {}
+
+        def _spy(files, *, extractor_cls, transcriber=None, max_transcribe_seconds=None):
+            captured["transcriber"] = transcriber
+            return []
+
+        monkeypatch.setattr("core.organizer.dispatcher.process_audio_files", _spy)
+
+        organizer = FileOrganizer(dry_run=True, transcribe_audio=False)
+        organizer._process_audio_files([tmp_path / "x.mp3"])
+
+        assert captured["transcriber"] is None
+```
+
+- [ ] **Step 2: Run — expected failure**
+
+- [ ] **Step 3: Modify `FileOrganizer.__init__`**
+
+Add two parameters with sensible defaults:
+
+```python
+def __init__(
+    self,
+    ...,
+    transcribe_audio: bool = False,
+    max_transcribe_seconds: float | None = 600.0,  # 10-minute default cap
+) -> None:
+    ...
+    self.transcribe_audio = transcribe_audio
+    self.max_transcribe_seconds = max_transcribe_seconds
+    self._audio_model = None  # lazy-init in _process_audio_files
+```
+
+- [ ] **Step 4: Modify `_process_audio_files`**
+
+Replace the body at line 528 with:
+
+```python
+def _process_audio_files(self, files: list[Path]) -> list[ProcessedFile]:
+    """Extract metadata + optionally transcribe; return processed files."""
+    transcriber = None
+    if self.transcribe_audio:
+        try:
+            from models.audio_model import AudioModel
+            from models.base import ModelConfig, ModelType
+
+            if self._audio_model is None:
+                config = ModelConfig(name="tiny", model_type=ModelType.AUDIO)
+                self._audio_model = AudioModel(config)
+                self._audio_model.initialize()
+            transcriber = self._audio_model
+        except ImportError as exc:
+            self.console.print(
+                f"[yellow]--transcribe-audio requires [media] extra: {exc}. "
+                "Falling back to metadata-only.[/yellow]"
+            )
+
+    return dispatcher.process_audio_files(
+        files,
+        extractor_cls=AudioMetadataExtractor,
+        transcriber=transcriber,
+        max_transcribe_seconds=self.max_transcribe_seconds,
+    )
+```
+
+Also extend the existing `try/finally` in `_process_all_file_types` to clean up `self._audio_model` if it was initialized:
+
+```python
+finally:
+    if self.text_processor:
+        self.text_processor.cleanup()
+    if self.vision_processor:
+        self.vision_processor.cleanup()
+    if getattr(self, "_audio_model", None):
+        self._audio_model.safe_cleanup()
+```
+
+- [ ] **Step 5: Run — expected pass**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/organizer.py tests/test_organizer_audio_transcription.py
+git commit -m "feat(organizer): thread transcribe_audio flag through to dispatcher"
+```
+
+---
+
+## Task 5: CLI flags `--transcribe-audio` and `--max-transcribe-seconds`
+
+**Files:**
+- Modify: `src/cli/organize.py` (the `organize` and `preview` functions)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/cli/test_organize_transcribe_flag.py`:
+
+```python
+"""Test that the --transcribe-audio CLI flag reaches FileOrganizer."""
+from __future__ import annotations
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from cli.main import app
+
+
+@pytest.mark.unit
+def test_transcribe_audio_flag_reaches_organizer(tmp_path: Path) -> None:
+    input_dir = tmp_path / "in"
+    input_dir.mkdir()
+    output_dir = tmp_path / "out"
+
+    runner = CliRunner()
+    with patch("cli.organize._check_setup_completed", return_value=True), \
+         patch("core.organizer.FileOrganizer") as mock_org_cls:
+        mock_org_cls.return_value.organize.return_value.processed_files = 0
+        mock_org_cls.return_value.organize.return_value.skipped_files = 0
+        mock_org_cls.return_value.organize.return_value.failed_files = 0
+
+        result = runner.invoke(
+            app,
+            [
+                "organize",
+                str(input_dir),
+                str(output_dir),
+                "--transcribe-audio",
+                "--max-transcribe-seconds", "300",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    init_kwargs = mock_org_cls.call_args.kwargs
+    assert init_kwargs.get("transcribe_audio") is True
+    assert init_kwargs.get("max_transcribe_seconds") == 300
+```
+
+- [ ] **Step 2: Run — expected failure**
+
+- [ ] **Step 3: Add the flags to `organize` and `preview` in `src/cli/organize.py`**
+
+In both `organize` and `preview` signatures, add two new options after `--no-prefetch`:
+
+```python
+    transcribe_audio: bool = typer.Option(
+        False,
+        "--transcribe-audio",
+        help=(
+            "Transcribe audio files (requires [media] extra) and use the "
+            "transcript for content-aware categorization. Off by default."
+        ),
+    ),
+    max_transcribe_seconds: float = typer.Option(
+        600.0,
+        "--max-transcribe-seconds",
+        min=0.0,
+        help=(
+            "Skip transcription for audio files longer than this (seconds). "
+            "Default: 600 (10 min). Set to 0 to disable the cap entirely."
+        ),
+    ),
+```
+
+Then thread them into the `FileOrganizer(...)` call in both functions:
+
+```python
+    organizer = FileOrganizer(
+        dry_run=...,
+        parallel_workers=resolved_workers,
+        prefetch_depth=resolved_prefetch_depth,
+        enable_vision=not no_vision,
+        no_prefetch=no_prefetch,
+        transcribe_audio=transcribe_audio,
+        max_transcribe_seconds=max_transcribe_seconds if max_transcribe_seconds > 0 else None,
+    )
+```
+
+- [ ] **Step 4: Run — expected pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/organize.py tests/cli/test_organize_transcribe_flag.py
+git commit -m "feat(cli): add --transcribe-audio and --max-transcribe-seconds flags"
+```
+
+---
+
+## Task 6: End-to-end integration test with a real WAV file
+
+**Files:**
+- Create: `tests/integration/test_organize_audio_e2e.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+"""End-to-end: fo organize --transcribe-audio on a directory with a WAV file."""
+from __future__ import annotations
+import struct
+import wave
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from cli.main import app
+
+
+def _silent_wav(path: Path, seconds: float = 1.0) -> None:
+    sample_rate = 16000
+    n_frames = int(seconds * sample_rate)
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        w.writeframes(struct.pack("<h", 0) * n_frames)
+
+
+@pytest.mark.integration
+class TestOrganizeAudioEndToEnd:
+    @pytest.fixture(autouse=True)
+    def _require_faster_whisper(self) -> None:
+        pytest.importorskip("faster_whisper")
+
+    def test_organize_with_transcribe_audio_completes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Bypass setup gate
+        monkeypatch.setattr("cli.organize._check_setup_completed", lambda: True)
+
+        input_dir = tmp_path / "in"
+        input_dir.mkdir()
+        _silent_wav(input_dir / "sample.wav")
+        output_dir = tmp_path / "out"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "organize",
+                str(input_dir),
+                str(output_dir),
+                "--dry-run",
+                "--transcribe-audio",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # Smoke: no crash on transcription path; dry-run prevents file moves
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+pytest tests/integration/test_organize_audio_e2e.py -v
+```
+
+Expected: PASS (skipped without `[media]`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_organize_audio_e2e.py
+git commit -m "test(organize): e2e --transcribe-audio with generated silent WAV"
+```
+
+---
+
+## Task 7: Documentation honesty pass
+
+**Files:**
+- Modify: `README.md` (Optional Feature Packs row)
+- Modify: `docs/USER_GUIDE.md` (add a section on audio transcription)
+
+- [ ] **Step 1: Update README**
+
+Replace the `[media]` row with:
+
+```markdown
+| Media | `pip install -e ".[media]"` | Audio transcription (faster-whisper) + video scene detection. Use `fo organize --transcribe-audio` to categorize audio by transcript content, or `fo benchmark --suite audio --transcribe-smoke` to verify the install. |
+```
+
+- [ ] **Step 2: Add a User Guide section**
+
+Append to `docs/USER_GUIDE.md` (under the existing "Organizing files" section):
+
+````markdown
+### Audio transcription (optional)
+
+When the `[media]` extra is installed, you can categorize audio files by
+transcript content rather than just metadata:
+
+```bash
+fo organize ~/Downloads ~/Organized --transcribe-audio
+```
+
+Transcription is off by default because it's CPU-intensive. The default
+duration cap (10 minutes per file, override with `--max-transcribe-seconds`)
+prevents podcast-length files from monopolizing the run; over-cap files
+fall back to metadata-only categorization with a warning.
+
+The first run downloads the Whisper "tiny" model (~39 MB). Subsequent runs
+use the cache.
+````
+
+- [ ] **Step 3: Lint markdown**
+
+```bash
+pymarkdown -c .pymarkdown.json scan README.md docs/USER_GUIDE.md
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/USER_GUIDE.md
+git commit -m "docs: document --transcribe-audio in README and USER_GUIDE"
+```
+
+---
+
+## Task 8: Pre-commit + CI verification + PR
+
+- [ ] **Step 1: Run validation**
+
+```bash
+bash .claude/scripts/pre-commit-validation.sh
+pytest -m "ci" -v
+pytest -m "integration" tests/integration/test_organize_audio_e2e.py -v
+```
+
+- [ ] **Step 2: Code review**
+
+Invoke `/code-reviewer`. Focus areas: graceful-degrade when `[media]` missing, lifecycle of `_audio_model` (must be cleaned up even on exceptions), duration-cap edge cases (0, None, negative — currently the CLI flag enforces `min=0.0` and 0 means "no cap").
+
+- [ ] **Step 3: Push and open PR**
+
+Title: `feat(organize): transcribe audio for content-aware categorization`
+
+Body should reference §2 of `docs/release/beta-criteria.md` (closes the second-half of "Audio works end-to-end") and link [Step 2A](2026-04-27-audio-model-wiring-2a.md) as the prerequisite.
+
+---
+
+## Verification
+
+After this plan executes:
+
+- `fo organize --transcribe-audio` on a directory containing audio files produces transcript-tagged categorization.
+- `fo organize` without the flag remains identical to current behavior (no new dep on `[media]`).
+- README and USER_GUIDE describe what `[media]` actually delivers.
+- The "Audio works end-to-end" entry in `docs/release/beta-criteria.md` §2 is fully closed (combined with Step 2A, which closes the AudioModel wiring half).

--- a/docs/superpowers/plans/2026-04-27-organize-audio-transcription-2b.md
+++ b/docs/superpowers/plans/2026-04-27-organize-audio-transcription-2b.md
@@ -610,7 +610,7 @@ git commit -m "test(organize): e2e --transcribe-audio with generated silent WAV"
 Replace the `[media]` row with:
 
 ```markdown
-| Media | `pip install -e ".[media]"` | Audio transcription (faster-whisper) + video scene detection. Use `fo organize --transcribe-audio` to categorize audio by transcript content, or `fo benchmark --suite audio --transcribe-smoke` to verify the install. |
+| Media | `pip install -e ".[media]"` | Audio transcription (faster-whisper) + video scene detection. Use `fo organize --transcribe-audio` to categorize audio by transcript content, or `fo benchmark run --suite audio --transcribe-smoke` to verify the install. |
 ```
 
 - [ ] **Step 2: Add a User Guide section**

--- a/docs/superpowers/plans/2026-04-27-organize-audio-transcription-2b.md
+++ b/docs/superpowers/plans/2026-04-27-organize-audio-transcription-2b.md
@@ -56,18 +56,18 @@ Note the line numbers; subsequent tasks reference them.
 ## Task 2: Extend `ProcessedFile` to optionally carry a transcript
 
 **Files:**
-- Read: `src/core/types.py` (or wherever `ProcessedFile` is defined — `grep -rn "class ProcessedFile" src/`)
-- Modify: that file
+- Modify: `src/services/text_processor.py` (the `ProcessedFile` dataclass at line 23)
+- Test: `tests/services/test_processed_file_transcript_field.py`
 
-- [ ] **Step 1: Locate `ProcessedFile`**
+The `ProcessedFile` dataclass (verified in `src/services/text_processor.py:22-32`)
+currently has fields `file_path: Path`, `description: str`, `folder_name: str`,
+`filename: str`, plus optional `original_content`, `processing_time`, and
+`error`. We add a new optional `transcript: str | None = None` field. Existing
+consumers continue to work because the new field has a default value.
 
-```bash
-grep -rn "class ProcessedFile" src/
-```
+- [ ] **Step 1: Write a failing test**
 
-- [ ] **Step 2: Write a failing test**
-
-Create `tests/test_processed_file_transcript_field.py`:
+Create `tests/services/test_processed_file_transcript_field.py`:
 
 ```python
 """Test that ProcessedFile carries an optional transcript field."""
@@ -77,45 +77,73 @@ import pytest
 
 
 @pytest.mark.unit
-def test_processed_file_has_optional_transcript_field() -> None:
-    from core.types import ProcessedFile  # adjust if located elsewhere
+def test_processed_file_default_transcript_is_none(tmp_path: Path) -> None:
+    from services.text_processor import ProcessedFile
 
     pf = ProcessedFile(
-        path=Path("/tmp/x.mp3"),
-        category="music",
-        transcript=None,  # NEW field
+        file_path=tmp_path / "x.mp3",
+        description="A short audio clip",
+        folder_name="Audio",
+        filename="x.mp3",
     )
     assert pf.transcript is None
 
-    pf2 = ProcessedFile(
-        path=Path("/tmp/podcast.mp3"),
-        category="news",
+
+@pytest.mark.unit
+def test_processed_file_accepts_transcript(tmp_path: Path) -> None:
+    from services.text_processor import ProcessedFile
+
+    pf = ProcessedFile(
+        file_path=tmp_path / "podcast.mp3",
+        description="News podcast",
+        folder_name="News",
+        filename="podcast.mp3",
         transcript="Hello and welcome to the news",
     )
-    assert pf2.transcript == "Hello and welcome to the news"
+    assert pf.transcript == "Hello and welcome to the news"
 ```
 
-- [ ] **Step 3: Run — expected failure if `transcript` does not exist**
+- [ ] **Step 2: Run — expected failure**
 
 ```bash
-pytest tests/test_processed_file_transcript_field.py -v
+pytest tests/services/test_processed_file_transcript_field.py -v
 ```
 
-Expected: FAIL.
+Expected: FAIL — `TypeError: ProcessedFile.__init__() got an unexpected keyword argument 'transcript'`.
 
-- [ ] **Step 4: Add `transcript: str | None = None` to `ProcessedFile`**
+- [ ] **Step 3: Add the field**
 
-Edit the dataclass to add `transcript: str | None = None` as the last field. Other consumers continue to work because the field has a default.
+In `src/services/text_processor.py`, modify the `ProcessedFile` dataclass
+(currently at lines 22-32):
 
-- [ ] **Step 5: Run — expected pass**
+```python
+@dataclass
+class ProcessedFile:
+    """Result of file processing."""
+
+    file_path: Path
+    description: str
+    folder_name: str
+    filename: str
+    original_content: str | None = None
+    processing_time: float = 0.0
+    error: str | None = None
+    transcript: str | None = None  # NEW: populated for audio files when --transcribe-audio is set
+```
+
+- [ ] **Step 4: Run — expected pass**
+
+```bash
+pytest tests/services/test_processed_file_transcript_field.py -v
+```
 
 Expected: PASS.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add src/core/types.py tests/test_processed_file_transcript_field.py
-git commit -m "feat(types): add optional transcript field to ProcessedFile"
+git add src/services/text_processor.py tests/services/test_processed_file_transcript_field.py
+git commit -m "feat(text_processor): add optional transcript field to ProcessedFile"
 ```
 
 ---
@@ -226,17 +254,30 @@ def process_audio_files(
                 logger.warning("transcription failed for %s: %s", file_path, exc)
                 transcript = None
 
+        description, folder_name, filename = _categorize_audio(
+            file_path, metadata, transcript=transcript
+        )
         results.append(
             ProcessedFile(
-                path=file_path,
-                category=_category_from_audio(metadata, transcript=transcript),
+                file_path=file_path,
+                description=description,
+                folder_name=folder_name,
+                filename=filename,
                 transcript=transcript,
             )
         )
     return results
 ```
 
-(Add `_category_from_audio` as a helper that uses transcript if non-empty, else falls back to the existing metadata-only categorization.)
+Add `_categorize_audio(file_path, metadata, *, transcript)` as a private helper
+that returns the `(description, folder_name, filename)` triple. When `transcript`
+is non-empty it uses the transcript content to derive a richer description and
+folder name (mirroring how `_process_text_files` uses extracted text); otherwise
+it falls back to metadata-only categorization (filename + extension + duration
+bucket) — the existing behavior. Read the existing pattern in
+`src/core/dispatcher.py:process_audio_files` and copy its categorization
+contract verbatim into the metadata-only branch so behavior is preserved when
+`transcribe_audio` is off.
 
 - [ ] **Step 4: Run — expected pass**
 


### PR DESCRIPTION
## Summary

Documents the contract with public pre-release testers and the five-step implementation path from `2.0.0-alpha.3` to `2.0.0-beta.1`. **Pure docs PR — no code changes.** All implementation lands in subsequent PRs that reference these plans.

## What's in here

- **`docs/release/beta-criteria.md`** — the contract:
  - §1 What beta means here (low-ceremony, no feature freeze, indefinite duration)
  - §2 Entry checklist (audio works end-to-end, integration coverage ≥75% global / ≥70% per-module, daemon smoke test, `--debug` flag, doc-honesty pass, schema-stability test, beta-bug template)
  - §3 The one stable promise: schema frozen across the beta line
  - §4 Tester contract (opt-in via `fo update --pre-release`, rollback path, bug-report requirements)
  - §5 Explicit non-promise about GA
- **Five step plans** in `docs/superpowers/plans/2026-04-27-*.md`, each self-contained and TDD-shaped:
  - `2a` Wire `AudioModel.generate()` + benchmark transcribe-smoke
  - `2b` `fo organize --transcribe-audio` for content-aware audio categorization (depends on 2a)
  - `2c` CI schema-stability round-trip test (independent)
  - `step-3` `--debug` flag, global setup gate, hint-rich config validation errors
  - `step-4` Lift 9 weak modules to ≥70%, global to ≥75%, daemon smoke
  - `step-5` Pre-bump audit, beta-bug template, version + classifier flip, README CLI command list fix
- **`README.md`** — adds a "Releases" section linking to the beta-criteria doc

## Why this lands first

Each subsequent implementation PR will close specific rows of the §2 entry checklist. Landing the criteria + plans on main first means those PRs can link to stable URLs rather than carrying the contract in their own descriptions, and the checklist itself is publicly visible to anyone watching the repo.

## Plan provenance

Plans went through `brainstorming` → `writing-plans` → external review pass before this commit. Reviewer feedback was incorporated (notably: a fix to `step-5` adding the `fo profile` description correction and missing `fo hardware-info` row to the README's CLI command table during the bump).

The `docs/superpowers/plans/` directory is in `.gitignore` by convention (line 136). Three existing curated plans in that directory were force-added historically; these five follow the same precedent.

## Test plan

- [ ] `pymarkdown -c .pymarkdown.json scan docs/release/beta-criteria.md docs/superpowers/plans/2026-04-27-*.md README.md` — passes (verified locally; zero violations)
- [ ] `bash .claude/scripts/pre-commit-validation.sh` — passes (verified locally: 566 passed, 1 skipped)
- [ ] No code changes; CI's `test`, `test-full`, and `test-integration` jobs should be green by virtue of touching no `.py` files
- [ ] Reviewer reads all five plans + the criteria doc and validates the contract before subsequent implementation PRs reference them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive beta release criteria documentation outlining testing requirements and tester expectations.
  * Added detailed implementation plans for upcoming features including audio transcription in organize, CLI debugging enhancements, and integration test coverage improvements.
  * Updated release information in README to reflect current pre-release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->