### PR TITLE
fix(ci): pull beta-bug ISSUE_TEMPLATE forward to unbreak main

### DIFF
--- a/.github/ISSUE_TEMPLATE/beta-bug.md
+++ b/.github/ISSUE_TEMPLATE/beta-bug.md
@@ -1,0 +1,64 @@
+---
+name: Beta bug
+about: Report a bug in a 2.0.0-beta.X release
+title: "[BETA] "
+labels: bug, beta
+assignees: ""
+---
+
+<!--
+Thanks for testing the fo-core beta channel!
+Filing a bug here helps us decide when this build is ready to graduate to GA.
+-->
+
+## What happened
+
+<!-- One-line description of the bug. -->
+
+## fo --debug output
+
+<!--
+REQUIRED. Re-run your failing command with --debug and paste the FULL output
+below (red error line + traceback). Without this, triage usually has to ask
+you to re-run.
+
+Note: the --debug flag is wired in Step 3 of the alpha→beta path. If you
+are filing a bug against an alpha release where --debug is not yet available,
+substitute `--verbose` and capture stderr.
+-->
+
+```text
+$ fo --debug <your command>
+<paste output here>
+```
+
+## fo doctor output
+
+<!-- REQUIRED. Output of `fo doctor`. -->
+
+```text
+$ fo doctor
+<paste output here>
+```
+
+## Environment
+
+- OS:
+- Python version (`python --version`):
+- fo-core version (`fo version`):
+- How installed (`pip install fo-core`, `pip install -e .`, etc.):
+- Optional extras installed (`pip show fo-core`):
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What did you think would happen? -->
+
+## Actual behavior
+
+<!-- What happened instead? -->


### PR DESCRIPTION
## Summary

Hotfix for the `Test full suite` failure on main introduced by PR #231:

```
FAILED tests/docs/test_doc_file_paths.py::test_referenced_path_exists[docs/release/beta-criteria.md-.github/ISSUE_TEMPLATE/beta-bug.md]
AssertionError: docs/release/beta-criteria.md: references non-existent path '.github/ISSUE_TEMPLATE/beta-bug.md'
```

The §2 entry checklist in `docs/release/beta-criteria.md` lists this template as a beta-entry requirement; the path-resolution test (which only runs on the post-merge full suite, not PR runs) caught that the file is referenced but doesn't exist yet on main.

## Approach

Pulled forward Step 5 Task 2 of the alpha→beta path ([2026-04-27-classifier-bump-step-5.md](docs/superpowers/plans/2026-04-27-classifier-bump-step-5.md)) as a precursor: ship just the bug template as a single static file. Considered alternatives:

- **Add to ALLOWLIST** in `tests/docs/test_doc_file_paths.py` — fixes main now but creates cleanup tech debt for whenever Step 5 lands.
- **Do nothing, accept red main** — leaves a real test broken, obscures any future regression.
- **Pull the template forward** (this PR) — smallest total surface, no test-file edits, zero coupling to Steps 2-4, no follow-up cleanup needed.

Content is verbatim from Step 5's plan, with one clarifying note: the template asks for `fo --debug` output (Step 3 work). Until Step 3 lands, alpha-era reporters can substitute `--verbose` + stderr.

## Step 5 plan impact

When Step 5 eventually ships, its Task 2 ("Add the Beta bug-report template") becomes a no-op — the file already exists. Plan left unchanged; Task 2 will be checked off at execution time.

## Test plan

- [ ] `pytest tests/docs/test_doc_file_paths.py -v` — passes locally (verified)
- [ ] CI's `Test full suite (py3.11)` and `(py3.12)` go green on main after merge
- [ ] No new GitHub issue templates are auto-rendered incorrectly (template is selectable from `.github/ISSUE_TEMPLATE/` dropdown)
- [ ] No regressions in other path-resolution tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)