### PR TITLE
feat(cli): --debug flag, global setup gate, hint-rich config errors (Step 3) + main-CI fixes

### DIFF
--- a/docs/testing/testing-strategy.md
+++ b/docs/testing/testing-strategy.md
@@ -51,6 +51,7 @@ pytest -k "backup or dedup"                        # Filter by name
 @pytest.mark.regression    # Regression tests (full suite only)
 @pytest.mark.no_ollama     # Tests that verify fallback behavior when Ollama is unavailable
 @pytest.mark.playwright    # Browser-based E2E tests (requires: playwright install chromium; run with --override-ini='addopts=')
+@pytest.mark.uses_setup_gate  # Opt-out of the autouse setup-gate bypass (for tests that exercise the gate directly)
 
 def test_example():
     pass

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -750,3 +750,24 @@ ollama ps
 # Restart Ollama if unresponsive
 ollama serve
 ```
+
+## Filing a bug report
+
+If you hit an error, the most useful thing you can attach to a bug report is
+the output with `--debug` enabled:
+
+```bash
+fo --debug <your command and args>
+```
+
+`--debug` enables verbose logging and surfaces the full traceback when an
+error occurs. Without it, the CLI prints only the error summary, which is
+often not enough for triage.
+
+Your bug report should include:
+
+- The full output of `fo --debug <command>` (use the [Beta bug
+  template](https://github.com/curdriceaurora/fo-core/issues/new?template=beta-bug.md))
+- Output of `fo doctor` (Ollama + dependency check)
+- Your OS, Python version, and `fo version`
+- Minimal reproduction steps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -332,6 +332,7 @@ markers = [
     "e2e: end-to-end tests against real file trees (no Ollama required)",
     "benchmark: performance benchmark tests (use --benchmark-only to run)",
     "asyncio: marks tests as async (requires pytest-asyncio)",
+    "uses_setup_gate: opt-out of the tests/cli autouse setup-gate bypass — for tests that exercise the gate directly",
     "playwright: browser-based E2E tests (requires playwright install chromium; run with --override-ini='addopts=')",
 ]
 filterwarnings = [

--- a/src/cli/config_cli.py
+++ b/src/cli/config_cli.py
@@ -58,11 +58,16 @@ def config_edit(
 ) -> None:
     """Edit a configuration profile."""
     from config import ConfigManager
+    from utils.cli_errors import format_validation_error
 
     _VALID_DEVICES = {"auto", "cpu", "cuda", "mps", "metal"}
     _VALID_METHODOLOGIES = {"none", "para", "jd"}
 
-    # Validate constrained inputs before touching the config file.
+    # Validate constrained inputs before touching the config file. Use
+    # `format_validation_error` so each site emits a "valid values: ..."
+    # tail plus a "did you mean 'cuda'?" suggestion when the input is a
+    # near-typo. Pulling from `_VALID_*` constants keeps the error in
+    # sync with the validator (a future addition flows automatically).
     if temperature is not None and not (0.0 <= temperature <= 1.0):
         console.print(
             f"[red]Error: temperature must be between 0.0 and 1.0 (got {temperature}).[/red]"
@@ -70,13 +75,12 @@ def config_edit(
         raise typer.Exit(code=1)
     if device is not None and device not in _VALID_DEVICES:
         console.print(
-            f"[red]Error: device must be one of {sorted(_VALID_DEVICES)} (got '{device}').[/red]"
+            f"[red]Error: {format_validation_error(field='device', value=device, valid_values=sorted(_VALID_DEVICES))}[/red]"
         )
         raise typer.Exit(code=1)
     if methodology is not None and methodology not in _VALID_METHODOLOGIES:
         console.print(
-            f"[red]Error: methodology must be one of "
-            f"{sorted(_VALID_METHODOLOGIES)} (got '{methodology}').[/red]"
+            f"[red]Error: {format_validation_error(field='methodology', value=methodology, valid_values=sorted(_VALID_METHODOLOGIES))}[/red]"
         )
         raise typer.Exit(code=1)
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -53,6 +53,24 @@ def _version_callback(value: bool) -> None:
     raise typer.Exit()
 
 
+_SETUP_GATE_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "setup",
+        "version",
+        "doctor",
+        "update",
+        "recover",
+        "config",
+        "hardware-info",
+    }
+)
+"""Commands that work pre-setup. They're either bootstrap (`setup`,
+`config`), read-only diagnostics (`doctor`, `version`, `hardware-info`),
+the updater, or emergency recovery. Adding a command here relaxes the
+first-run gate for it — verify the command doesn't write or organize
+files first."""
+
+
 @app.callback()
 def main_callback(
     ctx: typer.Context,
@@ -62,6 +80,14 @@ def main_callback(
     yes: bool = typer.Option(False, "--yes", "-y", help="Auto-confirm all prompts."),
     interactive: bool = typer.Option(
         True, "--interactive/--no-interactive", help="Toggle interactive prompts."
+    ),
+    debug: bool = typer.Option(
+        False,
+        "--debug",
+        help=(
+            "Enable verbose logging and surface tracebacks on errors. "
+            "Required for filing useful beta bug reports."
+        ),
     ),
     version_flag: bool = typer.Option(
         False,
@@ -88,7 +114,21 @@ def main_callback(
         json_output=json_output,
         yes=yes,
         no_interactive=not interactive,
+        debug=debug,
     )
+
+    if debug:
+        # Install a loguru DEBUG-level stderr handler so every
+        # `loguru.logger.*` call across `src/` surfaces during this
+        # invocation. `backtrace=True, diagnose=True` give Rich-style
+        # tracebacks for any swallowed exception logged via
+        # `logger.exception(...)`. Adding here (vs at module import)
+        # keeps the no-debug path zero-overhead.
+        import sys as _sys
+
+        from loguru import logger as _loguru_logger
+
+        _loguru_logger.add(_sys.stderr, level="DEBUG", backtrace=True, diagnose=True)
 
     from utils.log_redact import install_on_root
 
@@ -112,6 +152,17 @@ def main_callback(
     # state (unlink, compact) before the preview ran and then report
     # "no retained entries" — breaking the read-only contract and
     # making the preview unreliable.
+    # Step 3 (UX): the first-run setup gate covered only `organize`/`preview`
+    # before — every other command would fail with cryptic stack traces if
+    # the user hadn't run `fo setup` yet. Promote the check to the callback
+    # so all entry commands except an explicit allowlist get the friendly
+    # "First-time setup required" panel. The allowlist holds bootstrap +
+    # read-only diagnostic commands.
+    if ctx.invoked_subcommand and ctx.invoked_subcommand not in _SETUP_GATE_ALLOWLIST:
+        from cli.organize import _check_setup_completed
+
+        _check_setup_completed()
+
     if ctx.invoked_subcommand != "recover":
         try:
             _durable_move_sweep(_default_journal_path())

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -120,15 +120,19 @@ def main_callback(
     if debug:
         # Install a loguru DEBUG-level stderr handler so every
         # `loguru.logger.*` call across `src/` surfaces during this
-        # invocation. `backtrace=True, diagnose=True` give Rich-style
-        # tracebacks for any swallowed exception logged via
-        # `logger.exception(...)`. Adding here (vs at module import)
+        # invocation. `backtrace=True` gives frame-linked tracebacks for
+        # swallowed exceptions logged via `logger.exception(...)`.
+        # `diagnose=False` (deliberately): diagnose=True annotates each
+        # frame with local variable values, which can expose credentials,
+        # API keys, or other sensitive runtime state when the output is
+        # shared in a bug report. Adding here (vs at module import)
         # keeps the no-debug path zero-overhead.
         import sys as _sys
 
         from loguru import logger as _loguru_logger
 
-        _loguru_logger.add(_sys.stderr, level="DEBUG", backtrace=True, diagnose=True)
+        _sink_id = _loguru_logger.add(_sys.stderr, level="DEBUG", backtrace=True, diagnose=False)
+        ctx.call_on_close(lambda: _loguru_logger.remove(_sink_id))
 
     from utils.log_redact import install_on_root
 
@@ -158,7 +162,14 @@ def main_callback(
     # so all entry commands except an explicit allowlist get the friendly
     # "First-time setup required" panel. The allowlist holds bootstrap +
     # read-only diagnostic commands.
-    if ctx.invoked_subcommand and ctx.invoked_subcommand not in _SETUP_GATE_ALLOWLIST:
+    # ctx.resilient_parsing is True when Click is parsing for completion
+    # or --help. Skip the gate in that case so `fo organize --help` works
+    # pre-setup without showing "First-time setup required".
+    if (
+        ctx.invoked_subcommand
+        and ctx.invoked_subcommand not in _SETUP_GATE_ALLOWLIST
+        and not ctx.resilient_parsing
+    ):
         from cli.organize import _check_setup_completed
 
         _check_setup_completed()

--- a/src/cli/organize.py
+++ b/src/cli/organize.py
@@ -129,8 +129,9 @@ def organize(
     ),
 ) -> None:
     """Organize files in a directory using AI models."""
-    # Check if setup has been completed
-    _check_setup_completed()
+    # First-run setup gate now lives in `cli.main.main_callback` and runs
+    # for every non-allowlisted command. The previous inline call here
+    # is removed (Step 3); leaving both would double-print the panel.
 
     # A.cli: resolve + validate both path args before any filesystem work.
     # Input must exist and be a dir; output may not exist yet (the
@@ -167,6 +168,11 @@ def organize(
         )
     except Exception as exc:
         console.print(f"[red]Error: {exc}[/red]")
+        # Step 3: surface the full Rich traceback when --debug is set so
+        # beta testers can attach actionable repro info to bug reports.
+        # Without --debug, only the red one-liner shows (current behavior).
+        if _get_state().debug:
+            console.print_exception(show_locals=False)
         raise typer.Exit(code=1) from exc
 
 
@@ -222,8 +228,7 @@ def preview(
     ),
 ) -> None:
     """Preview how files would be organized (dry-run)."""
-    # Check if setup has been completed
-    _check_setup_completed()
+    # Setup gate moved to `cli.main.main_callback` (Step 3).
 
     # A.cli: single-path validation — preview never writes, so no
     # output-dir pair check needed.
@@ -250,4 +255,6 @@ def preview(
         console.print(f"[green]Preview:[/green] {result.total_files} files would be organized")
     except Exception as exc:
         console.print(f"[red]Error: {exc}[/red]")
+        if _get_state().debug:
+            console.print_exception(show_locals=False)
         raise typer.Exit(code=1) from exc

--- a/src/cli/state.py
+++ b/src/cli/state.py
@@ -19,6 +19,11 @@ class CLIState:
     json_output: bool = False
     yes: bool = False
     no_interactive: bool = False
+    # When true, --debug installs a loguru DEBUG-level stderr handler and
+    # CLI exception handlers surface full Rich tracebacks via
+    # console.print_exception(). This is the contract `fo --debug <cmd>`
+    # offers beta testers for filing actionable bug reports.
+    debug: bool = False
 
 
 def _get_state() -> CLIState:

--- a/src/utils/cli_errors.py
+++ b/src/utils/cli_errors.py
@@ -1,0 +1,55 @@
+"""Helpers for hint-rich CLI validation errors.
+
+Beta-criteria §2: bare error messages like "Invalid value 'cdua' for
+device" make beta testers re-read the docs to discover valid values.
+This helper centralizes the format so error sites can pass a `valid_values`
+list once and get a "valid values: …" tail plus a "did you mean 'cuda'?"
+suggestion when the input is a near-typo. Caller passes the canonical
+constant (e.g. ``sorted(_VALID_DEVICES)``) so a future addition to that
+constant flows into the message automatically.
+"""
+
+from __future__ import annotations
+
+import difflib
+from collections.abc import Iterable
+
+
+def format_validation_error(
+    *,
+    field: str,
+    value: object,
+    valid_values: Iterable[str],
+) -> str:
+    """Format a validation error with valid-values list and 'did you mean'.
+
+    The output is a single-line plain string suitable for embedding in a
+    Rich-marked-up panel (e.g. ``console.print(f"[red]{...}[/red]")``).
+    The caller is responsible for the styling — this helper deliberately
+    emits no markup so it's also usable in plain stdout/stderr contexts
+    and JSON error payloads without escape concerns.
+
+    Args:
+        field: The config / option name being validated, used in the
+            "Invalid value … for {field}" prefix.
+        value: The user-supplied value that failed validation. Quoted via
+            ``repr`` so a stray newline / non-ASCII char is visible
+            rather than silently embedded in the message.
+        valid_values: The canonical set of acceptable values. The caller
+            should pass the same constant the validator checks against
+            so the message stays in sync with the schema (avoid inlining
+            literal lists here).
+
+    Returns:
+        A multi-clause string: ``"Invalid value 'X' for device. Valid
+        values: auto, cpu, cuda, mps. Did you mean 'cuda'?"``. The
+        "did you mean" clause appears only when a fuzzy match exceeds the
+        ``difflib`` cutoff (0.6) and ``value`` is a string.
+    """
+    valid = list(valid_values)
+    base = f"Invalid value {value!r} for {field}. Valid values: {', '.join(valid)}."
+    if isinstance(value, str):
+        close = difflib.get_close_matches(value, valid, n=1, cutoff=0.6)
+        if close:
+            base += f" Did you mean {close[0]!r}?"
+    return base

--- a/tests/cli/test_cli_config.py
+++ b/tests/cli/test_cli_config.py
@@ -136,15 +136,25 @@ class TestConfigEdit:
 
     @patch("config.ConfigManager")
     def test_edit_invalid_device(self, mock_cls: MagicMock) -> None:
+        # Step 3 swapped the validation-error format from "device must be
+        # one of [...]" to the hint-rich "Invalid value 'tpu' for device.
+        # Valid values: ..." style (lists valid values + "did you mean").
+        # Use wrap-immune word checks since Rich may break long messages.
         result = runner.invoke(app, ["config", "edit", "--device", "tpu"])
         assert result.exit_code == 1
-        assert "device must be one of" in result.output
+        normalized = " ".join(result.output.lower().split())
+        assert "invalid value" in normalized
+        assert "device" in normalized
+        assert "'tpu'" in normalized
 
     @patch("config.ConfigManager")
     def test_edit_invalid_methodology(self, mock_cls: MagicMock) -> None:
         result = runner.invoke(app, ["config", "edit", "--methodology", "custom"])
         assert result.exit_code == 1
-        assert "methodology must be one of" in result.output
+        normalized = " ".join(result.output.lower().split())
+        assert "invalid value" in normalized
+        assert "methodology" in normalized
+        assert "'custom'" in normalized
 
     @patch("config.ConfigManager")
     def test_edit_valid_device(self, mock_cls: MagicMock) -> None:

--- a/tests/cli/test_cli_organize.py
+++ b/tests/cli/test_cli_organize.py
@@ -110,6 +110,8 @@ class TestOrganize:
             prefetch_depth=2,
             enable_vision=True,
             no_prefetch=False,
+            transcribe_audio=False,
+            max_transcribe_seconds=600.0,
         )
 
     @patch("core.organizer.FileOrganizer")
@@ -132,6 +134,8 @@ class TestOrganize:
             prefetch_depth=2,
             enable_vision=True,
             no_prefetch=False,
+            transcribe_audio=False,
+            max_transcribe_seconds=600.0,
         )
 
     @patch("core.organizer.FileOrganizer")
@@ -166,6 +170,8 @@ class TestOrganize:
             prefetch_depth=1,
             enable_vision=False,
             no_prefetch=False,
+            transcribe_audio=False,
+            max_transcribe_seconds=600.0,
         )
 
     @patch("core.organizer.FileOrganizer")
@@ -193,6 +199,8 @@ class TestOrganize:
             prefetch_depth=0,
             enable_vision=True,
             no_prefetch=False,
+            transcribe_audio=False,
+            max_transcribe_seconds=600.0,
         )
 
     @patch("core.organizer.FileOrganizer")
@@ -245,6 +253,8 @@ class TestOrganize:
             prefetch_depth=2,
             enable_vision=False,
             no_prefetch=False,
+            transcribe_audio=False,
+            max_transcribe_seconds=600.0,
         )
 
     @patch("core.organizer.FileOrganizer")
@@ -272,6 +282,8 @@ class TestOrganize:
             prefetch_depth=0,
             enable_vision=True,
             no_prefetch=True,
+            transcribe_audio=False,
+            max_transcribe_seconds=600.0,
         )
 
     @patch("core.organizer.FileOrganizer")
@@ -306,6 +318,8 @@ class TestOrganize:
             prefetch_depth=0,
             enable_vision=True,
             no_prefetch=False,
+            transcribe_audio=False,
+            max_transcribe_seconds=600.0,
         )
 
     @patch("core.organizer.FileOrganizer")
@@ -333,6 +347,8 @@ class TestOrganize:
             prefetch_depth=0,
             enable_vision=True,
             no_prefetch=False,
+            transcribe_audio=False,
+            max_transcribe_seconds=600.0,
         )
 
     @patch(
@@ -385,6 +401,8 @@ class TestPreview:
             prefetch_depth=2,
             enable_vision=True,
             no_prefetch=False,
+            transcribe_audio=False,
+            max_transcribe_seconds=600.0,
         )
 
     @patch("core.organizer.FileOrganizer")
@@ -401,6 +419,8 @@ class TestPreview:
             prefetch_depth=2,
             enable_vision=True,
             no_prefetch=False,
+            transcribe_audio=False,
+            max_transcribe_seconds=600.0,
         )
 
     @patch("core.organizer.FileOrganizer")
@@ -417,6 +437,8 @@ class TestPreview:
             prefetch_depth=0,
             enable_vision=True,
             no_prefetch=False,
+            transcribe_audio=False,
+            max_transcribe_seconds=600.0,
         )
 
     @patch("core.organizer.FileOrganizer")
@@ -433,6 +455,8 @@ class TestPreview:
             prefetch_depth=2,
             enable_vision=False,
             no_prefetch=False,
+            transcribe_audio=False,
+            max_transcribe_seconds=600.0,
         )
 
     @patch("core.organizer.FileOrganizer")
@@ -449,6 +473,8 @@ class TestPreview:
             prefetch_depth=2,
             enable_vision=False,
             no_prefetch=False,
+            transcribe_audio=False,
+            max_transcribe_seconds=600.0,
         )
 
     @patch("core.organizer.FileOrganizer")
@@ -465,6 +491,8 @@ class TestPreview:
             prefetch_depth=0,
             enable_vision=True,
             no_prefetch=True,
+            transcribe_audio=False,
+            max_transcribe_seconds=600.0,
         )
 
     def test_preview_sequential_conflicts_with_max_workers(self, tmp_path: Path) -> None:

--- a/tests/cli/test_config_validation_hints.py
+++ b/tests/cli/test_config_validation_hints.py
@@ -1,0 +1,99 @@
+"""Test that config edit errors include valid-values hints.
+
+Step 3 replaced bare "must be one of [...]" messages with the new
+`format_validation_error` helper, which adds a "did you mean" suggestion
+when the input is a near-typo. Pins both:
+- The valid-values list appears verbatim (so `_VALID_*` constant
+  additions automatically flow into the message).
+- A near-typo gets a `'did you mean ...'` suggestion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from cli.main import app
+
+
+@pytest.fixture
+def isolated_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolate config from the real user config dir.
+
+    Bypass the global setup gate too — this test is about validation
+    error formatting, not the gate.
+    """
+    monkeypatch.setattr("config.manager.DEFAULT_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr("cli.organize._check_setup_completed", lambda: True)
+    return tmp_path
+
+
+@pytest.mark.integration
+@pytest.mark.ci
+def test_config_edit_invalid_device_includes_valid_values(
+    isolated_config: Path,
+) -> None:
+    """A typo'd `--device cdua` produces a hint-rich error.
+
+    Rich wraps long error strings across newlines on narrow terminals;
+    normalize whitespace + check word components individually so the
+    assertions are wrap-immune.
+    """
+    runner = CliRunner()
+    result = runner.invoke(app, ["config", "edit", "--device", "cdua"])
+    assert result.exit_code != 0, result.output
+    normalized = " ".join(result.output.lower().split())
+    # All valid devices appear so the user can pick one.
+    assert "auto" in normalized
+    assert "cuda" in normalized
+    assert "mps" in normalized
+    # And the close-match suggestion fires for the typo.
+    assert "did" in normalized
+    assert "you mean" in normalized
+    assert "'cuda'" in normalized  # the suggested correction (quoted)
+
+
+@pytest.mark.integration
+@pytest.mark.ci
+def test_config_edit_invalid_methodology_includes_valid_values(
+    isolated_config: Path,
+) -> None:
+    """Methodology gets the same treatment as device.
+
+    Use ``parq`` (one-char typo of ``para``, edit-distance 1) so the
+    difflib 0.6 cutoff fires reliably. Shorter typos like ``pra`` fall
+    below the threshold and return no suggestion — that's a feature
+    of the helper (silent on uncertain matches), pinned in
+    ``test_no_suggestion_when_input_is_distant_from_all_valid``.
+    """
+    runner = CliRunner()
+    result = runner.invoke(app, ["config", "edit", "--methodology", "parq"])
+    assert result.exit_code != 0, result.output
+    normalized = " ".join(result.output.lower().split())
+    assert "para" in normalized
+    assert "jd" in normalized
+    # Rich may wrap "Did you mean" across a newline; check word
+    # components individually for wrap-immunity.
+    assert "did" in normalized
+    assert "you mean" in normalized
+    assert "'para'" in normalized  # suggested correction (quoted)
+
+
+@pytest.mark.integration
+@pytest.mark.ci
+def test_config_edit_distant_value_no_suggestion(isolated_config: Path) -> None:
+    """When the input is too far from any valid value, no 'did you mean'
+    appears — better to say nothing than to suggest something obviously
+    wrong."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["config", "edit", "--device", "zzzzzz"])
+    assert result.exit_code != 0, result.output
+    normalized = " ".join(result.output.lower().split())
+    assert "auto" in normalized  # valid-values list still appears
+    # The "Did you mean" clause must NOT appear at all (any word order
+    # / wrap permutation). The most reliable check: the suggestion
+    # phrase requires "you mean" right after "did" — both absent
+    # together is the contract.
+    assert "you mean" not in normalized

--- a/tests/cli/test_config_validation_hints.py
+++ b/tests/cli/test_config_validation_hints.py
@@ -35,20 +35,20 @@ def isolated_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 def test_config_edit_invalid_device_includes_valid_values(
     isolated_config: Path,
 ) -> None:
-    """A typo'd `--device cdua` produces a hint-rich error.
+    """A typo'd `--device cdua` produces a hint-rich error listing ALL valid devices.
 
     Rich wraps long error strings across newlines on narrow terminals;
     normalize whitespace + check word components individually so the
-    assertions are wrap-immune.
+    assertions are wrap-immune. All five values from ``_VALID_DEVICES``
+    must appear so a future removal would fail this test.
     """
     runner = CliRunner()
     result = runner.invoke(app, ["config", "edit", "--device", "cdua"])
     assert result.exit_code != 0, result.output
     normalized = " ".join(result.output.lower().split())
-    # All valid devices appear so the user can pick one.
-    assert "auto" in normalized
-    assert "cuda" in normalized
-    assert "mps" in normalized
+    # Every value in _VALID_DEVICES must be present in the error message.
+    for value in ("auto", "cpu", "cuda", "metal", "mps"):
+        assert value in normalized, f"missing valid device '{value}' in error output"
     # And the close-match suggestion fires for the typo.
     assert "did" in normalized
     assert "you mean" in normalized
@@ -60,7 +60,7 @@ def test_config_edit_invalid_device_includes_valid_values(
 def test_config_edit_invalid_methodology_includes_valid_values(
     isolated_config: Path,
 ) -> None:
-    """Methodology gets the same treatment as device.
+    """Methodology error lists ALL valid methodology values.
 
     Use ``parq`` (one-char typo of ``para``, edit-distance 1) so the
     difflib 0.6 cutoff fires reliably. Shorter typos like ``pra`` fall
@@ -72,8 +72,9 @@ def test_config_edit_invalid_methodology_includes_valid_values(
     result = runner.invoke(app, ["config", "edit", "--methodology", "parq"])
     assert result.exit_code != 0, result.output
     normalized = " ".join(result.output.lower().split())
-    assert "para" in normalized
-    assert "jd" in normalized
+    # Every value in _VALID_METHODOLOGIES must appear.
+    for value in ("none", "para", "jd"):
+        assert value in normalized, f"missing valid methodology '{value}' in error output"
     # Rich may wrap "Did you mean" across a newline; check word
     # components individually for wrap-immunity.
     assert "did" in normalized

--- a/tests/cli/test_debug_flag.py
+++ b/tests/cli/test_debug_flag.py
@@ -41,11 +41,12 @@ def test_cli_state_debug_defaults_false() -> None:
 def test_debug_flag_installs_loguru_debug_handler(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """--debug attaches a loguru sink at level=DEBUG with backtrace+diagnose.
+    """--debug attaches a loguru sink at level=DEBUG with backtrace=True, diagnose=False.
 
-    Without this the user-visible logs from `loguru.logger.debug(...)`
-    calls scattered across `src/` stay hidden and bug reports lose
-    most of their signal.
+    backtrace=True gives frame-linked tracebacks for swallowed exceptions.
+    diagnose=False is intentional: diagnose annotates frames with local
+    variable values, which can expose credentials or API keys when the
+    output is shared in a bug report.
     """
     captured: list[dict[str, Any]] = []
 
@@ -53,17 +54,20 @@ def test_debug_flag_installs_loguru_debug_handler(
         captured.append(kwargs)
         return 1  # handler id
 
+    def _noop_remove(_handler_id: int) -> None:
+        pass  # ctx.call_on_close fires remove(); no real handler exists in tests
+
     monkeypatch.setattr("loguru.logger.add", _spy_add)
+    monkeypatch.setattr("loguru.logger.remove", _noop_remove)
 
     runner = CliRunner()
     result = runner.invoke(app, ["--debug", "version"])
     assert result.exit_code == 0
     debug_handlers = [c for c in captured if c.get("level") == "DEBUG"]
     assert len(debug_handlers) >= 1
-    # backtrace + diagnose are what give Rich-style tracebacks for
-    # exceptions logged via `logger.exception(...)`.
     assert debug_handlers[0].get("backtrace") is True
-    assert debug_handlers[0].get("diagnose") is True
+    # diagnose=False keeps local variable values out of shared bug reports.
+    assert debug_handlers[0].get("diagnose") is False
 
 
 @pytest.mark.unit

--- a/tests/cli/test_debug_flag.py
+++ b/tests/cli/test_debug_flag.py
@@ -1,0 +1,156 @@
+"""Tests for the global --debug flag.
+
+Pin the contract: `--debug` (a) populates `CLIState.debug=True`, (b)
+installs a loguru DEBUG-level stderr handler at callback time, and (c)
+surfaces a Rich traceback via `console.print_exception` when a CLI
+command's exception handler fires. Without `--debug` only the red
+one-liner appears.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from cli.main import app
+from cli.state import CLIState
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+def test_cli_state_has_debug_field() -> None:
+    """The dataclass exposes the new `debug` field."""
+    state = CLIState(debug=True)
+    assert state.debug is True
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+def test_cli_state_debug_defaults_false() -> None:
+    """Default-constructed CLIState has debug off — backwards-compat
+    contract for any callsite that doesn't explicitly set the flag."""
+    state = CLIState()
+    assert state.debug is False
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+def test_debug_flag_installs_loguru_debug_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--debug attaches a loguru sink at level=DEBUG with backtrace+diagnose.
+
+    Without this the user-visible logs from `loguru.logger.debug(...)`
+    calls scattered across `src/` stay hidden and bug reports lose
+    most of their signal.
+    """
+    captured: list[dict[str, Any]] = []
+
+    def _spy_add(_sink: Any, **kwargs: Any) -> int:
+        captured.append(kwargs)
+        return 1  # handler id
+
+    monkeypatch.setattr("loguru.logger.add", _spy_add)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--debug", "version"])
+    assert result.exit_code == 0
+    debug_handlers = [c for c in captured if c.get("level") == "DEBUG"]
+    assert len(debug_handlers) >= 1
+    # backtrace + diagnose are what give Rich-style tracebacks for
+    # exceptions logged via `logger.exception(...)`.
+    assert debug_handlers[0].get("backtrace") is True
+    assert debug_handlers[0].get("diagnose") is True
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+def test_no_debug_flag_skips_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without --debug, the callback must not install our DEBUG sink.
+
+    Loguru's default sink stays in place; we only assert that we don't
+    *additionally* attach one (no-debug path stays zero-overhead).
+    """
+    captured: list[dict[str, Any]] = []
+
+    def _spy_add(_sink: Any, **kwargs: Any) -> int:
+        captured.append(kwargs)
+        return 1
+
+    monkeypatch.setattr("loguru.logger.add", _spy_add)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert all(c.get("level") != "DEBUG" for c in captured)
+
+
+@pytest.mark.integration
+@pytest.mark.ci
+def test_debug_surfaces_traceback_on_organize_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failing `fo --debug organize ...` shows the traceback in addition
+    to the red error line. Without `--debug` only the red line appears.
+
+    Marked integration so it can call into FileOrganizer's import chain
+    realistically; the gate-bypass + organize.organize patch keep the
+    test fast and deterministic.
+    """
+    # Bypass first-run gate (this test exercises the error-handler path,
+    # not the gate path).
+    monkeypatch.setattr("cli.organize._check_setup_completed", lambda: True)
+
+    # Named raiser per T14: `(_ for _ in ()).throw(...)` is banned —
+    # use a named function so intent is clear.
+    def _raise_runtime(*_a: object, **_kw: object) -> None:
+        raise RuntimeError("boom-from-test")
+
+    monkeypatch.setattr("core.organizer.FileOrganizer.organize", _raise_runtime)
+
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    out_dir = tmp_path / "out"
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--debug", "organize", str(in_dir), str(out_dir)])
+
+    assert result.exit_code == 1
+    # The red one-liner is always there.
+    assert "boom-from-test" in result.output
+    # And under --debug we additionally get the Rich traceback (file:line refs).
+    assert ".py" in result.output  # at least one frame's file path appears
+
+
+@pytest.mark.integration
+@pytest.mark.ci
+def test_no_debug_omits_traceback_on_organize_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Without --debug, only the red one-liner appears — no traceback noise.
+
+    Pins the no-debug contract; if a future refactor accidentally
+    surfaces the traceback unconditionally, this test fails.
+    """
+    monkeypatch.setattr("cli.organize._check_setup_completed", lambda: True)
+
+    # Named raiser per T14.
+    def _raise_quiet(*_a: object, **_kw: object) -> None:
+        raise RuntimeError("boom-quiet")
+
+    monkeypatch.setattr("core.organizer.FileOrganizer.organize", _raise_quiet)
+
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    out_dir = tmp_path / "out"
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["organize", str(in_dir), str(out_dir)])
+
+    assert result.exit_code == 1
+    assert "boom-quiet" in result.output
+    # No "Traceback" header from Rich's print_exception.
+    assert "Traceback" not in result.output

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 from cli.main import app
@@ -19,6 +20,7 @@ def test_version_command():
         assert "fo 1.2.3" in result.stdout
 
 
+@pytest.mark.uses_setup_gate
 @patch("config.manager.ConfigManager")
 def test_organize_requires_setup_completed(mock_cm):
     """organize exits with code 1 when setup is incomplete."""
@@ -28,6 +30,7 @@ def test_organize_requires_setup_completed(mock_cm):
     assert "setup" in result.stdout.lower()
 
 
+@pytest.mark.uses_setup_gate
 @patch("config.manager.ConfigManager")
 def test_preview_requires_setup_completed(mock_cm):
     """preview exits with code 1 when setup is incomplete."""
@@ -61,6 +64,8 @@ def test_organize_command_live(mock_organizer_cls, _mock_setup, tmp_path):
         prefetch_depth=2,
         enable_vision=True,
         no_prefetch=False,
+        transcribe_audio=False,
+        max_transcribe_seconds=600.0,
     )
     mock_instance.organize.assert_called_once_with(in_dir, out_dir)
 
@@ -89,6 +94,8 @@ def test_organize_command_dry_run(mock_organizer_cls, _mock_setup, tmp_path):
         prefetch_depth=2,
         enable_vision=True,
         no_prefetch=False,
+        transcribe_audio=False,
+        max_transcribe_seconds=600.0,
     )
     # A.cli resolves the path args before dispatching; the service sees
     # the canonical absolute form.
@@ -135,6 +142,8 @@ def test_preview_command(mock_organizer_cls, _mock_setup, tmp_path):
         prefetch_depth=2,
         enable_vision=True,
         no_prefetch=False,
+        transcribe_audio=False,
+        max_transcribe_seconds=600.0,
     )
     resolved = in_dir.resolve()
     mock_instance.organize.assert_called_once_with(resolved, resolved)

--- a/tests/cli/test_setup_gate.py
+++ b/tests/cli/test_setup_gate.py
@@ -37,16 +37,41 @@ def fresh_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 @pytest.mark.unit
 @pytest.mark.ci
 @pytest.mark.uses_setup_gate
-@pytest.mark.parametrize("cmd", ["setup", "version", "doctor", "config", "hardware-info"])
-def test_allowlisted_commands_bypass_gate(cmd: str, fresh_config: Path) -> None:
-    """Allowlisted commands must work pre-setup.
+@pytest.mark.parametrize(
+    "cmd_args",
+    [
+        ["version"],  # prints version, no config or services needed
+        ["config", "list"],  # list profiles; returns "No profiles found" on empty dir
+        ["hardware-info"],  # reads local hardware; no config or services needed
+    ],
+)
+def test_allowlisted_commands_bypass_gate(cmd_args: list[str], fresh_config: Path) -> None:
+    """Allowlisted commands reach their handler even when setup_completed=False.
 
-    `--help` always exits 0 regardless of the gate; what matters is
-    that the panel doesn't appear (which would mean the gate ran).
+    Uses real invocations (not ``--help``) because ``--help`` now
+    short-circuits via ``ctx.resilient_parsing`` before the gate logic
+    runs — making ``--help``-based tests vacuous. Real invocations
+    prove the allowlist actually works.
     """
     runner = CliRunner()
-    result = runner.invoke(app, [cmd, "--help"])
+    result = runner.invoke(app, cmd_args)
     assert result.exit_code == 0, result.output
+    assert "First-time setup required" not in result.output
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+@pytest.mark.uses_setup_gate
+@pytest.mark.parametrize("cmd", ["doctor", "setup"])
+def test_allowlisted_entry_commands_not_gated(cmd: str, fresh_config: Path) -> None:
+    """Entry-level allowlisted commands never show the setup gate panel.
+
+    Exit code may be non-zero (doctor service checks may fail; setup
+    expects an interactive tty), but the first-run gate panel must be
+    absent — that's the contract this test pins.
+    """
+    runner = CliRunner()
+    result = runner.invoke(app, [cmd])
     assert "First-time setup required" not in result.output
 
 

--- a/tests/cli/test_setup_gate.py
+++ b/tests/cli/test_setup_gate.py
@@ -1,0 +1,92 @@
+"""Test that the setup gate runs for all commands except an allowlist.
+
+Pins the contract: pre-setup, the gate fires and shows the friendly
+"First-time setup required" panel for every non-allowlisted command;
+allowlisted commands (`setup`, `version`, `doctor`, `update`,
+`recover`, `config`, `hardware-info`) bypass the gate so users can run
+diagnostics or finish setup without a chicken-and-egg loop.
+
+Step 3 promoted the gate from organize/preview to the global Typer
+callback. This test guards against regression — without it, a future
+edit to the allowlist could re-introduce the original bug where every
+non-organize command crashes pre-setup with a cryptic stack trace.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from cli.main import app
+
+
+@pytest.fixture
+def fresh_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Force a config dir where setup_completed is False.
+
+    Patches `config.manager.DEFAULT_CONFIG_DIR` so the gate's
+    `ConfigManager().load()` reads from an empty dir → returns a
+    default `AppConfig(setup_completed=False)`.
+    """
+    monkeypatch.setattr("config.manager.DEFAULT_CONFIG_DIR", tmp_path)
+    return tmp_path
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+@pytest.mark.uses_setup_gate
+@pytest.mark.parametrize("cmd", ["setup", "version", "doctor", "config", "hardware-info"])
+def test_allowlisted_commands_bypass_gate(cmd: str, fresh_config: Path) -> None:
+    """Allowlisted commands must work pre-setup.
+
+    `--help` always exits 0 regardless of the gate; what matters is
+    that the panel doesn't appear (which would mean the gate ran).
+    """
+    runner = CliRunner()
+    result = runner.invoke(app, [cmd, "--help"])
+    assert result.exit_code == 0, result.output
+    assert "First-time setup required" not in result.output
+
+
+@pytest.mark.integration
+@pytest.mark.ci
+@pytest.mark.uses_setup_gate
+def test_organize_blocked_pre_setup(fresh_config: Path, tmp_path: Path) -> None:
+    """`fo organize ...` pre-setup hits the gate and shows the panel.
+
+    Uses real input/output dirs to get past path validation and into
+    the actual gate path. The gate is in `main_callback` so any
+    invocation without `--help` triggers it.
+    """
+    in_dir = tmp_path / "in"
+    in_dir.mkdir()
+    out_dir = tmp_path / "out"
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["organize", str(in_dir), str(out_dir)])
+    # The gate exits the process; result.output carries the panel.
+    assert "First-time setup required" in result.output
+
+
+@pytest.mark.integration
+@pytest.mark.ci
+@pytest.mark.uses_setup_gate
+@pytest.mark.parametrize("cmd", ["search", "analyze"])
+def test_other_entry_commands_blocked_pre_setup(
+    cmd: str, fresh_config: Path, tmp_path: Path
+) -> None:
+    """Step 3's win: search/analyze are now gated like organize.
+
+    Before Step 3, only organize/preview ran the gate; search and
+    analyze would fail pre-setup with cryptic errors. This test pins
+    the new behavior — they show the friendly panel instead.
+    """
+    runner = CliRunner()
+    # `--help` is the safest no-arg invocation; it would show usage
+    # output if the gate didn't fire first.
+    result = runner.invoke(app, [cmd])  # no --help so the gate runs
+    # Some commands may also error on missing required args; the
+    # panel must appear regardless of the secondary failure.
+    assert "First-time setup required" in result.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -217,3 +217,29 @@ def provider_env(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
                 monkeypatch.setenv(name, value)
 
     return _set
+
+
+# ---------------------------------------------------------------------------
+# Step 3: global setup-gate bypass for all CLI-invoking tests.
+# ---------------------------------------------------------------------------
+# The first-run setup gate now lives in `cli.main.main_callback` and runs
+# for every non-allowlisted command. Existing CLI smoke/contract tests
+# don't pre-mark setup as complete (they assumed the command-level gate
+# they patched explicitly), so the gate would block them and break
+# dozens of pre-existing tests.
+#
+# This autouse fixture patches `cli.organize._check_setup_completed` to
+# return True for ALL tests project-wide. Tests that specifically
+# exercise the gate must opt out by adding `@pytest.mark.uses_setup_gate`.
+# Those tests configure the on-disk `setup_completed` flag via a
+# tmp_path config dir and need the gate to actually run.
+@pytest.fixture(autouse=True)
+def _bypass_setup_gate(request: pytest.FixtureRequest) -> object:
+    """Default-bypass the global setup gate; opt-out via `uses_setup_gate` marker."""
+    if request.node.get_closest_marker("uses_setup_gate") is not None:
+        yield
+        return
+    from unittest.mock import patch
+
+    with patch("cli.organize._check_setup_completed", return_value=True):
+        yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,8 +229,13 @@ def provider_env(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
 # dozens of pre-existing tests.
 #
 # This autouse fixture patches `cli.organize._check_setup_completed` to
-# return True for ALL tests project-wide. Tests that specifically
-# exercise the gate must opt out by adding `@pytest.mark.uses_setup_gate`.
+# return True for ALL tests project-wide. The gate in `cli.main` imports
+# this function LAZILY (inside the callback body via
+# `from cli.organize import _check_setup_completed`) rather than at
+# module level, so each invocation re-fetches the attribute from
+# `cli.organize` — patching the origin module is therefore correct.
+# Tests that specifically exercise the gate must opt out by adding
+# `@pytest.mark.uses_setup_gate`.
 # Those tests configure the on-disk `setup_completed` flag via a
 # tmp_path config dir and need the gate to actually run.
 @pytest.fixture(autouse=True)

--- a/tests/services/audio/test_audio_transcriber_service.py
+++ b/tests/services/audio/test_audio_transcriber_service.py
@@ -191,7 +191,10 @@ class TestAudioTranscriberInit:
     def test_default_values(self, transcriber):
         assert transcriber.model_size == ModelSize.BASE
         assert transcriber.device == "cpu"
-        assert transcriber.compute_type == ComputeType.FLOAT16
+        # PR #236 (Step 2A): compute_type default is now device-aware —
+        # CPU defaults to INT8 (CTranslate2 doesn't support efficient
+        # FLOAT16 on CPU). FLOAT16 still applies on CUDA.
+        assert transcriber.compute_type == ComputeType.INT8
         assert transcriber.cache_dir is None
         assert transcriber.num_workers == 1
         assert transcriber._model is None
@@ -237,6 +240,11 @@ class TestDetectDevice:
         assert result == "cuda"
 
     def test_auto_mps(self):
+        # PR #236 (Step 2A): CTranslate2 (the engine under faster-whisper)
+        # doesn't support MPS — `_detect_device` no longer returns "mps"
+        # even when torch reports it available. The Apple Silicon path
+        # falls back to CPU here (and AudioModel coerces explicit MPS
+        # configs to CPU upstream too).
         mock_torch = MagicMock()
         mock_torch.cuda.is_available.return_value = False
         mock_torch.backends.mps.is_available.return_value = True
@@ -244,7 +252,7 @@ class TestDetectDevice:
         with patch.dict("sys.modules", {"torch": mock_torch}):
             t = AudioTranscriber.__new__(AudioTranscriber)
             result = AudioTranscriber._detect_device(t, "auto")
-        assert result == "mps"
+        assert result == "cpu"
 
     def test_auto_cpu_no_torch(self):
         def fake_import(name, *args, **kwargs):

--- a/tests/utils/test_cli_errors.py
+++ b/tests/utils/test_cli_errors.py
@@ -1,0 +1,84 @@
+"""Tests for the CLI validation-error formatter.
+
+Pins the contract that `format_validation_error` (a) lists every valid
+value verbatim, (b) suggests a near-match via difflib, and (c) silently
+omits the "did you mean" clause when the input isn't a string or no
+fuzzy match exists. Step 3 uses this helper to replace bare validation
+errors in `cli/config_cli.py` with hint-rich messages.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from utils.cli_errors import format_validation_error
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+def test_format_validation_error_lists_valid_values() -> None:
+    """Every valid value appears in the message, comma-separated."""
+    msg = format_validation_error(
+        field="device",
+        value="unknown",
+        valid_values=["auto", "cpu", "cuda", "mps"],
+    )
+    assert "device" in msg
+    assert "unknown" in msg
+    assert "auto, cpu, cuda, mps" in msg
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+def test_format_validation_error_suggests_close_match() -> None:
+    """A typo close to a valid value gets a 'did you mean' suggestion."""
+    msg = format_validation_error(
+        field="device",
+        value="cdua",  # typo for "cuda"
+        valid_values=["auto", "cpu", "cuda", "mps"],
+    )
+    assert "did you mean" in msg.lower()
+    assert "cuda" in msg
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+def test_no_suggestion_when_input_is_not_a_string() -> None:
+    """Non-string `value` skips difflib so an `int`/`None` doesn't
+    crash on the type-checked path. The base "Valid values: ..." clause
+    still fires."""
+    msg = format_validation_error(
+        field="max_workers",
+        value=-1,
+        valid_values=["1", "2", "4", "8"],
+    )
+    assert "max_workers" in msg
+    assert "1, 2, 4, 8" in msg
+    assert "did you mean" not in msg.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+def test_no_suggestion_when_input_is_distant_from_all_valid() -> None:
+    """Below difflib's 0.6 cutoff, no suggestion appears — better to
+    say nothing than to suggest something the user obviously didn't mean."""
+    msg = format_validation_error(
+        field="device",
+        value="zzzzzz",
+        valid_values=["auto", "cpu", "cuda", "mps"],
+    )
+    assert "did you mean" not in msg.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+def test_value_is_repr_quoted() -> None:
+    """The bad value is `repr`-quoted so stray whitespace / non-ASCII
+    is visible in the message, not silently embedded."""
+    msg = format_validation_error(
+        field="device",
+        value="cuda\n",  # stray newline
+        valid_values=["auto", "cuda"],
+    )
+    # repr() of a string with newline is "'cuda\\n'" with the literal backslash-n.
+    assert "'cuda\\n'" in msg


### PR DESCRIPTION
## Summary

Step 3 of the alpha→beta plan + RCA-driven fix for the 19 main-CI failures introduced by PRs #236 (Step 2A) and #237 (Step 2B).

Closes the three CLI-surface UX gaps in [docs/release/beta-criteria.md](docs/release/beta-criteria.md) §2 that make beta tester bug reports hard to triage.

## What changed

### Group A: --debug flag

| | |
|---|---|
| `CLIState.debug` | new `bool = False` field |
| `cli/main.py:main_callback` | new `--debug` global option (`fo --debug <command>`); installs loguru DEBUG-level stderr handler with `backtrace=True, diagnose=True` |
| `cli/organize.py` | `organize` + `preview` exception handlers now call `console.print_exception(show_locals=False)` after the red one-liner when `_get_state().debug` is true |
| `docs/troubleshooting.md` | new "Filing a bug report" section pointing testers at `--debug` |

Without `--debug`, only the red one-liner appears (no behavior change for existing users).

### Group B: global setup gate

| | |
|---|---|
| `cli/main.py` | new `_SETUP_GATE_ALLOWLIST` (`setup`, `version`, `doctor`, `update`, `recover`, `config`, `hardware-info` — bootstrap + read-only diagnostics) |
| `main_callback` | runs `_check_setup_completed()` for every non-allowlisted subcommand |
| `cli/organize.py` | removed redundant inline `_check_setup_completed()` calls |

So `fo search` / `fo analyze` / `fo dedupe` / etc. now show the friendly "First-time setup required" panel pre-setup instead of cryptic stack traces. Was organize/preview-only before.

### Group C: hint-rich config validation errors

| | |
|---|---|
| `src/utils/cli_errors.py` | new `format_validation_error(field=, value=, valid_values=)` — emits `"Invalid value 'X' for device. Valid values: auto, cpu, cuda, mps. Did you mean 'cuda'?"`. Difflib-based "did you mean" above 0.6 cutoff; silent below. |
| `cli/config_cli.py:config_edit` | swaps bare `"device must be one of [...]"` for the helper, pulling from `_VALID_DEVICES` / `_VALID_METHODOLOGIES` constants so future additions flow into the message automatically |

### Test infra: setup-gate bypass for existing CLI tests

The new global gate would block every existing CLI test that didn't pre-mark setup as complete. Added an autouse fixture to `tests/conftest.py` that patches `_check_setup_completed` to True. Tests that exercise the gate opt out via `@pytest.mark.uses_setup_gate` (e.g. `test_setup_gate.py`, `test_main.py::test_*_requires_setup_completed`). Marker registered in `pyproject.toml` and documented in `docs/testing/testing-strategy.md`.

### Main-CI fixes (Step 2A + 2B test regressions)

PR #237 added `transcribe_audio` and `max_transcribe_seconds` kwargs to `FileOrganizer.__init__` but missed updating two test files. PR #236 changed `AudioTranscriber` defaults but missed two assertions. Main has been red since #237 merged. All four fixed in this PR:

| File | Fix |
|---|---|
| `tests/cli/test_cli_organize.py` | added the new kwargs to 14 `assert_called_once_with(...)` sites |
| `tests/cli/test_main.py` | same for 3 sites; marked the 2 setup-gate tests with `@pytest.mark.uses_setup_gate` |
| `tests/services/audio/test_audio_transcriber_service.py::test_default_values` | expects `ComputeType.INT8` (CPU default; CTranslate2 doesn't support efficient FLOAT16 on CPU) |
| `tests/services/audio/test_audio_transcriber_service.py::test_auto_mps` | expects `"cpu"` (CTranslate2 doesn't support MPS) |

## Test coverage

22 new tests under `@pytest.mark.unit @pytest.mark.ci` (or integration where the test invokes a real CLI command via CliRunner):

- `tests/utils/test_cli_errors.py` (5 cases) — listing, fuzzy match, missing-suggestion, non-string value, repr-quoting
- `tests/cli/test_debug_flag.py` (6 cases) — `CLIState.debug` field default + populate, loguru handler installed/skipped, traceback surfaced/omitted on organize error
- `tests/cli/test_setup_gate.py` (3+5 cases) — allowlisted commands bypass; non-allowlisted commands show the panel
- `tests/cli/test_config_validation_hints.py` (3 cases) — invalid device + methodology with hints; distant value gets no suggestion

837 tests pass under the touched scope. Pre-commit hook (now actually wired up post #239) catches everything CI runs.

## Reviewer focus areas

1. **`_SETUP_GATE_ALLOWLIST` completeness** — does any other read-only diagnostic command belong here? The current list is `setup, version, doctor, update, recover, config, hardware-info`. Anything else that should work pre-setup?
2. **`uses_setup_gate` marker semantics** — opt-out for the autouse bypass. Is the polarity right? (Default-off-the-gate means new tests don't accidentally invoke a half-initialized config tree.)
3. **Main-CI fix scope** — bundled here vs separate hotfix PR? Bundling lets reviewers see the test regressions alongside the related code (Step 3 also touches CLI tests). Splitting would keep this PR strictly Step 3.

## Test plan

- [x] `bash .claude/scripts/pre-commit-validation.sh` (full local validation, all gates pass)
- [x] `pytest tests/cli/ tests/utils/test_cli_errors.py tests/services/audio/test_audio_transcriber_service.py tests/docs/test_pyproject_sync.py` — 837 passed
- [x] CI: lint, type-check, ci-marker tests, integration tests, audit-extras matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global --debug flag to enable verbose diagnostics and full tracebacks.
  * Improved validation errors that include quoted invalid inputs and “Did you mean?” suggestions.
  * First-run setup gating now prevents non-allowlisted commands from running and shows a friendly setup-required panel.

* **Documentation**
  * Added “Filing a bug report” guidance for collecting debug output and required diagnostics.
  * Documented pytest marker for tests that exercise the setup gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->