### PR TITLE
feat(audio): Step 2A — wire AudioModel.generate() + transcription smoke verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Core file types (PDF, DOCX, XLSX, PPTX, EPUB, ZIP) work out of the box. RAR also
 
 | Pack | Install | Adds |
 |------|---------|------|
-| `media` | `pip install "fo-core[media]"` | Audio transcription, video scene detection |
+| `media` | `pip install "fo-core[media]"` | Audio transcription (faster-whisper) + video scene detection. Verify with `fo benchmark run --suite audio --transcribe-smoke`. |
 | `dedup-text` | `pip install "fo-core[dedup-text]"` | TF-IDF/cosine text deduplication |
 | `dedup-image` | `pip install "fo-core[dedup-image]"` | Image similarity deduplication |
 | `scientific` | `pip install "fo-core[scientific]"` | HDF5, NetCDF, MATLAB formats |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,10 @@ claude = [
     "anthropic>=0.20.0",  # 0.x — unstable API, keep >=; Anthropic Claude API provider
 ]
 
+# Optional: audio transcription (faster-whisper) and video scene detection.
+# Audio is exposed via the `AudioModel` class and is exercised end-to-end
+# by `fo benchmark run --suite audio --transcribe-smoke`. Video scene
+# detection is invoked by services/video/scene_detector.py callers.
 media = [
     "faster-whisper~=1.0",
     "torch~=2.1",

--- a/src/cli/benchmark.py
+++ b/src/cli/benchmark.py
@@ -736,6 +736,34 @@ def _bind_transcribe_smoke(
     return runner
 
 
+def _validate_transcribe_smoke_preconditions(
+    files: list[Path], *, transcribe_smoke: bool
+) -> None:
+    """Fail fast when ``--transcribe-smoke`` can't possibly run end-to-end.
+
+    Otherwise the empty-input and no-audio-candidates paths short-circuit
+    the benchmark before the smoke check fires, but ``run()`` still exits 0 —
+    a false-positive verification signal for CI/scripts that key off exit
+    code.
+
+    Raises ``typer.BadParameter`` when ``transcribe_smoke`` is set and either
+    ``files`` is empty (no input at all) or the input has no audio candidates.
+    """
+    if not transcribe_smoke:
+        return
+    if not files:
+        raise typer.BadParameter(
+            "--transcribe-smoke requires at least one input file; the input "
+            "directory is empty."
+        )
+    audio_candidates = _suite_candidates(files, _AUDIO_EXTENSIONS, fallback_to_all=False)
+    if not audio_candidates:
+        raise typer.BadParameter(
+            "--transcribe-smoke requires at least one audio file in the input; "
+            "none were found."
+        )
+
+
 def _exit_if_transcribe_smoke_failed(console: Any, degradation_reasons: Sequence[str]) -> None:
     """Exit non-zero when ``--transcribe-smoke`` ran but no smoke completed.
 
@@ -1121,6 +1149,10 @@ def run(
     runner = suite_spec["run"]
     classifier = suite_spec["classify"]
     runner = _bind_transcribe_smoke(runner, suite=suite, transcribe_smoke=transcribe_smoke)
+    # Block the empty-input and no-audio-candidates paths from short-circuiting
+    # past the smoke-failure exit guard, which would otherwise cause
+    # `--transcribe-smoke` to exit 0 without verifying anything.
+    _validate_transcribe_smoke_preconditions(files, transcribe_smoke=transcribe_smoke)
 
     if not files:
         if json_output:

--- a/src/cli/benchmark.py
+++ b/src/cli/benchmark.py
@@ -9,6 +9,7 @@ regression flagging.
 from __future__ import annotations
 
 import contextlib
+import functools
 import io
 import json
 import logging
@@ -26,7 +27,8 @@ import typer
 
 from cli.path_validation import resolve_cli_path
 from core.path_guard import safe_walk
-from models.base import ModelType
+from models.audio_model import AudioModel
+from models.base import ModelConfig, ModelType
 
 if TYPE_CHECKING:
     from services.audio.metadata_extractor import AudioMetadata
@@ -91,6 +93,7 @@ class _SuiteIterationOutcome:
 
     processed_count: int
     used_synthetic_audio_metadata: bool = False
+    transcription_smoke_passed: bool = False
 
 
 class _SuiteRunner(TypedDict):
@@ -497,8 +500,16 @@ def _synthesized_audio_metadata(file_path: Path) -> AudioMetadata:
     )
 
 
-def _run_audio_suite(files: list[Path]) -> _SuiteIterationOutcome:
-    """Benchmark audio metadata + classification path."""
+def _run_audio_suite(
+    files: list[Path],
+    transcribe_smoke: bool = False,
+) -> _SuiteIterationOutcome:
+    """Benchmark audio metadata + classification path.
+
+    With ``transcribe_smoke=True``, additionally runs ``AudioModel.generate()``
+    on the first candidate file to prove end-to-end transcription works.
+    Counted as a single smoke pass; not a per-file benchmark.
+    """
     candidates = _suite_candidates(files, _AUDIO_EXTENSIONS, fallback_to_all=False)
     if not candidates:
         typer.echo("Warning: no audio files found; falling back to IO-only benchmark.", err=True)
@@ -519,9 +530,28 @@ def _run_audio_suite(files: list[Path]) -> _SuiteIterationOutcome:
         except Exception as exc:
             raise RuntimeError(f"Audio benchmark runner failed for {file_path}: {exc}") from exc
         _ = classifier.classify(metadata)
+
+    transcription_smoke_passed = False
+    if transcribe_smoke:
+        try:
+            config = ModelConfig(name="tiny", model_type=ModelType.AUDIO)
+            model = AudioModel(config)
+            model.initialize()
+            try:
+                _ = model.generate(str(candidates[0]))
+                transcription_smoke_passed = True
+            finally:
+                model.safe_cleanup()
+        except ImportError as exc:
+            typer.echo(
+                f"Warning: --transcribe-smoke requires [media] extra: {exc}",
+                err=True,
+            )
+
     return _SuiteIterationOutcome(
         processed_count=len(candidates),
         used_synthetic_audio_metadata=used_synthetic_metadata,
+        transcription_smoke_passed=transcription_smoke_passed,
     )
 
 
@@ -982,6 +1012,16 @@ def run(
         "--compare",
         help="Path to baseline JSON file for regression comparison.",
     ),
+    transcribe_smoke: bool = typer.Option(
+        False,
+        "--transcribe-smoke",
+        help=(
+            "Run AudioModel.generate() on one candidate file as an "
+            "end-to-end smoke test. Only meaningful with --suite audio. "
+            "Requires the [media] extra. Off by default to keep "
+            "benchmark runs fast."
+        ),
+    ),
 ) -> None:
     """Run a performance benchmark with statistical output.
 
@@ -1020,6 +1060,8 @@ def run(
         raise typer.Exit(code=1)
     runner = suite_spec["run"]
     classifier = suite_spec["classify"]
+    if suite == "audio" and transcribe_smoke:
+        runner = functools.partial(_run_audio_suite, transcribe_smoke=True)
 
     if not files:
         if json_output:

--- a/src/cli/benchmark.py
+++ b/src/cli/benchmark.py
@@ -89,10 +89,18 @@ class _SuiteExecutionClassification:
 
 @dataclass(frozen=True, slots=True)
 class _SuiteIterationOutcome:
-    """Per-iteration suite runner outcome consumed by classification."""
+    """Per-iteration suite runner outcome consumed by classification.
+
+    The smoke pair (``transcription_smoke_requested`` /
+    ``transcription_smoke_passed``) lets ``_classify_audio_suite`` distinguish
+    "smoke not asked for" from "smoke asked for but couldn't run" — required
+    so ``--transcribe-smoke`` doesn't silently succeed when the ``[media]``
+    extra is missing.
+    """
 
     processed_count: int
     used_synthetic_audio_metadata: bool = False
+    transcription_smoke_requested: bool = False
     transcription_smoke_passed: bool = False
 
 
@@ -543,6 +551,10 @@ def _run_audio_suite(
             finally:
                 model.safe_cleanup()
         except ImportError as exc:
+            # The smoke check was requested but couldn't run. Leave
+            # transcription_smoke_passed=False so _classify_audio_suite
+            # marks the run degraded; run() will surface a non-zero exit
+            # at the end. The warning is for the human reading stderr.
             typer.echo(
                 f"Warning: --transcribe-smoke requires [media] extra: {exc}",
                 err=True,
@@ -551,6 +563,7 @@ def _run_audio_suite(
     return _SuiteIterationOutcome(
         processed_count=len(candidates),
         used_synthetic_audio_metadata=used_synthetic_metadata,
+        transcription_smoke_requested=transcribe_smoke,
         transcription_smoke_passed=transcription_smoke_passed,
     )
 
@@ -712,11 +725,20 @@ def _classify_audio_suite(
             degraded=True,
             degradation_reasons=("audio-no-candidates-fallback-to-io",),
         )
+    reasons: list[str] = []
     if outcome.used_synthetic_audio_metadata:
+        reasons.append("audio-synthesized-metadata-fallback")
+    if outcome.transcription_smoke_requested and not outcome.transcription_smoke_passed:
+        # --transcribe-smoke was requested but couldn't run end-to-end
+        # (typically [media] extra missing). Surface the gap to the JSON
+        # consumer; run() will also exit non-zero so CI / scripts treat
+        # this as a real failure rather than a successful audio benchmark.
+        reasons.append("audio-transcribe-smoke-skipped")
+    if reasons:
         return _SuiteExecutionClassification(
             effective_suite="audio",
             degraded=True,
-            degradation_reasons=("audio-synthesized-metadata-fallback",),
+            degradation_reasons=tuple(reasons),
         )
     return _SuiteExecutionClassification(effective_suite="audio", degraded=False)
 
@@ -1060,6 +1082,13 @@ def run(
         raise typer.Exit(code=1)
     runner = suite_spec["run"]
     classifier = suite_spec["classify"]
+    if transcribe_smoke and suite != "audio":
+        # Fail fast rather than letting the flag become a silent no-op for
+        # non-audio suites (which would falsely report a successful "smoke
+        # check" in CI/scripts).
+        raise typer.BadParameter(
+            "--transcribe-smoke is only supported with --suite audio"
+        )
     if suite == "audio" and transcribe_smoke:
         runner = functools.partial(_run_audio_suite, transcribe_smoke=True)
 
@@ -1073,6 +1102,7 @@ def run(
                 "degraded": classification.degraded,
                 "degradation_reasons": sorted(set(classification.degradation_reasons)),
                 "runner_profile_version": _RUNNER_PROFILE_VERSION,
+                "transcribe_smoke": transcribe_smoke,
                 "files_count": 0,
                 "hardware_profile": _detect_hardware_profile(),
                 "results": compute_stats([], 0),
@@ -1136,13 +1166,17 @@ def run(
     # Statistics
     stats = compute_stats(measured, actual_processed_count)
 
-    # Build output
+    # Build output. `transcribe_smoke` is included so `--compare` can avoid
+    # mixing smoke and non-smoke baselines (which would otherwise show
+    # misleading regressions from the extra AudioModel.generate() call per
+    # iteration).
     output: dict[str, Any] = {
         "suite": suite,
         "effective_suite": effective_suite,
         "degraded": degraded,
         "degradation_reasons": degradation_reasons,
         "runner_profile_version": _RUNNER_PROFILE_VERSION,
+        "transcribe_smoke": transcribe_smoke,
         "files_count": actual_processed_count,
         "hardware_profile": _detect_hardware_profile(),
         "results": stats,
@@ -1171,3 +1205,16 @@ def run(
         if "comparison" in output:
             _print_comparison(console, output["comparison"], json_output=False)
         console.print("\n[bold green]Benchmark completed[/bold green]")
+
+    # `--transcribe-smoke` is a verification flag — if it was requested but
+    # didn't actually run end-to-end (typically [media] extra missing), the
+    # run must exit non-zero. The output above reports the failure for
+    # human + JSON consumers; this exits so CI / scripts treat it as a
+    # real failure instead of a successful audio benchmark.
+    if "audio-transcribe-smoke-skipped" in degradation_reasons:
+        console.print(
+            "[red]Error: --transcribe-smoke was requested but could not run "
+            "end-to-end (see warnings above). Install the [media] extra "
+            "(`pip install -e \".[media]\"`) and retry.[/red]",
+        )
+        raise typer.Exit(code=1)

--- a/src/cli/benchmark.py
+++ b/src/cli/benchmark.py
@@ -544,8 +544,8 @@ def _run_audio_suite(
         try:
             config = ModelConfig(name="tiny", model_type=ModelType.AUDIO)
             model = AudioModel(config)
-            model.initialize()
             try:
+                model.initialize()
                 _ = model.generate(str(candidates[0]))
                 transcription_smoke_passed = True
             finally:

--- a/src/cli/benchmark.py
+++ b/src/cli/benchmark.py
@@ -715,6 +715,44 @@ def _classify_vision_suite(
     return _SuiteExecutionClassification(effective_suite="vision", degraded=False)
 
 
+def _bind_transcribe_smoke(
+    runner: Callable[[list[Path]], _SuiteIterationOutcome],
+    *,
+    suite: str,
+    transcribe_smoke: bool,
+) -> Callable[[list[Path]], _SuiteIterationOutcome]:
+    """Validate ``--transcribe-smoke`` against ``suite`` and bind it to the runner.
+
+    Raises ``typer.BadParameter`` if the flag is set with a non-audio suite —
+    the flag becomes a silent no-op otherwise, which falsely reports a
+    successful "smoke check" to CI/scripts. When set with ``--suite audio``,
+    pre-binds ``transcribe_smoke=True`` to the audio runner so the dispatch
+    surface in :func:`run` doesn't need a special case.
+    """
+    if transcribe_smoke and suite != "audio":
+        raise typer.BadParameter("--transcribe-smoke is only supported with --suite audio")
+    if suite == "audio" and transcribe_smoke:
+        return functools.partial(_run_audio_suite, transcribe_smoke=True)
+    return runner
+
+
+def _exit_if_transcribe_smoke_failed(console: Any, degradation_reasons: Sequence[str]) -> None:
+    """Exit non-zero when ``--transcribe-smoke`` ran but no smoke completed.
+
+    Requested but couldn't run end-to-end (typically because the ``[media]``
+    extra is missing). The benchmark output is already emitted by the time
+    this fires, so JSON/human consumers see the degradation classification;
+    this just propagates the failure to the shell exit code.
+    """
+    if "audio-transcribe-smoke-skipped" in degradation_reasons:
+        console.print(
+            "[red]Error: --transcribe-smoke was requested but could not run "
+            "end-to-end (see warnings above). Install the [media] extra "
+            '(`pip install -e ".[media]"`) and retry.[/red]',
+        )
+        raise typer.Exit(code=1)
+
+
 def _classify_audio_suite(
     files: list[Path], outcome: _SuiteIterationOutcome
 ) -> _SuiteExecutionClassification:
@@ -1082,15 +1120,7 @@ def run(
         raise typer.Exit(code=1)
     runner = suite_spec["run"]
     classifier = suite_spec["classify"]
-    if transcribe_smoke and suite != "audio":
-        # Fail fast rather than letting the flag become a silent no-op for
-        # non-audio suites (which would falsely report a successful "smoke
-        # check" in CI/scripts).
-        raise typer.BadParameter(
-            "--transcribe-smoke is only supported with --suite audio"
-        )
-    if suite == "audio" and transcribe_smoke:
-        runner = functools.partial(_run_audio_suite, transcribe_smoke=True)
+    runner = _bind_transcribe_smoke(runner, suite=suite, transcribe_smoke=transcribe_smoke)
 
     if not files:
         if json_output:
@@ -1206,15 +1236,4 @@ def run(
             _print_comparison(console, output["comparison"], json_output=False)
         console.print("\n[bold green]Benchmark completed[/bold green]")
 
-    # `--transcribe-smoke` is a verification flag — if it was requested but
-    # didn't actually run end-to-end (typically [media] extra missing), the
-    # run must exit non-zero. The output above reports the failure for
-    # human + JSON consumers; this exits so CI / scripts treat it as a
-    # real failure instead of a successful audio benchmark.
-    if "audio-transcribe-smoke-skipped" in degradation_reasons:
-        console.print(
-            "[red]Error: --transcribe-smoke was requested but could not run "
-            "end-to-end (see warnings above). Install the [media] extra "
-            "(`pip install -e \".[media]\"`) and retry.[/red]",
-        )
-        raise typer.Exit(code=1)
+    _exit_if_transcribe_smoke_failed(console, degradation_reasons)

--- a/src/cli/benchmark.py
+++ b/src/cli/benchmark.py
@@ -1328,7 +1328,13 @@ def run(
     )
 
     if json_output:
+        # JSON consumers parse the document on stdout; the smoke-failure
+        # exit fires after so they still get the full payload (including
+        # `degraded` + `degradation_reasons`) before the non-zero exit.
         console.print(json.dumps(output, indent=2))
+        _exit_if_transcribe_smoke_failed(
+            console, degradation_reasons, json_output=json_output
+        )
     else:
         if degraded:
             console.print(
@@ -1340,6 +1346,11 @@ def run(
         _print_table(console, suite, warmup, stats, actual_processed_count)
         if "comparison" in output:
             _print_comparison(console, output["comparison"], json_output=False)
+        # In human mode, exit BEFORE the success banner — printing
+        # "Benchmark completed" and then exiting non-zero produces
+        # contradictory output that misleads operators and breaks any
+        # automation that scrapes the human log for completion status.
+        _exit_if_transcribe_smoke_failed(
+            console, degradation_reasons, json_output=json_output
+        )
         console.print("\n[bold green]Benchmark completed[/bold green]")
-
-    _exit_if_transcribe_smoke_failed(console, degradation_reasons, json_output=json_output)

--- a/src/cli/benchmark.py
+++ b/src/cli/benchmark.py
@@ -933,9 +933,27 @@ def _check_baseline_smoke_compatibility(
     Returns a warning string when the baseline's ``transcribe_smoke`` flag
     differs from the current run, otherwise ``None``. Treats a missing
     field on the baseline as ``False`` since older baselines predate the
-    flag.
+    flag. A non-boolean value (e.g. the string ``"false"`` from a hand-
+    edited or malformed baseline) is reported via a malformed-field warning
+    instead of being coerced — ``bool("false")`` is ``True``, which would
+    silently invert the mismatch signal.
     """
-    baseline_smoke = bool(baseline.get("transcribe_smoke", False))
+    raw = baseline.get("transcribe_smoke")
+    if raw is None:
+        baseline_smoke = False
+    elif isinstance(raw, bool):
+        baseline_smoke = raw
+    else:
+        warning = (
+            "Baseline transcribe_smoke field is not a boolean "
+            f"(got {type(raw).__name__}={raw!r}); treating as missing. "
+            "The baseline file may be hand-edited or corrupted; "
+            "smoke-mode mismatch detection is unreliable for this comparison."
+        )
+        if not json_output:
+            console.print(f"[yellow]{warning}[/yellow]")
+        return warning
+
     if baseline_smoke == transcribe_smoke:
         return None
 

--- a/src/cli/benchmark.py
+++ b/src/cli/benchmark.py
@@ -736,9 +736,7 @@ def _bind_transcribe_smoke(
     return runner
 
 
-def _validate_transcribe_smoke_preconditions(
-    files: list[Path], *, transcribe_smoke: bool
-) -> None:
+def _validate_transcribe_smoke_preconditions(files: list[Path], *, transcribe_smoke: bool) -> None:
     """Fail fast when ``--transcribe-smoke`` can't possibly run end-to-end.
 
     Otherwise the empty-input and no-audio-candidates paths short-circuit
@@ -753,14 +751,12 @@ def _validate_transcribe_smoke_preconditions(
         return
     if not files:
         raise typer.BadParameter(
-            "--transcribe-smoke requires at least one input file; the input "
-            "directory is empty."
+            "--transcribe-smoke requires at least one input file; the input directory is empty."
         )
     audio_candidates = _suite_candidates(files, _AUDIO_EXTENSIONS, fallback_to_all=False)
     if not audio_candidates:
         raise typer.BadParameter(
-            "--transcribe-smoke requires at least one audio file in the input; "
-            "none were found."
+            "--transcribe-smoke requires at least one audio file in the input; none were found."
         )
 
 

--- a/src/cli/benchmark.py
+++ b/src/cli/benchmark.py
@@ -760,21 +760,36 @@ def _validate_transcribe_smoke_preconditions(files: list[Path], *, transcribe_sm
         )
 
 
-def _exit_if_transcribe_smoke_failed(console: Any, degradation_reasons: Sequence[str]) -> None:
+def _exit_if_transcribe_smoke_failed(
+    console: Any,
+    degradation_reasons: Sequence[str],
+    *,
+    json_output: bool = False,
+) -> None:
     """Exit non-zero when ``--transcribe-smoke`` ran but no smoke completed.
 
     Requested but couldn't run end-to-end (typically because the ``[media]``
     extra is missing). The benchmark output is already emitted by the time
     this fires, so JSON/human consumers see the degradation classification;
     this just propagates the failure to the shell exit code.
+
+    When ``json_output`` is true, the failure notice is routed to stderr so
+    the JSON document already on stdout stays machine-parseable.
     """
-    if "audio-transcribe-smoke-skipped" in degradation_reasons:
-        console.print(
-            "[red]Error: --transcribe-smoke was requested but could not run "
-            "end-to-end (see warnings above). Install the [media] extra "
-            '(`pip install -e ".[media]"`) and retry.[/red]',
-        )
-        raise typer.Exit(code=1)
+    if "audio-transcribe-smoke-skipped" not in degradation_reasons:
+        return
+    error_msg = (
+        "[red]Error: --transcribe-smoke was requested but could not run "
+        "end-to-end (see warnings above). Install the [media] extra "
+        '(`pip install -e ".[media]"`) and retry.[/red]'
+    )
+    if json_output:
+        from rich.console import Console
+
+        Console(stderr=True).print(error_msg)
+    else:
+        console.print(error_msg)
+    raise typer.Exit(code=1)
 
 
 def _classify_audio_suite(
@@ -901,6 +916,40 @@ def _check_baseline_profile_compatibility(
     return warning
 
 
+def _check_baseline_smoke_compatibility(
+    baseline: dict[str, Any],
+    *,
+    transcribe_smoke: bool,
+    console: Any,
+    json_output: bool,
+) -> str | None:
+    """Validate that current and baseline runs used the same smoke mode.
+
+    A smoke run adds an ``AudioModel.generate()`` call per iteration and
+    skews the per-iteration timings. Comparing a smoke run against a
+    non-smoke baseline (or vice versa) yields misleading regression signals
+    for non-equivalent workloads.
+
+    Returns a warning string when the baseline's ``transcribe_smoke`` flag
+    differs from the current run, otherwise ``None``. Treats a missing
+    field on the baseline as ``False`` since older baselines predate the
+    flag.
+    """
+    baseline_smoke = bool(baseline.get("transcribe_smoke", False))
+    if baseline_smoke == transcribe_smoke:
+        return None
+
+    warning = (
+        "Baseline smoke-mode mismatch "
+        f"(baseline transcribe_smoke={baseline_smoke}, current={transcribe_smoke}). "
+        "Smoke runs add an AudioModel.generate() call per iteration; the "
+        "comparison may show misleading regressions or improvements."
+    )
+    if not json_output:
+        console.print(f"[yellow]{warning}[/yellow]")
+    return warning
+
+
 def _execute_suite_iteration(
     *,
     runner: Callable[[list[Path]], _SuiteIterationOutcome],
@@ -1010,6 +1059,7 @@ def _maybe_attach_comparison_output(
     output: dict[str, Any],
     compare_path: Path | None,
     suite: str,
+    transcribe_smoke: bool,
     console: Any,
     json_output: bool,
 ) -> dict[str, Any]:
@@ -1028,10 +1078,18 @@ def _maybe_attach_comparison_output(
         console=console,
         json_output=json_output,
     )
+    smoke_warning = _check_baseline_smoke_compatibility(
+        baseline,
+        transcribe_smoke=transcribe_smoke,
+        console=console,
+        json_output=json_output,
+    )
     comp = compare_results(output, baseline)
     output["comparison"] = comp
     if profile_warning is not None:
         output["comparison_profile_warning"] = profile_warning
+    if smoke_warning is not None:
+        output["comparison_smoke_warning"] = smoke_warning
     return output
 
 
@@ -1170,6 +1228,7 @@ def run(
                 output=empty_output,
                 compare_path=compare_path,
                 suite=suite,
+                transcribe_smoke=transcribe_smoke,
                 console=console,
                 json_output=json_output,
             )
@@ -1245,6 +1304,7 @@ def run(
         output=output,
         compare_path=compare_path,
         suite=suite,
+        transcribe_smoke=transcribe_smoke,
         console=console,
         json_output=json_output,
     )
@@ -1264,4 +1324,4 @@ def run(
             _print_comparison(console, output["comparison"], json_output=False)
         console.print("\n[bold green]Benchmark completed[/bold green]")
 
-    _exit_if_transcribe_smoke_failed(console, degradation_reasons)
+    _exit_if_transcribe_smoke_failed(console, degradation_reasons, json_output=json_output)

--- a/src/cli/benchmark.py
+++ b/src/cli/benchmark.py
@@ -1332,9 +1332,7 @@ def run(
         # exit fires after so they still get the full payload (including
         # `degraded` + `degradation_reasons`) before the non-zero exit.
         console.print(json.dumps(output, indent=2))
-        _exit_if_transcribe_smoke_failed(
-            console, degradation_reasons, json_output=json_output
-        )
+        _exit_if_transcribe_smoke_failed(console, degradation_reasons, json_output=json_output)
     else:
         if degraded:
             console.print(
@@ -1350,7 +1348,5 @@ def run(
         # "Benchmark completed" and then exiting non-zero produces
         # contradictory output that misleads operators and breaks any
         # automation that scrapes the human log for completion status.
-        _exit_if_transcribe_smoke_failed(
-            console, degradation_reasons, json_output=json_output
-        )
+        _exit_if_transcribe_smoke_failed(console, degradation_reasons, json_output=json_output)
         console.print("\n[bold green]Benchmark completed[/bold green]")

--- a/src/models/audio_model.py
+++ b/src/models/audio_model.py
@@ -1,36 +1,62 @@
-"""Audio model implementation (placeholder for Phase 3)."""
+"""Audio model — wraps services.audio.transcriber for the BaseModel interface."""
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
 from models.base import BaseModel, ModelConfig, ModelType
 
+if TYPE_CHECKING:
+    from services.audio.transcriber import AudioTranscriber, ModelSize
+
+
+# F9-allowed lazy-import helper: services.audio.transcriber lives under
+# services/, and services/__init__.py eagerly pulls in text_processor which
+# in turn imports models.TextModel. Because models/__init__.py imports
+# AudioModel at package init, a top-level import of services.audio.transcriber
+# here closes the cycle and crashes models package init with
+# "cannot import name 'TextModel' from partially initialized module 'models'".
+# Deferring the import to first call breaks the cycle: by the time AudioModel
+# is constructed, both packages are fully loaded.
+def _audio_transcriber_classes() -> tuple[type, type, type]:
+    """Return ``(AudioTranscriber, ModelSize, TranscriptionOptions)`` lazily."""
+    from services.audio.transcriber import (
+        AudioTranscriber,
+        ModelSize,
+        TranscriptionOptions,
+    )
+    return AudioTranscriber, ModelSize, TranscriptionOptions
+
+
+def _resolve_model_size(name: str) -> ModelSize:
+    """Map a ``ModelConfig.name`` to a faster-whisper ``ModelSize``.
+
+    Accepts forms like ``"base"``, ``"whisper-base"``, ``"Whisper_Large-V3"``.
+    Falls back to ``ModelSize.BASE`` for unknown names — keeps the call live
+    rather than crashing on a config typo.
+    """
+    _, ModelSize, _ = _audio_transcriber_classes()
+    normalized = name.lower().replace("whisper-", "").replace("_", "-")
+    for size in ModelSize:
+        if size.value == normalized:
+            return size
+    return ModelSize.BASE
+
 
 class AudioModel(BaseModel):
-    """Audio transcription model (to be implemented in Phase 3).
-
-    This will wrap Distil-Whisper or Faster-Whisper for:
-    - Audio transcription
-    - Speech-to-text conversion
-    - Audio file categorization
-    """
+    """Audio transcription model backed by faster-whisper."""
 
     def __init__(self, config: ModelConfig):
-        """Initialize audio model.
-
-        Args:
-            config: Model configuration
-
-        Raises:
-            ValueError: If model type is not AUDIO
-        """
         if config.model_type != ModelType.AUDIO:
             raise ValueError(f"Expected AUDIO model type, got {config.model_type}")
-
         super().__init__(config)
+        AudioTranscriber, _, _ = _audio_transcriber_classes()
+        self._transcriber = AudioTranscriber(
+            model_size=_resolve_model_size(config.name),
+            device=config.device.value if config.device else "auto",
+        )
 
     def initialize(self) -> None:
         """Initialize the audio model (not implemented yet)."""

--- a/src/models/audio_model.py
+++ b/src/models/audio_model.py
@@ -21,29 +21,35 @@ if TYPE_CHECKING:
 # "cannot import name 'TextModel' from partially initialized module 'models'".
 # Deferring the import to first call breaks the cycle: by the time AudioModel
 # is constructed, both packages are fully loaded.
-def _audio_transcriber_classes() -> tuple[type, type, type]:
+def _audio_transcriber_classes() -> (
+    tuple[
+        type["AudioTranscriber"],
+        type["ModelSize"],
+        type["TranscriptionOptions"],
+    ]
+):
     """Return ``(AudioTranscriber, ModelSize, TranscriptionOptions)`` lazily."""
     from services.audio.transcriber import (
-        AudioTranscriber,
-        ModelSize,
-        TranscriptionOptions,
+        AudioTranscriber as _AudioTranscriber,
+        ModelSize as _ModelSize,
+        TranscriptionOptions as _TranscriptionOptions,
     )
-    return AudioTranscriber, ModelSize, TranscriptionOptions
+    return _AudioTranscriber, _ModelSize, _TranscriptionOptions
 
 
-def _resolve_model_size(name: str) -> ModelSize:
+def _resolve_model_size(name: str) -> "ModelSize":
     """Map a ``ModelConfig.name`` to a faster-whisper ``ModelSize``.
 
     Accepts forms like ``"base"``, ``"whisper-base"``, ``"Whisper_Large-V3"``.
     Falls back to ``ModelSize.BASE`` for unknown names — keeps the call live
     rather than crashing on a config typo.
     """
-    _, ModelSize, _ = _audio_transcriber_classes()
+    _, ModelSizeCls, _ = _audio_transcriber_classes()
     normalized = name.lower().replace("whisper-", "").replace("_", "-")
-    for size in ModelSize:
+    for size in ModelSizeCls:
         if size.value == normalized:
             return size
-    return ModelSize.BASE
+    return ModelSizeCls.BASE
 
 
 class AudioModel(BaseModel):

--- a/src/models/audio_model.py
+++ b/src/models/audio_model.py
@@ -90,9 +90,10 @@ class AudioModel(BaseModel):
             self._exit_generate()
 
     def cleanup(self) -> None:
-        """Cleanup model resources."""
+        """Cleanup model resources. Unloads the underlying Whisper model."""
         logger.debug("Cleaning up audio model")
         with self._lifecycle_lock:
+            self._transcriber.unload_model()
             self._initialized = False
 
     @staticmethod

--- a/src/models/audio_model.py
+++ b/src/models/audio_model.py
@@ -73,16 +73,21 @@ class AudioModel(BaseModel):
         # `if config.device else "auto"` form had an unreachable else arm
         # under strict typing.
         device = config.device.value
-        # CTranslate2 (the engine under faster-whisper) does not support
-        # MPS — passing it through would crash later at transcription time
-        # with an opaque "unsupported device mps" error. Coerce to CPU here
-        # to match `AudioTranscriber._detect_device`'s auto-fallback
-        # behavior on Apple Silicon, with a loud log so callers explicitly
-        # passing DeviceType.MPS don't wonder why the backend changed.
-        if device == "mps":
+        # CTranslate2 (the engine under faster-whisper) only supports
+        # "auto", "cpu", and "cuda". `ModelConfig.device` accepts MPS and
+        # METAL too — passing either through unchanged would crash later
+        # at transcription time with an opaque "unsupported device" error.
+        # Coerce any non-supported value to CPU here to match
+        # `AudioTranscriber._detect_device`'s auto-fallback behavior on
+        # Apple Silicon, with a loud log so callers don't wonder why the
+        # backend changed. Allowlist (not denylist) so future DeviceType
+        # additions get the same defensive fallback.
+        _CTRANSLATE2_SUPPORTED = {"auto", "cpu", "cuda"}
+        if device not in _CTRANSLATE2_SUPPORTED:
             logger.warning(
-                "AudioModel: requested device=MPS is not supported by CTranslate2; "
-                "falling back to CPU."
+                "AudioModel: requested device=%s is not supported by CTranslate2; "
+                "falling back to CPU.",
+                device,
             )
             device = "cpu"
         self._transcriber = AudioTranscriber(

--- a/src/models/audio_model.py
+++ b/src/models/audio_model.py
@@ -85,10 +85,11 @@ class AudioModel(BaseModel):
             self._initialized = False
 
     @staticmethod
-    def get_default_config(
-        model_name: str = "distil-whisper-large-v3",
-    ) -> ModelConfig:
+    def get_default_config(model_name: str = "base") -> ModelConfig:
         """Get default configuration for audio model.
+
+        Default is faster-whisper ``"base"`` (~150 MB, multilingual). Override
+        via ``model_name`` for ``"tiny"``, ``"small"``, ``"large-v3"``, etc.
 
         Args:
             model_name: Name of the audio model

--- a/src/models/audio_model.py
+++ b/src/models/audio_model.py
@@ -72,9 +72,22 @@ class AudioModel(BaseModel):
         # ModelConfig), so we can read `.value` directly. The previous
         # `if config.device else "auto"` form had an unreachable else arm
         # under strict typing.
+        device = config.device.value
+        # CTranslate2 (the engine under faster-whisper) does not support
+        # MPS — passing it through would crash later at transcription time
+        # with an opaque "unsupported device mps" error. Coerce to CPU here
+        # to match `AudioTranscriber._detect_device`'s auto-fallback
+        # behavior on Apple Silicon, with a loud log so callers explicitly
+        # passing DeviceType.MPS don't wonder why the backend changed.
+        if device == "mps":
+            logger.warning(
+                "AudioModel: requested device=MPS is not supported by CTranslate2; "
+                "falling back to CPU."
+            )
+            device = "cpu"
         self._transcriber = AudioTranscriber(
             model_size=_resolve_model_size(config.name),
-            device=config.device.value,
+            device=device,
         )
 
     def initialize(self) -> None:

--- a/src/models/audio_model.py
+++ b/src/models/audio_model.py
@@ -21,23 +21,26 @@ if TYPE_CHECKING:
 # "cannot import name 'TextModel' from partially initialized module 'models'".
 # Deferring the import to first call breaks the cycle: by the time AudioModel
 # is constructed, both packages are fully loaded.
-def _audio_transcriber_classes() -> (
-    tuple[
-        type["AudioTranscriber"],
-        type["ModelSize"],
-        type["TranscriptionOptions"],
-    ]
-):
+def _audio_transcriber_classes() -> tuple[
+    type[AudioTranscriber],
+    type[ModelSize],
+    type[TranscriptionOptions],
+]:
     """Return ``(AudioTranscriber, ModelSize, TranscriptionOptions)`` lazily."""
     from services.audio.transcriber import (
         AudioTranscriber as _AudioTranscriber,
+    )
+    from services.audio.transcriber import (
         ModelSize as _ModelSize,
+    )
+    from services.audio.transcriber import (
         TranscriptionOptions as _TranscriptionOptions,
     )
+
     return _AudioTranscriber, _ModelSize, _TranscriptionOptions
 
 
-def _resolve_model_size(name: str) -> "ModelSize":
+def _resolve_model_size(name: str) -> ModelSize:
     """Map a ``ModelConfig.name`` to a faster-whisper ``ModelSize``.
 
     Accepts forms like ``"base"``, ``"whisper-base"``, ``"Whisper_Large-V3"``.
@@ -56,13 +59,22 @@ class AudioModel(BaseModel):
     """Audio transcription model backed by faster-whisper."""
 
     def __init__(self, config: ModelConfig):
+        """Initialize the audio model and instantiate the lazy transcriber.
+
+        Raises:
+            ValueError: If ``config.model_type`` is not ``ModelType.AUDIO``.
+        """
         if config.model_type != ModelType.AUDIO:
             raise ValueError(f"Expected AUDIO model type, got {config.model_type}")
         super().__init__(config)
         AudioTranscriber, _, _ = _audio_transcriber_classes()
+        # `config.device` is always a `DeviceType` (defaults to AUTO in
+        # ModelConfig), so we can read `.value` directly. The previous
+        # `if config.device else "auto"` form had an unreachable else arm
+        # under strict typing.
         self._transcriber = AudioTranscriber(
             model_size=_resolve_model_size(config.name),
-            device=config.device.value if config.device else "auto",
+            device=config.device.value,
         )
 
     def initialize(self) -> None:

--- a/src/models/audio_model.py
+++ b/src/models/audio_model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
@@ -9,7 +10,7 @@ from loguru import logger
 from models.base import BaseModel, ModelConfig, ModelType
 
 if TYPE_CHECKING:
-    from services.audio.transcriber import AudioTranscriber, ModelSize
+    from services.audio.transcriber import AudioTranscriber, ModelSize, TranscriptionOptions
 
 
 # F9-allowed lazy-import helper: services.audio.transcriber lives under
@@ -63,19 +64,30 @@ class AudioModel(BaseModel):
         super().initialize()
 
     def generate(self, prompt: str, **kwargs: Any) -> str:
-        """Transcribe audio (not implemented yet).
+        """Transcribe an audio file.
 
         Args:
-            prompt: Audio file path
-            **kwargs: Additional parameters
+            prompt: Path to the audio file (treated as a filesystem path).
+            **kwargs: Reserved for future per-call options. Currently ignored.
 
         Returns:
-            Transcribed text
+            Transcribed text. May be the empty string for silent or
+            unintelligible audio.
 
         Raises:
-            NotImplementedError: Audio processing not implemented yet
+            FileNotFoundError: If ``prompt`` does not name an existing file.
+            ImportError: If the ``[media]`` extra is not installed
+                (faster-whisper missing).
+            RuntimeError: If the model is shutting down or not initialized.
         """
-        raise NotImplementedError("Audio processing will be implemented in Phase 3")
+        self._enter_generate()
+        try:
+            _, _, TranscriptionOptions = _audio_transcriber_classes()
+            options = TranscriptionOptions()
+            result = self._transcriber.transcribe(Path(prompt), options=options)
+            return result.text
+        finally:
+            self._exit_generate()
 
     def cleanup(self) -> None:
         """Cleanup model resources."""

--- a/src/models/audio_model.py
+++ b/src/models/audio_model.py
@@ -59,8 +59,7 @@ class AudioModel(BaseModel):
         )
 
     def initialize(self) -> None:
-        """Initialize the audio model (not implemented yet)."""
-        logger.warning("Audio model not fully implemented yet (Phase 3)")
+        """Initialize the model. Whisper weights load lazily on first generate()."""
         super().initialize()
 
     def generate(self, prompt: str, **kwargs: Any) -> str:

--- a/src/services/audio/transcriber.py
+++ b/src/services/audio/transcriber.py
@@ -125,33 +125,49 @@ class AudioTranscriber:
         self,
         model_size: ModelSize = ModelSize.BASE,
         device: str = "auto",
-        compute_type: ComputeType = ComputeType.FLOAT16,
+        compute_type: ComputeType | None = None,
         cache_dir: Path | None = None,
         num_workers: int = 1,
     ):
         """Initialize the audio transcriber.
 
         Args:
-            model_size: Whisper model size to use
-            device: Device to run on ("cpu", "cuda", "mps", or "auto")
-            compute_type: Computation precision
-            cache_dir: Directory to cache models (None = default)
-            num_workers: Number of parallel workers for inference
+            model_size: Whisper model size to use.
+            device: Device to run on (``"cpu"``, ``"cuda"``, or ``"auto"``).
+                Apple Silicon's MPS is not supported by CTranslate2 and is
+                never auto-selected; see :meth:`_detect_device`.
+            compute_type: Computation precision. ``None`` (default) auto-
+                selects ``float16`` on CUDA and ``int8`` on CPU. CTranslate2
+                rejects ``float16`` on CPU with "target device or backend
+                do not support efficient float16 computation"; auto-selection
+                avoids that footgun.
+            cache_dir: Directory to cache models (``None`` = default).
+            num_workers: Number of parallel workers for inference.
         """
         self.model_size = model_size
         self.device = self._detect_device(device)
-        self.compute_type = compute_type
+        self.compute_type = compute_type if compute_type is not None else (
+            ComputeType.FLOAT16 if self.device == "cuda" else ComputeType.INT8
+        )
         self.cache_dir = cache_dir
         self.num_workers = num_workers
         self._model = None
 
         logger.info(
             f"Initializing AudioTranscriber with model={model_size.value}, "
-            f"device={self.device}, compute_type={compute_type.value}"
+            f"device={self.device}, compute_type={self.compute_type.value}"
         )
 
     def _detect_device(self, device: str) -> str:
-        """Detect the best available device."""
+        """Detect the best available device for faster-whisper.
+
+        faster-whisper wraps CTranslate2, which supports ``cpu`` and ``cuda``
+        only. Apple Silicon's MPS backend is **not** a supported CTranslate2
+        device — passing ``device="mps"`` produces ``RuntimeError: unsupported
+        device mps``. We therefore never auto-detect ``mps`` and fall back to
+        CPU on Apple Silicon. Callers that want explicit override can still
+        pass ``device="cuda"`` or ``device="cpu"`` directly.
+        """
         if device != "auto":
             return device
 
@@ -160,8 +176,6 @@ class AudioTranscriber:
 
             if torch.cuda.is_available():
                 return "cuda"
-            elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-                return "mps"
         except ImportError:
             pass
 

--- a/src/services/audio/transcriber.py
+++ b/src/services/audio/transcriber.py
@@ -146,8 +146,10 @@ class AudioTranscriber:
         """
         self.model_size = model_size
         self.device = self._detect_device(device)
-        self.compute_type = compute_type if compute_type is not None else (
-            ComputeType.FLOAT16 if self.device == "cuda" else ComputeType.INT8
+        self.compute_type = (
+            compute_type
+            if compute_type is not None
+            else (ComputeType.FLOAT16 if self.device == "cuda" else ComputeType.INT8)
         )
         self.cache_dir = cache_dir
         self.num_workers = num_workers

--- a/tests/cli/test_benchmark_audio_transcribe.py
+++ b/tests/cli/test_benchmark_audio_transcribe.py
@@ -15,6 +15,7 @@ from cli.benchmark import (
     _bind_transcribe_smoke,
     _exit_if_transcribe_smoke_failed,
     _run_audio_suite,
+    _validate_transcribe_smoke_preconditions,
 )
 from cli.main import app
 
@@ -60,6 +61,37 @@ class TestBindTranscribeSmoke:
         assert result is not sentinel
         assert getattr(result, "func", None) is _run_audio_suite
         assert result.keywords == {"transcribe_smoke": True}
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestValidateTranscribeSmokePreconditions:
+    """Direct coverage of the empty-input / no-audio-candidates fail-fast
+    helper. Both paths used to short-circuit the benchmark before the
+    smoke-failure exit guard ran, exiting 0 with no verification done."""
+
+    def test_passes_silently_when_smoke_off(self, tmp_path: Path) -> None:
+        # No raise even with empty file list when smoke is off.
+        _validate_transcribe_smoke_preconditions([], transcribe_smoke=False)
+
+    def test_passes_when_smoke_on_and_audio_candidate_present(
+        self, tmp_path: Path
+    ) -> None:
+        audio = tmp_path / "a.wav"
+        audio.touch()
+        _validate_transcribe_smoke_preconditions([audio], transcribe_smoke=True)
+
+    def test_raises_when_smoke_on_and_no_files(self) -> None:
+        with pytest.raises(typer.BadParameter, match="empty"):
+            _validate_transcribe_smoke_preconditions([], transcribe_smoke=True)
+
+    def test_raises_when_smoke_on_but_no_audio_candidates(
+        self, tmp_path: Path
+    ) -> None:
+        text_file = tmp_path / "x.txt"
+        text_file.touch()
+        with pytest.raises(typer.BadParameter, match="audio file"):
+            _validate_transcribe_smoke_preconditions([text_file], transcribe_smoke=True)
 
 
 @pytest.mark.unit

--- a/tests/cli/test_benchmark_audio_transcribe.py
+++ b/tests/cli/test_benchmark_audio_transcribe.py
@@ -353,6 +353,33 @@ class TestCheckBaselineSmokeCompatibility:
         assert warning is not None
         console.print.assert_not_called()
 
+    def test_returns_malformed_warning_when_baseline_field_is_string(self) -> None:
+        # `bool("false")` is True — naive coercion would silently invert the
+        # mismatch signal. The helper must detect non-bool values and warn
+        # rather than fall through to a misleading "no mismatch" result.
+        warning = _check_baseline_smoke_compatibility(
+            {"transcribe_smoke": "false"},
+            transcribe_smoke=False,
+            console=MagicMock(),
+            json_output=False,
+        )
+        assert warning is not None
+        assert "not a boolean" in warning.lower()
+        assert "str" in warning  # type name is surfaced
+
+    def test_returns_malformed_warning_when_baseline_field_is_int(self) -> None:
+        # Same defensive check for ints (0/1) — Python treats them as bools
+        # in arithmetic but the schema requires the JSON boolean.
+        warning = _check_baseline_smoke_compatibility(
+            {"transcribe_smoke": 1},
+            transcribe_smoke=True,
+            console=MagicMock(),
+            json_output=False,
+        )
+        assert warning is not None
+        assert "not a boolean" in warning.lower()
+        assert "int" in warning
+
 
 @pytest.mark.unit
 @pytest.mark.ci

--- a/tests/cli/test_benchmark_audio_transcribe.py
+++ b/tests/cli/test_benchmark_audio_transcribe.py
@@ -74,9 +74,7 @@ class TestValidateTranscribeSmokePreconditions:
         # No raise even with empty file list when smoke is off.
         _validate_transcribe_smoke_preconditions([], transcribe_smoke=False)
 
-    def test_passes_when_smoke_on_and_audio_candidate_present(
-        self, tmp_path: Path
-    ) -> None:
+    def test_passes_when_smoke_on_and_audio_candidate_present(self, tmp_path: Path) -> None:
         audio = tmp_path / "a.wav"
         audio.touch()
         _validate_transcribe_smoke_preconditions([audio], transcribe_smoke=True)
@@ -85,9 +83,7 @@ class TestValidateTranscribeSmokePreconditions:
         with pytest.raises(typer.BadParameter, match="empty"):
             _validate_transcribe_smoke_preconditions([], transcribe_smoke=True)
 
-    def test_raises_when_smoke_on_but_no_audio_candidates(
-        self, tmp_path: Path
-    ) -> None:
+    def test_raises_when_smoke_on_but_no_audio_candidates(self, tmp_path: Path) -> None:
         text_file = tmp_path / "x.txt"
         text_file.touch()
         with pytest.raises(typer.BadParameter, match="audio file"):

--- a/tests/cli/test_benchmark_audio_transcribe.py
+++ b/tests/cli/test_benchmark_audio_transcribe.py
@@ -275,6 +275,12 @@ class TestBenchmarkTranscribeSmoke:
         assert "transcribe" in normalized
         assert "smoke" in normalized
         assert "media" in normalized
+        # The "Benchmark completed" success banner must NOT appear when
+        # the smoke check failed — printing success and then exiting
+        # non-zero produces contradictory output that misleads operators
+        # and breaks any automation that scrapes the human log for
+        # completion status.
+        assert "benchmark completed" not in normalized
 
 
 @pytest.mark.unit

--- a/tests/cli/test_benchmark_audio_transcribe.py
+++ b/tests/cli/test_benchmark_audio_transcribe.py
@@ -177,11 +177,13 @@ class TestBenchmarkTranscribeSmoke:
         )
 
         assert result.exit_code != 0
-        # Rich panels can wrap long words; collapse whitespace before
-        # matching so `--transcribe-smoke` split across two lines still
-        # registers.
+        # Rich panels at the CI runner's narrower default width wrap
+        # `--transcribe-smoke` mid-token in unpredictable spots (after the
+        # dashes, between syllables). Asserting on individual word
+        # components is wrap-immune.
         normalized = " ".join(result.output.lower().split())
-        assert "transcribe-smoke" in normalized or "transcribesmoke" in normalized
+        assert "transcribe" in normalized
+        assert "smoke" in normalized
         assert "audio" in normalized
 
     def test_transcribe_smoke_exits_nonzero_when_audio_model_unavailable(
@@ -217,7 +219,9 @@ class TestBenchmarkTranscribeSmoke:
         assert result.exit_code != 0
         # Both the warning (from _run_audio_suite) and the failure error
         # (from run()) should appear so the user sees the cause and the
-        # consequence. Normalize whitespace to survive Rich panel wrap.
+        # consequence. Normalize whitespace and use word-component
+        # assertions to survive Rich panel wrap on narrow terminals.
         normalized = " ".join(result.output.lower().split())
-        assert "transcribe-smoke" in normalized or "transcribesmoke" in normalized
+        assert "transcribe" in normalized
+        assert "smoke" in normalized
         assert "media" in normalized

--- a/tests/cli/test_benchmark_audio_transcribe.py
+++ b/tests/cli/test_benchmark_audio_transcribe.py
@@ -72,7 +72,7 @@ class TestValidateTranscribeSmokePreconditions:
     helper. Both paths used to short-circuit the benchmark before the
     smoke-failure exit guard ran, exiting 0 with no verification done."""
 
-    def test_passes_silently_when_smoke_off(self, tmp_path: Path) -> None:
+    def test_passes_silently_when_smoke_off(self) -> None:
         # No raise even with empty file list when smoke is off.
         _validate_transcribe_smoke_preconditions([], transcribe_smoke=False)
 

--- a/tests/cli/test_benchmark_audio_transcribe.py
+++ b/tests/cli/test_benchmark_audio_transcribe.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 import struct
 import wave
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
+from cli.benchmark import (
+    _bind_transcribe_smoke,
+    _exit_if_transcribe_smoke_failed,
+    _run_audio_suite,
+)
 from cli.main import app
 
 
@@ -22,6 +28,61 @@ def _generate_silence_wav(path: Path, seconds: float = 0.5) -> None:
         w.setsampwidth(2)
         w.setframerate(sample_rate)
         w.writeframes(struct.pack("<h", 0) * n_frames)
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestBindTranscribeSmoke:
+    """Direct coverage of the _bind_transcribe_smoke helper. Cheap unit tests
+    so the CI diff-coverage gate sees the new branches without needing the
+    full Typer/Click stack."""
+
+    def test_returns_unchanged_runner_when_smoke_off(self) -> None:
+        sentinel = MagicMock(name="default_runner")
+        result = _bind_transcribe_smoke(sentinel, suite="audio", transcribe_smoke=False)
+        assert result is sentinel
+
+    def test_returns_unchanged_runner_when_non_audio_and_smoke_off(self) -> None:
+        sentinel = MagicMock(name="io_runner")
+        result = _bind_transcribe_smoke(sentinel, suite="io", transcribe_smoke=False)
+        assert result is sentinel
+
+    def test_raises_bad_parameter_for_smoke_on_non_audio(self) -> None:
+        sentinel = MagicMock(name="io_runner")
+        with pytest.raises(typer.BadParameter, match="audio"):
+            _bind_transcribe_smoke(sentinel, suite="io", transcribe_smoke=True)
+
+    def test_binds_transcribe_smoke_for_audio_suite(self) -> None:
+        sentinel = MagicMock(name="default_audio_runner")
+        result = _bind_transcribe_smoke(sentinel, suite="audio", transcribe_smoke=True)
+        # Returns a functools.partial pre-bound to _run_audio_suite — not the
+        # sentinel default audio runner.
+        assert result is not sentinel
+        assert getattr(result, "func", None) is _run_audio_suite
+        assert result.keywords == {"transcribe_smoke": True}
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestExitIfTranscribeSmokeFailed:
+    """Direct coverage of the _exit_if_transcribe_smoke_failed helper."""
+
+    def test_no_exit_when_reason_absent(self) -> None:
+        console = MagicMock()
+        # Should NOT raise when the smoke-skipped reason isn't present.
+        _exit_if_transcribe_smoke_failed(console, ["audio-synthesized-metadata-fallback"])
+        console.print.assert_not_called()
+
+    def test_exits_nonzero_when_smoke_skipped_reason_present(self) -> None:
+        console = MagicMock()
+        with pytest.raises(typer.Exit) as exc_info:
+            _exit_if_transcribe_smoke_failed(console, ["audio-transcribe-smoke-skipped"])
+        assert exc_info.value.exit_code == 1
+        # Error message goes to console so the human reader sees the cause.
+        console.print.assert_called_once()
+        msg = console.print.call_args.args[0]
+        assert "transcribe-smoke" in msg.lower()
+        assert "media" in msg.lower()
 
 
 @pytest.mark.integration
@@ -88,9 +149,7 @@ class TestBenchmarkTranscribeSmoke:
         assert result.exit_code == 0, result.output
         mock_model_cls.assert_not_called()
 
-    def test_transcribe_smoke_with_non_audio_suite_fails_fast(
-        self, tmp_path: Path
-    ) -> None:
+    def test_transcribe_smoke_with_non_audio_suite_fails_fast(self, tmp_path: Path) -> None:
         """--transcribe-smoke without --suite audio must error, not silently
         no-op. Otherwise CI scripts that combine the wrong flags get a false
         positive (exit 0 with no smoke verification done)."""
@@ -118,8 +177,12 @@ class TestBenchmarkTranscribeSmoke:
         )
 
         assert result.exit_code != 0
-        assert "transcribe-smoke" in result.output.lower()
-        assert "audio" in result.output.lower()
+        # Rich panels can wrap long words; collapse whitespace before
+        # matching so `--transcribe-smoke` split across two lines still
+        # registers.
+        normalized = " ".join(result.output.lower().split())
+        assert "transcribe-smoke" in normalized or "transcribesmoke" in normalized
+        assert "audio" in normalized
 
     def test_transcribe_smoke_exits_nonzero_when_audio_model_unavailable(
         self, tmp_path: Path
@@ -154,6 +217,7 @@ class TestBenchmarkTranscribeSmoke:
         assert result.exit_code != 0
         # Both the warning (from _run_audio_suite) and the failure error
         # (from run()) should appear so the user sees the cause and the
-        # consequence.
-        assert "transcribe-smoke" in result.output.lower()
-        assert "media" in result.output.lower()
+        # consequence. Normalize whitespace to survive Rich panel wrap.
+        normalized = " ".join(result.output.lower().split())
+        assert "transcribe-smoke" in normalized or "transcribesmoke" in normalized
+        assert "media" in normalized

--- a/tests/cli/test_benchmark_audio_transcribe.py
+++ b/tests/cli/test_benchmark_audio_transcribe.py
@@ -1,0 +1,84 @@
+"""Test that fo benchmark run --transcribe-smoke exercises AudioModel.generate()."""
+
+from __future__ import annotations
+
+import struct
+import wave
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from cli.main import app
+
+
+def _generate_silence_wav(path: Path, seconds: float = 0.5) -> None:
+    """Write a mono 16-bit 16kHz silent WAV file at ``path``."""
+    sample_rate = 16000
+    n_frames = int(seconds * sample_rate)
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        w.writeframes(struct.pack("<h", 0) * n_frames)
+
+
+@pytest.mark.integration
+class TestBenchmarkTranscribeSmoke:
+    def test_transcribe_smoke_invokes_audio_model_once(
+        self, tmp_path: Path
+    ) -> None:
+        """With --transcribe-smoke, exactly one AudioModel.generate call
+        happens regardless of the candidate count."""
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir()
+        _generate_silence_wav(audio_dir / "a.wav")
+        _generate_silence_wav(audio_dir / "b.wav")
+
+        runner = CliRunner()
+        with patch("cli.benchmark.AudioModel") as mock_model_cls:
+            instance = mock_model_cls.return_value
+            instance.generate.return_value = ""
+            result = runner.invoke(
+                app,
+                [
+                    "benchmark", "run",
+                    str(audio_dir),
+                    "--suite", "audio",
+                    "--transcribe-smoke",
+                    "--iterations", "1",
+                    "--warmup", "0",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # Smoke contract: exactly one transcription per benchmark run, even
+        # when multiple candidate audio files are present. Counts may exceed
+        # 1 across iterations — for this test iterations=1 so the one call
+        # is unambiguous.
+        assert instance.generate.call_count == 1
+
+    def test_no_transcribe_smoke_means_no_audio_model_call(
+        self, tmp_path: Path
+    ) -> None:
+        """Default benchmark (no flag) must not instantiate AudioModel."""
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir()
+        _generate_silence_wav(audio_dir / "a.wav")
+
+        runner = CliRunner()
+        with patch("cli.benchmark.AudioModel") as mock_model_cls:
+            result = runner.invoke(
+                app,
+                [
+                    "benchmark", "run",
+                    str(audio_dir),
+                    "--suite", "audio",
+                    "--iterations", "1",
+                    "--warmup", "0",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_model_cls.assert_not_called()

--- a/tests/cli/test_benchmark_audio_transcribe.py
+++ b/tests/cli/test_benchmark_audio_transcribe.py
@@ -87,3 +87,73 @@ class TestBenchmarkTranscribeSmoke:
 
         assert result.exit_code == 0, result.output
         mock_model_cls.assert_not_called()
+
+    def test_transcribe_smoke_with_non_audio_suite_fails_fast(
+        self, tmp_path: Path
+    ) -> None:
+        """--transcribe-smoke without --suite audio must error, not silently
+        no-op. Otherwise CI scripts that combine the wrong flags get a false
+        positive (exit 0 with no smoke verification done)."""
+        # Arrange a non-empty input dir so the early "no files" path doesn't
+        # short-circuit before we hit the validation.
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        (input_dir / "x.txt").write_text("seed", encoding="utf-8")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "benchmark",
+                "run",
+                str(input_dir),
+                "--suite",
+                "io",
+                "--transcribe-smoke",
+                "--iterations",
+                "1",
+                "--warmup",
+                "0",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "transcribe-smoke" in result.output.lower()
+        assert "audio" in result.output.lower()
+
+    def test_transcribe_smoke_exits_nonzero_when_audio_model_unavailable(
+        self, tmp_path: Path
+    ) -> None:
+        """When --transcribe-smoke is requested but AudioModel raises
+        ImportError (e.g. [media] missing), the run must exit non-zero so
+        CI doesn't treat the silently-skipped smoke as a passing audio
+        benchmark."""
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir()
+        _generate_silence_wav(audio_dir / "a.wav")
+
+        runner = CliRunner()
+        with patch("cli.benchmark.AudioModel") as mock_model_cls:
+            mock_model_cls.side_effect = ImportError("faster-whisper is not installed")
+            result = runner.invoke(
+                app,
+                [
+                    "benchmark",
+                    "run",
+                    str(audio_dir),
+                    "--suite",
+                    "audio",
+                    "--transcribe-smoke",
+                    "--iterations",
+                    "1",
+                    "--warmup",
+                    "0",
+                ],
+            )
+
+        assert result.exit_code != 0
+        # Both the warning (from _run_audio_suite) and the failure error
+        # (from run()) should appear so the user sees the cause and the
+        # consequence.
+        assert "transcribe-smoke" in result.output.lower()
+        assert "media" in result.output.lower()

--- a/tests/cli/test_benchmark_audio_transcribe.py
+++ b/tests/cli/test_benchmark_audio_transcribe.py
@@ -25,6 +25,7 @@ def _generate_silence_wav(path: Path, seconds: float = 0.5) -> None:
 
 
 @pytest.mark.integration
+@pytest.mark.ci
 class TestBenchmarkTranscribeSmoke:
     def test_transcribe_smoke_invokes_audio_model_once(
         self, tmp_path: Path

--- a/tests/cli/test_benchmark_audio_transcribe.py
+++ b/tests/cli/test_benchmark_audio_transcribe.py
@@ -27,9 +27,7 @@ def _generate_silence_wav(path: Path, seconds: float = 0.5) -> None:
 @pytest.mark.integration
 @pytest.mark.ci
 class TestBenchmarkTranscribeSmoke:
-    def test_transcribe_smoke_invokes_audio_model_once(
-        self, tmp_path: Path
-    ) -> None:
+    def test_transcribe_smoke_invokes_audio_model_once(self, tmp_path: Path) -> None:
         """With --transcribe-smoke, exactly one AudioModel.generate call
         happens regardless of the candidate count."""
         audio_dir = tmp_path / "audio"
@@ -44,12 +42,16 @@ class TestBenchmarkTranscribeSmoke:
             result = runner.invoke(
                 app,
                 [
-                    "benchmark", "run",
+                    "benchmark",
+                    "run",
                     str(audio_dir),
-                    "--suite", "audio",
+                    "--suite",
+                    "audio",
                     "--transcribe-smoke",
-                    "--iterations", "1",
-                    "--warmup", "0",
+                    "--iterations",
+                    "1",
+                    "--warmup",
+                    "0",
                 ],
             )
 
@@ -60,9 +62,7 @@ class TestBenchmarkTranscribeSmoke:
         # is unambiguous.
         assert instance.generate.call_count == 1
 
-    def test_no_transcribe_smoke_means_no_audio_model_call(
-        self, tmp_path: Path
-    ) -> None:
+    def test_no_transcribe_smoke_means_no_audio_model_call(self, tmp_path: Path) -> None:
         """Default benchmark (no flag) must not instantiate AudioModel."""
         audio_dir = tmp_path / "audio"
         audio_dir.mkdir()
@@ -73,11 +73,15 @@ class TestBenchmarkTranscribeSmoke:
             result = runner.invoke(
                 app,
                 [
-                    "benchmark", "run",
+                    "benchmark",
+                    "run",
                     str(audio_dir),
-                    "--suite", "audio",
-                    "--iterations", "1",
-                    "--warmup", "0",
+                    "--suite",
+                    "audio",
+                    "--iterations",
+                    "1",
+                    "--warmup",
+                    "0",
                 ],
             )
 

--- a/tests/cli/test_benchmark_audio_transcribe.py
+++ b/tests/cli/test_benchmark_audio_transcribe.py
@@ -13,7 +13,9 @@ from typer.testing import CliRunner
 
 from cli.benchmark import (
     _bind_transcribe_smoke,
+    _check_baseline_smoke_compatibility,
     _exit_if_transcribe_smoke_failed,
+    _maybe_attach_comparison_output,
     _run_audio_suite,
     _validate_transcribe_smoke_preconditions,
 )
@@ -111,6 +113,26 @@ class TestExitIfTranscribeSmokeFailed:
         msg = console.print.call_args.args[0]
         assert "transcribe-smoke" in msg.lower()
         assert "media" in msg.lower()
+
+    def test_json_mode_routes_error_to_stderr_keeping_stdout_console_silent(self) -> None:
+        # When --json is requested, the JSON document is already on stdout by
+        # the time the smoke-failure exit guard fires. Routing the error to
+        # the stdout console would append non-JSON text and break consumers
+        # that parse output on failure. The stdout console must NOT receive
+        # the print; the message goes to a stderr-bound Rich console instead.
+        stdout_console = MagicMock()
+        with patch("rich.console.Console") as mock_console_cls:
+            stderr_console = MagicMock()
+            mock_console_cls.return_value = stderr_console
+            with pytest.raises(typer.Exit):
+                _exit_if_transcribe_smoke_failed(
+                    stdout_console,
+                    ["audio-transcribe-smoke-skipped"],
+                    json_output=True,
+                )
+        stdout_console.print.assert_not_called()
+        mock_console_cls.assert_called_once_with(stderr=True)
+        stderr_console.print.assert_called_once()
 
 
 @pytest.mark.integration
@@ -253,3 +275,145 @@ class TestBenchmarkTranscribeSmoke:
         assert "transcribe" in normalized
         assert "smoke" in normalized
         assert "media" in normalized
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestCheckBaselineSmokeCompatibility:
+    """Direct coverage of the smoke-mode compatibility helper that gates
+    ``--compare`` mixing of smoke and non-smoke baselines.
+
+    A smoke run adds an ``AudioModel.generate()`` call per iteration, which
+    skews the per-iteration timings. Comparing across smoke modes without
+    surfacing the mismatch produces misleading regression signals.
+    """
+
+    def test_returns_none_when_modes_match_both_true(self) -> None:
+        warning = _check_baseline_smoke_compatibility(
+            {"transcribe_smoke": True},
+            transcribe_smoke=True,
+            console=MagicMock(),
+            json_output=False,
+        )
+        assert warning is None
+
+    def test_returns_none_when_modes_match_both_false(self) -> None:
+        warning = _check_baseline_smoke_compatibility(
+            {"transcribe_smoke": False},
+            transcribe_smoke=False,
+            console=MagicMock(),
+            json_output=False,
+        )
+        assert warning is None
+
+    def test_returns_none_when_baseline_missing_field_and_current_false(self) -> None:
+        # Older baselines predate the transcribe_smoke field; treat as False.
+        warning = _check_baseline_smoke_compatibility(
+            {},
+            transcribe_smoke=False,
+            console=MagicMock(),
+            json_output=False,
+        )
+        assert warning is None
+
+    def test_returns_warning_when_current_smoke_baseline_not(self) -> None:
+        console = MagicMock()
+        warning = _check_baseline_smoke_compatibility(
+            {"transcribe_smoke": False},
+            transcribe_smoke=True,
+            console=console,
+            json_output=False,
+        )
+        assert warning is not None
+        assert "smoke-mode mismatch" in warning.lower()
+        assert "baseline transcribe_smoke=false" in warning.lower()
+        # Human-mode prints to console; JSON-mode would suppress the print.
+        console.print.assert_called_once()
+
+    def test_returns_warning_when_baseline_smoke_current_not(self) -> None:
+        warning = _check_baseline_smoke_compatibility(
+            {"transcribe_smoke": True},
+            transcribe_smoke=False,
+            console=MagicMock(),
+            json_output=False,
+        )
+        assert warning is not None
+        assert "current=false" in warning.lower()
+
+    def test_json_mode_returns_warning_but_does_not_print(self) -> None:
+        # Under --json, the warning is attached to the output dict rather
+        # than printed, so stdout stays valid JSON for downstream consumers.
+        console = MagicMock()
+        warning = _check_baseline_smoke_compatibility(
+            {"transcribe_smoke": False},
+            transcribe_smoke=True,
+            console=console,
+            json_output=True,
+        )
+        assert warning is not None
+        console.print.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestMaybeAttachComparisonOutputSmokeWarning:
+    """Coverage for the smoke-mode wiring inside ``_maybe_attach_comparison_output``.
+
+    The helper attaches a ``comparison_smoke_warning`` field whenever the
+    baseline's ``transcribe_smoke`` flag disagrees with the current run.
+    The unit-level helper test pins the wording; this test pins the wiring
+    so a future refactor can't silently drop the field.
+    """
+
+    def _write_baseline(self, tmp_path: Path, *, transcribe_smoke: bool) -> Path:
+        import json as _json
+
+        baseline_path = tmp_path / "baseline.json"
+        baseline_path.write_text(
+            _json.dumps(
+                {
+                    "suite": "audio",
+                    "runner_profile_version": 1,
+                    "transcribe_smoke": transcribe_smoke,
+                    "results": {"p50_ms": 1.0, "p95_ms": 1.0, "files_processed": 0},
+                }
+            )
+        )
+        return baseline_path
+
+    def test_attaches_smoke_warning_when_modes_differ(self, tmp_path: Path) -> None:
+        baseline_path = self._write_baseline(tmp_path, transcribe_smoke=False)
+        output: dict = {
+            "suite": "audio",
+            "runner_profile_version": 1,
+            "transcribe_smoke": True,
+            "results": {"p50_ms": 1.0, "p95_ms": 1.0, "files_processed": 0},
+        }
+        result = _maybe_attach_comparison_output(
+            output=output,
+            compare_path=baseline_path,
+            suite="audio",
+            transcribe_smoke=True,
+            console=MagicMock(),
+            json_output=True,
+        )
+        assert "comparison_smoke_warning" in result
+        assert "smoke-mode mismatch" in result["comparison_smoke_warning"].lower()
+
+    def test_no_smoke_warning_when_modes_match(self, tmp_path: Path) -> None:
+        baseline_path = self._write_baseline(tmp_path, transcribe_smoke=True)
+        output: dict = {
+            "suite": "audio",
+            "runner_profile_version": 1,
+            "transcribe_smoke": True,
+            "results": {"p50_ms": 1.0, "p95_ms": 1.0, "files_processed": 0},
+        }
+        result = _maybe_attach_comparison_output(
+            output=output,
+            compare_path=baseline_path,
+            suite="audio",
+            transcribe_smoke=True,
+            console=MagicMock(),
+            json_output=True,
+        )
+        assert "comparison_smoke_warning" not in result

--- a/tests/integration/test_audio_model_integration.py
+++ b/tests/integration/test_audio_model_integration.py
@@ -61,15 +61,20 @@ class TestAudioModelEndToEnd:
         config = ModelConfig(name="tiny", model_type=ModelType.AUDIO)
         model = AudioModel(config)
         model.initialize()
+        # The transcriber's underlying Whisper model is lazy-loaded on first
+        # transcribe() call, so it should be None right after initialize().
+        assert model._transcriber._model is None
         try:
             output = model.generate(str(audio_path))
+            # Pipeline ran end-to-end without raising. Two non-vacuous
+            # assertions cover the contract:
+            #   1. generate() returned a string (not None, not an exception).
+            #   2. The lazy-load fired: _transcriber._model is now populated.
+            # Output text content is non-deterministic across whisper
+            # versions for silent audio, so we don't pin its value.
+            assert isinstance(output, str)
+            assert model._transcriber._model is not None
         finally:
             model.safe_cleanup()
-
-        assert isinstance(output, str)
-        # Silence may transcribe to empty or to a short artifact; both are
-        # valid. The contract we're proving here is: pipeline runs end-to-end
-        # without crashing. The isinstance(str) check above covers it; we
-        # don't pin an upper-length bound because a) `len(x) <= N` is
-        # T9-vacuous (passes for empty), and b) the actual transcription
-        # quality of silence is non-deterministic across whisper versions.
+        # cleanup() unloads the model — _transcriber._model is None again.
+        assert model._transcriber._model is None

--- a/tests/integration/test_audio_model_integration.py
+++ b/tests/integration/test_audio_model_integration.py
@@ -1,0 +1,73 @@
+"""Integration tests for AudioModel — end-to-end with faster-whisper.
+
+Skipped automatically when the [media] extra is not installed.
+"""
+
+from __future__ import annotations
+
+import struct
+import sys
+import wave
+from pathlib import Path
+
+import pytest
+
+from models.audio_model import AudioModel
+from models.base import ModelConfig, ModelType
+
+
+def _generate_silence_wav(path: Path, seconds: float = 1.0) -> None:
+    """Write a mono 16-bit 16kHz silent WAV file at ``path``."""
+    sample_rate = 16000
+    n_frames = int(seconds * sample_rate)
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        # 16-bit signed silence = b"\x00\x00" per sample
+        w.writeframes(struct.pack("<h", 0) * n_frames)
+
+
+@pytest.mark.integration
+# Real-faster-whisper test — must run isolated from tests that mock
+# sys.modules["torch"] / sys.modules["faster_whisper"] (notably in
+# tests/integration/test_services_video_audio_extractor_transcriber.py).
+# `--dist=loadgroup` (project default per xdist-safe-patterns Pattern 3)
+# serializes everything in this group, so the mock fixtures in the other
+# file can't pollute this test's view of the real packages.
+@pytest.mark.xdist_group(name="audio_real_whisper")
+class TestAudioModelEndToEnd:
+    @pytest.fixture(autouse=True)
+    def _require_real_faster_whisper(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Defense against sys.modules pollution from peer tests that mock
+        # faster_whisper / torch (T12 fixture-state-leak class). Clear any
+        # cached module entries so AudioTranscriber gets the real package.
+        for key in list(sys.modules.keys()):
+            if (
+                key == "faster_whisper"
+                or key.startswith("faster_whisper.")
+                or key == "ctranslate2"
+                or key.startswith("ctranslate2.")
+            ):
+                monkeypatch.delitem(sys.modules, key, raising=False)
+        pytest.importorskip("faster_whisper")
+
+    def test_generate_returns_string_for_silent_wav(self, tmp_path: Path) -> None:
+        audio_path = tmp_path / "silence.wav"
+        _generate_silence_wav(audio_path, seconds=1.0)
+
+        config = ModelConfig(name="tiny", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        model.initialize()
+        try:
+            output = model.generate(str(audio_path))
+        finally:
+            model.safe_cleanup()
+
+        assert isinstance(output, str)
+        # Silence may transcribe to empty or to a short artifact; both are
+        # valid. The contract we're proving: pipeline runs end-to-end without
+        # crashing. Cap at 200 chars so a runaway garbage dump fails loudly.
+        assert len(output) <= 200

--- a/tests/integration/test_audio_model_integration.py
+++ b/tests/integration/test_audio_model_integration.py
@@ -38,9 +38,7 @@ def _generate_silence_wav(path: Path, seconds: float = 1.0) -> None:
 @pytest.mark.xdist_group(name="audio_real_whisper")
 class TestAudioModelEndToEnd:
     @pytest.fixture(autouse=True)
-    def _require_real_faster_whisper(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def _require_real_faster_whisper(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Defense against sys.modules pollution from peer tests that mock
         # faster_whisper / torch (T12 fixture-state-leak class). Clear any
         # cached module entries so AudioTranscriber gets the real package.

--- a/tests/integration/test_audio_model_integration.py
+++ b/tests/integration/test_audio_model_integration.py
@@ -68,6 +68,8 @@ class TestAudioModelEndToEnd:
 
         assert isinstance(output, str)
         # Silence may transcribe to empty or to a short artifact; both are
-        # valid. The contract we're proving: pipeline runs end-to-end without
-        # crashing. Cap at 200 chars so a runaway garbage dump fails loudly.
-        assert len(output) <= 200
+        # valid. The contract we're proving here is: pipeline runs end-to-end
+        # without crashing. The isinstance(str) check above covers it; we
+        # don't pin an upper-length bound because a) `len(x) <= N` is
+        # T9-vacuous (passes for empty), and b) the actual transcription
+        # quality of silence is non-deterministic across whisper versions.

--- a/tests/integration/test_cli_benchmark_analytics_undo_display_utils.py
+++ b/tests/integration/test_cli_benchmark_analytics_undo_display_utils.py
@@ -654,6 +654,7 @@ class TestBenchmarkSuiteHelpers:
             output=output,
             compare_path=None,
             suite="io",
+            transcribe_smoke=False,
             console=MagicMock(),
             json_output=False,
         )
@@ -689,6 +690,7 @@ class TestBenchmarkSuiteHelpers:
             output=output,
             compare_path=compare_path,
             suite="io",
+            transcribe_smoke=False,
             console=MagicMock(),
             json_output=False,
         )
@@ -705,6 +707,7 @@ class TestBenchmarkSuiteHelpers:
                 output={},
                 compare_path=bad_path,
                 suite="io",
+                transcribe_smoke=False,
                 console=MagicMock(),
                 json_output=False,
             )

--- a/tests/integration/test_models_claude_openai_audio.py
+++ b/tests/integration/test_models_claude_openai_audio.py
@@ -956,20 +956,26 @@ class TestAudioModel:
         assert model._initialized is True
 
     def test_generate_propagates_filenotfound_for_missing_audio(
-        self, tmp_path: pytest.TempPathFactory
+        self, tmp_path: Path
     ) -> None:
         # Step 2A wired generate() to faster-whisper. After initialize(),
         # passing a non-existent audio path now propagates the underlying
         # FileNotFoundError from AudioTranscriber.transcribe rather than
         # the previous NotImplementedError("Phase 3") stub.
+        # Use tmp_path to construct a guaranteed-missing path so the
+        # FileNotFoundError assertion stays reliable under xdist
+        # parallelization (the bare "does-not-exist.wav" relative form is
+        # vulnerable to a same-named file in the worker's cwd).
         from models.audio_model import AudioModel
+
+        missing_audio = tmp_path / "does-not-exist.wav"
 
         config = AudioModel.get_default_config()
         model = AudioModel(config)
         model.initialize()
         try:
             with pytest.raises(FileNotFoundError):
-                model.generate("does-not-exist.wav")
+                model.generate(str(missing_audio))
         finally:
             model.safe_cleanup()
 

--- a/tests/integration/test_models_claude_openai_audio.py
+++ b/tests/integration/test_models_claude_openai_audio.py
@@ -955,14 +955,23 @@ class TestAudioModel:
         model.initialize()
         assert model._initialized is True
 
-    def test_generate_raises_not_implemented(self) -> None:
+    def test_generate_propagates_filenotfound_for_missing_audio(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        # Step 2A wired generate() to faster-whisper. After initialize(),
+        # passing a non-existent audio path now propagates the underlying
+        # FileNotFoundError from AudioTranscriber.transcribe rather than
+        # the previous NotImplementedError("Phase 3") stub.
         from models.audio_model import AudioModel
 
         config = AudioModel.get_default_config()
         model = AudioModel(config)
         model.initialize()
-        with pytest.raises(NotImplementedError, match="Phase 3"):
-            model.generate("audio.wav")
+        try:
+            with pytest.raises(FileNotFoundError):
+                model.generate("does-not-exist.wav")
+        finally:
+            model.safe_cleanup()
 
     def test_cleanup_clears_initialized(self) -> None:
         from models.audio_model import AudioModel

--- a/tests/integration/test_models_claude_openai_audio.py
+++ b/tests/integration/test_models_claude_openai_audio.py
@@ -955,9 +955,7 @@ class TestAudioModel:
         model.initialize()
         assert model._initialized is True
 
-    def test_generate_propagates_filenotfound_for_missing_audio(
-        self, tmp_path: Path
-    ) -> None:
+    def test_generate_propagates_filenotfound_for_missing_audio(self, tmp_path: Path) -> None:
         # Step 2A wired generate() to faster-whisper. After initialize(),
         # passing a non-existent audio path now propagates the underlying
         # FileNotFoundError from AudioTranscriber.transcribe rather than

--- a/tests/integration/test_models_utils_config_undo.py
+++ b/tests/integration/test_models_utils_config_undo.py
@@ -199,21 +199,6 @@ class TestAudioModelConstructor:
             AudioModel(config)
 
 
-class TestAudioModelConstructor:
-    def test_init_rejects_non_audio_model_type(self) -> None:
-        # AudioModel.__init__ guards against being constructed with a non-
-        # AUDIO ModelConfig — this pinned the "Expected AUDIO model type"
-        # ValueError. Covers the otherwise-unreached raise at
-        # src/models/audio_model.py:60 (the only integration-coverage gap
-        # post-Step-2A; happy paths all use ModelType.AUDIO).
-        from models.audio_model import AudioModel
-        from models.base import ModelConfig, ModelType
-
-        bad_config = ModelConfig(name="base", model_type=ModelType.TEXT)
-        with pytest.raises(ValueError, match="Expected AUDIO model type"):
-            AudioModel(bad_config)
-
-
 class TestAudioModelInitialize:
     def test_initialize_sets_initialized_flag(self) -> None:
         from models.audio_model import AudioModel
@@ -264,6 +249,33 @@ class TestAudioModelGenerate:
 
         with pytest.raises(RuntimeError, match="not initialized"):
             model.generate("prompt", temperature=0.5, max_tokens=100)
+
+    def test_generate_returns_transcription_text_with_mocked_transcriber(
+        self, tmp_path: Path
+    ) -> None:
+        # Covers the generate() success-path body (lines through
+        # _audio_transcriber_classes / TranscriptionOptions / transcribe /
+        # _exit_generate). Mocked transcriber so this runs even when the
+        # [media] extra isn't installed in the integration runner — the
+        # real-whisper end-to-end test in test_audio_model_integration.py
+        # skips without [media], so this test fills the coverage gap.
+        from models.audio_model import AudioModel
+        from models.base import ModelConfig, ModelType
+
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        model.initialize()
+
+        fake_audio = tmp_path / "sample.wav"
+        fake_result = MagicMock()
+        fake_result.text = "hello integration"
+        with patch.object(
+            model._transcriber, "transcribe", return_value=fake_result
+        ) as mock_transcribe:
+            output = model.generate(str(fake_audio))
+
+        assert output == "hello integration"
+        mock_transcribe.assert_called_once()
 
 
 class TestAudioModelCleanup:

--- a/tests/integration/test_models_utils_config_undo.py
+++ b/tests/integration/test_models_utils_config_undo.py
@@ -210,6 +210,22 @@ class TestAudioModelInitialize:
 
         assert model._initialized is True
 
+    def test_init_coerces_mps_device_to_cpu(self) -> None:
+        # CTranslate2 doesn't support MPS — AudioModel must coerce
+        # DeviceType.MPS to CPU at construction time. Without this branch
+        # being covered in the integration suite, the per-module floor
+        # for src/models/audio_model.py drops below 100%.
+        from models.audio_model import AudioModel
+        from models.base import DeviceType, ModelConfig, ModelType
+
+        config = ModelConfig(
+            name="test-audio",
+            model_type=ModelType.AUDIO,
+            device=DeviceType.MPS,
+        )
+        model = AudioModel(config)
+        assert model._transcriber.device == "cpu"
+
     def test_initialize_completes_without_error(self) -> None:
         from models.audio_model import AudioModel
         from models.base import ModelConfig, ModelType

--- a/tests/integration/test_models_utils_config_undo.py
+++ b/tests/integration/test_models_utils_config_undo.py
@@ -222,24 +222,32 @@ class TestAudioModelInitialize:
 
 
 class TestAudioModelGenerate:
-    def test_generate_raises_not_implemented(self) -> None:
+    def test_generate_before_initialize_raises_runtime_error(self) -> None:
+        # Step 2A wired AudioModel.generate() to faster-whisper. The model
+        # is no longer a NotImplementedError stub; calling generate()
+        # before initialize() now raises RuntimeError via the BaseModel
+        # _enter_generate guard. (Was: assert NotImplementedError,
+        # match="Phase 3" — superseded by Step 2A Tasks 5/6.)
         from models.audio_model import AudioModel
         from models.base import ModelConfig, ModelType
 
-        config = ModelConfig(name="test-audio", model_type=ModelType.AUDIO)
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
         model = AudioModel(config)
 
-        with pytest.raises(NotImplementedError, match="Phase 3"):
+        with pytest.raises(RuntimeError, match="not initialized"):
             model.generate("audio/file.wav")
 
-    def test_generate_raises_regardless_of_kwargs(self) -> None:
+    def test_generate_kwargs_currently_ignored(self) -> None:
+        # generate() accepts **kwargs reserved for future per-call options.
+        # They're currently ignored. Calling without initialize() still
+        # raises the RuntimeError lifecycle guard regardless of kwargs.
         from models.audio_model import AudioModel
         from models.base import ModelConfig, ModelType
 
-        config = ModelConfig(name="test-audio", model_type=ModelType.AUDIO)
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
         model = AudioModel(config)
 
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(RuntimeError, match="not initialized"):
             model.generate("prompt", temperature=0.5, max_tokens=100)
 
 
@@ -281,11 +289,16 @@ class TestAudioModelGetDefaultConfig:
         assert cfg.model_type == ModelType.AUDIO
 
     def test_default_config_uses_default_model_name(self) -> None:
+        # Step 2A Task 3 changed the default from "distil-whisper-large-v3"
+        # (which silently fell back to ModelSize.BASE through the resolver)
+        # to "base" (a real ModelSize value). The new default makes the
+        # config self-describing — anyone reading it sees the actual
+        # whisper size that will load.
         from models.audio_model import AudioModel
 
         cfg = AudioModel.get_default_config()
 
-        assert cfg.name == "distil-whisper-large-v3"
+        assert cfg.name == "base"
 
     def test_default_config_custom_model_name(self) -> None:
         from models.audio_model import AudioModel

--- a/tests/integration/test_models_utils_config_undo.py
+++ b/tests/integration/test_models_utils_config_undo.py
@@ -274,8 +274,16 @@ class TestAudioModelGenerate:
         ) as mock_transcribe:
             output = model.generate(str(fake_audio))
 
+        assert isinstance(output, str)
         assert output == "hello integration"
         mock_transcribe.assert_called_once()
+        # Pin the wiring contract: generate() forwards the prompt path as the
+        # first positional arg and passes a TranscriptionOptions via kwarg.
+        # Without these checks, a future refactor could swap arg order or
+        # drop options and the count-only check would still pass.
+        called_path = mock_transcribe.call_args.args[0]
+        assert Path(called_path) == fake_audio
+        assert mock_transcribe.call_args.kwargs.get("options") is not None
 
 
 class TestAudioModelCleanup:

--- a/tests/integration/test_models_utils_config_undo.py
+++ b/tests/integration/test_models_utils_config_undo.py
@@ -199,6 +199,21 @@ class TestAudioModelConstructor:
             AudioModel(config)
 
 
+class TestAudioModelConstructor:
+    def test_init_rejects_non_audio_model_type(self) -> None:
+        # AudioModel.__init__ guards against being constructed with a non-
+        # AUDIO ModelConfig — this pinned the "Expected AUDIO model type"
+        # ValueError. Covers the otherwise-unreached raise at
+        # src/models/audio_model.py:60 (the only integration-coverage gap
+        # post-Step-2A; happy paths all use ModelType.AUDIO).
+        from models.audio_model import AudioModel
+        from models.base import ModelConfig, ModelType
+
+        bad_config = ModelConfig(name="base", model_type=ModelType.TEXT)
+        with pytest.raises(ValueError, match="Expected AUDIO model type"):
+            AudioModel(bad_config)
+
+
 class TestAudioModelInitialize:
     def test_initialize_sets_initialized_flag(self) -> None:
         from models.audio_model import AudioModel

--- a/tests/integration/test_services_video_audio_extractor_transcriber.py
+++ b/tests/integration/test_services_video_audio_extractor_transcriber.py
@@ -899,9 +899,30 @@ class TestAudioTranscriberInit:
 
         transcriber = AudioTranscriber()
         assert transcriber.model_size == ModelSize.BASE
-        assert transcriber.compute_type == ComputeType.FLOAT16
+        # compute_type now auto-selects based on device: float16 on CUDA,
+        # int8 on CPU. Default device resolves to CPU on a non-CUDA host
+        # (the test runner), so int8 is the expected default here.
+        assert transcriber.compute_type in {ComputeType.FLOAT16, ComputeType.INT8}
         assert transcriber.num_workers == 1
         assert transcriber._model is None
+
+    def test_default_compute_type_is_int8_on_cpu(self) -> None:
+        from services.audio.transcriber import AudioTranscriber, ComputeType
+
+        transcriber = AudioTranscriber(device="cpu")
+        assert transcriber.compute_type == ComputeType.INT8
+
+    def test_default_compute_type_is_float16_on_cuda(self) -> None:
+        from services.audio.transcriber import AudioTranscriber, ComputeType
+
+        transcriber = AudioTranscriber(device="cuda")
+        assert transcriber.compute_type == ComputeType.FLOAT16
+
+    def test_explicit_compute_type_overrides_default(self) -> None:
+        from services.audio.transcriber import AudioTranscriber, ComputeType
+
+        transcriber = AudioTranscriber(device="cpu", compute_type=ComputeType.FLOAT32)
+        assert transcriber.compute_type == ComputeType.FLOAT32
 
     def test_custom_model_size_stored(self) -> None:
         from services.audio.transcriber import AudioTranscriber, ModelSize
@@ -944,7 +965,10 @@ class TestAudioTranscriberDetectDevice:
 
         assert result == "cuda"
 
-    def test_auto_returns_mps_when_cuda_unavailable(self) -> None:
+    def test_auto_returns_cpu_on_apple_silicon_not_mps(self) -> None:
+        """faster-whisper / CTranslate2 do not support MPS — on Apple Silicon
+        the auto-detect must fall back to CPU rather than crash with
+        'unsupported device mps'."""
         from services.audio.transcriber import AudioTranscriber
 
         mock_torch = MagicMock()
@@ -955,7 +979,7 @@ class TestAudioTranscriberDetectDevice:
             transcriber = AudioTranscriber(device="cpu")
             result = transcriber._detect_device("auto")
 
-        assert result == "mps"
+        assert result == "cpu"
 
     def test_auto_returns_cpu_when_neither_available(self) -> None:
         from services.audio.transcriber import AudioTranscriber

--- a/tests/test_audio_model.py
+++ b/tests/test_audio_model.py
@@ -62,6 +62,15 @@ class TestAudioModelLifecycle:
         model.initialize()
         assert model.is_initialized is True
 
+    def test_cleanup_unloads_transcriber(self) -> None:
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        model.initialize()
+        with patch.object(model._transcriber, "unload_model") as mock_unload:
+            model.cleanup()
+        mock_unload.assert_called_once()
+        assert model.is_initialized is False
+
 
 @pytest.mark.unit
 class TestAudioModelGenerate:

--- a/tests/test_audio_model.py
+++ b/tests/test_audio_model.py
@@ -37,9 +37,7 @@ class TestAudioModelInit:
         # auto-fallback on Apple Silicon.
         from models.base import DeviceType
 
-        config = ModelConfig(
-            name="base", model_type=ModelType.AUDIO, device=DeviceType.MPS
-        )
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO, device=DeviceType.MPS)
         model = AudioModel(config)
 
         # The transcriber must see "cpu", not "mps", so it doesn't blow up

--- a/tests/test_audio_model.py
+++ b/tests/test_audio_model.py
@@ -51,3 +51,13 @@ def test_default_config_resolves_to_valid_model_size() -> None:
         size.value == config.name
         or size.value == config.name.replace("whisper-", "")
     )
+
+
+@pytest.mark.unit
+class TestAudioModelLifecycle:
+    def test_initialize_sets_initialized_flag(self) -> None:
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        assert model.is_initialized is False
+        model.initialize()
+        assert model.is_initialized is True

--- a/tests/test_audio_model.py
+++ b/tests/test_audio_model.py
@@ -37,3 +37,17 @@ def test_resolve_model_size_maps_to_valid_size(
     from models.audio_model import _resolve_model_size
 
     assert _resolve_model_size(name).value == expected_value
+
+
+@pytest.mark.unit
+def test_default_config_resolves_to_valid_model_size() -> None:
+    from models.audio_model import _resolve_model_size
+
+    config = AudioModel.get_default_config()
+    size = _resolve_model_size(config.name)
+    # Must be one of the real ModelSize values (not the silent BASE fallback
+    # that hides unrecognized names).
+    assert (
+        size.value == config.name
+        or size.value == config.name.replace("whisper-", "")
+    )

--- a/tests/test_audio_model.py
+++ b/tests/test_audio_model.py
@@ -12,6 +12,7 @@ from models.base import ModelConfig, ModelType
 
 
 @pytest.mark.unit
+@pytest.mark.ci
 class TestAudioModelInit:
     def test_init_creates_transcriber_attribute(self) -> None:
         config = ModelConfig(name="base", model_type=ModelType.AUDIO)
@@ -19,8 +20,18 @@ class TestAudioModelInit:
         assert model._transcriber is not None
         assert hasattr(model._transcriber, "transcribe")
 
+    def test_init_rejects_non_audio_model_type(self) -> None:
+        # AudioModel.__init__ guards against being constructed with a non-
+        # AUDIO ModelConfig — covers the ValueError raise. Without this
+        # test the diff-coverage gate fails because every other call site
+        # uses ModelType.AUDIO.
+        bad_config = ModelConfig(name="base", model_type=ModelType.TEXT)
+        with pytest.raises(ValueError, match="Expected AUDIO model type"):
+            AudioModel(bad_config)
+
 
 @pytest.mark.unit
+@pytest.mark.ci
 @pytest.mark.parametrize(
     "name,expected_value",
     [
@@ -40,6 +51,7 @@ def test_resolve_model_size_maps_to_valid_size(
 
 
 @pytest.mark.unit
+@pytest.mark.ci
 def test_default_config_resolves_to_valid_model_size() -> None:
     from models.audio_model import _resolve_model_size
 
@@ -54,6 +66,7 @@ def test_default_config_resolves_to_valid_model_size() -> None:
 
 
 @pytest.mark.unit
+@pytest.mark.ci
 class TestAudioModelLifecycle:
     def test_initialize_sets_initialized_flag(self) -> None:
         config = ModelConfig(name="base", model_type=ModelType.AUDIO)
@@ -73,6 +86,7 @@ class TestAudioModelLifecycle:
 
 
 @pytest.mark.unit
+@pytest.mark.ci
 class TestAudioModelGenerate:
     def test_generate_returns_transcription_text(self, tmp_path: Path) -> None:
         config = ModelConfig(name="base", model_type=ModelType.AUDIO)
@@ -101,6 +115,7 @@ class TestAudioModelGenerate:
 
 
 @pytest.mark.unit
+@pytest.mark.ci
 class TestAudioModelGenerateErrors:
     def test_generate_before_initialize_raises_runtime_error(
         self, tmp_path: Path

--- a/tests/test_audio_model.py
+++ b/tests/test_audio_model.py
@@ -1,53 +1,20 @@
-"""Tests for AudioModel class - Phase 3 placeholder."""
+"""Unit tests for AudioModel — wires services.audio.transcriber."""
 
 from __future__ import annotations
 
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-# Note: AudioModel is a Phase 3 placeholder
-# Tests document expected behavior for when implemented
+from models.audio_model import AudioModel
+from models.base import ModelConfig, ModelType
 
 
 @pytest.mark.unit
-class TestAudioModelPlaceholder:
-    """Test AudioModel Phase 3 placeholder."""
-
-    def test_audio_model_exists(self):
-        """Test that AudioModel class exists."""
-        try:
-            from models.audio_model import AudioModel
-
-            assert AudioModel is not None
-        except ImportError:
-            pytest.skip("AudioModel not yet implemented (Phase 3)")
-
-    def test_audio_model_init(self):
-        """Test AudioModel initialization."""
-        try:
-            from models.audio_model import AudioModel
-            from models.base import ModelConfig, ModelType
-
-            config = ModelConfig(
-                name="whisper-base",
-                model_type=ModelType.AUDIO,
-            )
-            model = AudioModel(config)
-            assert model is not None
-        except (ImportError, NotImplementedError):
-            pytest.skip("AudioModel not yet fully implemented (Phase 3)")
-
-    def test_audio_model_config_validation(self):
-        """Test that AudioModel validates configuration."""
-        try:
-            from models.audio_model import AudioModel
-            from models.base import ModelConfig, ModelType
-
-            config = ModelConfig(
-                name="whisper-base",
-                model_type=ModelType.AUDIO,
-                framework="faster-whisper",
-            )
-            model = AudioModel(config)
-            assert model.config.model_type == ModelType.AUDIO
-        except (ImportError, NotImplementedError):
-            pytest.skip("AudioModel not yet fully implemented (Phase 3)")
+class TestAudioModelInit:
+    def test_init_creates_transcriber_attribute(self) -> None:
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        assert model._transcriber is not None
+        assert hasattr(model._transcriber, "transcribe")

--- a/tests/test_audio_model.py
+++ b/tests/test_audio_model.py
@@ -89,3 +89,37 @@ class TestAudioModelGenerate:
         # First positional arg is the audio path
         called_path = mock_transcribe.call_args.args[0]
         assert Path(called_path) == fake_audio
+
+
+@pytest.mark.unit
+class TestAudioModelGenerateErrors:
+    def test_generate_before_initialize_raises_runtime_error(
+        self, tmp_path: Path
+    ) -> None:
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        # Note: not calling initialize()
+        fake_audio = tmp_path / "sample.wav"
+        fake_audio.touch()
+        with pytest.raises(RuntimeError, match="not initialized"):
+            model.generate(str(fake_audio))
+
+    def test_generate_after_shutdown_raises_runtime_error(
+        self, tmp_path: Path
+    ) -> None:
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        model.initialize()
+        model.safe_cleanup()  # marks _shutting_down
+        fake_audio = tmp_path / "sample.wav"
+        fake_audio.touch()
+        with pytest.raises(RuntimeError, match="shutting down"):
+            model.generate(str(fake_audio))
+
+    def test_generate_propagates_filenotfound(self, tmp_path: Path) -> None:
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        model.initialize()
+        missing = tmp_path / "does-not-exist.wav"
+        with pytest.raises(FileNotFoundError):
+            model.generate(str(missing))

--- a/tests/test_audio_model.py
+++ b/tests/test_audio_model.py
@@ -18,3 +18,22 @@ class TestAudioModelInit:
         model = AudioModel(config)
         assert model._transcriber is not None
         assert hasattr(model._transcriber, "transcribe")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "name,expected_value",
+    [
+        ("base", "base"),
+        ("whisper-base", "base"),
+        ("tiny", "tiny"),
+        ("Whisper-Large-V3", "large-v3"),
+        ("nonsense-model-name", "base"),  # falls back to BASE
+    ],
+)
+def test_resolve_model_size_maps_to_valid_size(
+    name: str, expected_value: str
+) -> None:
+    from models.audio_model import _resolve_model_size
+
+    assert _resolve_model_size(name).value == expected_value

--- a/tests/test_audio_model.py
+++ b/tests/test_audio_model.py
@@ -42,9 +42,7 @@ class TestAudioModelInit:
         ("nonsense-model-name", "base"),  # falls back to BASE
     ],
 )
-def test_resolve_model_size_maps_to_valid_size(
-    name: str, expected_value: str
-) -> None:
+def test_resolve_model_size_maps_to_valid_size(name: str, expected_value: str) -> None:
     from models.audio_model import _resolve_model_size
 
     assert _resolve_model_size(name).value == expected_value
@@ -59,10 +57,7 @@ def test_default_config_resolves_to_valid_model_size() -> None:
     size = _resolve_model_size(config.name)
     # Must be one of the real ModelSize values (not the silent BASE fallback
     # that hides unrecognized names).
-    assert (
-        size.value == config.name
-        or size.value == config.name.replace("whisper-", "")
-    )
+    assert size.value == config.name or size.value == config.name.replace("whisper-", "")
 
 
 @pytest.mark.unit
@@ -117,9 +112,7 @@ class TestAudioModelGenerate:
 @pytest.mark.unit
 @pytest.mark.ci
 class TestAudioModelGenerateErrors:
-    def test_generate_before_initialize_raises_runtime_error(
-        self, tmp_path: Path
-    ) -> None:
+    def test_generate_before_initialize_raises_runtime_error(self, tmp_path: Path) -> None:
         config = ModelConfig(name="base", model_type=ModelType.AUDIO)
         model = AudioModel(config)
         # Note: not calling initialize()
@@ -128,9 +121,7 @@ class TestAudioModelGenerateErrors:
         with pytest.raises(RuntimeError, match="not initialized"):
             model.generate(str(fake_audio))
 
-    def test_generate_after_shutdown_raises_runtime_error(
-        self, tmp_path: Path
-    ) -> None:
+    def test_generate_after_shutdown_raises_runtime_error(self, tmp_path: Path) -> None:
         config = ModelConfig(name="base", model_type=ModelType.AUDIO)
         model = AudioModel(config)
         model.initialize()

--- a/tests/test_audio_model.py
+++ b/tests/test_audio_model.py
@@ -29,6 +29,25 @@ class TestAudioModelInit:
         with pytest.raises(ValueError, match="Expected AUDIO model type"):
             AudioModel(bad_config)
 
+    def test_init_coerces_mps_device_to_cpu(self) -> None:
+        # CTranslate2 (the engine under faster-whisper) doesn't support MPS.
+        # AudioModel must coerce DeviceType.MPS to CPU rather than letting
+        # it hit the engine and crash with an opaque "unsupported device"
+        # error. Match the behavior of AudioTranscriber._detect_device's
+        # auto-fallback on Apple Silicon.
+        from models.base import DeviceType
+
+        config = ModelConfig(
+            name="base", model_type=ModelType.AUDIO, device=DeviceType.MPS
+        )
+        model = AudioModel(config)
+
+        # The transcriber must see "cpu", not "mps", so it doesn't blow up
+        # downstream. (The warning emitted via loguru is observable
+        # interactively; capturing it under caplog requires a loguru sink
+        # fixture which the project doesn't currently expose.)
+        assert model._transcriber.device == "cpu"
+
 
 @pytest.mark.unit
 @pytest.mark.ci

--- a/tests/test_audio_model.py
+++ b/tests/test_audio_model.py
@@ -61,3 +61,31 @@ class TestAudioModelLifecycle:
         assert model.is_initialized is False
         model.initialize()
         assert model.is_initialized is True
+
+
+@pytest.mark.unit
+class TestAudioModelGenerate:
+    def test_generate_returns_transcription_text(self, tmp_path: Path) -> None:
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO)
+        model = AudioModel(config)
+        model.initialize()
+
+        fake_audio = tmp_path / "sample.wav"
+        # No need to actually create the file: patching
+        # `model._transcriber.transcribe` replaces AudioTranscriber.transcribe
+        # entirely, including its `audio_path.exists()` check at
+        # src/services/audio/transcriber.py:212. We pass the path through to
+        # verify generate() forwards it correctly.
+
+        fake_result = MagicMock()
+        fake_result.text = "hello world"
+        with patch.object(
+            model._transcriber, "transcribe", return_value=fake_result
+        ) as mock_transcribe:
+            output = model.generate(str(fake_audio))
+
+        assert output == "hello world"
+        mock_transcribe.assert_called_once()
+        # First positional arg is the audio path
+        called_path = mock_transcribe.call_args.args[0]
+        assert Path(called_path) == fake_audio

--- a/tests/test_audio_model.py
+++ b/tests/test_audio_model.py
@@ -46,6 +46,18 @@ class TestAudioModelInit:
         # fixture which the project doesn't currently expose.)
         assert model._transcriber.device == "cpu"
 
+    def test_init_coerces_metal_device_to_cpu(self) -> None:
+        # `ModelConfig.device` accepts DeviceType.METAL too (used by MLX
+        # paths). CTranslate2 doesn't recognize "metal" either, so the
+        # same defensive coercion must apply or transcription crashes at
+        # runtime with an opaque "unsupported device" error. Allowlist
+        # (auto/cpu/cuda) covers any future DeviceType additions too.
+        from models.base import DeviceType
+
+        config = ModelConfig(name="base", model_type=ModelType.AUDIO, device=DeviceType.METAL)
+        model = AudioModel(config)
+        assert model._transcriber.device == "cpu"
+
 
 @pytest.mark.unit
 @pytest.mark.ci


### PR DESCRIPTION
## Summary

Closes Step 2A of the alpha→beta path per the plan in [docs/superpowers/plans/2026-04-27-audio-model-wiring-2a.md](https://github.com/curdriceaurora/fo-core/blob/main/docs/superpowers/plans/2026-04-27-audio-model-wiring-2a.md). Closes the "Audio works end-to-end" row of `docs/release/beta-criteria.md` §2.

**All 11 plan tasks complete + two scope expansions surfaced during execution:**

1. **`AudioModel.generate()` is wired** to the existing `services.audio.transcriber.AudioTranscriber` (was a `NotImplementedError("Phase 3")` stub). Lifecycle is BaseModel-correct: `_enter_generate` / `_exit_generate` guards, `cleanup()` unloads the underlying Whisper model, `initialize()` is the standard pass-through.
2. **`fo benchmark run --suite audio --transcribe-smoke`** is a real verification flag — runs `AudioModel.generate()` end-to-end on one candidate and exits non-zero (with clear error + degradation reason in JSON) when the smoke can't actually run. Off by default.
3. **README + pyproject `[media]` description honesty pass** — both now name `faster-whisper` and point at the smoke flag for verification.

## Scope expansions (intentional, documented)

The plan said "out of scope: consolidating `models.audio_transcriber`," but the integration test in Task 8 surfaced two distinct categories of pre-existing issues that made beta-criteria.md §2's "Audio works end-to-end" literally unachievable. Fixing these was in scope because Step 2A is what the criteria row depends on:

### Pre-existing transcriber bugs in `services/audio/transcriber.py`

- **`_detect_device` returned `"mps"` on Apple Silicon** but CTranslate2 (faster-whisper's engine) rejects MPS — `RuntimeError: unsupported device mps`. Removed the MPS branch; auto-detect now falls back to CPU on Apple Silicon.
- **Default `compute_type` was unconditional `FLOAT16`** — CTranslate2 rejects `float16` on CPU with "target device or backend do not support efficient float16 computation". Now auto-selects `float16` on CUDA, `int8` on CPU.
- **`AudioModel.__init__` coerces `DeviceType.MPS` → `"cpu"`** with a clear log message, so callers who pass MPS explicitly don't hit the same downstream crash.
- Two pinned tests for the old (buggy) behavior were updated to match the corrected contract; three new tests pin the device→compute_type pairing.

### Legacy `NotImplementedError` test contract updates

Three tests in the existing audio integration suite were pinning the previous placeholder behavior:

- `test_generate_raises_not_implemented` (×2) → renamed and rewritten to assert `RuntimeError, match="not initialized"` from the BaseModel `_enter_generate` guard, OR `FileNotFoundError` from the real transcriber (depending on intent).
- `test_default_config_uses_default_model_name` → asserts `cfg.name == "base"` (was `"distil-whisper-large-v3"` which silently fell back to `ModelSize.BASE`).

## Implementation notes

- **Circular import resolution**: `models/__init__.py` eagerly imports `AudioModel`, which would close a cycle if `audio_model.py` imported `services.audio.transcriber` at module top (`services/__init__.py` → `text_processor` → `models.TextModel` partial-init crash). Resolved with a documented F9-exception lazy-import helper `_audio_transcriber_classes()` at module scope; `TYPE_CHECKING` keeps annotations honest for static analysis.
- **Test isolation**: `tests/integration/test_audio_model_integration.py` clears `sys.modules` of any `faster_whisper` / `ctranslate2` mocks in an autouse fixture (T12 fixture-state-leak defense — peer integration test files mock these), and uses `xdist_group="audio_real_whisper"` for a stable lane under `--dist=loadgroup`.
- **`--transcribe-smoke` is a strict verification flag**: fails fast with `typer.BadParameter` when paired with a non-audio suite, when the input is empty, or when no audio candidates are found; exits non-zero with a degradation classification when the smoke check is requested but can't run end-to-end (typically `[media]` extra missing). The benchmark JSON output carries a `transcribe_smoke: bool` so `--compare` consumers can refuse mixing smoke vs non-smoke baselines.

## Files changed

| File | Change |
|---|---|
| `src/models/audio_model.py` | New module: lazy-import helper, `_resolve_model_size`, wired `__init__`/`generate`/`cleanup`, MPS coercion |
| `src/services/audio/transcriber.py` | Pre-existing bug fixes: MPS device removal, device-aware `compute_type` default |
| `src/cli/benchmark.py` | New `--transcribe-smoke` flag, `_run_audio_suite` smoke pass, `_classify_audio_suite` smoke-skipped degradation, three helpers (`_bind_transcribe_smoke`, `_validate_transcribe_smoke_preconditions`, `_exit_if_transcribe_smoke_failed`), JSON payload `transcribe_smoke` field |
| `README.md` | `[media]` row mentions faster-whisper + smoke verification command |
| `pyproject.toml` | `[media]` extra comment names what the extra delivers |
| `tests/test_audio_model.py` | 14 unit tests (init/lifecycle/generate/errors/MPS coercion/_resolve_model_size); replaced placeholder skip-tests |
| `tests/integration/test_audio_model_integration.py` | New: end-to-end test against generated silent WAV; xdist-group serialized; sys.modules pollution defense |
| `tests/cli/test_benchmark_audio_transcribe.py` | 4 unit tests for helpers + 4 integration tests for `--transcribe-smoke` flag (mocked AudioModel for 3, fail-fast paths for 1) |
| `tests/integration/test_models_utils_config_undo.py` | Updated 3 legacy `NotImplementedError` pins → new contract; new mocked-transcriber test for diff coverage |
| `tests/integration/test_models_claude_openai_audio.py` | Updated 1 legacy `NotImplementedError` pin → `FileNotFoundError` propagation; uses `tmp_path` for guaranteed-missing path |

## Test plan

- [x] `pytest tests/test_audio_model.py -v` — 14 unit tests pass
- [x] `pytest tests/integration/test_audio_model_integration.py -v --no-cov` — end-to-end test passes on Apple Silicon (downloads tiny model ~39 MB on first run; cached after)
- [x] `pytest tests/cli/test_benchmark_audio_transcribe.py -v --no-cov` — 14 tests pass
- [x] `pytest tests/integration/test_models_*.py -k Audio -v --no-cov` — all updated legacy tests pass against the new contract
- [x] Combined audio surface: 132+ tests pass together with `--dist=loadgroup`
- [x] `mypy src/models/audio_model.py src/services/audio/transcriber.py src/cli/benchmark.py` — clean
- [x] `ruff check + format` — clean
- [x] All CI gates green on PR #236 (28 SUCCESS · 4 SKIPPED · 0 FAILURES at last green push)

## Reviewer focus areas

1. **Transcriber device-detection change** — is removing the MPS branch from `_detect_device` the right call, or should we keep MPS as a tier and pass `device="cpu"` from AudioModel as a workaround? My read: removing is correct because no caller of `AudioTranscriber` ever benefits from MPS being suggested.
2. **`compute_type` auto-default** — is `int8` on CPU the right default, or should we offer `int8_float32` for slight quality-vs-speed tradeoff?
3. **F9 lazy-import helper** — acceptable per the documented project exception, or should we restructure `models/__init__.py` to break the cycle structurally? (Latter is bigger, ripples into other consumers.)
4. **`--transcribe-smoke` failure semantics** — current behavior is fail-fast on flag misuse (non-audio suite, empty input, no audio candidates) via `typer.BadParameter` (exit 2), and fail-loud after the run when ImportError prevents transcription (exit 1). Reasonable distinction or should both be the same exit code?

## Step in the alpha→beta path

This closes the "Audio works end-to-end" entry in `docs/release/beta-criteria.md` §2. Step 2B (organize-transcription) becomes unblocked once this merges. Step 2C (schema-stability test) is fully independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end audio transcription enabled with the faster-whisper backend; default audio model now "base".
  * Added --transcribe-smoke to the benchmark CLI to run a one-shot transcription check and fail fast on unmet preconditions.

* **Documentation**
  * Media install docs updated to name faster-whisper and show the benchmark smoke-test command for verification.

* **Behavior**
  * Audio runtime now auto-selects precision and falls back to CPU on Apple Silicon; benchmark output includes smoke-related fields and warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->