### PR TITLE
test(security): regression-test anchor + advisory SafeDir lint rail

### DIFF
--- a/scripts/check_safedir_required.py
+++ b/scripts/check_safedir_required.py
@@ -90,6 +90,8 @@ _FLAGGED_CALLS: frozenset[str] = frozenset(
         "rarfile.RarFile",
         "RarFile",
         "tarfile.open",
+        "zipfile.ZipFile",
+        "ZipFile",
         # shutil — copy/move follow symlinks on the source side by default
         "shutil.copy",
         "shutil.copy2",
@@ -101,7 +103,7 @@ _FLAGGED_CALLS: frozenset[str] = frozenset(
 )
 
 
-_OPT_OUT_RE = re.compile(r"#\s*safedir:\s*ok\b")
+_OPT_OUT_RE = re.compile(r"#\s*safedir:\s*ok\s*[-—]\s*\S")
 _MARKER_WINDOW_ABOVE = 2
 _MARKER_WINDOW_BELOW = 6
 
@@ -175,9 +177,28 @@ def find_violations(path: Path) -> list[tuple[int, str, str]]:
 
 
 def scan_tree(src_dir: Path = _SRC_DIR) -> list[tuple[Path, int, str, str]]:
-    """Scan every ``*.py`` under *src_dir*; return all violations."""
+    """Scan every ``*.py`` under *src_dir*; return all violations.
+
+    Symlinks and dot-prefixed paths are filtered before indexing (S1/S2 —
+    `search-generation-patterns.md`). A symlinked source file could point at a
+    target outside `src/` whose contents shouldn't drive rail decisions; hidden
+    directories (`.venv/`, `.tox/`) sometimes appear under `src/` in unusual
+    checkouts and would balloon the scan scope.
+    """
     out: list[tuple[Path, int, str, str]] = []
+    src_root = src_dir.resolve()
     for py in sorted(src_dir.rglob("*.py")):
+        try:
+            if py.is_symlink():
+                continue
+        except OSError:
+            continue
+        try:
+            rel_parts = py.resolve().relative_to(src_root).parts
+        except (OSError, ValueError):
+            continue
+        if any(part.startswith(".") for part in rel_parts):
+            continue
         rel = py.relative_to(_ROOT).as_posix()
         if rel in _ALLOWLISTED_FILES:
             continue
@@ -203,10 +224,13 @@ def main(argv: list[str]) -> int:
     for name, count in sorted(by_call.items(), key=lambda kv: (-kv[1], kv[0])):
         print(f"  {count:>4}  {name}", file=sys.stderr)
     if "--verbose" in argv:
+        # Metadata only — no source-line excerpts in CI logs (S5,
+        # `search-generation-patterns.md`). Path + line + callee is enough
+        # to navigate from `gh run view` to the offending site.
         print("[safedir-rail] Call sites:", file=sys.stderr)
-        for path, lineno, name, excerpt in violations:
+        for path, lineno, name, _excerpt in violations:
             rel = path.relative_to(_ROOT).as_posix()
-            print(f"  {rel}:{lineno}  {name}\n    {excerpt}", file=sys.stderr)
+            print(f"  {rel}:{lineno}  {name}", file=sys.stderr)
     if advisory:
         print(
             "[safedir-rail] ADVISORY mode (phase 1 — tracking #264). Exit 0.",

--- a/scripts/check_safedir_required.py
+++ b/scripts/check_safedir_required.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""SafeDir rail — security hardening anchor (tracking: #264).
+
+This rail flags filesystem-access call sites in ``src/`` that read or write
+files **from the user-supplied organize root** without going through the
+``SafeDir`` primitive (#266). Symlink-following content readers are the
+LLM-exfiltration vector documented in #264.
+
+Status — phase 1 (PR1 / #265): **ADVISORY** for the whole tree. The detector
+runs, reports counts, and exits 0 regardless. The companion CI test
+``tests/ci/test_symlink_safety_lints.py`` records the current baseline.
+
+Subsequent PRs flip directories from ADVISORY → ENFORCING as they migrate:
+
+- PR3 / #267 — read-side (services/text_processor, pipeline/stages,
+  utils/readers, services/deduplication/extractor, services/search/
+  hybrid_retriever, core/organizer, methodologies/para/detection/heuristics)
+- PR4 / #268 — services/deduplication/{hasher, backup}, cli/dedupe_v2
+- PR5 / #269 — undo/{durable_move, rollback}, history
+- PR6 / #270 — watcher, daemon, pipeline/stages/{writer, postprocessor},
+  core/file_ops
+
+When all of ``src/`` is enforcing, this script exits 1 on any violation.
+
+Detection
+---------
+AST-based. Flags calls whose function is one of ``_FLAGGED_CALLS`` — content
+readers and shutil move/copy that follow symlinks by default.
+
+The opt-out marker ``# safedir: ok — <reason>`` works the same as the
+atomic-write rail: tokenised comments only (no bypass via string literal),
+window of 2 lines above through 6 below.
+
+Compliant call sites are recognised once SafeDir lands (PR2) — calls that
+go through ``safe_dir.open_for_reader`` / ``safe_dir.unlink`` etc. are not
+flagged because they don't match the surface patterns below.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import re
+import sys
+import tokenize
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SRC_DIR = _ROOT / "src"
+
+
+_ALLOWLISTED_FILES = frozenset(
+    {
+        # The SafeDir primitive itself, once it lands (PR2 / #266).
+        "src/utils/safedir.py",
+        # Already-hardened FS primitives.
+        "src/utils/atomic_write.py",
+        "src/utils/atomic_io.py",
+        # path_guard owns safe_walk; the symlink filtering is the rail.
+        "src/core/path_guard.py",
+        # Undo storage paths are app-owned; the trash/durable-move modules
+        # have their own dedicated symlink-aware codepaths.
+        "src/undo/trash_gc.py",
+        "src/undo/durable_move.py",
+    }
+)
+
+
+# Function/attribute names that follow symlinks by default and read or move
+# user-root content. Detection is by function NAME — the receiver doesn't
+# matter, because every library reader on this list takes a path string and
+# opens it with the platform default (which follows symlinks).
+_FLAGGED_CALLS: frozenset[str] = frozenset(
+    {
+        # Document readers — both `from X import Y; Y(...)` and `import X; X.Y(...)`
+        "fitz.open",
+        "docx.Document",
+        "Document",
+        "openpyxl.load_workbook",
+        "load_workbook",
+        "pptx.Presentation",
+        "Presentation",
+        "pypdf.PdfReader",
+        "PdfReader",
+        # Image
+        "Image.open",
+        # Archives
+        "py7zr.SevenZipFile",
+        "SevenZipFile",
+        "rarfile.RarFile",
+        "RarFile",
+        "tarfile.open",
+        # shutil — copy/move follow symlinks on the source side by default
+        "shutil.copy",
+        "shutil.copy2",
+        "shutil.copyfile",
+        "shutil.copytree",
+        "shutil.copystat",
+        "shutil.move",
+    }
+)
+
+
+_OPT_OUT_RE = re.compile(r"#\s*safedir:\s*ok\b")
+_MARKER_WINDOW_ABOVE = 2
+_MARKER_WINDOW_BELOW = 6
+
+
+def _call_name(node: ast.Call) -> str | None:
+    """Return the dotted name of *node*'s callee, or ``None`` if dynamic.
+
+    Examples::
+
+        fitz.open(...)               -> "fitz.open"
+        Image.open(...)              -> "Image.open"
+        shutil.copy2(...)            -> "shutil.copy2"
+        Document(...)                -> "Document"
+        Path(p).read_text(...)       -> None     (not a flagged surface)
+        getattr(x, "open")(...)      -> None     (dynamic)
+    """
+    func = node.func
+    parts: list[str] = []
+    while isinstance(func, ast.Attribute):
+        parts.append(func.attr)
+        func = func.value
+    if isinstance(func, ast.Name):
+        parts.append(func.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _collect_marker_comment_lines(source: str) -> set[int]:
+    """1-based line numbers of every Python comment carrying the opt-out marker."""
+    marker_lines: set[int] = set()
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            if tok.type == tokenize.COMMENT and _OPT_OUT_RE.search(tok.string):
+                marker_lines.add(tok.start[0])
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        return set()
+    return marker_lines
+
+
+def _has_opt_out_in_window(marker_lines: set[int], call_line: int, total_lines: int) -> bool:
+    start = max(1, call_line - _MARKER_WINDOW_ABOVE)
+    end = min(total_lines, call_line + _MARKER_WINDOW_BELOW)
+    return any(lineno in marker_lines for lineno in range(start, end + 1))
+
+
+def find_violations(path: Path) -> list[tuple[int, str, str]]:
+    """Return ``[(line_no, call_name, line_text)]`` for each unexempted flagged call."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    lines = source.splitlines()
+    marker_lines = _collect_marker_comment_lines(source)
+    total = len(lines)
+    out: list[tuple[int, str, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _call_name(node)
+        if name is None or name not in _FLAGGED_CALLS:
+            continue
+        if _has_opt_out_in_window(marker_lines, node.lineno, total):
+            continue
+        excerpt = lines[node.lineno - 1].rstrip() if 1 <= node.lineno <= total else ""
+        out.append((node.lineno, name, excerpt))
+    return out
+
+
+def scan_tree(src_dir: Path = _SRC_DIR) -> list[tuple[Path, int, str, str]]:
+    """Scan every ``*.py`` under *src_dir*; return all violations."""
+    out: list[tuple[Path, int, str, str]] = []
+    for py in sorted(src_dir.rglob("*.py")):
+        rel = py.relative_to(_ROOT).as_posix()
+        if rel in _ALLOWLISTED_FILES:
+            continue
+        for lineno, name, excerpt in find_violations(py):
+            out.append((py, lineno, name, excerpt))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    advisory = "--advisory" in argv
+    violations = scan_tree()
+    if not violations:
+        return 0
+    by_call: dict[str, int] = {}
+    for _, _, name, _ in violations:
+        by_call[name] = by_call.get(name, 0) + 1
+    print(
+        f"[safedir-rail] {len(violations)} call site(s) read/move user-root data "
+        "without going through SafeDir.",
+        file=sys.stderr,
+    )
+    print("[safedir-rail] Breakdown by callee:", file=sys.stderr)
+    for name, count in sorted(by_call.items(), key=lambda kv: (-kv[1], kv[0])):
+        print(f"  {count:>4}  {name}", file=sys.stderr)
+    if "--verbose" in argv:
+        print("[safedir-rail] Call sites:", file=sys.stderr)
+        for path, lineno, name, excerpt in violations:
+            rel = path.relative_to(_ROOT).as_posix()
+            print(f"  {rel}:{lineno}  {name}\n    {excerpt}", file=sys.stderr)
+    if advisory:
+        print(
+            "[safedir-rail] ADVISORY mode (phase 1 — tracking #264). Exit 0.",
+            file=sys.stderr,
+        )
+        return 0
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover — CLI entrypoint
+    sys.exit(main(sys.argv[1:]))

--- a/tests/ci/test_symlink_safety_lints.py
+++ b/tests/ci/test_symlink_safety_lints.py
@@ -71,6 +71,8 @@ class TestDetectorPositiveCases:
             "import tarfile\ntarfile.open('/foo/bar.tar')\n",
             "from py7zr import SevenZipFile\nSevenZipFile('/foo/bar.7z')\n",
             "import rarfile\nrarfile.RarFile('/foo/bar.rar')\n",
+            "import zipfile\nzipfile.ZipFile('/foo/bar.zip')\n",
+            "from zipfile import ZipFile\nZipFile('/foo/bar.zip')\n",
         ],
     )
     def test_flagged_call(self, tmp_path: Path, source: str) -> None:
@@ -98,6 +100,20 @@ class TestDetectorOptOut:
         source = "import shutil\nmsg = \"# safedir: ok — fake marker\"\nshutil.copy2('/a', '/b')\n"
         violations = find_violations(_synth(tmp_path, source))
         assert len(violations) == 1
+
+    def test_bare_marker_without_reason_does_not_opt_out(self, tmp_path: Path) -> None:
+        """``# safedir: ok`` without a separator + reason is rejected.
+
+        The documented contract is ``# safedir: ok — <reason>``. A bare
+        marker would let drive-by exemptions slip through review.
+        """
+        source = "import shutil\nshutil.copy2('/a', '/b')  # safedir: ok\n"
+        assert len(find_violations(_synth(tmp_path, source))) == 1
+
+    def test_marker_with_hyphen_separator_opts_out(self, tmp_path: Path) -> None:
+        """Both ``— em-dash`` and ``- hyphen`` are accepted separators."""
+        source = "import shutil\nshutil.copy2('/a', '/b')  # safedir: ok - one-shot user export\n"
+        assert find_violations(_synth(tmp_path, source)) == []
 
 
 class TestDetectorNegativeCases:
@@ -180,9 +196,17 @@ class TestPredicateNegativeCases:
         assert find_violations(_synth(tmp_path, source)) == []
 
     def test_unrelated_open_method_not_flagged(self, tmp_path: Path) -> None:
-        """``socket.open(...)`` isn't a content reader. Not flagged."""
-        source = "class S:\n    def open(self, addr): pass\nS().open('localhost')\n"
-        # _call_name returns "S().open" — not exact match.
+        """A method called ``open`` on an unrelated receiver is not flagged.
+
+        Exercises the dotted-call path: ``s.open(...)`` parses to
+        ``Attribute(Name('s'), 'open')``, so ``_call_name`` returns
+        ``"s.open"`` — not in ``_FLAGGED_CALLS``. Compare with calling
+        ``S()`` directly, where ``_call_name`` would return ``None``
+        because the base is a ``Call`` rather than a ``Name`` (that
+        false-negative path is tested separately in
+        ``TestDetectorHelpers.test_call_name_dynamic_returns_none``).
+        """
+        source = "class S:\n    def open(self, addr): pass\ns = S()\ns.open('localhost')\n"
         assert find_violations(_synth(tmp_path, source)) == []
 
 
@@ -253,6 +277,8 @@ class TestFlaggedCallsContract:
             "shutil.copy2",
             "shutil.move",
             "shutil.copytree",
+            "zipfile.ZipFile",
+            "ZipFile",
         }
         missing = required - _FLAGGED_CALLS
         assert not missing, f"watch list dropped flagged calls: {missing}"

--- a/tests/ci/test_symlink_safety_lints.py
+++ b/tests/ci/test_symlink_safety_lints.py
@@ -1,0 +1,258 @@
+"""SafeDir rail — CI test (security hardening tracking: #264).
+
+Companion to ``scripts/check_safedir_required.py``. The rail is in **advisory
+mode** for PR1 — every test in this file passes regardless of how many
+violations the detector finds. As PRs #267 / #268 / #269 / #270 migrate
+call sites to SafeDir, the rail's enforcement scope expands per-directory.
+
+The CI test verifies three things:
+
+1. The detector itself works on synthetic inputs (positive + negative cases).
+2. Running ``check_safedir_required.py --advisory`` against the live tree
+   exits 0 (no false-positive on the implementation modules).
+3. The current baseline count is recorded so any regression that adds new
+   call sites in PRs targeting unrelated areas is visible in CI logs.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.ci
+
+_FO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _FO_ROOT / "scripts" / "check_safedir_required.py"
+
+sys.path.insert(0, str(_FO_ROOT / "scripts"))
+from check_safedir_required import (  # noqa: E402  — sys.path manipulation above
+    _ALLOWLISTED_FILES,
+    _FLAGGED_CALLS,
+    _call_name,
+    _collect_marker_comment_lines,
+    _has_opt_out_in_window,
+    find_violations,
+    scan_tree,
+)
+
+
+def _synth(tmp_path: Path, content: str, name: str = "mod.py") -> Path:
+    src = tmp_path / "src" / "x"
+    src.mkdir(parents=True)
+    target = src / name
+    target.write_text(content)
+    return target
+
+
+# ---------------------------------------------------------------------------
+# Self-test: detector flags the expected surface
+# ---------------------------------------------------------------------------
+
+
+class TestDetectorPositiveCases:
+    """The detector must flag every call form on the watch list."""
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "import fitz\nfitz.open('/foo/bar.pdf')\n",
+            "from PIL import Image\nImage.open('/foo/bar.jpg')\n",
+            "import shutil\nshutil.copy2('/a', '/b')\n",
+            "import shutil\nshutil.move('/a', '/b')\n",
+            "import shutil\nshutil.copytree('/a', '/b')\n",
+            "from docx import Document\nDocument('/foo/bar.docx')\n",
+            "import docx\ndocx.Document('/foo/bar.docx')\n",
+            "from pptx import Presentation\nPresentation('/foo/bar.pptx')\n",
+            "from pypdf import PdfReader\nPdfReader(open('/foo/bar.pdf', 'rb'))\n",
+            "from openpyxl import load_workbook\nload_workbook('/foo/bar.xlsx')\n",
+            "import tarfile\ntarfile.open('/foo/bar.tar')\n",
+            "from py7zr import SevenZipFile\nSevenZipFile('/foo/bar.7z')\n",
+            "import rarfile\nrarfile.RarFile('/foo/bar.rar')\n",
+        ],
+    )
+    def test_flagged_call(self, tmp_path: Path, source: str) -> None:
+        violations = find_violations(_synth(tmp_path, source))
+        assert len(violations) == 1, f"expected 1 violation, got {violations}"
+
+
+class TestDetectorOptOut:
+    """Calls carrying the ``# safedir: ok`` marker are not flagged."""
+
+    def test_trailing_comment_opt_out(self, tmp_path: Path) -> None:
+        source = "import shutil\nshutil.copy2('/a', '/b')  # safedir: ok — one-shot user export\n"
+        assert find_violations(_synth(tmp_path, source)) == []
+
+    def test_preceding_comment_opt_out(self, tmp_path: Path) -> None:
+        source = (
+            "import shutil\n"
+            "# safedir: ok — backup of app-owned state, not user-root data\n"
+            "shutil.copy2('/a', '/b')\n"
+        )
+        assert find_violations(_synth(tmp_path, source)) == []
+
+    def test_string_literal_marker_does_not_opt_out(self, tmp_path: Path) -> None:
+        """A string containing the marker text cannot bypass the rail."""
+        source = "import shutil\nmsg = \"# safedir: ok — fake marker\"\nshutil.copy2('/a', '/b')\n"
+        violations = find_violations(_synth(tmp_path, source))
+        assert len(violations) == 1
+
+
+class TestDetectorNegativeCases:
+    """The detector must NOT flag unrelated calls."""
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            # Read-only that doesn't follow symlinks for content
+            "from pathlib import Path\nPath('/foo').exists()\n",
+            # safe_walk is the safe primitive
+            "from core.path_guard import safe_walk\nlist(safe_walk('/foo'))\n",
+            # open() with a read mode — covered by atomic-write rail, not this one
+            "open('/foo', 'r')\n",
+            # logger noise
+            "import logging\nlogging.info('shutil.copy2 was called')\n",
+        ],
+    )
+    def test_not_flagged(self, tmp_path: Path, source: str) -> None:
+        assert find_violations(_synth(tmp_path, source)) == []
+
+
+class TestDetectorHelpers:
+    """Unit-coverage on the AST helper functions."""
+
+    def test_call_name_dotted(self, tmp_path: Path) -> None:
+        import ast as _ast
+
+        tree = _ast.parse("a.b.c(1)")
+        call = next(n for n in _ast.walk(tree) if isinstance(n, _ast.Call))
+        assert _call_name(call) == "a.b.c"
+
+    def test_call_name_bare(self, tmp_path: Path) -> None:
+        import ast as _ast
+
+        tree = _ast.parse("Document('x')")
+        call = next(n for n in _ast.walk(tree) if isinstance(n, _ast.Call))
+        assert _call_name(call) == "Document"
+
+    def test_call_name_dynamic_returns_none(self, tmp_path: Path) -> None:
+        import ast as _ast
+
+        tree = _ast.parse("getattr(x, 'open')(1)")
+        call = next(n for n in _ast.walk(tree) if isinstance(n, _ast.Call))
+        assert _call_name(call) is None
+
+    def test_marker_window_bounds(self) -> None:
+        """Marker on the call line + 6 below = inside; 7 below = outside."""
+        # call at line 10; window covers 8..16 inclusive
+        assert _has_opt_out_in_window({16}, call_line=10, total_lines=100) is True
+        assert _has_opt_out_in_window({17}, call_line=10, total_lines=100) is False
+        assert _has_opt_out_in_window({8}, call_line=10, total_lines=100) is True
+        assert _has_opt_out_in_window({7}, call_line=10, total_lines=100) is False
+
+    def test_marker_comment_only_real_comments(self) -> None:
+        """A docstring or string literal containing the marker doesn't count."""
+        source = (
+            '"""# safedir: ok — fake"""\n'
+            'x = "# safedir: ok — also fake"\n'
+            "# safedir: ok — real\n"
+            "y = 1\n"
+        )
+        marker_lines = _collect_marker_comment_lines(source)
+        assert marker_lines == {3}
+
+
+class TestPredicateNegativeCases:
+    """T10 backfill — predicate-style detectors need negative cases that
+    pass the same surface shape with wrong context and assert ``False``.
+
+    ``_call_name`` returns the dotted attribute chain. The detector then
+    matches against ``_FLAGGED_CALLS``. Two false-positive shapes worth
+    verifying explicitly:
+    """
+
+    def test_attribute_chain_with_different_base_not_flagged(self, tmp_path: Path) -> None:
+        """``other.copy2`` (not ``shutil.copy2``) must not match."""
+        source = "class X:\n    def copy2(self, a, b): pass\nx = X()\nx.copy2('a', 'b')\n"
+        # _call_name returns "x.copy2" — not in _FLAGGED_CALLS.
+        assert find_violations(_synth(tmp_path, source)) == []
+
+    def test_unrelated_open_method_not_flagged(self, tmp_path: Path) -> None:
+        """``socket.open(...)`` isn't a content reader. Not flagged."""
+        source = "class S:\n    def open(self, addr): pass\nS().open('localhost')\n"
+        # _call_name returns "S().open" — not exact match.
+        assert find_violations(_synth(tmp_path, source)) == []
+
+
+# ---------------------------------------------------------------------------
+# Live-tree advisory run
+# ---------------------------------------------------------------------------
+
+
+class TestLiveTreeAdvisory:
+    """Run the detector against the real ``src/`` in advisory mode."""
+
+    def test_advisory_run_exits_zero(self) -> None:
+        """The rail is advisory in PR1 — must not fail CI on the current tree."""
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT), "--advisory"],
+            capture_output=True,
+            text=True,
+            cwd=_FO_ROOT,
+        )
+        assert result.returncode == 0, (
+            f"advisory rail unexpectedly failed (rc={result.returncode}):\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_baseline_visible_in_stderr(self) -> None:
+        """The advisory run prints the violation count so PR reviewers see drift.
+
+        Phase-1 baseline: ~42 call sites across read-side, dedupe, undo, and
+        watcher paths. The exact number is implementation-noise (one shuffle
+        of ``shutil.copy2`` lands ±1). We assert the report is present and
+        the per-callee breakdown emits something useful, not the exact count.
+        """
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT), "--advisory"],
+            capture_output=True,
+            text=True,
+            cwd=_FO_ROOT,
+        )
+        assert "[safedir-rail]" in result.stderr
+        assert "call site(s)" in result.stderr
+        assert "Breakdown by callee:" in result.stderr
+        assert "ADVISORY mode" in result.stderr
+
+    def test_allowlist_files_not_scanned(self) -> None:
+        """Allowlisted implementation files don't generate self-flags."""
+        violations = scan_tree()
+        flagged_files = {p.relative_to(_FO_ROOT).as_posix() for p, _, _, _ in violations}
+        for allowlisted in _ALLOWLISTED_FILES:
+            assert allowlisted not in flagged_files, (
+                f"allowlisted file {allowlisted} appeared in violations"
+            )
+
+
+class TestFlaggedCallsContract:
+    """Lock in the set of detected calls so silent changes are visible."""
+
+    def test_flagged_calls_covers_the_audited_surface(self) -> None:
+        """The minimum surface flagged by phase 1 — listed in #265."""
+        required = {
+            "fitz.open",
+            "Image.open",
+            "Presentation",
+            "load_workbook",
+            "PdfReader",
+            "tarfile.open",
+            "SevenZipFile",
+            "RarFile",
+            "shutil.copy2",
+            "shutil.move",
+            "shutil.copytree",
+        }
+        missing = required - _FLAGGED_CALLS
+        assert not missing, f"watch list dropped flagged calls: {missing}"

--- a/tests/security/test_symlink_safety.py
+++ b/tests/security/test_symlink_safety.py
@@ -1,0 +1,275 @@
+"""Symlink / TOCTOU regression tests — security hardening (tracking: #264).
+
+This module is the *anchor* for the security hardening series. Every subsequent
+PR un-skips one of the tests below:
+
+- ``test_safe_walk_skips_file_symlink``           — passes today (PR1)
+- ``test_safe_walk_skips_directory_symlink``      — passes today (PR1)
+- ``test_dedupe_refuses_unlink_on_inode_swap``    — blocked on #268 (PR4)
+- ``test_organize_destination_symlink_swap``      — blocked on #270 (PR6)
+- ``test_daemon_skips_symlink_created_post_start``— blocked on #270 (PR6)
+- ``test_undo_refuses_replay_on_inode_change``    — blocked on #269 (PR5)
+- ``test_reader_does_not_open_symlink_target``    — blocked on #267 (PR3)
+
+The threat model:
+
+1. **LLM exfiltration**: A symlink dropped into the organize root targets a
+   sensitive file outside it (``~/.ssh/id_rsa``, browser cookies, etc.). A
+   content reader called by ``fo organize`` follows the link, the secret leaves
+   the host through the inference path.
+2. **Destination symlink swap**: A category subdir is replaced with a symlink
+   to an attacker-controlled location between mkdir and rename.
+3. **Dedupe TOCTOU**: A victim file's inode is swapped for a symlink to
+   important data between the hash and the unlink.
+4. **Undo replay TOCTOU**: The file at the original location at undo time is
+   a different file than the one that was moved.
+
+Tests are POSIX-only. Windows doesn't have ``O_NOFOLLOW`` / ``dir_fd=`` and
+the SafeDir primitive isn't implemented for it (see #264 → #266).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.path_guard import safe_walk
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+    pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_HONEY_CONTENT = b"do_not_exfiltrate"
+
+
+def _make_honey(tmp_path: Path) -> Path:
+    """Create a sensitive file outside the organize root and return its path."""
+    honey_dir = tmp_path / "honey"
+    honey_dir.mkdir()
+    honey_file = honey_dir / "SECRET"
+    honey_file.write_bytes(_HONEY_CONTENT)
+    return honey_file
+
+
+def _make_organize_root(tmp_path: Path) -> Path:
+    organize = tmp_path / "organize"
+    organize.mkdir()
+    return organize
+
+
+# ---------------------------------------------------------------------------
+# Tests that pass against current `main` (safe_walk filters symlinks)
+# ---------------------------------------------------------------------------
+
+
+class TestSafeWalkSymlinkFiltering:
+    """Anchor the existing ``safe_walk`` guarantees as security regressions.
+
+    These pass today. They exist so any future "convenience" PR that flips
+    ``safe_walk`` to follow symlinks fails CI loudly.
+    """
+
+    def test_safe_walk_skips_file_symlink(self, tmp_path: Path) -> None:
+        """A symlink to a file outside the root is never yielded."""
+        honey = _make_honey(tmp_path)
+        organize = _make_organize_root(tmp_path)
+
+        legit = organize / "legit.txt"
+        legit.write_text("normal content")
+
+        # Planted symlink with a benign-looking name.
+        link = organize / "report.pdf"
+        try:
+            link.symlink_to(honey)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        yielded = list(safe_walk(organize))
+
+        assert legit in yielded
+        assert link not in yielded
+        # Belt-and-braces: nothing under the honey directory leaks in.
+        for path in yielded:
+            assert "honey" not in path.parts, f"safe_walk leaked: {path}"
+
+    def test_safe_walk_skips_directory_symlink(self, tmp_path: Path) -> None:
+        """A directory symlink is not descended into."""
+        honey_dir = tmp_path / "honey"
+        honey_dir.mkdir()
+        (honey_dir / "secrets.txt").write_bytes(_HONEY_CONTENT)
+        (honey_dir / "more_secrets.txt").write_bytes(_HONEY_CONTENT)
+
+        organize = _make_organize_root(tmp_path)
+        (organize / "legit.txt").write_text("normal content")
+
+        link_dir = organize / "documents"
+        try:
+            link_dir.symlink_to(honey_dir, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        yielded = list(safe_walk(organize))
+
+        # No yielded entry should live under the honey tree, regardless of how
+        # it resolves. Use lexical parts (safe_walk yields lexical paths) and
+        # then double-check via resolve() — neither path nor target may leak.
+        for path in yielded:
+            assert "honey" not in path.parts, f"lexical leak: {path}"
+            resolved = path.resolve()
+            assert "honey" not in resolved.parts, f"resolved leak: {path} -> {resolved}"
+
+    def test_safe_walk_skips_symlink_to_self(self, tmp_path: Path) -> None:
+        """A self-referential symlink doesn't crash the walker or leak its name.
+
+        Defensive — ``safe_walk`` calls ``entry.is_symlink()`` first so it
+        should never resolve a cycle, but lock the behavior in.
+        """
+        organize = _make_organize_root(tmp_path)
+        (organize / "legit.txt").write_text("normal content")
+
+        loop = organize / "loop"
+        try:
+            loop.symlink_to(loop)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        yielded = list(safe_walk(organize))
+
+        assert loop not in yielded
+
+
+# ---------------------------------------------------------------------------
+# Tests blocked on subsequent PRs in the hardening series
+# ---------------------------------------------------------------------------
+
+
+class TestReadSideSymlinkSafety:
+    """Tests for the LLM-exfiltration vector (blocked on PR3, #267)."""
+
+    def test_reader_does_not_open_symlink_target(self, tmp_path: Path) -> None:
+        """A swapped symlink between enumeration and read is rejected.
+
+        Sequence the test will exercise once SafeDir is wired in:
+
+        1. ``safe_walk`` yields ``organize/report.pdf`` as a regular file.
+        2. Between yield and read, the file is replaced by a symlink to the
+           honey file (simulated via patched ``open`` callback or a sleep +
+           subprocess swap).
+        3. ``SafeDir.open_for_reader`` uses ``O_NOFOLLOW`` and raises
+           ``SymlinkRejected``. The content reader is never called.
+
+        Acceptance: a recorder mock attached to the LLM processor never
+        receives ``_HONEY_CONTENT``.
+        """
+        pytest.skip("blocked on PR3 (#267) — SafeDir read-side migration")
+
+    def test_organize_large_symlink_target_not_opened(self, tmp_path: Path) -> None:
+        """A 200MB out-of-tree symlink target is not read.
+
+        Today ``collect_files`` (legacy ``os.walk``) yields the symlink and
+        the content reader opens it. After PR3+PR6 this path goes through
+        SafeDir and the read is refused. The test measures wall-clock + I/O
+        — if the reader actually opens 200MB the test will trip a timeout
+        guard. Once green, it becomes the canary for "fo organize doesn't
+        accidentally pull arbitrary files into memory via a planted link".
+        """
+        pytest.skip("blocked on PR3 (#267) and PR6 (#270) — legacy collect_files")
+
+
+class TestDedupeSymlinkSafety:
+    """TOCTOU between hash and unlink (blocked on PR4, #268)."""
+
+    def test_dedupe_refuses_unlink_on_inode_swap(self, tmp_path: Path) -> None:
+        """Dedupe refuses to unlink if (dev, ino, size) changed since hash.
+
+        Sequence the test will exercise once inode-pinning lands:
+
+        1. Two identical files A and B; A is the victim.
+        2. ``compute_hash(A)`` records ``HashResult(digest, dev, ino, size)``.
+        3. Between hash and unlink, A is replaced by a symlink to the honey
+           file (simulated by manipulating the path between scan and resolve
+           phases).
+        4. Dedupe re-lstats and detects the mismatch, refuses the unlink,
+           logs a ``security_event``.
+
+        Acceptance: honey file still exists, anomaly is logged, exit code
+        reflects the partial-skip.
+        """
+        pytest.skip("blocked on PR4 (#268) — inode pinning in dedupe")
+
+
+class TestDestinationSymlinkSafety:
+    """Category-dir-replaced-with-symlink (blocked on PR6, #270)."""
+
+    def test_organize_destination_symlink_swap(self, tmp_path: Path) -> None:
+        """A category dir replaced by a symlink between mkdir and rename is rejected.
+
+        Sequence the test will exercise once SafeDir-based moves land:
+
+        1. ``fo organize`` plans to move ``input/doc.txt`` to
+           ``output/category_X/doc.txt``.
+        2. After ``mkdir`` but before ``rename``, ``output/category_X`` is
+           replaced by a symlink to an attacker-controlled directory outside
+           the organize root.
+        3. The SafeDir-based ``os.rename(src_name, dst_name, dst_dir_fd=...)``
+           opens the dst dir with ``O_NOFOLLOW`` and fails; the file is not
+           written to the attacker location.
+
+        Acceptance: the attacker directory is empty; the operation either
+        fails or lands inside the real output root.
+        """
+        pytest.skip("blocked on PR6 (#270) — destination SafeDir + dir_fd=")
+
+
+class TestDaemonSymlinkSafety:
+    """Watcher event → open gap (blocked on PR6, #270)."""
+
+    def test_daemon_skips_symlink_created_post_start(self, tmp_path: Path) -> None:
+        """A symlink created inside the watch root after daemon start is skipped.
+
+        Sequence the test will exercise once the daemon routes through
+        SafeDir:
+
+        1. Daemon starts watching ``organize/``.
+        2. ``organize/report.pdf`` is created as a symlink to the honey file.
+        3. The watcher event handler routes through
+           ``safe_dir.open_child('report.pdf')`` which raises
+           ``SymlinkRejected``.
+        4. Event is dropped; no content reader is invoked.
+
+        Acceptance: the LLM processor recorder never sees ``_HONEY_CONTENT``;
+        a ``security_event`` is logged.
+        """
+        pytest.skip("blocked on PR6 (#270) — watcher SafeDir routing")
+
+
+class TestUndoSymlinkSafety:
+    """Replay TOCTOU (blocked on PR5, #269)."""
+
+    def test_undo_refuses_replay_on_inode_change(self, tmp_path: Path) -> None:
+        """Undo refuses to overwrite a destination whose (dev, ino) changed.
+
+        Sequence the test will exercise once history records (dev, ino):
+
+        1. ``fo organize`` moves ``input/A`` to ``output/cat/A``; history
+           records ``dest_dev`` / ``dest_ino`` from ``os.fstat`` on the open
+           fd.
+        2. ``output/cat/A`` is deleted and replaced by a different file with
+           the same name (different inode).
+        3. ``fo undo`` re-stats the destination; the recorded
+           ``(dest_dev, dest_ino)`` doesn't match.
+        4. Undo refuses, logs a ``security_event``.
+
+        Acceptance: the replacement file at ``output/cat/A`` is untouched
+        and ``input/A`` is not re-created.
+        """
+        pytest.skip("blocked on PR5 (#269) — history (dev, ino) + verify on undo")

--- a/tests/security/test_symlink_safety.py
+++ b/tests/security/test_symlink_safety.py
@@ -109,7 +109,8 @@ class TestSafeWalkSymlinkFiltering:
         (honey_dir / "more_secrets.txt").write_bytes(_HONEY_CONTENT)
 
         organize = _make_organize_root(tmp_path)
-        (organize / "legit.txt").write_text("normal content")
+        legit = organize / "legit.txt"
+        legit.write_text("normal content")
 
         link_dir = organize / "documents"
         try:
@@ -118,6 +119,11 @@ class TestSafeWalkSymlinkFiltering:
             pytest.skip("symlink creation not supported on this filesystem")
 
         yielded = list(safe_walk(organize))
+
+        # Positive control: the legit file MUST appear. Otherwise a regression
+        # that makes safe_walk yield an empty list would pass this test
+        # vacuously (the "honey" leak loop runs zero iterations).
+        assert legit in yielded
 
         # No yielded entry should live under the honey tree, regardless of how
         # it resolves. Use lexical parts (safe_walk yields lexical paths) and
@@ -134,7 +140,8 @@ class TestSafeWalkSymlinkFiltering:
         should never resolve a cycle, but lock the behavior in.
         """
         organize = _make_organize_root(tmp_path)
-        (organize / "legit.txt").write_text("normal content")
+        legit = organize / "legit.txt"
+        legit.write_text("normal content")
 
         loop = organize / "loop"
         try:
@@ -144,6 +151,8 @@ class TestSafeWalkSymlinkFiltering:
 
         yielded = list(safe_walk(organize))
 
+        # Positive control — prevents vacuous pass on a safe_walk regression.
+        assert legit in yielded
         assert loop not in yielded
 
 


### PR DESCRIPTION
Closes #265. First PR in the security hardening series tracked under #264.

## Summary

- Adds `tests/security/test_symlink_safety.py` — 9 regression tests across 6 threat-model scenarios. **3 pass today**, anchoring the existing `safe_walk` symlink filtering. **6 skip** with explicit `blocked on PR<N>` markers; each subsequent PR removes one skip.
- Adds `scripts/check_safedir_required.py` — AST-based detector for content readers and `shutil` move/copy calls that follow symlinks by default. Recognises the `# safedir: ok — <reason>` opt-out marker (same window semantics as the atomic-write rail).
- Adds `tests/ci/test_symlink_safety_lints.py` — companion CI test. Self-tests the detector on positive, negative, and T10-style predicate cases, then runs the live tree in **advisory mode** and asserts exit-0. Current baseline: **46 call sites**, PRs 3–6 will migrate these.

## Baseline (advisory output on this branch)

```
[safedir-rail] 46 call site(s) read/move user-root data without going through SafeDir.
[safedir-rail] Breakdown by callee:
    18  shutil.copy2
     9  Image.open
     7  shutil.move
     3  shutil.copytree
     2  docx.Document
     1  Presentation
     1  fitz.open
     1  openpyxl.load_workbook
     1  py7zr.SevenZipFile
     1  pypdf.PdfReader
     1  rarfile.RarFile
     1  tarfile.open
[safedir-rail] ADVISORY mode (phase 1 — tracking #264). Exit 0.
```

## Test plan

- [x] `tests/security/test_symlink_safety.py` — 3 pass, 6 skip with the documented reasons
- [x] `tests/ci/test_symlink_safety_lints.py` — 31 detector self-tests + 3 live-tree advisory checks all pass
- [x] No production code changes (`src/` untouched)
- [x] `ruff check` + `ruff format --check` clean
- [x] G2 hardcoded-paths rail clean (one docstring rewritten to drop a `/tmp/` literal)
- [x] Two pre-existing `tests/` failures on `main` (`test_path_validation_wiring`, `md031_ratchet`) confirmed unrelated via `git stash`

## What this is NOT

- This PR does **not** close any of the four threat-model gaps on its own. It locks in the existing `safe_walk` guarantees as security regressions and ships the rail + skeleton tests that PRs 2–6 will fill in.
- The rail is **advisory only**. CI passes regardless of violation count. PRs 3–6 will flip directories to enforcing as they migrate.

## Follow-ups in the series

- #266 — `SafeDir` primitive (`src/utils/safedir.py`)
- #267 — Read-side migration (closes LLM-exfiltration vector)
- #268 — Inode-pin dedupe
- #269 — History (dev, ino) + undo verification
- #270 — Watcher + move-destination hardening

https://claude.ai/code/session_01EnPpeovvetPSR8Vwhxsn9j

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnPpeovvetPSR8Vwhxsn9j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated security scanning to detect unsafe filesystem operations with an opt-out mechanism for legitimate use cases.

* **Tests**
  * Added comprehensive test suites validating the security detection system.
  * Added symlink safety regression tests to prevent symlink-based security vulnerabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->