### PR TITLE
feat: promote fo-core from alpha to beta (Step 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   2. ✅ Config schema version `1.0` frozen with a round-trip migration test.
   3. ✅ `--debug` flag, global setup gate, and hint-rich config validation errors.
   4. ✅ Integration coverage lifted to ≥70% on all 9 previously weak modules
-     (search 38→95%, daemon 57→80%, dedup-init 60→95%, profile-migrator 60→70%,
+     (measured via `scripts/coverage/integration_module_floor_baseline.json`,
+     enforced by the `test-integration` CI job):
+     search 38→95%, daemon 57→80%, dedup-init 60→95%, profile-migrator 60→70%,
      profile-merger 67→90%, JD adapters 67→90%, epub-enhanced 55→70%,
-     hardware-profile 68→90%, JD numbering 68→70%).
+     hardware-profile 68→90%, JD numbering 68→70%.
   5. ✅ Beta criteria documented in `docs/release/beta-criteria.md`.
 - Version bumped from `2.0.0-alpha.3` to `2.0.0-beta.1`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-beta.1] - 2026-05-01
+
+### Changed
+
+- **Development status promoted from Alpha to Beta** — all five alpha→beta acceptance
+  criteria are now met:
+  1. ✅ `AudioModel` wired to the existing transcriber; `fo benchmark --suite audio` passes.
+  2. ✅ Config schema version `1.0` frozen with a round-trip migration test.
+  3. ✅ `--debug` flag, global setup gate, and hint-rich config validation errors.
+  4. ✅ Integration coverage lifted to ≥70% on all 9 previously weak modules
+     (search 38→95%, daemon 57→80%, dedup-init 60→95%, profile-migrator 60→70%,
+     profile-merger 67→90%, JD adapters 67→90%, epub-enhanced 55→70%,
+     hardware-profile 68→90%, JD numbering 68→70%).
+  5. ✅ Beta criteria documented in `docs/release/beta-criteria.md`.
+- Version bumped from `2.0.0-alpha.3` to `2.0.0-beta.1`.
+
 ## [Unreleased]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/curdriceaurora/fo-core/actions/workflows/ci.yml/badge.svg)](https://github.com/curdriceaurora/fo-core/actions/workflows/ci.yml)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/downloads/)
-[![Version](https://img.shields.io/badge/version-2.0.0--alpha.3-orange)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-2.0.0--beta.1-blue)](CHANGELOG.md)
 
 ---
 
@@ -146,8 +146,8 @@ See [DEVELOPER.md](DEVELOPER.md) for architecture, local setup, testing, and con
 
 ## Releases
 
-Currently `2.0.0-alpha.3`. The criteria for promoting to beta and the contract
-with public pre-release testers are documented in
+Currently `2.0.0-beta.1`. The acceptance criteria that were required for this
+promotion and the contract with public pre-release testers are documented in
 [docs/release/beta-criteria.md](docs/release/beta-criteria.md).
 
 ## License

--- a/docs/release/beta-criteria.md
+++ b/docs/release/beta-criteria.md
@@ -108,10 +108,17 @@ fo update check --pre      # see the latest pre-release if any
 fo update install --pre    # download and install it
 ```
 
-To stay on stable: just don't pass `--pre`. To pin a specific older version:
+To install the current beta release explicitly:
 
 ```bash
-pip install 'fo-core==2.0.0-beta.1'   # or whatever stable version you prefer
+pip install 'fo-core==2.0.0-beta.1'
+```
+
+To stay on the latest stable (non-pre-release) version: just don't pass `--pre`.
+To pin a specific earlier version once newer betas exist:
+
+```bash
+pip install 'fo-core==2.0.0-beta.1'   # replace with the desired beta tag
 ```
 
 ### Rolling back

--- a/docs/release/beta-criteria.md
+++ b/docs/release/beta-criteria.md
@@ -111,7 +111,7 @@ fo update install --pre    # download and install it
 To stay on stable: just don't pass `--pre`. To pin a specific older version:
 
 ```bash
-pip install 'fo-core==2.0.0-alpha.3'   # or whatever stable version you prefer
+pip install 'fo-core==2.0.0-beta.1'   # or whatever stable version you prefer
 ```
 
 ### Rolling back

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fo-core"
-version = "2.0.0-alpha.3"
+version = "2.0.0-beta.1"
 description = "Streamlined CLI file organizer powered by local AI (Ollama)"
 authors = [
     {name = "fo-core Team", email = "noreply@example.com"}
@@ -14,7 +14,7 @@ license = {text = "MIT OR Apache-2.0"}
 requires-python = ">=3.11"
 keywords = ["file-management", "ai", "organization", "local-llm", "privacy"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: End Users/Desktop",
     "License :: OSI Approved :: MIT License",
     "License :: OSI Approved :: Apache Software License",

--- a/src/version.py
+++ b/src/version.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-__version__ = "2.0.0-alpha.3"
+__version__ = "2.0.0-beta.1"
 
 # Pattern for semantic versioning with optional pre-release and build metadata
 _VERSION_PATTERN = re.compile(

--- a/tests/integration/test_epub_enhanced_coverage.py
+++ b/tests/integration/test_epub_enhanced_coverage.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -38,7 +39,7 @@ class TestEpubEnhancedImportGuards:
     """
 
     @staticmethod
-    def _fresh_import(blocked: dict) -> object:
+    def _fresh_import(blocked: dict[str, object]) -> ModuleType:
         """Import utils.epub_enhanced fresh with the given sys.modules overrides.
 
         Saves and evicts the current module, imports a new copy with the blocked

--- a/tests/integration/test_epub_enhanced_coverage.py
+++ b/tests/integration/test_epub_enhanced_coverage.py
@@ -9,7 +9,6 @@ code path using a real EPUB book created with ebooklib.
 
 from __future__ import annotations
 
-import importlib
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -27,51 +26,58 @@ pytestmark = pytest.mark.integration
 class TestEpubEnhancedImportGuards:
     """Cover the optional-dependency ``except ImportError`` branches in the module.
 
-    Pattern: use patch.dict to mock away a dep, reload the module (it is
-    already in sys.modules so reload works), assert the flag, then reload
-    again in a finally block to restore the live module state.  This is
-    T12-safe — patch.dict is the xdist-recommended sys.modules patch tool.
+    Pattern: save the original module object, evict it from sys.modules, then
+    import a *fresh* copy with the dependency blocked — asserting on the fresh
+    copy's flag values.  The original module object is restored to sys.modules
+    in a finally block so that other tests which hold pre-bound references to
+    classes (e.g. ``EPUBMetadata``) see the same class objects they imported at
+    collection time.  Using reload() would mutate the shared module object and
+    create new class objects, breaking ``isinstance`` checks in unit tests that
+    imported the class before the reload (the root cause of the
+    ``test_get_epub_metadata`` xdist failure).
     """
+
+    @staticmethod
+    def _fresh_import(blocked: dict) -> object:
+        """Import utils.epub_enhanced fresh with the given sys.modules overrides.
+
+        Saves and evicts the current module, imports a new copy with the blocked
+        entries active, records the fresh module, evicts *that* copy, then
+        restores the original — all inside a finally block so the original is
+        always restored even on assertion failure.
+
+        Returns the freshly-imported module for assertion.
+        """
+        original = sys.modules.pop("utils.epub_enhanced", None)
+        try:
+            with patch.dict(sys.modules, blocked):
+                import utils.epub_enhanced as fresh
+
+                return fresh
+        finally:
+            # Evict whatever copy is in sys.modules now (the fresh test-only copy)
+            sys.modules.pop("utils.epub_enhanced", None)
+            # Restore the original module (class objects preserved for unit tests)
+            if original is not None:
+                sys.modules["utils.epub_enhanced"] = original
 
     @pytest.mark.ci
     def test_ebooklib_unavailable_sets_flag_false(self) -> None:
         """When ebooklib is absent, EBOOKLIB_AVAILABLE is False (lines 26-27)."""
-        import utils.epub_enhanced as m
-
-        with patch.dict(sys.modules, {"ebooklib": None, "ebooklib.epub": None}):
-            try:
-                importlib.reload(m)
-                assert m.EBOOKLIB_AVAILABLE is False
-            finally:
-                # Restore: patch.dict exits → ebooklib back in sys.modules → reload
-                pass
-        importlib.reload(m)  # runs after patch.dict restores sys.modules
+        fresh = self._fresh_import({"ebooklib": None, "ebooklib.epub": None})
+        assert fresh.EBOOKLIB_AVAILABLE is False
 
     @pytest.mark.ci
     def test_pillow_unavailable_sets_flag_false(self) -> None:
         """When PIL is absent, PILLOW_AVAILABLE is False (lines 33-34)."""
-        import utils.epub_enhanced as m
-
-        with patch.dict(sys.modules, {"PIL": None, "PIL.Image": None}):
-            try:
-                importlib.reload(m)
-                assert m.PILLOW_AVAILABLE is False
-            finally:
-                pass
-        importlib.reload(m)
+        fresh = self._fresh_import({"PIL": None, "PIL.Image": None})
+        assert fresh.PILLOW_AVAILABLE is False
 
     @pytest.mark.ci
     def test_bs4_unavailable_sets_flag_false(self) -> None:
         """When bs4 is absent, BS4_AVAILABLE is False (lines 40-41)."""
-        import utils.epub_enhanced as m
-
-        with patch.dict(sys.modules, {"bs4": None}):
-            try:
-                importlib.reload(m)
-                assert m.BS4_AVAILABLE is False
-            finally:
-                pass
-        importlib.reload(m)
+        fresh = self._fresh_import({"bs4": None})
+        assert fresh.BS4_AVAILABLE is False
 
     @pytest.mark.ci
     def test_xml_parsed_as_html_warning_unavailable_sets_none(self) -> None:
@@ -81,16 +87,9 @@ class TestEpubEnhancedImportGuards:
         real attribute; accessing it via ``from bs4 import XMLParsedAsHTMLWarning``
         raises ImportError, which the guard converts to ``None``.
         """
-        import utils.epub_enhanced as m
-
         fake_bs4 = MagicMock(spec=[])  # spec=[] → AttributeError on any attr access
-        with patch.dict(sys.modules, {"bs4": fake_bs4}):
-            try:
-                importlib.reload(m)
-                assert m.XMLParsedAsHTMLWarning is None
-            finally:
-                pass
-        importlib.reload(m)
+        fresh = self._fresh_import({"bs4": fake_bs4})
+        assert fresh.XMLParsedAsHTMLWarning is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Bumps version from `2.0.0-alpha.3` → `2.0.0-beta.1`
- Changes classifier from `Development Status :: 3 - Alpha` → `4 - Beta`
- Updates `src/version.py`, `pyproject.toml`, `README.md` badge, `CHANGELOG.md`, and `docs/release/beta-criteria.md`
- Also fixes a cross-test module-reimport isolation bug in `tests/integration/test_epub_enhanced_coverage.py` that was causing `test_get_epub_metadata` to fail in xdist

**All five alpha→beta acceptance criteria met:**
1. ✅ AudioModel wired to transcriber; `fo benchmark --suite audio` passes
2. ✅ Config schema `1.0` frozen with round-trip migration test
3. ✅ `--debug` flag, global setup gate, hint-rich config errors (Step 3)
4. ✅ Integration coverage ≥70% on all 9 previously weak modules (Step 4)
5. ✅ Beta criteria documented in `docs/release/beta-criteria.md`

## Test plan

- CI passes (all jobs green)
- `pip show fo-core | grep Status` reports `4 - Beta` after install
- `python -c "from version import __version__; print(__version__)"` shows `2.0.0-beta.1`
- `test_get_epub_metadata` no longer fails under xdist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 2.0.0-beta.1, officially advancing the project from Alpha to Beta status. All acceptance criteria have been satisfied, verified, and documented. Project version metadata, release documentation, and installation guidance have been updated comprehensively.

* **Tests**
  * Improved integration test coverage and robustness for optional dependency handling, validation, and detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->