### PR TITLE
Fix: Resolve Matrix CI Failures (audit-extras pip version drift)

### DIFF
--- a/.github/accepted-risks-extras.yml
+++ b/.github/accepted-risks-extras.yml
@@ -39,21 +39,3 @@ allowlist:
       upstream fix is expected. Re-evaluate when pytest drops the ``py``
       dependency entirely (upstream tracking issue pytest-dev/pytest#10462).
     expires_on: 2026-10-23
-  - advisory_id: CVE-2026-3219
-    package: pip
-    version_spec: "<=26.0.1"
-    reason: >-
-      Pip 26.0.1 is installed transitively into the ``.[all]`` CI
-      environment as the package installer itself. The advisory
-      (published 2026-04-23) affects pip's wheel installation path when
-      processing an attacker-crafted package index response. fo-core's
-      only use of pip in production is the self-install flow (``fo
-      update``) which pins to explicit GitHub releases — not a mutable
-      index — so the vulnerable code path is unreachable for end users.
-      CI jobs that invoke pip do so against the curated PyPI mirror
-      inside the GitHub-hosted runner, not an attacker-controlled index.
-      Base (``.``) audit does not pull pip as a project dep and isn't
-      affected; this entry scopes solely to the ``.[all]`` extras job.
-      Re-evaluate when pip 26.0.2+ ships the fix (upstream tracking
-      pypa/pip#13245).
-    expires_on: 2026-07-24

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -101,12 +101,20 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
       - name: Install pip-audit + gate deps
+        # Upgrade pip first so both matrix variants (ubuntu-latest +
+        # macos-latest) audit the same pip version. Without the explicit
+        # upgrade, the GitHub-hosted runner's bundled pip drifted between
+        # OSes (ubuntu-latest installed pip 26.1, macos-latest stayed on
+        # the cached 26.0.1), producing platform-asymmetric pip-audit
+        # output and breaking the gate's allowlist accounting.
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
         with:
           timeout_minutes: 5
           max_attempts: 3
           retry_on: error
-          command: pip install pip-audit pyyaml packaging
+          command: |
+            python -m pip install --upgrade pip
+            pip install pip-audit pyyaml packaging
       - name: Audit dependencies (.[all])
         # `.[all]` pulls torch / opencv / faster-whisper / etc. — expect this
         # step to be slower than the base audit. The retry wrapper also guards

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -113,8 +113,9 @@ jobs:
           max_attempts: 3
           retry_on: error
           command: |
+            set -euo pipefail
             python -m pip install --upgrade pip
-            pip install pip-audit pyyaml packaging
+            python -m pip install pip-audit pyyaml packaging
       - name: Audit dependencies (.[all])
         # `.[all]` pulls torch / opencv / faster-whisper / etc. — expect this
         # step to be slower than the base audit. The retry wrapper also guards


### PR DESCRIPTION
## Summary

The `audit-dependencies-extras` matrix job has been failing on **ubuntu-latest** while **macos-latest** succeeds, blocking CI on every PR. Reproduced on PRs [#232](https://github.com/curdriceaurora/fo-core/pull/232) and [#233](https://github.com/curdriceaurora/fo-core/pull/233):

| Matrix variant | Conclusion | Run |
|----------------|------------|-----|
| `audit-dependencies-extras (ubuntu-latest)` | ❌ failure | [#232 job 73297983400](https://github.com/curdriceaurora/fo-core/actions/runs/25026282403/job/73297983400), [#233 job 73298017265](https://github.com/curdriceaurora/fo-core/actions/runs/25026294596/job/73298017265) |
| `audit-dependencies-extras (macos-latest)` | ✅ success | same workflow, sibling job |

## Root Cause Analysis

The GitHub-hosted runners drifted to different pip versions inside the same matrix job:

- **ubuntu-latest** ended up with **pip 26.1** (post-`actions/setup-python@v6` install).
- **macos-latest** stayed on **pip 26.0.1** (cached or bundled with the runner image).

`pip-audit` only reports `CVE-2026-3219` against pip ≤ 26.0.1 — the OSV/PyPA database now treats pip 26.1 as fixed (verified locally: `pip-audit` emits the advisory for 26.0.1 but not for 26.1). The allowlist entry's `version_spec: "<=26.0.1"` therefore matched on macOS (used → pass) but **on ubuntu the entry was "installed but advisory not reported"**, which `scripts/pip_audit_gate.py` evaluates as an `unused_entries` failure (rule #4 in `evaluate()`).

> Note: pip 26.0.2 referenced in the original allowlist comment never shipped on PyPI — pip released 26.1 directly after 26.0.1, so the comment's "Re-evaluate when pip 26.0.2+ ships the fix" condition has effectively been met by 26.1.

### Failure classification

| Group | Type | Affected variant | Cause |
|-------|------|-----------------|-------|
| audit-dependencies-extras | Deterministic config issue (allowlist drift) | ubuntu-latest only | pip version drift between matrix variants → `unused_entries` gate failure |

This is **not** a flaky test, transient infrastructure issue, or code regression — it's an environment config issue triggered by upstream OSV DB updating pip's affected-version range.

## Fix

Two coordinated changes in `.github/workflows/security.yml` and `.github/accepted-risks-extras.yml`:

1. **`security.yml`** — prepend `python -m pip install --upgrade pip` to the "Install pip-audit + gate deps" step in `audit-dependencies-extras`. This ensures both matrix variants audit a consistent pip version (the latest unaffected one), eliminating the platform asymmetry.
2. **`accepted-risks-extras.yml`** — remove the now-stale `CVE-2026-3219` (pip) allowlist entry. With pip upgraded to 26.1+ on both runners, no vuln will be reported for pip and the entry would otherwise be flagged as `unused_entries` → fail.

The two changes are tightly coupled and must land together: keeping the entry without the upgrade leaves macOS green and ubuntu red; removing the entry without the upgrade flips that polarity (macOS red because CVE is reported but unallowlisted).

The `diskcache` (CVE-2025-69872) and `py` (PYSEC-2022-42969) allowlist entries are **unchanged** — both packages are still reported by pip-audit and still installed transitively under `.[all]` (diskcache via llama-cpp-python, py via interrogate).

## Trade-offs

- **Tests not weakened.** No allowlist entry is being added, no `continue-on-error` introduced, no test-skip pragma added. Removing the entry strengthens the gate (no longer suppresses an advisory that no longer applies).
- **No suppression of failures.** If a regression reintroduces a vulnerable pip version, the gate will surface it as an `unknown_vuln` rather than a silent pass — exactly what we want.
- **One extra `pip install --upgrade pip` call.** Adds <5s to the install step; the existing retry wrapper already bounds it.

## Verification

Verified locally end-to-end:

```bash
# pip 26.0.1 (vulnerable) — pip-audit reports CVE-2026-3219
$ pip install pip==26.0.1 && pip-audit --format=json | jq '.dependencies[] | select(.name=="pip") | .vulns[].id'
"CVE-2026-3219"

# pip 26.1 (current) — pip-audit reports nothing for pip
$ pip install --upgrade pip && pip-audit --format=json | jq '.dependencies[] | select(.name=="pip") | .vulns'
[]

# Gate with updated allowlist + .[all]-equivalent install (diskcache 5.6.3 + py 1.11.0 + pip 26.1):
$ python3 scripts/pip_audit_gate.py --audit audit.json --allowlist .github/accepted-risks-extras.yml
pip-audit gate: OK
EXIT_CODE=0

# Existing unit-test suite for the gate still green:
$ python3 -m pytest tests/scripts/test_pip_audit_gate.py -q
17 passed in 14.69s
```

## Test plan

- [x] CI runs on this PR and `audit-dependencies-extras (ubuntu-latest)` passes
- [x] `audit-dependencies-extras (macos-latest)` continues to pass
- [x] `audit-dependencies` (base, ubuntu-only) is unaffected (no change to that job)
- [x] Other security jobs (`bandit-scan`, `codeql-analysis`) continue to pass
- [x] No new `unused_entries` warnings emitted for the remaining diskcache / py entries

## Impacted areas

- `.github/workflows/security.yml` (the `audit-dependencies-extras` job only)
- `.github/accepted-risks-extras.yml` (one entry removed)
- No source-code changes; no test changes.

https://claude.ai/code/session_01NFJ1xbH8yBfqcG3VYsBrJW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFJ1xbH8yBfqcG3VYsBrJW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an accepted security exception to enforce stricter dependency audit standards.
  * Standardized and stabilized the dependency-audit setup across build environments to ensure consistent audit results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
