### PR TITLE
test(cli): strengthen Rich traceback assertion in debug flag test

### DIFF
--- a/tests/cli/test_debug_flag.py
+++ b/tests/cli/test_debug_flag.py
@@ -125,8 +125,11 @@ def test_debug_surfaces_traceback_on_organize_error(
     assert result.exit_code == 1
     # The red one-liner is always there.
     assert "boom-from-test" in result.output
-    # And under --debug we additionally get the Rich traceback (file:line refs).
-    assert ".py" in result.output  # at least one frame's file path appears
+    # Under --debug the Rich traceback header must appear — this pins the actual
+    # contract (traceback rendered) rather than a generic ".py" substring that
+    # could match the error message itself.
+    assert "Traceback" in result.output
+    assert ".py" in result.output  # at least one frame's file path (secondary check)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

- Strengthens the weak `assert ".py" in result.output` assertion in `test_debug_surfaces_traceback_on_organize_error` to directly assert `"Traceback" in result.output`, which pins that Rich exception rendering actually fired rather than matching any `.py` path that might appear in an error message
- Keeps `.py` as a secondary frame-path sanity check

## Context

Post-merge CodeRabbit review (PRRT_kwDOR_Rkws5-nFlP) on PR #240 correctly identified the weak assertion. The `"Traceback"` header is what Rich's `console.print_exception()` emits, making it the precise contract to test.

The second post-merge thread (Codex P2 — `ctx.resilient_parsing=False` for `--help`) is DEFER'd to issue #241 which requires a `LazyTyperGroup.parse_args` override to stash `ctx.meta['help_requested']` before Click consumes the args.

## Test plan

- [ ] `pytest tests/cli/test_debug_flag.py -xvs` passes (all 6 tests green)
- [ ] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test validation for the `--debug` flag's traceback rendering. Improved assertions now verify the presence of Rich traceback formatting headers and validate proper error output structure, replacing less reliable checks with more robust detection methods to ensure accurate debugging information and consistent test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->