### PR TITLE
test(config): schema-stability round-trip suite for beta line (Step 2C)

### DIFF
--- a/tests/integration/test_config_schema_stability.py
+++ b/tests/integration/test_config_schema_stability.py
@@ -77,6 +77,9 @@ class TestConfigRoundTrip:
         # Read back via a fresh manager pointing at the same tmp dir.
         roundtripped = ConfigManager(config_dir=tmp_path).load()
 
+        # Pin the return-type contract — `ConfigManager.load()` must
+        # produce an `AppConfig`, not a fallback dict or partial object.
+        assert isinstance(roundtripped, AppConfig)
         # The round-tripped config must equal the original on every field.
         # Comparing via asdict() catches sub-dataclass field drift too
         # (e.g. ModelPreset losing `framework`).
@@ -139,6 +142,8 @@ class TestConfigCrossVersionRoundTrip:
 
         loaded = ConfigManager(config_dir=tmp_path).load()
 
+        # Pin the return-type contract.
+        assert isinstance(loaded, AppConfig)
         # Every field except `version` round-trips identically. `version`
         # is updated to current after the migration (correct behavior).
         # Comparing the full asdict() (with `version` neutralized) catches
@@ -184,6 +189,8 @@ class TestConfigCrossVersionRoundTrip:
         with caplog.at_level(logging.WARNING, logger="config.manager"):
             loaded = ConfigManager(config_dir=tmp_path).load()
 
+        # Pin the return-type contract.
+        assert isinstance(loaded, AppConfig)
         # Loaded best-effort: ALL known fields preserved (not just a
         # sampled subset — Copilot review on PR #238 caught that the
         # original 2-field check would let `models`/`updates`/`watcher`
@@ -195,15 +202,24 @@ class TestConfigCrossVersionRoundTrip:
         original_dict = asdict(original)
         loaded_dict["version"] = original_dict["version"] = "<<ignored>>"
         assert loaded_dict == original_dict
-        # And a warning was emitted naming the offending version. Check
-        # both `getMessage()` (formatted) and the raw `args` tuple — the
-        # warning uses %s formatting so the version may show up either
-        # in the formatted text or the args list depending on capture
-        # timing.
-        warned_for_future_version = any(
-            "99.0" in rec.getMessage() or "99.0" in str(rec.args or ()) for rec in caplog.records
-        )
-        assert warned_for_future_version, (
-            "Expected a WARNING naming the future version; got: "
-            f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
+
+        # Filter the captured records to the exact source + severity we
+        # expect. CodeRabbit review on PR #238: without this, a
+        # regression from logger.warning -> logger.error would still pass
+        # because caplog.at_level(WARNING) captures higher severities too.
+        # Pin both the source ("config.manager") and the level (WARNING)
+        # explicitly.
+        warnings = [
+            rec
+            for rec in caplog.records
+            if rec.name == "config.manager" and rec.levelno == logging.WARNING
+        ]
+        # The warning uses %s formatting so the version may show up
+        # either in the formatted text or the raw args tuple, depending
+        # on capture timing — check both.
+        assert any(
+            "99.0" in rec.getMessage() or "99.0" in str(rec.args or ()) for rec in warnings
+        ), (
+            "Expected a WARNING from config.manager naming the future version; got: "
+            f"{[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
         )

--- a/tests/integration/test_config_schema_stability.py
+++ b/tests/integration/test_config_schema_stability.py
@@ -88,16 +88,22 @@ class TestConfigRoundTrip:
 class TestConfigCrossVersionRoundTrip:
     """Cross-version compat: schema stays frozen but the walker still works."""
 
-    def test_synthetic_future_version_preserves_known_fields(
+    def test_past_version_migration_preserves_all_fields(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Write at a synthetic past version; load() must preserve all fields.
+        """Write at a synthetic PAST version; the migration walker must
+        preserve all fields when the migration is identity.
 
         We don't register an actual migration — beta promises the schema does
         not change across the line — but we DO promise that adding fields in
         the future won't drop existing fields. This test exercises that path
         using a registry monkeypatch, simulating what a future migration
         landing in beta.5 (say) would do during a beta.4 → beta.5 read.
+
+        Renamed from ``test_synthetic_future_version_preserves_known_fields``
+        per Copilot review on PR #238 — "future" was misleading because the
+        on-disk version is OLDER than the binary's, and the migration walker
+        ratchets it forward.
         """
         from config.migrations import MIGRATIONS, Migration
 
@@ -135,14 +141,16 @@ class TestConfigCrossVersionRoundTrip:
 
         # Every field except `version` round-trips identically. `version`
         # is updated to current after the migration (correct behavior).
+        # Comparing the full asdict() (with `version` neutralized) catches
+        # regressions on fields the test author forgot to enumerate
+        # (e.g. daemon/parallel/pipeline/events/deploy/johnny_decimal
+        # silently defaulting differently post-migration). Per Copilot
+        # review on PR #238.
         assert loaded.version == CURRENT_SCHEMA_VERSION
-        assert loaded.profile_name == original.profile_name
-        assert loaded.default_methodology == original.default_methodology
-        assert loaded.setup_completed == original.setup_completed
-        assert asdict(loaded.models) == asdict(original.models)
-        assert asdict(loaded.updates) == asdict(original.updates)
-        assert loaded.watcher == original.watcher
-        assert loaded.para == original.para
+        loaded_dict = asdict(loaded)
+        original_dict = asdict(original)
+        loaded_dict["version"] = original_dict["version"] = "<<ignored>>"
+        assert loaded_dict == original_dict
 
     def test_future_version_loads_best_effort_with_warning(
         self,
@@ -176,9 +184,17 @@ class TestConfigCrossVersionRoundTrip:
         with caplog.at_level(logging.WARNING, logger="config.manager"):
             loaded = ConfigManager(config_dir=tmp_path).load()
 
-        # Loaded best-effort: known fields preserved.
-        assert loaded.profile_name == original.profile_name
-        assert loaded.setup_completed == original.setup_completed
+        # Loaded best-effort: ALL known fields preserved (not just a
+        # sampled subset — Copilot review on PR #238 caught that the
+        # original 2-field check would let `models`/`updates`/`watcher`
+        # etc. silently regress). Compare full asdict() with `version`
+        # neutralized — it doesn't ratchet for future-version configs
+        # the binary doesn't know how to migrate, but the contract for
+        # known fields is unconditional.
+        loaded_dict = asdict(loaded)
+        original_dict = asdict(original)
+        loaded_dict["version"] = original_dict["version"] = "<<ignored>>"
+        assert loaded_dict == original_dict
         # And a warning was emitted naming the offending version. Check
         # both `getMessage()` (formatted) and the raw `args` tuple — the
         # warning uses %s formatting so the version may show up either

--- a/tests/integration/test_config_schema_stability.py
+++ b/tests/integration/test_config_schema_stability.py
@@ -1,0 +1,193 @@
+"""Schema-stability tests guarding the beta-line config-compat promise.
+
+Beta-criteria §3: any config written by 2.0.0-beta.X reads cleanly under
+2.0.0-beta.Y for all X, Y. The AppConfig schema stays at version 1.0 for
+the duration of beta. These tests prove the round-trip is lossless and
+that the migration walker handles synthetic version bumps + future
+versions correctly.
+
+This is the guard for the frozen-schema promise — any future PR that
+breaks it fails the `ci` job.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+import yaml
+
+from config.manager import ConfigManager
+from config.schema import CURRENT_SCHEMA_VERSION, AppConfig, ModelPreset, UpdateSettings
+
+
+def _make_realistic_config() -> AppConfig:
+    """Build an AppConfig populated like a real user config.
+
+    Non-default values across the surface so the round-trip can detect
+    dropped fields. A pure-defaults config wouldn't catch e.g. a missing
+    ``setup_completed=True`` field — defaults would mask the loss.
+
+    ``profile_name`` stays as ``"default"`` because ``ConfigManager.save``
+    keys the on-disk record by ``config.profile_name`` while
+    ``ConfigManager.load`` defaults to ``profile="default"`` — using a
+    custom name here would silently fall back to defaults on load.
+    """
+    return AppConfig(
+        profile_name="default",
+        version=CURRENT_SCHEMA_VERSION,
+        default_methodology="para",
+        setup_completed=True,
+        models=ModelPreset(
+            text_model="qwen2.5:7b",
+            vision_model="qwen2.5vl:14b",
+            temperature=0.3,
+            max_tokens=4096,
+            device="mps",
+            framework="ollama",
+        ),
+        updates=UpdateSettings(
+            check_on_startup=True,
+            interval_hours=12,
+            include_prereleases=True,
+            repo="curdriceaurora/fo-core",
+        ),
+        watcher={"enabled": True, "interval_seconds": 30},
+        para={"areas_root": "Areas", "projects_root": "Projects"},
+    )
+
+
+@pytest.mark.ci
+@pytest.mark.integration
+class TestConfigRoundTrip:
+    """Same-version save → load round-trip must be lossless."""
+
+    def test_save_load_round_trip_at_current_version(self, tmp_path: Path) -> None:
+        """A config saved by the current binary loads back identically.
+
+        Inject ``config_dir`` explicitly so the test is isolated from
+        ``DEFAULT_CONFIG_DIR`` and the ``FO_CONFIG`` env var (which would
+        otherwise take precedence per ``src/config/manager.py``).
+        """
+        original = _make_realistic_config()
+        ConfigManager(config_dir=tmp_path).save(original)
+
+        # Read back via a fresh manager pointing at the same tmp dir.
+        roundtripped = ConfigManager(config_dir=tmp_path).load()
+
+        # The round-tripped config must equal the original on every field.
+        # Comparing via asdict() catches sub-dataclass field drift too
+        # (e.g. ModelPreset losing `framework`).
+        assert asdict(roundtripped) == asdict(original)
+
+
+@pytest.mark.ci
+@pytest.mark.integration
+class TestConfigCrossVersionRoundTrip:
+    """Cross-version compat: schema stays frozen but the walker still works."""
+
+    def test_synthetic_future_version_preserves_known_fields(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Write at a synthetic past version; load() must preserve all fields.
+
+        We don't register an actual migration — beta promises the schema does
+        not change across the line — but we DO promise that adding fields in
+        the future won't drop existing fields. This test exercises that path
+        using a registry monkeypatch, simulating what a future migration
+        landing in beta.5 (say) would do during a beta.4 → beta.5 read.
+        """
+        from config.migrations import MIGRATIONS, Migration
+
+        # Save with the current binary, injecting config_dir explicitly so the
+        # test is isolated from DEFAULT_CONFIG_DIR and the FO_CONFIG env var.
+        original = _make_realistic_config()
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.save(original)
+
+        # Mutate the file's version to a synthetic past version; register a
+        # no-op migration to current. This simulates a future beta whose
+        # binary knows how to migrate from "0.9" to "1.0" — except for us
+        # the migration is identity, proving "no fields dropped" when the
+        # only schema delta is "version bumped". The version lives at
+        # ``data["profiles"][profile_name]["version"]`` — top-level
+        # ``data["version"]`` is unused by the loader.
+        config_file = manager.config_path
+        with config_file.open("r") as f:
+            data = yaml.safe_load(f)
+        data["profiles"]["default"]["version"] = "0.9"
+        with config_file.open("w") as f:
+            yaml.safe_dump(data, f)
+
+        def _identity_migration(d: dict[str, object]) -> dict[str, object]:
+            d["version"] = CURRENT_SCHEMA_VERSION
+            return d
+
+        monkeypatch.setitem(
+            MIGRATIONS,
+            "0.9",
+            Migration(to_version=CURRENT_SCHEMA_VERSION, transform=_identity_migration),
+        )
+
+        loaded = ConfigManager(config_dir=tmp_path).load()
+
+        # Every field except `version` round-trips identically. `version`
+        # is updated to current after the migration (correct behavior).
+        assert loaded.version == CURRENT_SCHEMA_VERSION
+        assert loaded.profile_name == original.profile_name
+        assert loaded.default_methodology == original.default_methodology
+        assert loaded.setup_completed == original.setup_completed
+        assert asdict(loaded.models) == asdict(original.models)
+        assert asdict(loaded.updates) == asdict(original.updates)
+        assert loaded.watcher == original.watcher
+        assert loaded.para == original.para
+
+    def test_future_version_loads_best_effort_with_warning(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Config newer than the binary loads best-effort with a WARNING.
+
+        If a user opts back into alpha after running beta, the alpha binary
+        sees a future-version config. Per ``src/config/migrations.py`` the
+        load proceeds best-effort with a WARNING. This test pins that
+        contract — without it, a future change to make future-version
+        configs hard-fail would silently break the alpha→beta→alpha
+        round-trip flow that beta-criteria §3 implicitly relies on.
+        """
+        original = _make_realistic_config()
+        manager = ConfigManager(config_dir=tmp_path)
+        manager.save(original)
+
+        config_file = manager.config_path
+        with config_file.open("r") as f:
+            data = yaml.safe_load(f)
+        # As above, mutate the profile-scoped version, not top-level.
+        data["profiles"]["default"]["version"] = "99.0"  # synthetic future
+        with config_file.open("w") as f:
+            yaml.safe_dump(data, f)
+
+        # `config.manager` uses stdlib logging; caplog captures it directly.
+        # Set level on the specific logger to defeat any propagation tweaks
+        # other tests may have left in the global root.
+        with caplog.at_level(logging.WARNING, logger="config.manager"):
+            loaded = ConfigManager(config_dir=tmp_path).load()
+
+        # Loaded best-effort: known fields preserved.
+        assert loaded.profile_name == original.profile_name
+        assert loaded.setup_completed == original.setup_completed
+        # And a warning was emitted naming the offending version. Check
+        # both `getMessage()` (formatted) and the raw `args` tuple — the
+        # warning uses %s formatting so the version may show up either
+        # in the formatted text or the args list depending on capture
+        # timing.
+        warned_for_future_version = any(
+            "99.0" in rec.getMessage() or "99.0" in str(rec.args or ()) for rec in caplog.records
+        )
+        assert warned_for_future_version, (
+            "Expected a WARNING naming the future version; got: "
+            f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
+        )


### PR DESCRIPTION
## Summary

Step 2C of the alpha→beta hardening plan. Adds three CI-blocking tests that pin the schema-frozen promise from [docs/release/beta-criteria.md](docs/release/beta-criteria.md) §3.

The promise: any config written by 2.0.0-beta.X reads cleanly under 2.0.0-beta.Y for all X, Y. The AppConfig schema stays at v1.0 for the duration of beta. Without a CI guard, a refactor could silently drop fields and we'd find out from a beta tester.

## What changed

| Test | What it pins |
|---|---|
| `TestConfigRoundTrip.test_save_load_round_trip_at_current_version` | `save()` → `load()` is lossless on a fully-populated config (non-default values across the surface). `asdict()` comparison catches sub-dataclass field drift in `ModelPreset` / `UpdateSettings`. |
| `TestConfigCrossVersionRoundTrip.test_synthetic_future_version_preserves_known_fields` | Exercises the migration walker via `monkeypatch.setitem(MIGRATIONS, ...)` with an identity transform. Proves "adding migrations later won't drop existing fields" without needing an actual migration today. |
| `TestConfigCrossVersionRoundTrip.test_future_version_loads_best_effort_with_warning` | Alpha→beta→alpha downgrade path: a config tagged "99.0" loads best-effort with a `logger.warning(...)` naming the offending version. Without this, a future change to make future-version configs hard-fail would silently break the round-trip flow §3 implicitly relies on. |

All three are dual-marked `@pytest.mark.ci @pytest.mark.integration` so they run on every PR via the `ci` job and contribute to integration coverage.

## Discovery

The test scaffolding initially had two silent no-ops that the strict round-trip assertion caught:

1. `profile_name="beta-tester"` — `ConfigManager.save` keys profiles by `config.profile_name` while `load()` defaults to `profile="default"`, so a custom name silently fell back to defaults on load (every assertion passed by coincidence on the empty-defaults path).
2. `data["version"]` mutation at top-level — the version actually lives at `data["profiles"][profile]["version"]`, so top-level mutations had zero effect on the migration walker.

Both gotchas are documented inline so future test authors don't repeat them.

## Test plan

- [x] `bash .claude/scripts/pre-commit-validation.sh` (full local validation, all gates pass)
- [x] `pytest tests/integration/test_config_schema_stability.py -v` — 3/3 passing locally
- [ ] CI: lint, type-check, ci-marker tests, integration tests

## Reviewer focus areas

1. **Round-trip strictness** — `asdict()` comparison vs field-by-field. The first form catches sub-dataclass drift but is harder to debug; the second is more forgiving but can miss accidents. The first test uses `asdict()`, the second uses field-by-field. Reasonable to flip if you'd prefer consistency.
2. **`monkeypatch.setitem(MIGRATIONS, "0.9", ...)`** — does this leak across xdist workers? `MIGRATIONS` is a module-level dict; `monkeypatch.setitem` is function-scoped and restores on teardown, so leakage shouldn't happen. Worth a sanity check.
3. **Stdlib `caplog` vs loguru** — `config.manager` uses stdlib logging (line 39: `logger = logging.getLogger(__name__)`), so `caplog` works directly. If we ever migrate that module to loguru, the third test would need a loguru sink fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests to validate config schema stability and backward compatibility across versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->