### PR TITLE
chore(ci): sync pre-commit hook and validation script

### DIFF
--- a/.claude/scripts/pre-commit-validation.sh
+++ b/.claude/scripts/pre-commit-validation.sh
@@ -137,7 +137,12 @@ _src_py_changed=$(
 if [[ -n "$_src_py_changed" ]]; then
   echo "▶ Diff coverage gate (≥80% of changed lines)"
   pytest tests/ -q --override-ini="addopts=" --cov=src --cov-report=xml:coverage.xml --no-header
-  diff-cover coverage.xml --compare-branch="$_merge_base" --fail-under=80
+  # `--include-untracked` matches the trigger logic above: we treat new
+  # un-`git add`-ed src files as part of the validation scope, so
+  # diff-cover must also evaluate their lines. Without this flag, an
+  # untracked file would trigger the gate but fall outside diff-cover's
+  # default analysis, producing a false pass per Codex P2 review.
+  diff-cover coverage.xml --compare-branch="$_merge_base" --fail-under=80 --include-untracked
   echo "✓ Diff coverage gate"
   echo ""
 else

--- a/.claude/scripts/pre-commit-validation.sh
+++ b/.claude/scripts/pre-commit-validation.sh
@@ -103,33 +103,31 @@ run_step "Validate pre-commit configuration" pre-commit validate-config
 
 run_step "Run pre-commit on all files" pre-commit run --all-files
 
-run_step "Run semantic CI guardrails" pytest tests/ci -q --no-cov --override-ini="addopts="
-
-# ---------------------------------------------------------------------------
-# Docstring coverage gate (fast, no optional deps)
-# ---------------------------------------------------------------------------
-
-echo "▶ Docstring coverage gate (≥95%)"
-interrogate -v src/ --fail-under 95 -q
-echo "✓ Docstring coverage"
-echo ""
-
 # ---------------------------------------------------------------------------
 # Diff coverage gate (≥80% of changed lines must be covered)
-# Mirrors CI step in .github/workflows/ci.yml lines 184-185.
-# Skips gracefully when: not on a branch, no coverage.xml, or diff-cover
-# is not installed.
+# Mirrors the diff-cover hook in .pre-commit-config.yaml.
+# That hook uses --cached and is a no-op when run via --all-files, so we
+# run it here explicitly against the full branch diff.
+# Generates a fresh coverage.xml then compares against the merge base.
+# Skips only if no src/ Python files changed on this branch.
 # ---------------------------------------------------------------------------
 
-CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || true)
-if [[ -n "$CURRENT_BRANCH" ]] && command -v diff-cover &>/dev/null && [[ -f coverage.xml ]]; then
-  echo "▶ Diff coverage gate (>=80% of changed lines)"
-  git fetch origin main --quiet 2>/dev/null || true
-  diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
+git fetch origin main --quiet 2>/dev/null || true
+_diff_base="origin/main"
+if ! git rev-parse --verify "$_diff_base" >/dev/null 2>&1; then
+  _diff_base="main"
+fi
+_merge_base=$(git merge-base HEAD "$_diff_base" 2>/dev/null || echo "$_diff_base")
+_src_py_changed=$(git diff --name-only --diff-filter=ACMR "${_diff_base}...HEAD" -- 'src/*.py' 'src/**/*.py' 2>/dev/null | head -1)
+
+if [[ -n "$_src_py_changed" ]]; then
+  echo "▶ Diff coverage gate (≥80% of changed lines)"
+  pytest tests/ -q --override-ini="addopts=" --cov=src --cov-report=xml:coverage.xml --no-header
+  diff-cover coverage.xml --compare-branch="$_merge_base" --fail-under=80
   echo "✓ Diff coverage gate"
   echo ""
 else
-  echo "ℹ Diff coverage gate skipped (not on a branch, no coverage.xml, or diff-cover not installed)."
+  echo "ℹ Diff coverage gate skipped (no src/ Python changes on this branch)."
   echo ""
 fi
 

--- a/.claude/scripts/pre-commit-validation.sh
+++ b/.claude/scripts/pre-commit-validation.sh
@@ -118,7 +118,21 @@ if ! git rev-parse --verify "$_diff_base" >/dev/null 2>&1; then
   _diff_base="main"
 fi
 _merge_base=$(git merge-base HEAD "$_diff_base" 2>/dev/null || echo "$_diff_base")
-_src_py_changed=$(git diff --name-only --diff-filter=ACMR "${_diff_base}...HEAD" -- 'src/*.py' 'src/**/*.py' 2>/dev/null | head -1)
+# Codex P2 (PR #239 review): include unstaged + untracked src edits,
+# not just committed-on-branch ones. Without this, running validation
+# on a branch currently equal to main but with local working-tree edits
+# skipped the gate entirely — which is exactly the pre-commit scenario
+# we want covered. Three sources, deduped:
+#   1. Committed changes on this branch vs base (X...HEAD)
+#   2. Unstaged + staged working-tree changes (git diff HEAD)
+#   3. Untracked files (git ls-files --others --exclude-standard)
+_src_py_changed=$(
+  {
+    git diff --name-only --diff-filter=ACMR "${_diff_base}...HEAD" -- 'src/*.py' 'src/**/*.py' 2>/dev/null
+    git diff --name-only --diff-filter=ACMR HEAD -- 'src/*.py' 'src/**/*.py' 2>/dev/null
+    git ls-files --others --exclude-standard -- 'src/*.py' 'src/**/*.py' 2>/dev/null
+  } | sort -u | head -1
+)
 
 if [[ -n "$_src_py_changed" ]]; then
   echo "▶ Diff coverage gate (≥80% of changed lines)"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -195,6 +195,13 @@ repos:
         language: system
         pass_filenames: false
 
+      - id: docstring-coverage
+        name: docstring coverage (≥95%)
+        entry: interrogate src/ --fail-under 95 -q
+        language: system
+        pass_filenames: false
+        files: ^src/.*\.py$
+
       - id: pytest-affected
         name: pytest (affected tests)
         entry: bash -c "if ! PATHS=$(python scripts/select_tests_for_changes.py --staged --format args); then echo 'affected-test selector failed' >&2; exit 1; fi; [ -z \"$PATHS\" ] && exit 0; pytest $PATHS -q --override-ini='addopts=' --timeout=60"

--- a/docs/developer/guardrails.md
+++ b/docs/developer/guardrails.md
@@ -31,11 +31,10 @@ That command must expand to this canonical command set:
 
 1. `pre-commit validate-config`
 2. `pre-commit run --all-files`
-3. `pytest tests/ci -q --no-cov --override-ini="addopts="`
 
 Why this split:
 - `pre-commit` is the staged-file gate — `--all-files` ensures local and CI run the same hooks
-- `tests/ci` is the semantic gate
+- `tests/ci` is the semantic gate, invoked via the `pytest-ci-lint` hook inside `pre-commit run --all-files`
 - the shell script is just the orchestrator
 
 ## How to Add a New Guardrail

--- a/tests/ci/test_guardrail_governance.py
+++ b/tests/ci/test_guardrail_governance.py
@@ -53,7 +53,6 @@ def test_pre_pr_script_runs_canonical_enforced_layers() -> None:
     assert commands == [
         "pre-commit validate-config",
         "pre-commit run --all-files",
-        'pytest tests/ci -q --no-cov --override-ini="addopts="',
     ]
     assert "git ls-files --others --exclude-standard" in source
 


### PR DESCRIPTION
## Summary

- **Added `docstring-coverage` hook** to `.pre-commit-config.yaml` — `interrogate src/ --fail-under 95` was enforced by the validation script but missing from the actual git hook, so commits could land with 0% docstring coverage without being blocked
- **Removed redundant `pytest tests/ci` step** from the script — `pre-commit run --all-files` already invokes `pytest-ci-lint`, which runs the same command; running it twice added noise with no benefit
- **Rewrote the diff-cover block** in the script — the hook's `diff-cover` entry uses `git diff --cached` and is silently a no-op when called via `--all-files`; the script was also conditional on a pre-existing `coverage.xml`, silently skipping the gate on a clean checkout; now generates a fresh `coverage.xml` via `pytest tests/` and compares against the real merge base
- Updated `docs/developer/guardrails.md` and `tests/ci/test_guardrail_governance.py` to reflect the shorter canonical command set (semantic CI gate is now invoked inside `pre-commit run --all-files` via the `pytest-ci-lint` hook, not as a separate orchestrator step)

**Motivation**: agents were skipping one or the other; both are now independently comprehensive with no redundancy within each.

## Test plan

- [x] All pre-commit hooks pass locally (committed cleanly)
- [x] `test_pre_pr_script_runs_canonical_enforced_layers` updated and passes
- [x] `test_guardrail_docs_define_canonical_homes_and_conventions` updated and passes
- [x] `diff-cover gate (80%)` hook passes in CI run above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added docstring coverage validation requiring 95% minimum coverage across Python source files, automatically enforced via pre-commit hook.

* **Documentation**
  * Updated developer workflow documentation to reflect updated CI gate configuration.

* **Tests**
  * Updated CI guardrail test assertions to align with pre-commit hook configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->