### PR TITLE
feat(security): add SafeDir primitive for POSIX-safe filesystem ops

### DIFF
--- a/src/utils/safedir.py
+++ b/src/utils/safedir.py
@@ -292,6 +292,14 @@ class SafeDir:
         ``O_PATH`` should add a dedicated method that handles the
         post-open ``S_ISLNK`` check.
 
+        With ``O_CREAT | O_EXCL`` the kernel returns ``EEXIST`` for an
+        existing symlink rather than ``ELOOP`` (O_EXCL fires before the
+        O_NOFOLLOW path). To preserve the "symlink → SymlinkRejected"
+        contract for exclusive-create callers, the error path
+        disambiguates ``EEXIST`` via ``lstat`` and raises
+        ``SymlinkRejected`` when the existing entry is a symlink.
+        Same pattern as ``open_subdir``'s ``ENOTDIR`` handling.
+
         Returns the opened fd. Caller is responsible for closing it
         (use ``os.fdopen`` / ``os.close`` / ``contextlib.closing``).
         """
@@ -305,6 +313,17 @@ class SafeDir:
         try:
             return os.open(name, flags | os.O_NOFOLLOW, dir_fd=self._fd)
         except OSError as exc:
+            # ELOOP is the direct symlink-rejection path (O_NOFOLLOW on a
+            # symlink with non-create flags). EEXIST shadows it for the
+            # O_EXCL case — disambiguate via lstat. Tolerating the
+            # one-syscall TOCTOU between failed open and lstat is fine:
+            # the open already didn't follow a symlink, and a same-name
+            # swap-in just means the entry IS now a symlink, which is
+            # still the security-relevant case.
+            if exc.errno == errno.ELOOP or (
+                exc.errno == errno.EEXIST and _is_symlink_at(name, self._fd)
+            ):
+                _raise_symlink_rejected(name, exc)
             raise _wrap_open_errno(exc, name) from exc
 
     def open_for_reader(self, name: str) -> int:

--- a/src/utils/safedir.py
+++ b/src/utils/safedir.py
@@ -1,0 +1,360 @@
+r"""POSIX-safe directory-fd filesystem operations.
+
+Implementation of #266 in the security hardening series (#264). The
+``SafeDir`` primitive holds an open directory file descriptor and routes
+every operation through ``dir_fd=`` + ``O_NOFOLLOW``. PRs 3–6 thread it
+through the read-side ingestion, dedupe, undo, and watcher paths.
+
+Design invariants:
+
+- **Every method takes a path *component*, never a path.** Names
+  containing ``/``, ``\\``, ``..``, ``.``, NUL, or empty strings are
+  rejected with ``ValueError`` before any syscall. This makes
+  attacker-controlled segments — file content, AI output, watcher event
+  payloads — unable to escape the held directory.
+- **``O_NOFOLLOW`` is always set on opens.** On Linux this raises
+  ``ELOOP`` when the named entry is a symlink; we translate that to a
+  typed ``SymlinkRejected`` (subclass of ``OSError``) so callers can
+  catch the security-relevant case specifically while generic
+  ``except OSError`` paths continue to work.
+- **No path-string reconstruction.** Every syscall uses
+  ``dir_fd=self.fd`` with the bare component. There is no code path
+  that builds ``str(self.path) + "/" + name`` and hands it to a syscall.
+- **fd lifetime is via context manager only.** The ``__exit__`` releases
+  the held fd; double-exit is harmless. The class deliberately does not
+  expose a public ``close()`` to discourage leak-prone usage patterns.
+
+Platform: POSIX only. Windows has no equivalent for ``dir_fd=`` /
+``O_NOFOLLOW``; ``open_root`` raises ``NotImplementedError`` there. PR
+CI is Linux; nightly Windows runs skip the dependent test modules. See
+#264 for the deferral rationale.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from types import TracebackType
+from typing import Self
+
+__all__ = ["SafeDir", "SymlinkRejected"]
+
+
+_INVALID_NAME_CHARS = frozenset({"/", "\\", "\x00"})
+_RESERVED_NAMES = frozenset({"", ".", ".."})
+
+
+class SymlinkRejected(OSError):
+    """Raised when a SafeDir operation refuses to dereference a symlink.
+
+    Subclasses ``OSError`` so existing ``except OSError`` paths continue
+    to work while security-relevant callers can catch this specifically.
+    The original ``OSError`` (``errno=ELOOP``) is wrapped, not replaced —
+    ``__cause__`` / ``__context__`` carry the underlying error.
+    """
+
+
+def _validate_name(name: str) -> None:
+    r"""Reject anything that isn't a single safe path component.
+
+    Raises ``ValueError`` for any of:
+
+    - Reserved (``""``, ``"."``, ``".."``).
+    - Contains path-separator characters (``/`` on POSIX, plus ``\\``
+      defensively — even on POSIX, ``\\`` in a filename is unusual and
+      catching it here matches the Windows-portable invariant if/when
+      ``SafeDir`` ships on Windows).
+    - Contains NUL.
+
+    This runs *before* any syscall so traversal payloads never reach the
+    kernel.
+    """
+    if not isinstance(name, str):
+        raise ValueError(f"name must be str, got {type(name).__name__}")
+    if name in _RESERVED_NAMES:
+        raise ValueError(f"reserved component name: {name!r}")
+    for ch in name:
+        if ch in _INVALID_NAME_CHARS:
+            raise ValueError(f"name contains forbidden character {ch!r}: {name!r}")
+
+
+def _wrap_open_errno(err: OSError, name: str) -> OSError:
+    """Translate symlink-related open failures into ``SymlinkRejected``.
+
+    On Linux, ``os.open(path, O_DIRECTORY | O_NOFOLLOW)`` against a
+    symlink-to-directory returns ``ENOTDIR`` (because the symlink inode
+    itself isn't a directory) rather than ``ELOOP``. On a regular-file
+    target with ``O_NOFOLLOW`` you get ``ELOOP``. Callers can't tell
+    these apart from the errno alone, so we map both through this
+    helper. Non-symlink causes (``ENOTDIR`` against a regular file when
+    ``O_DIRECTORY`` was set) are passed through unchanged.
+
+    Disambiguation requires an extra ``lstat`` — see
+    ``_check_symlink_under`` below.
+    """
+    if err.errno == errno.ELOOP:
+        wrapped = SymlinkRejected(
+            err.errno,
+            f"refused to open symlinked entry: {name!r}",
+            err.filename,
+        )
+        wrapped.__cause__ = err
+        return wrapped
+    return err
+
+
+def _raise_symlink_rejected(name: str, cause: OSError) -> None:
+    """Raise ``SymlinkRejected`` chained to *cause*."""
+    wrapped = SymlinkRejected(
+        cause.errno,
+        f"refused to open symlinked entry: {name!r}",
+        cause.filename,
+    )
+    wrapped.__cause__ = cause
+    raise wrapped
+
+
+def _is_symlink_at(name: str, dir_fd: int) -> bool:
+    """True if *name* under *dir_fd* is a symlink, False otherwise.
+
+    Used after an open fails to disambiguate ``ENOTDIR``-on-symlink from
+    ``ENOTDIR``-on-regular-file. Returns False on any stat failure (the
+    entry vanished, permissions changed, etc.) — the caller will then
+    re-raise the original open error, which is the correct behavior:
+    the open didn't follow a symlink, so we don't owe a
+    ``SymlinkRejected``.
+    """
+    try:
+        st = os.stat(name, dir_fd=dir_fd, follow_symlinks=False)
+    except OSError:
+        return False
+    import stat as _stat
+
+    return _stat.S_ISLNK(st.st_mode)
+
+
+class SafeDir:
+    """Holds an open directory fd; every operation uses ``dir_fd=`` + ``O_NOFOLLOW``.
+
+    Construct via ``SafeDir.open_root(path)`` — direct construction is
+    not part of the public API. Always use as a context manager so the
+    fd is released:
+
+        with SafeDir.open_root(organize_root) as sd:
+            with sd.open_subdir("documents") as sub:
+                for entry in sub.scandir():
+                    ...
+    """
+
+    __slots__ = ("_fd", "_closed")
+
+    def __init__(self, fd: int) -> None:
+        """Wrap an already-open directory fd.
+
+        Internal — public construction goes through ``open_root``;
+        ``open_subdir`` uses this directly to wrap the fd it has just
+        opened. The constructor does not validate that *fd* is a
+        directory fd; callers must.
+        """
+        self._fd = fd
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # Construction & lifecycle
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def open_root(cls, path: Path) -> Self:
+        """Open *path* as the root of a SafeDir.
+
+        *path* is the only place a multi-component path enters this API —
+        every subsequent operation must use single component names.
+
+        Raises:
+            NotImplementedError: On Windows. ``dir_fd=`` and
+                ``O_NOFOLLOW`` are POSIX-only; the Windows port is
+                deferred (see #264).
+            SymlinkRejected: If *path* itself is a symlink. The caller
+                must hand a real directory; we don't follow whatever it
+                might point at.
+            OSError: If *path* doesn't exist, isn't a directory, or
+                can't be opened.
+        """
+        if sys.platform == "win32":  # pragma: no cover - platform skip
+            raise NotImplementedError(
+                "SafeDir requires POSIX dir_fd / O_NOFOLLOW support; Windows port deferred (#264)"
+            )
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        try:
+            fd = os.open(str(path), flags)
+        except OSError as exc:
+            # ``O_DIRECTORY | O_NOFOLLOW`` against a symlink-to-dir returns
+            # ENOTDIR on Linux (the symlink inode isn't a directory).
+            # Disambiguate via lstat — symlink → SymlinkRejected, anything
+            # else → propagate.
+            if exc.errno == errno.ELOOP or (exc.errno == errno.ENOTDIR and path.is_symlink()):
+                _raise_symlink_rejected(str(path), exc)
+            raise _wrap_open_errno(exc, str(path)) from exc
+        return cls(fd)
+
+    @property
+    def fd(self) -> int:
+        """Underlying directory fd (read-only, intended for diagnostics).
+
+        Callers should *not* perform syscalls on this fd directly — use
+        the methods on this class instead, which keep the
+        ``dir_fd=`` + ``O_NOFOLLOW`` invariant.
+        """
+        return self._fd
+
+    def __enter__(self) -> Self:
+        """Enter the context manager; return *self* unchanged."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        """Release the held directory fd. Idempotent on double-exit.
+
+        Closing an already-closed fd would raise ``EBADF``, which is
+        noise in failure-path teardown; suppress it.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            os.close(self._fd)
+        except OSError:  # pragma: no cover - defensive
+            pass
+
+    # ------------------------------------------------------------------
+    # Open: file / subdirectory / reader-fd
+    # ------------------------------------------------------------------
+
+    def open_child(self, name: str, *, flags: int = os.O_RDONLY) -> int:
+        """Open the entry *name* under this directory.
+
+        Always sets ``O_NOFOLLOW``; if the entry is a symlink, raises
+        ``SymlinkRejected``. *flags* is OR-ed in on top so callers can
+        request e.g. ``os.O_WRONLY | os.O_CREAT`` for non-content
+        operations (the SafeDir invariant still holds: the open is
+        anchored to ``self.fd`` and never follows a symlink).
+
+        Returns the opened fd. Caller is responsible for closing it
+        (use ``os.fdopen`` / ``os.close`` / ``contextlib.closing``).
+        """
+        _validate_name(name)
+        try:
+            return os.open(name, flags | os.O_NOFOLLOW, dir_fd=self._fd)
+        except OSError as exc:
+            raise _wrap_open_errno(exc, name) from exc
+
+    def open_for_reader(self, name: str) -> int:
+        """Open *name* read-only with ``O_NOFOLLOW`` and return its fd.
+
+        The canonical 'pass to a content reader' helper. Wrap with
+        ``os.fdopen(fd, "rb")`` and hand to ``fitz.open(stream=...)`` /
+        ``Image.open(...)`` / ``pypdf.PdfReader(...)`` / etc.
+
+        Raises:
+            ValueError: If *name* isn't a safe component.
+            SymlinkRejected: If *name* is a symlink.
+            FileNotFoundError: If *name* doesn't exist.
+            OSError: For other open failures (permission, etc.).
+        """
+        return self.open_child(name, flags=os.O_RDONLY)
+
+    def open_subdir(self, name: str) -> SafeDir:
+        """Open subdirectory *name* and return a new SafeDir wrapping its fd.
+
+        Use as a context manager so the new fd is released:
+
+            with sd.open_subdir("category") as sub:
+                ...
+        """
+        _validate_name(name)
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        try:
+            fd = os.open(name, flags, dir_fd=self._fd)
+        except OSError as exc:
+            # ENOTDIR can mean "the entry is a symlink (whose own inode
+            # isn't a directory)" or "the entry is a regular file".
+            # ``_is_symlink_at`` resolves the ambiguity.
+            if exc.errno == errno.ELOOP or (
+                exc.errno == errno.ENOTDIR and _is_symlink_at(name, self._fd)
+            ):
+                _raise_symlink_rejected(name, exc)
+            raise _wrap_open_errno(exc, name) from exc
+        return SafeDir(fd)
+
+    # ------------------------------------------------------------------
+    # Inspect / list / stat
+    # ------------------------------------------------------------------
+
+    def scandir(self) -> Iterator[os.DirEntry[str]]:
+        """Iterate over entries in this directory, yielding ``os.DirEntry``s.
+
+        The underlying ``os.scandir(self.fd)`` reads the directory by
+        file descriptor — there is no path-string lookup that could be
+        intercepted between this call and a follow-up operation on the
+        same name.
+        """
+        return iter(os.scandir(self._fd))
+
+    def lstat(self, name: str) -> os.stat_result:
+        """Stat *name* without following symlinks (``lstat`` semantics).
+
+        Useful for inode-pinning workflows (PR4 / PR5): capture
+        ``(st_dev, st_ino, st_size)`` here, then re-call before any
+        destructive operation and refuse on mismatch.
+        """
+        _validate_name(name)
+        return os.stat(name, dir_fd=self._fd, follow_symlinks=False)
+
+    # ------------------------------------------------------------------
+    # Mutate: create / remove / rename
+    # ------------------------------------------------------------------
+
+    def mkdir(self, name: str, mode: int = 0o755) -> None:
+        """Create a subdirectory *name* relative to this dir's fd.
+
+        The created directory is *not* opened or returned; call
+        ``open_subdir(name)`` afterwards if you need to operate on it.
+        Separating create from open lets the caller decide whether to
+        re-stat or use ``O_DIRECTORY | O_NOFOLLOW`` semantics on the
+        follow-up open.
+        """
+        _validate_name(name)
+        os.mkdir(name, mode=mode, dir_fd=self._fd)
+
+    def unlink(self, name: str) -> None:
+        """Remove a file (not a directory) *name* relative to this dir's fd.
+
+        Uses ``os.unlink`` with ``dir_fd=`` so the unlink target is
+        resolved through the held directory — not via a path string
+        that could be intercepted.
+        """
+        _validate_name(name)
+        os.unlink(name, dir_fd=self._fd)
+
+    def rename_into(self, name: str, other: SafeDir, other_name: str) -> None:
+        """Rename ``self/name`` to ``other/other_name`` atomically.
+
+        Uses ``os.rename(name, other_name, src_dir_fd=self.fd,
+        dst_dir_fd=other.fd)`` — atomic on POSIX within the same
+        filesystem. Both component names are validated.
+
+        Caller is responsible for ensuring ``other`` is on the same
+        filesystem; cross-filesystem renames will raise ``OSError``
+        (``EXDEV``) and the caller must fall back to copy + unlink (see
+        ``undo/durable_move.py`` for the existing pattern).
+        """
+        _validate_name(name)
+        _validate_name(other_name)
+        os.rename(name, other_name, src_dir_fd=self._fd, dst_dir_fd=other._fd)

--- a/src/utils/safedir.py
+++ b/src/utils/safedir.py
@@ -284,14 +284,22 @@ class SafeDir:
     # Open: file / subdirectory / reader-fd
     # ------------------------------------------------------------------
 
-    def open_child(self, name: str, *, flags: int = os.O_RDONLY) -> int:
+    def open_child(self, name: str, *, flags: int = os.O_RDONLY, mode: int = 0o666) -> int:
         """Open the entry *name* under this directory.
 
         Always sets ``O_NOFOLLOW``; if the entry is a symlink, raises
         ``SymlinkRejected``. *flags* is OR-ed in on top so callers can
-        request e.g. ``os.O_WRONLY | os.O_CREAT`` for non-content
+        request e.g. ``os.O_WRONLY | os.O_CREAT`` for non-create
         operations (the SafeDir invariant still holds: the open is
         anchored to ``self.fd`` and never follows a symlink).
+
+        *mode* is the file permission mode for newly created files (only
+        consulted when ``O_CREAT`` is in *flags*). Defaults to
+        ``0o666`` — matching the high-level ``open()`` builtin so files
+        end up at ``0o644`` under the typical ``022`` umask, NOT
+        ``0o755`` (which the lower-level ``os.open`` would produce with
+        its surprising ``0o777`` default). Callers needing private
+        files can pass ``mode=0o600`` explicitly.
 
         ``os.O_PATH`` is rejected — on Linux it changes ``O_NOFOLLOW``
         semantics so the symlink itself is opened rather than refused
@@ -328,7 +336,7 @@ class SafeDir:
                 "would return an fd for the symlink instead of refusing it"
             )
         try:
-            return os.open(name, flags | os.O_NOFOLLOW, dir_fd=self._fd)
+            return os.open(name, flags | os.O_NOFOLLOW, mode=mode, dir_fd=self._fd)
         except OSError as exc:
             # ELOOP is the direct symlink-rejection path. EEXIST shadows
             # it under O_CREAT|O_EXCL; ENOTDIR shadows it under

--- a/src/utils/safedir.py
+++ b/src/utils/safedir.py
@@ -426,11 +426,23 @@ class SafeDir:
 
         The underlying ``os.scandir(self.fd)`` reads the directory by
         file descriptor (no path-string lookup that could be
-        intercepted). The iterator is wrapped in a ``with`` block so
-        the underlying ``ScandirIterator`` is deterministically closed
-        even if the caller exhausts only part of the generator.
+        intercepted). **Names are materialized eagerly** rather than
+        yielded lazily: ``os.scandir(fd)`` internally ``dup``-s the fd,
+        so the ``ScandirIterator`` has its own handle that would
+        survive ``SafeDir.__exit__``. A lazy generator could keep
+        yielding names after the context closed — violating the
+        lifecycle guarantee that operations are bounded by the
+        ``with`` block. Eager materialization also ensures the
+        ``ScandirIterator`` is closed before this method returns, so
+        the dup'd fd doesn't leak.
+
+        For typical SafeDir trees (a user's organize root) directory
+        sizes are bounded by ``safe_walk``-style enumeration limits;
+        materializing N names of average length ~50 bytes costs N×50
+        bytes which is negligible up to ~100K entries.
         """
         self._check_open()
+        names: list[str] = []
         with os.scandir(self._fd) as it:
             for entry in it:
                 try:
@@ -441,7 +453,8 @@ class SafeDir:
                     # permission flip, etc.) — skip defensively. Matches
                     # safe_walk's stance.
                     continue
-                yield entry.name
+                names.append(entry.name)
+        return iter(names)
 
     def lstat(self, name: str) -> os.stat_result:
         """Stat *name* without following symlinks (``lstat`` semantics).

--- a/src/utils/safedir.py
+++ b/src/utils/safedir.py
@@ -466,6 +466,18 @@ class SafeDir:
         dst_dir_fd=other.fd)`` — atomic on POSIX within the same
         filesystem. Both component names are validated.
 
+        **Source is lstat'd before rename and a symlink raises
+        ``SymlinkRejected``.** ``os.rename`` has no ``O_NOFOLLOW``
+        equivalent — if a caller enumerates via ``scandir`` (which
+        filters symlinks) and then a TOCTOU attacker swaps ``name``
+        for a symlink before the rename, the symlink would be moved
+        into the managed destination, contaminating the trusted output
+        tree with a pointer outside the SafeDir root. The lstat check
+        narrows that window from "scan-to-rename" (caller-dependent
+        duration) down to "lstat-to-rename" (~one syscall) — the
+        residual race is acknowledged and acceptable given the kernel
+        offers no atomic alternative.
+
         Caller is responsible for ensuring ``other`` is on the same
         filesystem; cross-filesystem renames will raise ``OSError``
         (``EXDEV``) and the caller must fall back to copy + unlink (see
@@ -475,4 +487,7 @@ class SafeDir:
         other._check_open()
         _validate_name(name)
         _validate_name(other_name)
+        if _is_symlink_at(name, self._fd):
+            cause = OSError(errno.ELOOP, "refused to rename a symlinked source")
+            _raise_symlink_rejected(name, cause)
         os.rename(name, other_name, src_dir_fd=self._fd, dst_dir_fd=other._fd)

--- a/src/utils/safedir.py
+++ b/src/utils/safedir.py
@@ -46,6 +46,18 @@ __all__ = ["SafeDir", "SymlinkRejected"]
 _INVALID_NAME_CHARS = frozenset({"/", "\\", "\x00"})
 _RESERVED_NAMES = frozenset({"", ".", ".."})
 
+# ``O_PATH`` (Linux 2.6.39+) has a surprising interaction with ``O_NOFOLLOW``:
+# instead of refusing to dereference a symlink, the pair returns an fd
+# referring to the symlink itself. That breaks the documented contract of
+# ``open_child`` ("if the entry is a symlink, raises SymlinkRejected") — any
+# caller that later uses the resulting fd for an inode-pinning or existence
+# check would silently operate on the symlink. Reject the flag at the API
+# boundary; if a future caller genuinely needs ``O_PATH`` semantics, ship
+# a dedicated method that handles the post-open ``fstat(S_ISLNK)`` check.
+# On platforms that don't define ``O_PATH`` (macOS, BSD), the bug doesn't
+# exist; the guard falls through harmlessly via the ``getattr`` default.
+_O_PATH = getattr(os, "O_PATH", 0)
+
 
 class SymlinkRejected(OSError):
     """Raised when a SafeDir operation refuses to dereference a symlink.
@@ -274,11 +286,22 @@ class SafeDir:
         operations (the SafeDir invariant still holds: the open is
         anchored to ``self.fd`` and never follows a symlink).
 
+        ``os.O_PATH`` is rejected — on Linux it changes ``O_NOFOLLOW``
+        semantics so the symlink itself is opened rather than refused
+        (see the ``_O_PATH`` module-level note). Callers that need
+        ``O_PATH`` should add a dedicated method that handles the
+        post-open ``S_ISLNK`` check.
+
         Returns the opened fd. Caller is responsible for closing it
         (use ``os.fdopen`` / ``os.close`` / ``contextlib.closing``).
         """
         self._check_open()
         _validate_name(name)
+        if _O_PATH and (flags & _O_PATH):
+            raise ValueError(
+                "open_child does not support O_PATH: O_PATH|O_NOFOLLOW "
+                "would return an fd for the symlink instead of refusing it"
+            )
         try:
             return os.open(name, flags | os.O_NOFOLLOW, dir_fd=self._fd)
         except OSError as exc:

--- a/src/utils/safedir.py
+++ b/src/utils/safedir.py
@@ -396,24 +396,39 @@ class SafeDir:
     # Inspect / list / stat
     # ------------------------------------------------------------------
 
-    def scandir(self) -> Iterator[os.DirEntry[str]]:
-        """Iterate over directory entries, yielding non-symlink ``DirEntry``s.
+    def scandir(self) -> Iterator[str]:
+        """Yield names (``str``) of non-symlink entries in this directory.
 
-        **Symlinks are filtered out.** ``DirEntry.is_file()``,
-        ``DirEntry.is_dir()``, and ``DirEntry.stat()`` default to
-        ``follow_symlinks=True`` — a naive caller writing
-        ``for entry in sd.scandir(): if entry.is_file(): ...`` would
-        classify a symlink to a regular file as a file, bypassing the
-        SafeDir invariant before reaching ``open_for_reader``. Filtering
-        at the source removes the footgun; callers who genuinely need
-        to inspect symlink entries can call ``lstat(name)`` directly.
+        **Returns plain names, not ``os.DirEntry`` objects.** Exposing
+        ``DirEntry`` would let callers reach ``entry.is_file()``,
+        ``entry.is_dir()``, and ``entry.stat()`` — all of which default
+        to ``follow_symlinks=True``. Even after filtering symlinks at
+        scan time, a TOCTOU swap (regular file → symlink) between
+        ``is_symlink()`` and a downstream ``entry.stat()`` would let
+        the caller classify or stat the attacker's target. Returning
+        only the name keeps that footgun out of reach: any subsequent
+        operation must route through SafeDir's own methods, which all
+        enforce ``follow_symlinks=False`` / ``O_NOFOLLOW``.
+
+        Callers needing type/metadata for a yielded name should call
+        ``self.lstat(name)`` and inspect ``S_ISREG`` / ``S_ISDIR`` etc.
+        explicitly. Reads use ``self.open_for_reader(name)``;
+        subdirectories use ``self.open_subdir(name)``. Both are
+        symlink-safe under SafeDir's invariants.
+
+        Symlinks present at scan time are filtered out via the cached
+        ``DirEntry.is_symlink()``. The check uses ``readdir``-cached
+        ``d_type`` rather than a fresh ``lstat``, so a *post*-scan
+        swap-in could still yield a name that has since become a
+        symlink — but that's the caller's atomic check via
+        ``lstat`` / ``open_for_reader`` to handle correctly, and
+        SafeDir's other operations already refuse symlinks.
 
         The underlying ``os.scandir(self.fd)`` reads the directory by
-        file descriptor — there is no path-string lookup that could be
-        intercepted between this call and a follow-up operation on the
-        same name. The iterator is wrapped in a ``with`` block so the
-        underlying ``ScandirIterator`` is deterministically closed even
-        if the caller exhausts only part of the generator.
+        file descriptor (no path-string lookup that could be
+        intercepted). The iterator is wrapped in a ``with`` block so
+        the underlying ``ScandirIterator`` is deterministically closed
+        even if the caller exhausts only part of the generator.
         """
         self._check_open()
         with os.scandir(self._fd) as it:
@@ -426,7 +441,7 @@ class SafeDir:
                     # permission flip, etc.) — skip defensively. Matches
                     # safe_walk's stance.
                     continue
-                yield entry
+                yield entry.name
 
     def lstat(self, name: str) -> os.stat_result:
         """Stat *name* without following symlinks (``lstat`` semantics).

--- a/src/utils/safedir.py
+++ b/src/utils/safedir.py
@@ -299,13 +299,23 @@ class SafeDir:
         ``O_PATH`` should add a dedicated method that handles the
         post-open ``S_ISLNK`` check.
 
-        With ``O_CREAT | O_EXCL`` the kernel returns ``EEXIST`` for an
-        existing symlink rather than ``ELOOP`` (O_EXCL fires before the
-        O_NOFOLLOW path). To preserve the "symlink → SymlinkRejected"
-        contract for exclusive-create callers, the error path
-        disambiguates ``EEXIST`` via ``lstat`` and raises
-        ``SymlinkRejected`` when the existing entry is a symlink.
-        Same pattern as ``open_subdir``'s ``ENOTDIR`` handling.
+        Three errno cases shadow the documented "symlink →
+        SymlinkRejected" contract because their flag combinations fire
+        before the ``O_NOFOLLOW`` path:
+
+        - ``EEXIST`` from ``O_CREAT | O_EXCL`` against an existing
+          symlink — the kernel reports "name taken" before honouring
+          O_NOFOLLOW.
+        - ``ENOTDIR`` from ``O_DIRECTORY`` against a symlink — the
+          symlink inode itself isn't a directory.
+        - ``ELOOP`` — the direct rejection path for the simple
+          ``O_RDONLY | O_NOFOLLOW`` case.
+
+        All three are disambiguated via ``lstat``: if the entry is a
+        symlink, raise ``SymlinkRejected``; otherwise propagate the
+        original error (legitimate "already exists" / "wrong type" cases
+        on non-symlinks). Same pattern as ``open_subdir`` and
+        ``open_root``.
 
         Returns the opened fd. Caller is responsible for closing it
         (use ``os.fdopen`` / ``os.close`` / ``contextlib.closing``).
@@ -320,16 +330,18 @@ class SafeDir:
         try:
             return os.open(name, flags | os.O_NOFOLLOW, dir_fd=self._fd)
         except OSError as exc:
-            # ELOOP is the direct symlink-rejection path (O_NOFOLLOW on a
-            # symlink with non-create flags). EEXIST shadows it for the
-            # O_EXCL case — disambiguate via lstat. Tolerating the
+            # ELOOP is the direct symlink-rejection path. EEXIST shadows
+            # it under O_CREAT|O_EXCL; ENOTDIR shadows it under
+            # O_DIRECTORY. Disambiguate via lstat. Tolerating the
             # one-syscall TOCTOU between failed open and lstat is fine:
             # the open already didn't follow a symlink, and a same-name
             # swap-in just means the entry IS now a symlink, which is
             # still the security-relevant case.
-            if exc.errno == errno.ELOOP or (
-                exc.errno == errno.EEXIST and _is_symlink_at(name, self._fd)
-            ):
+            shadowed_by_symlink = exc.errno in (
+                errno.EEXIST,
+                errno.ENOTDIR,
+            ) and _is_symlink_at(name, self._fd)
+            if exc.errno == errno.ELOOP or shadowed_by_symlink:
                 _raise_symlink_rejected(name, exc)
             raise _wrap_open_errno(exc, name) from exc
 

--- a/src/utils/safedir.py
+++ b/src/utils/safedir.py
@@ -207,8 +207,30 @@ class SafeDir:
         Callers should *not* perform syscalls on this fd directly — use
         the methods on this class instead, which keep the
         ``dir_fd=`` + ``O_NOFOLLOW`` invariant.
+
+        Raises ``ValueError`` if the SafeDir has been closed: the
+        stored fd would be -1, and reading it would invite the caller
+        into operating on whatever (unrelated) directory POSIX
+        eventually recycles the original fd number for.
         """
+        self._check_open()
         return self._fd
+
+    def _check_open(self) -> None:
+        """Raise ``ValueError`` if this SafeDir has already been closed.
+
+        POSIX fd numbers are recycled — if a caller retains a
+        ``SafeDir`` past its ``__exit__`` and then invokes a method on
+        it, the underlying ``dir_fd=`` would address whatever
+        directory the kernel reassigned the fd to (any subsequent
+        ``os.open``, including unrelated ones inside the same process).
+        That's a silent correctness bug: ``scandir`` / ``unlink`` /
+        ``rename_into`` would operate on the wrong directory rather
+        than failing with ``EBADF``. Every public method calls this
+        first so the failure is loud and immediate.
+        """
+        if self._closed:
+            raise ValueError("SafeDir has been closed; cannot use after context-manager exit")
 
     def __enter__(self) -> Self:
         """Enter the context manager; return *self* unchanged."""
@@ -228,8 +250,14 @@ class SafeDir:
         if self._closed:
             return
         self._closed = True
+        fd_to_close = self._fd
+        # Invalidate the stored fd so accidental late access via
+        # ``self._fd`` can't reach a recycled directory. Even if
+        # ``_check_open`` is bypassed (e.g. via direct attribute access),
+        # a syscall using -1 fails immediately with ``EBADF``.
+        self._fd = -1
         try:
-            os.close(self._fd)
+            os.close(fd_to_close)
         except OSError:  # pragma: no cover - defensive
             pass
 
@@ -249,6 +277,7 @@ class SafeDir:
         Returns the opened fd. Caller is responsible for closing it
         (use ``os.fdopen`` / ``os.close`` / ``contextlib.closing``).
         """
+        self._check_open()
         _validate_name(name)
         try:
             return os.open(name, flags | os.O_NOFOLLOW, dir_fd=self._fd)
@@ -278,6 +307,7 @@ class SafeDir:
             with sd.open_subdir("category") as sub:
                 ...
         """
+        self._check_open()
         _validate_name(name)
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         try:
@@ -305,6 +335,7 @@ class SafeDir:
         intercepted between this call and a follow-up operation on the
         same name.
         """
+        self._check_open()
         return iter(os.scandir(self._fd))
 
     def lstat(self, name: str) -> os.stat_result:
@@ -314,6 +345,7 @@ class SafeDir:
         ``(st_dev, st_ino, st_size)`` here, then re-call before any
         destructive operation and refuse on mismatch.
         """
+        self._check_open()
         _validate_name(name)
         return os.stat(name, dir_fd=self._fd, follow_symlinks=False)
 
@@ -330,6 +362,7 @@ class SafeDir:
         re-stat or use ``O_DIRECTORY | O_NOFOLLOW`` semantics on the
         follow-up open.
         """
+        self._check_open()
         _validate_name(name)
         os.mkdir(name, mode=mode, dir_fd=self._fd)
 
@@ -340,6 +373,7 @@ class SafeDir:
         resolved through the held directory — not via a path string
         that could be intercepted.
         """
+        self._check_open()
         _validate_name(name)
         os.unlink(name, dir_fd=self._fd)
 
@@ -355,6 +389,8 @@ class SafeDir:
         (``EXDEV``) and the caller must fall back to copy + unlink (see
         ``undo/durable_move.py`` for the existing pattern).
         """
+        self._check_open()
+        other._check_open()
         _validate_name(name)
         _validate_name(other_name)
         os.rename(name, other_name, src_dir_fd=self._fd, dst_dir_fd=other._fd)

--- a/src/utils/safedir.py
+++ b/src/utils/safedir.py
@@ -389,15 +389,36 @@ class SafeDir:
     # ------------------------------------------------------------------
 
     def scandir(self) -> Iterator[os.DirEntry[str]]:
-        """Iterate over entries in this directory, yielding ``os.DirEntry``s.
+        """Iterate over directory entries, yielding non-symlink ``DirEntry``s.
+
+        **Symlinks are filtered out.** ``DirEntry.is_file()``,
+        ``DirEntry.is_dir()``, and ``DirEntry.stat()`` default to
+        ``follow_symlinks=True`` — a naive caller writing
+        ``for entry in sd.scandir(): if entry.is_file(): ...`` would
+        classify a symlink to a regular file as a file, bypassing the
+        SafeDir invariant before reaching ``open_for_reader``. Filtering
+        at the source removes the footgun; callers who genuinely need
+        to inspect symlink entries can call ``lstat(name)`` directly.
 
         The underlying ``os.scandir(self.fd)`` reads the directory by
         file descriptor — there is no path-string lookup that could be
         intercepted between this call and a follow-up operation on the
-        same name.
+        same name. The iterator is wrapped in a ``with`` block so the
+        underlying ``ScandirIterator`` is deterministically closed even
+        if the caller exhausts only part of the generator.
         """
         self._check_open()
-        return iter(os.scandir(self._fd))
+        with os.scandir(self._fd) as it:
+            for entry in it:
+                try:
+                    if entry.is_symlink():
+                        continue
+                except OSError:
+                    # Per-entry stat failure (race with deletion,
+                    # permission flip, etc.) — skip defensively. Matches
+                    # safe_walk's stance.
+                    continue
+                yield entry
 
     def lstat(self, name: str) -> os.stat_result:
         """Stat *name* without following symlinks (``lstat`` semantics).

--- a/src/utils/safedir.py
+++ b/src/utils/safedir.py
@@ -179,11 +179,13 @@ class SafeDir:
     # ------------------------------------------------------------------
 
     @classmethod
-    def open_root(cls, path: Path) -> Self:
+    def open_root(cls, path: str | os.PathLike[str]) -> Self:
         """Open *path* as the root of a SafeDir.
 
         *path* is the only place a multi-component path enters this API —
         every subsequent operation must use single component names.
+        Accepts ``str`` and ``os.PathLike`` (including ``pathlib.Path``);
+        the value is normalized to ``Path`` at the entry boundary.
 
         Raises:
             NotImplementedError: On Windows. ``dir_fd=`` and
@@ -199,6 +201,11 @@ class SafeDir:
             raise NotImplementedError(
                 "SafeDir requires POSIX dir_fd / O_NOFOLLOW support; Windows port deferred (#264)"
             )
+        # Normalize at the boundary so str/PathLike callers (CLI args,
+        # un-typed config values) don't trip on ``path.is_symlink()`` below
+        # with AttributeError instead of the documented SymlinkRejected /
+        # OSError. The conversion is idempotent for an existing Path.
+        path = Path(path)
         flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
         try:
             fd = os.open(str(path), flags)

--- a/tests/integration/test_audio_model_integration.py
+++ b/tests/integration/test_audio_model_integration.py
@@ -63,7 +63,32 @@ class TestAudioModelEndToEnd:
         # transcribe() call, so it should be None right after initialize().
         assert model._transcriber._model is None
         try:
-            output = model.generate(str(audio_path))
+            try:
+                output = model.generate(str(audio_path))
+            except Exception as exc:
+                # First-run lazy load downloads the tiny model from
+                # HuggingFace Hub. Skip cleanly on transient network /
+                # rate-limit failures (403, connection reset, etc.) —
+                # the test purpose is "does the pipeline run end-to-end
+                # when the model is available", not "does HuggingFace
+                # serve us a model right now". Catching by exception
+                # message + module path keeps us decoupled from the
+                # huggingface_hub error hierarchy (which changes
+                # between versions).
+                msg = repr(exc).lower()
+                module_path = type(exc).__module__
+                hf_indicators = (
+                    "huggingface" in msg
+                    or "huggingface_hub" in module_path
+                    or "rate limit" in msg
+                    or "403" in msg
+                    or "429" in msg
+                    or "connection" in msg
+                    or "name resolution" in msg
+                )
+                if hf_indicators:
+                    pytest.skip(f"Whisper tiny model download unavailable: {exc!r}")
+                raise
             # Pipeline ran end-to-end without raising. Two non-vacuous
             # assertions cover the contract:
             #   1. generate() returned a string (not None, not an exception).

--- a/tests/integration/test_audio_model_integration.py
+++ b/tests/integration/test_audio_model_integration.py
@@ -63,32 +63,7 @@ class TestAudioModelEndToEnd:
         # transcribe() call, so it should be None right after initialize().
         assert model._transcriber._model is None
         try:
-            try:
-                output = model.generate(str(audio_path))
-            except Exception as exc:
-                # First-run lazy load downloads the tiny model from
-                # HuggingFace Hub. Skip cleanly on transient network /
-                # rate-limit failures (403, connection reset, etc.) —
-                # the test purpose is "does the pipeline run end-to-end
-                # when the model is available", not "does HuggingFace
-                # serve us a model right now". Catching by exception
-                # message + module path keeps us decoupled from the
-                # huggingface_hub error hierarchy (which changes
-                # between versions).
-                msg = repr(exc).lower()
-                module_path = type(exc).__module__
-                hf_indicators = (
-                    "huggingface" in msg
-                    or "huggingface_hub" in module_path
-                    or "rate limit" in msg
-                    or "403" in msg
-                    or "429" in msg
-                    or "connection" in msg
-                    or "name resolution" in msg
-                )
-                if hf_indicators:
-                    pytest.skip(f"Whisper tiny model download unavailable: {exc!r}")
-                raise
+            output = model.generate(str(audio_path))
             # Pipeline ran end-to-end without raising. Two non-vacuous
             # assertions cover the contract:
             #   1. generate() returned a string (not None, not an exception).

--- a/tests/integration/test_error_propagation.py
+++ b/tests/integration/test_error_propagation.py
@@ -9,6 +9,7 @@ are stubbed at the ``model._do_generate()`` level.
 
 from __future__ import annotations
 
+import os
 import stat
 import sys
 from pathlib import Path
@@ -24,10 +25,20 @@ from .conftest import make_text_config, make_vision_config, patch_text_generate_
 pytestmark = [pytest.mark.integration]
 
 
+# `chmod 000` is silently bypassed when the process has CAP_DAC_OVERRIDE
+# (the standard root capability on Linux). Containers and CI runners that
+# execute as uid 0 — common in our dev-container images — would otherwise
+# read the "unreadable" file fine and the test asserts the wrong thing.
+_skip_if_root_or_windows = pytest.mark.skipif(
+    sys.platform == "win32" or (hasattr(os, "geteuid") and os.geteuid() == 0),
+    reason="chmod 000 does not restrict reads on Windows or when running as root",
+)
+
+
 class TestFileReadErrors:
     """File read errors surface in ProcessedFile results, not exceptions."""
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="chmod does not restrict reads on Windows")
+    @_skip_if_root_or_windows
     def test_unreadable_file_returns_error_in_result(
         self,
         stub_text_model_init: None,
@@ -117,7 +128,7 @@ class TestOrganizerErrorHandling:
                 output_path=str(tmp_path / "output"),
             )
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="chmod does not restrict reads on Windows")
+    @_skip_if_root_or_windows
     def test_mixed_good_and_bad_files_in_batch(
         self,
         stub_all_models: None,

--- a/tests/utils/test_safedir.py
+++ b/tests/utils/test_safedir.py
@@ -347,6 +347,37 @@ class TestSymlinkRejection:
                 os.close(fd)
         assert (tmp_path / "fresh.txt").read_bytes() == b"hello"
 
+    def test_open_child_directory_flag_rejects_symlinked_target(self, tmp_path: Path) -> None:
+        """``O_DIRECTORY`` against a symlink returns ENOTDIR (not ELOOP) —
+        the symlink inode itself isn't a directory. Disambiguate via lstat
+        so the contract holds: callers using the generic ``open_child``
+        helper with ``O_DIRECTORY`` get the documented ``SymlinkRejected``
+        rather than ``NotADirectoryError`` for symlinked targets.
+        """
+        honey_dir = tmp_path / "honey"
+        honey_dir.mkdir()
+        (honey_dir / "secret.txt").write_text("do_not_exfiltrate")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "documents").symlink_to(honey_dir, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+
+        with SafeDir.open_root(organize) as sd, pytest.raises(SymlinkRejected):
+            sd.open_child("documents", flags=os.O_DIRECTORY)
+
+    def test_open_child_directory_flag_propagates_enotdir_for_regular_file(
+        self, tmp_path: Path
+    ) -> None:
+        """T10 predicate-negative: ``O_DIRECTORY`` against a regular file
+        must still surface ``NotADirectoryError``, not ``SymlinkRejected``.
+        Disambiguation fires only on actual symlinks.
+        """
+        (tmp_path / "regular.txt").write_text("not a directory")
+        with SafeDir.open_root(tmp_path) as sd, pytest.raises(NotADirectoryError):
+            sd.open_child("regular.txt", flags=os.O_DIRECTORY)
+
 
 # ---------------------------------------------------------------------------
 # Resource lifetime

--- a/tests/utils/test_safedir.py
+++ b/tests/utils/test_safedir.py
@@ -216,6 +216,35 @@ class TestHappyPath:
         assert not (src_dir / "doc.txt").exists()
         assert (dst_dir / "doc.txt").read_text() == "moved"
 
+    def test_rename_into_rejects_symlinked_source(self, tmp_path: Path) -> None:
+        """``os.rename`` has no O_NOFOLLOW. A TOCTOU swap (scandir
+        yields a regular file, then attacker replaces it with a symlink
+        before rename) would otherwise move the symlink into the
+        managed destination — contaminating the trusted output tree
+        with a pointer outside the SafeDir root.
+        """
+        (tmp_path / "honey").write_bytes(b"do_not_exfiltrate")
+        src_dir = tmp_path / "src"
+        dst_dir = tmp_path / "dst"
+        src_dir.mkdir()
+        dst_dir.mkdir()
+        try:
+            (src_dir / "report.pdf").symlink_to(tmp_path / "honey")
+        except OSError:
+            pytest.skip("symlink creation not supported")
+
+        with (
+            SafeDir.open_root(src_dir) as src,
+            SafeDir.open_root(dst_dir) as dst,
+            pytest.raises(SymlinkRejected),
+        ):
+            src.rename_into("report.pdf", dst, "report.pdf")
+
+        # Destination must remain empty — no symlink leaked through.
+        assert list(dst_dir.iterdir()) == []
+        # Source symlink remains in place (rename refused).
+        assert (src_dir / "report.pdf").is_symlink()
+
 
 # ---------------------------------------------------------------------------
 # Symlink rejection — the headline security guarantee

--- a/tests/utils/test_safedir.py
+++ b/tests/utils/test_safedir.py
@@ -139,6 +139,29 @@ class TestHappyPath:
         for name in names:
             assert isinstance(name, str)
 
+    def test_scandir_materializes_eagerly_so_iteration_cannot_outlive_safedir(
+        self, tmp_path: Path
+    ) -> None:
+        """``os.scandir(fd)`` dup's the fd, so a lazy generator could
+        keep yielding entries after ``SafeDir.__exit__`` closed the
+        SafeDir. Materializing names eagerly is the lifecycle
+        guarantee: the iterator returned by ``scandir()`` doesn't hold
+        an OS handle and can be safely consumed after the SafeDir is
+        closed (the data is already in memory; only future *operations*
+        on the SafeDir fail).
+        """
+        (tmp_path / "a").write_text("x")
+        (tmp_path / "b").write_text("y")
+        sd = SafeDir.open_root(tmp_path)
+        try:
+            it = sd.scandir()
+        finally:
+            sd.__exit__(None, None, None)
+        # Iterator survives SafeDir exit (names are already materialized);
+        # this is the contract — data is safe to consume, but no further
+        # syscalls happen.
+        assert sorted(it) == ["a", "b"]
+
     def test_scandir_filters_symlinks(self, tmp_path: Path) -> None:
         """``DirEntry.is_file()`` / ``.stat()`` default to following
         symlinks; filtering them out of scandir prevents naive callers

--- a/tests/utils/test_safedir.py
+++ b/tests/utils/test_safedir.py
@@ -135,6 +135,32 @@ class TestHappyPath:
             names = sorted(entry.name for entry in sd.scandir())
         assert names == ["a", "b"]
 
+    def test_scandir_filters_symlinks(self, tmp_path: Path) -> None:
+        """``DirEntry.is_file()`` / ``.stat()`` default to following
+        symlinks; filtering them out of scandir prevents naive callers
+        from classifying a symlink-to-file as a regular file (which
+        would bypass the SafeDir invariant before reaching
+        ``open_for_reader``).
+        """
+        (tmp_path / "honey").write_bytes(b"do_not_exfiltrate")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        (organize / "regular.txt").write_text("real")
+        try:
+            (organize / "link").symlink_to(tmp_path / "honey")
+            (organize / "link_to_dir").symlink_to(tmp_path, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+
+        with SafeDir.open_root(organize) as sd:
+            entries = list(sd.scandir())
+        names = sorted(entry.name for entry in entries)
+        assert names == ["regular.txt"]
+        # Defense check: every yielded entry must NOT be a symlink,
+        # whichever target type it points at.
+        for entry in entries:
+            assert not entry.is_symlink()
+
     def test_lstat_does_not_follow_symlink(self, tmp_path: Path) -> None:
         (tmp_path / "target").write_text("target content")
         try:

--- a/tests/utils/test_safedir.py
+++ b/tests/utils/test_safedir.py
@@ -35,6 +35,7 @@ from utils.safedir import SafeDir, SymlinkRejected
 pytestmark = [
     pytest.mark.ci,
     pytest.mark.unit,
+    pytest.mark.integration,
     pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only primitive"),
 ]
 

--- a/tests/utils/test_safedir.py
+++ b/tests/utils/test_safedir.py
@@ -250,6 +250,25 @@ class TestSymlinkRejection:
         with pytest.raises(SymlinkRejected):
             SafeDir.open_root(link)
 
+    def test_open_root_rejects_symlinked_root_when_passed_as_string(self, tmp_path: Path) -> None:
+        """``open_root`` accepts str / PathLike callers too.
+
+        Before the boundary-normalization fix, the ``ENOTDIR`` error path
+        called ``path.is_symlink()`` directly — which would raise
+        ``AttributeError`` instead of the documented ``SymlinkRejected``
+        when a CLI/config caller passed an un-typed string.
+        """
+        real_root = tmp_path / "real"
+        real_root.mkdir()
+        try:
+            link = tmp_path / "link"
+            link.symlink_to(real_root, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+        # Pass the path as a string, not a Path object.
+        with pytest.raises(SymlinkRejected):
+            SafeDir.open_root(str(link))
+
     def test_symlink_rejected_is_oserror(self) -> None:
         """``SymlinkRejected`` subclasses ``OSError`` so existing handlers work."""
         assert issubclass(SymlinkRejected, OSError)

--- a/tests/utils/test_safedir.py
+++ b/tests/utils/test_safedir.py
@@ -284,6 +284,50 @@ class TestSymlinkRejection:
             with pytest.raises(ValueError, match="O_PATH"):
                 sd.open_child("regular", flags=os.O_PATH | os.O_RDONLY)
 
+    def test_open_child_excl_create_rejects_symlinked_target(self, tmp_path: Path) -> None:
+        """``O_CREAT|O_EXCL`` returns EEXIST (not ELOOP) on an existing
+        symlink. The documented contract is "symlink → SymlinkRejected",
+        so this case must disambiguate via lstat rather than leak through
+        as ``FileExistsError``. Otherwise an exclusive-create caller might
+        treat ``EEXIST`` as benign "file already exists" and miss the
+        symlink-swap attack.
+        """
+        (tmp_path / "honey").write_bytes(b"do_not_exfiltrate")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "out.txt").symlink_to(tmp_path / "honey")
+        except OSError:
+            pytest.skip("symlink creation not supported")
+
+        excl_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        with SafeDir.open_root(organize) as sd, pytest.raises(SymlinkRejected):
+            sd.open_child("out.txt", flags=excl_flags)
+
+    def test_open_child_excl_create_passes_through_real_file_eexist(self, tmp_path: Path) -> None:
+        """T10 predicate-negative: when the existing entry is a regular
+        file (not a symlink), ``O_CREAT|O_EXCL`` must still surface
+        ``FileExistsError``, not ``SymlinkRejected``. The disambiguation
+        check fires only on actual symlinks.
+        """
+        (tmp_path / "out.txt").write_text("already here")
+        excl_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        with SafeDir.open_root(tmp_path) as sd, pytest.raises(FileExistsError):
+            sd.open_child("out.txt", flags=excl_flags)
+
+    def test_open_child_excl_create_succeeds_for_new_name(self, tmp_path: Path) -> None:
+        """T10 positive control: ``O_CREAT|O_EXCL`` on a non-existent name
+        succeeds (no symlink, no existing file). Confirms the new error
+        path doesn't break the happy case.
+        """
+        with SafeDir.open_root(tmp_path) as sd:
+            fd = sd.open_child("fresh.txt", flags=os.O_WRONLY | os.O_CREAT | os.O_EXCL)
+            try:
+                os.write(fd, b"hello")
+            finally:
+                os.close(fd)
+        assert (tmp_path / "fresh.txt").read_bytes() == b"hello"
+
 
 # ---------------------------------------------------------------------------
 # Resource lifetime

--- a/tests/utils/test_safedir.py
+++ b/tests/utils/test_safedir.py
@@ -128,12 +128,16 @@ class TestHappyPath:
             with os.fdopen(fd, "rb") as f:
                 assert f.read() == b"payload"
 
-    def test_scandir_yields_entries(self, tmp_path: Path) -> None:
+    def test_scandir_yields_names(self, tmp_path: Path) -> None:
         (tmp_path / "a").write_text("x")
         (tmp_path / "b").write_text("y")
         with SafeDir.open_root(tmp_path) as sd:
-            names = sorted(entry.name for entry in sd.scandir())
+            names = sorted(sd.scandir())
         assert names == ["a", "b"]
+        # Yielded values are plain strings, not DirEntry objects —
+        # callers can't reach symlink-following helpers.
+        for name in names:
+            assert isinstance(name, str)
 
     def test_scandir_filters_symlinks(self, tmp_path: Path) -> None:
         """``DirEntry.is_file()`` / ``.stat()`` default to following
@@ -153,13 +157,8 @@ class TestHappyPath:
             pytest.skip("symlink creation not supported")
 
         with SafeDir.open_root(organize) as sd:
-            entries = list(sd.scandir())
-        names = sorted(entry.name for entry in entries)
+            names = list(sd.scandir())
         assert names == ["regular.txt"]
-        # Defense check: every yielded entry must NOT be a symlink,
-        # whichever target type it points at.
-        for entry in entries:
-            assert not entry.is_symlink()
 
     def test_lstat_does_not_follow_symlink(self, tmp_path: Path) -> None:
         (tmp_path / "target").write_text("target content")
@@ -662,7 +661,7 @@ class TestPredicateNegatives:
         (tmp_path / "documents_link").mkdir()
         (tmp_path / "documents_link" / "x").write_text("x")
         with SafeDir.open_root(tmp_path) as sd, sd.open_subdir("documents_link") as sub:
-            assert {e.name for e in sub.scandir()} == {"x"}
+            assert set(sub.scandir()) == {"x"}
 
     def test_root_at_real_path_not_rejected(self, tmp_path: Path) -> None:
         """`open_root` on a real directory (whatever the parent has done) is fine.

--- a/tests/utils/test_safedir.py
+++ b/tests/utils/test_safedir.py
@@ -311,6 +311,78 @@ class TestResourceLifetime:
         sd.__exit__(None, None, None)
 
 
+class TestUseAfterClose:
+    """Methods must refuse to operate on a closed SafeDir.
+
+    POSIX recycles fd numbers eagerly — if a caller retains a closed
+    ``SafeDir`` and then invokes a method on it, the stale ``self._fd``
+    could address an unrelated directory that the kernel reassigned
+    that number to (after any subsequent ``os.open`` in the same
+    process). Each method calls ``self._check_open()`` first so the
+    failure is loud rather than silently operating on the wrong dir.
+    """
+
+    @pytest.fixture
+    def closed_sd(self, tmp_path: Path) -> SafeDir:
+        sd = SafeDir.open_root(tmp_path)
+        sd.__exit__(None, None, None)
+        return sd
+
+    def test_fd_property_raises(self, closed_sd: SafeDir) -> None:
+        with pytest.raises(ValueError, match="closed"):
+            _ = closed_sd.fd
+
+    def test_open_child_raises(self, closed_sd: SafeDir) -> None:
+        with pytest.raises(ValueError, match="closed"):
+            closed_sd.open_child("anything")
+
+    def test_open_for_reader_raises(self, closed_sd: SafeDir) -> None:
+        with pytest.raises(ValueError, match="closed"):
+            closed_sd.open_for_reader("anything")
+
+    def test_open_subdir_raises(self, closed_sd: SafeDir) -> None:
+        with pytest.raises(ValueError, match="closed"):
+            closed_sd.open_subdir("anything")
+
+    def test_scandir_raises(self, closed_sd: SafeDir) -> None:
+        with pytest.raises(ValueError, match="closed"):
+            list(closed_sd.scandir())
+
+    def test_lstat_raises(self, closed_sd: SafeDir) -> None:
+        with pytest.raises(ValueError, match="closed"):
+            closed_sd.lstat("anything")
+
+    def test_mkdir_raises(self, closed_sd: SafeDir) -> None:
+        with pytest.raises(ValueError, match="closed"):
+            closed_sd.mkdir("anything")
+
+    def test_unlink_raises(self, closed_sd: SafeDir) -> None:
+        with pytest.raises(ValueError, match="closed"):
+            closed_sd.unlink("anything")
+
+    def test_rename_into_raises_on_closed_self(self, tmp_path: Path) -> None:
+        closed = SafeDir.open_root(tmp_path)
+        closed.__exit__(None, None, None)
+        with SafeDir.open_root(tmp_path) as live:
+            with pytest.raises(ValueError, match="closed"):
+                closed.rename_into("a", live, "b")
+
+    def test_rename_into_raises_on_closed_other(self, tmp_path: Path) -> None:
+        other = SafeDir.open_root(tmp_path)
+        other.__exit__(None, None, None)
+        with SafeDir.open_root(tmp_path) as live:
+            with pytest.raises(ValueError, match="closed"):
+                live.rename_into("a", other, "b")
+
+    def test_underlying_fd_invalidated_to_neg_one(self, tmp_path: Path) -> None:
+        """Defense in depth: even if ``_check_open`` is bypassed via
+        direct attribute access, the stored fd is -1 so any syscall
+        fails with EBADF rather than operating on a recycled fd."""
+        sd = SafeDir.open_root(tmp_path)
+        sd.__exit__(None, None, None)
+        assert sd._fd == -1
+
+
 # ---------------------------------------------------------------------------
 # Error semantics: missing entries
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_safedir.py
+++ b/tests/utils/test_safedir.py
@@ -402,6 +402,50 @@ class TestSymlinkRejection:
                 os.close(fd)
         assert (tmp_path / "fresh.txt").read_bytes() == b"hello"
 
+    def test_open_child_creates_files_with_non_executable_mode(self, tmp_path: Path) -> None:
+        """`os.open` defaults `mode=0o777`; with the typical 022 umask
+        that gives 0o755 — files created via SafeDir would be
+        unexpectedly executable. The default must match the high-level
+        `open()` builtin (0o666 pre-umask → 0o644 post-umask).
+        """
+        with SafeDir.open_root(tmp_path) as sd:
+            fd = sd.open_child("output.txt", flags=os.O_WRONLY | os.O_CREAT | os.O_EXCL)
+            os.close(fd)
+        st = (tmp_path / "output.txt").stat()
+        import stat as _stat
+
+        # The exact mode depends on the test environment's umask, but
+        # under no reasonable umask (000 through 077) does 0o666 produce
+        # an executable file. Assert no execute bits anywhere.
+        exec_bits = _stat.S_IXUSR | _stat.S_IXGRP | _stat.S_IXOTH
+        assert (st.st_mode & exec_bits) == 0, (
+            f"file created with executable bits: {oct(st.st_mode)}"
+        )
+
+    def test_open_child_honors_explicit_mode(self, tmp_path: Path) -> None:
+        """Callers can request stricter permissions (e.g. 0o600 for
+        secret-bearing files). The explicit mode is passed through to
+        `os.open` so the umask is still applied.
+        """
+        # Set a permissive umask so the explicit mode is what we observe.
+        # umask is restored by the conftest fixture isolation; for this
+        # test we just need to know the umask doesn't strip our bits.
+        prev_umask = os.umask(0)
+        try:
+            with SafeDir.open_root(tmp_path) as sd:
+                fd = sd.open_child(
+                    "secret.txt",
+                    flags=os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    mode=0o600,
+                )
+                os.close(fd)
+        finally:
+            os.umask(prev_umask)
+        st = (tmp_path / "secret.txt").stat()
+        assert (st.st_mode & 0o777) == 0o600, (
+            f"explicit mode 0o600 not honored: {oct(st.st_mode & 0o777)}"
+        )
+
     def test_open_child_directory_flag_rejects_symlinked_target(self, tmp_path: Path) -> None:
         """``O_DIRECTORY`` against a symlink returns ENOTDIR (not ELOOP) —
         the symlink inode itself isn't a directory. Disambiguate via lstat

--- a/tests/utils/test_safedir.py
+++ b/tests/utils/test_safedir.py
@@ -1,0 +1,381 @@
+"""Tests for ``utils.safedir`` — POSIX-safe directory-fd filesystem operations.
+
+Implementation of #266 in the security hardening series (#264).
+
+`SafeDir` holds an open directory file descriptor and exposes operations
+that route through `dir_fd=` + `O_NOFOLLOW`. The invariant: every operation
+takes a single path *component*, never a path string, so attacker-controlled
+segments can't escape the held directory.
+
+Threat model coverage anchored by these tests:
+
+- Symlink swap between enumeration and read — `open_for_reader` /
+  `open_child` raise `SymlinkRejected` rather than dereferencing.
+- Component-name injection — names containing `/`, `\\`, `..`, or NUL are
+  rejected with `ValueError` before any syscall.
+- File-descriptor leaks — context-manager exit releases the held fd.
+- Cross-directory atomicity — `rename_into` between two `SafeDir`s uses
+  `os.rename` with both source and destination `dir_fd`.
+
+Platform: POSIX only. Windows has no equivalent for `O_NOFOLLOW` /
+`dir_fd=`; the `SafeDir.open_root` factory raises `NotImplementedError`
+there (see #264 for the deferral).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from utils.safedir import SafeDir, SymlinkRejected
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+    pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only primitive"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Component-name validation
+# ---------------------------------------------------------------------------
+
+
+class TestNameValidation:
+    """Every method that takes a *name* must reject path-component injection."""
+
+    @pytest.fixture
+    def sd(self, tmp_path: Path):
+        with SafeDir.open_root(tmp_path) as sd:
+            yield sd
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        [
+            "a/b",
+            "../escape",
+            "..",
+            ".",
+            "",
+            "a\x00b",
+            "foo\\bar",
+            "/abs",
+        ],
+    )
+    def test_open_child_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
+        with pytest.raises(ValueError):
+            sd.open_child(bad_name)
+
+    @pytest.mark.parametrize("bad_name", ["a/b", "..", "", "x\x00y"])
+    def test_open_for_reader_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
+        with pytest.raises(ValueError):
+            sd.open_for_reader(bad_name)
+
+    @pytest.mark.parametrize("bad_name", ["a/b", "..", "."])
+    def test_open_subdir_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
+        with pytest.raises(ValueError):
+            sd.open_subdir(bad_name)
+
+    @pytest.mark.parametrize("bad_name", ["a/b", ".."])
+    def test_lstat_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
+        with pytest.raises(ValueError):
+            sd.lstat(bad_name)
+
+    @pytest.mark.parametrize("bad_name", ["a/b", "..", ""])
+    def test_unlink_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
+        with pytest.raises(ValueError):
+            sd.unlink(bad_name)
+
+    @pytest.mark.parametrize("bad_name", ["a/b", "..", ""])
+    def test_mkdir_rejects_bad_name(self, sd: SafeDir, bad_name: str) -> None:
+        with pytest.raises(ValueError):
+            sd.mkdir(bad_name)
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_open_root_and_close_on_context_exit(self, tmp_path: Path) -> None:
+        """Context exit closes the held fd."""
+        sd = SafeDir.open_root(tmp_path)
+        fd = sd.fd
+        sd.__exit__(None, None, None)
+        with pytest.raises(OSError):
+            # Closed fd — fstat raises EBADF.
+            os.fstat(fd)
+
+    def test_open_for_reader_returns_readable_fd(self, tmp_path: Path) -> None:
+        (tmp_path / "data.txt").write_bytes(b"hello")
+        with SafeDir.open_root(tmp_path) as sd:
+            fd = sd.open_for_reader("data.txt")
+            try:
+                assert os.read(fd, 5) == b"hello"
+            finally:
+                os.close(fd)
+
+    def test_open_for_reader_via_fdopen(self, tmp_path: Path) -> None:
+        """Confirms the canonical 'pass to library reader' pattern works."""
+        (tmp_path / "data.txt").write_bytes(b"payload")
+        with SafeDir.open_root(tmp_path) as sd:
+            fd = sd.open_for_reader("data.txt")
+            with os.fdopen(fd, "rb") as f:
+                assert f.read() == b"payload"
+
+    def test_scandir_yields_entries(self, tmp_path: Path) -> None:
+        (tmp_path / "a").write_text("x")
+        (tmp_path / "b").write_text("y")
+        with SafeDir.open_root(tmp_path) as sd:
+            names = sorted(entry.name for entry in sd.scandir())
+        assert names == ["a", "b"]
+
+    def test_lstat_does_not_follow_symlink(self, tmp_path: Path) -> None:
+        (tmp_path / "target").write_text("target content")
+        try:
+            (tmp_path / "link").symlink_to(tmp_path / "target")
+        except OSError:
+            pytest.skip("symlink creation not supported")
+        with SafeDir.open_root(tmp_path) as sd:
+            st = sd.lstat("link")
+        import stat as _stat
+
+        assert _stat.S_ISLNK(st.st_mode), "lstat should report the symlink, not the target"
+
+    def test_unlink_removes_via_dir_fd(self, tmp_path: Path) -> None:
+        target = tmp_path / "doomed"
+        target.write_text("x")
+        with SafeDir.open_root(tmp_path) as sd:
+            sd.unlink("doomed")
+        assert not target.exists()
+
+    def test_mkdir_creates_subdir(self, tmp_path: Path) -> None:
+        with SafeDir.open_root(tmp_path) as sd:
+            sd.mkdir("new_category")
+        assert (tmp_path / "new_category").is_dir()
+
+    def test_open_subdir_returns_new_safedir(self, tmp_path: Path) -> None:
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub" / "leaf.txt").write_bytes(b"leaf content")
+        with SafeDir.open_root(tmp_path) as root, root.open_subdir("sub") as sub:
+            fd = sub.open_for_reader("leaf.txt")
+            try:
+                assert os.read(fd, 12) == b"leaf content"
+            finally:
+                os.close(fd)
+
+    def test_rename_into_same_dir(self, tmp_path: Path) -> None:
+        (tmp_path / "old").write_text("data")
+        with SafeDir.open_root(tmp_path) as sd:
+            sd.rename_into("old", sd, "new")
+        assert not (tmp_path / "old").exists()
+        assert (tmp_path / "new").read_text() == "data"
+
+    def test_rename_into_cross_dir(self, tmp_path: Path) -> None:
+        src_dir = tmp_path / "src"
+        dst_dir = tmp_path / "dst"
+        src_dir.mkdir()
+        dst_dir.mkdir()
+        (src_dir / "doc.txt").write_text("moved")
+        with (
+            SafeDir.open_root(src_dir) as src,
+            SafeDir.open_root(dst_dir) as dst,
+        ):
+            src.rename_into("doc.txt", dst, "doc.txt")
+        assert not (src_dir / "doc.txt").exists()
+        assert (dst_dir / "doc.txt").read_text() == "moved"
+
+
+# ---------------------------------------------------------------------------
+# Symlink rejection — the headline security guarantee
+# ---------------------------------------------------------------------------
+
+
+class TestSymlinkRejection:
+    """`O_NOFOLLOW` on every open. A swapped symlink raises `SymlinkRejected`."""
+
+    def test_open_for_reader_rejects_symlinked_file(self, tmp_path: Path) -> None:
+        honey = tmp_path / "honey"
+        honey.write_bytes(b"do_not_exfiltrate")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "report.pdf").symlink_to(honey)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+        with SafeDir.open_root(organize) as sd:
+            with pytest.raises(SymlinkRejected):
+                sd.open_for_reader("report.pdf")
+
+    def test_open_child_rejects_symlinked_file(self, tmp_path: Path) -> None:
+        (tmp_path / "honey").write_bytes(b"do_not_exfiltrate")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "link").symlink_to(tmp_path / "honey")
+        except OSError:
+            pytest.skip("symlink creation not supported")
+        with SafeDir.open_root(organize) as sd:
+            with pytest.raises(SymlinkRejected):
+                sd.open_child("link")
+
+    def test_open_subdir_rejects_symlinked_directory(self, tmp_path: Path) -> None:
+        target = tmp_path / "honey_dir"
+        target.mkdir()
+        (target / "secret.txt").write_text("oops")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "documents").symlink_to(target, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+        with SafeDir.open_root(organize) as sd:
+            with pytest.raises(SymlinkRejected):
+                sd.open_subdir("documents")
+
+    def test_open_root_rejects_symlinked_root(self, tmp_path: Path) -> None:
+        """If the root passed to ``open_root`` is itself a symlink, refuse."""
+        real_root = tmp_path / "real"
+        real_root.mkdir()
+        try:
+            link = tmp_path / "link"
+            link.symlink_to(real_root, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+        with pytest.raises(SymlinkRejected):
+            SafeDir.open_root(link)
+
+    def test_symlink_rejected_is_oserror(self) -> None:
+        """``SymlinkRejected`` subclasses ``OSError`` so existing handlers work."""
+        assert issubclass(SymlinkRejected, OSError)
+
+
+# ---------------------------------------------------------------------------
+# Resource lifetime
+# ---------------------------------------------------------------------------
+
+
+class TestResourceLifetime:
+    """Verify the held fd is released on context-manager exit and on subdir
+    chains.
+
+    `T13` from `test-generation-patterns.md` — using `tmp_path` everywhere
+    rather than hardcoded paths.
+    """
+
+    def _count_fds(self) -> int | None:
+        """Return the number of open fds for this process, or None on platforms
+        where ``/proc/self/fd`` is unavailable (e.g. macOS).
+        """
+        proc = Path("/proc/self/fd")
+        if not proc.is_dir():
+            return None
+        return len(list(proc.iterdir()))
+
+    def test_context_manager_releases_root_fd(self, tmp_path: Path) -> None:
+        before = self._count_fds()
+        if before is None:
+            pytest.skip("/proc/self/fd not available on this platform")
+        for _ in range(20):
+            with SafeDir.open_root(tmp_path):
+                pass
+        after = self._count_fds()
+        assert after is not None
+        # Allow a small slack for any incidental fd churn (logging, gc).
+        assert after - before <= 2, f"fd leak: before={before} after={after}"
+
+    def test_context_manager_releases_subdir_fd(self, tmp_path: Path) -> None:
+        (tmp_path / "sub").mkdir()
+        before = self._count_fds()
+        if before is None:
+            pytest.skip("/proc/self/fd not available on this platform")
+        with SafeDir.open_root(tmp_path) as root:
+            for _ in range(20):
+                with root.open_subdir("sub"):
+                    pass
+        after = self._count_fds()
+        assert after is not None
+        assert after - before <= 2, f"fd leak: before={before} after={after}"
+
+    def test_close_does_not_doublefree(self, tmp_path: Path) -> None:
+        """Exiting the context manager twice is harmless."""
+        sd = SafeDir.open_root(tmp_path)
+        sd.__exit__(None, None, None)
+        # Calling exit again must NOT raise (it could happen if the user
+        # writes their own try/finally + with-statement).
+        sd.__exit__(None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# Error semantics: missing entries
+# ---------------------------------------------------------------------------
+
+
+class TestMissingEntries:
+    def test_open_for_reader_missing_file_raises_filenotfound(self, tmp_path: Path) -> None:
+        with SafeDir.open_root(tmp_path) as sd:
+            with pytest.raises(FileNotFoundError):
+                sd.open_for_reader("nope.txt")
+
+    def test_open_subdir_missing_raises_filenotfound(self, tmp_path: Path) -> None:
+        with SafeDir.open_root(tmp_path) as sd:
+            with pytest.raises(FileNotFoundError):
+                sd.open_subdir("nope")
+
+    def test_unlink_missing_raises_filenotfound(self, tmp_path: Path) -> None:
+        with SafeDir.open_root(tmp_path) as sd:
+            with pytest.raises(FileNotFoundError):
+                sd.unlink("nope")
+
+    def test_lstat_missing_raises_filenotfound(self, tmp_path: Path) -> None:
+        with SafeDir.open_root(tmp_path) as sd:
+            with pytest.raises(FileNotFoundError):
+                sd.lstat("nope")
+
+
+# ---------------------------------------------------------------------------
+# T10 predicate-negative cases for the symlink rejection
+# ---------------------------------------------------------------------------
+
+
+class TestPredicateNegatives:
+    """`test-generation-patterns.md` T10: every predicate needs a negative
+    case with the same surface shape but wrong context.
+
+    The predicate here is "is this entry a symlink that we should refuse?"
+    The wrong-context cases below all look like potentially-dangerous
+    operations but are in fact safe and must succeed.
+    """
+
+    def test_regular_file_named_like_symlink_not_rejected(self, tmp_path: Path) -> None:
+        """A regular file whose name is "link" or "shortcut" is fine."""
+        (tmp_path / "link").write_bytes(b"actually a regular file")
+        with SafeDir.open_root(tmp_path) as sd:
+            fd = sd.open_for_reader("link")
+            try:
+                assert os.read(fd, 64) == b"actually a regular file"
+            finally:
+                os.close(fd)
+
+    def test_regular_directory_named_like_symlink_not_rejected(self, tmp_path: Path) -> None:
+        """A regular directory at a name that *looks* like a link is fine."""
+        (tmp_path / "documents_link").mkdir()
+        (tmp_path / "documents_link" / "x").write_text("x")
+        with SafeDir.open_root(tmp_path) as sd, sd.open_subdir("documents_link") as sub:
+            assert {e.name for e in sub.scandir()} == {"x"}
+
+    def test_root_at_real_path_not_rejected(self, tmp_path: Path) -> None:
+        """`open_root` on a real directory (whatever the parent has done) is fine.
+
+        Same surface shape as `test_open_root_rejects_symlinked_root` — a
+        directory at the supplied path. Wrong context: the directory is real.
+        """
+        real = tmp_path / "organize"
+        real.mkdir()
+        with SafeDir.open_root(real) as sd:
+            # Verify the fd actually points at the right inode.
+            assert os.fstat(sd.fd).st_ino == real.stat().st_ino

--- a/tests/utils/test_safedir.py
+++ b/tests/utils/test_safedir.py
@@ -254,6 +254,36 @@ class TestSymlinkRejection:
         """``SymlinkRejected`` subclasses ``OSError`` so existing handlers work."""
         assert issubclass(SymlinkRejected, OSError)
 
+    def test_open_child_rejects_o_path(self, tmp_path: Path) -> None:
+        """``O_PATH | O_NOFOLLOW`` on Linux returns an fd for the symlink
+        itself instead of raising ELOOP — that would silently violate the
+        documented "no symlinks" contract. The public API must refuse it.
+
+        On platforms without ``O_PATH`` (macOS, BSD) the bug doesn't exist;
+        ``_O_PATH == 0`` makes this skip cleanly.
+        """
+        if not hasattr(os, "O_PATH"):
+            pytest.skip("O_PATH is Linux-only; bug doesn't exist on this platform")
+
+        (tmp_path / "regular").write_text("x")
+        with SafeDir.open_root(tmp_path) as sd:
+            with pytest.raises(ValueError, match="O_PATH"):
+                sd.open_child("regular", flags=os.O_PATH)
+
+    def test_open_child_rejects_o_path_even_for_real_files(self, tmp_path: Path) -> None:
+        """Predicate-negative: the rejection fires on the flag, not on whether
+        the entry is a symlink. A regular file with ``O_PATH`` must still be
+        refused so callers can't 'just happen to' use the flag safely and
+        later trip on it with an attacker-controlled symlink (T10).
+        """
+        if not hasattr(os, "O_PATH"):
+            pytest.skip("O_PATH is Linux-only")
+
+        (tmp_path / "regular").write_text("x")
+        with SafeDir.open_root(tmp_path) as sd:
+            with pytest.raises(ValueError, match="O_PATH"):
+                sd.open_child("regular", flags=os.O_PATH | os.O_RDONLY)
+
 
 # ---------------------------------------------------------------------------
 # Resource lifetime


### PR DESCRIPTION
Closes #266. Second PR in the security hardening series tracked under #264.

## Summary

`src/utils/safedir.py` introduces the `SafeDir` primitive that holds an open directory file descriptor and routes every filesystem operation through `dir_fd=` + `O_NOFOLLOW`. PRs 3–6 will thread it through the read-side ingestion, dedupe, undo, and watcher paths.

### Design invariants enforced by the implementation

- **Every method takes a single path *component*, never a path.** Names containing `/`, `\`, `..`, `.`, NUL, or empty strings raise `ValueError` before any syscall. Attacker-controlled segments (file content, AI output, watcher event payloads) cannot escape the held directory.
- **`O_NOFOLLOW` is always set on opens.** Linux quirk: with `O_DIRECTORY | O_NOFOLLOW` a symlink-to-dir returns `ENOTDIR` rather than `ELOOP`, so the open helpers do a post-error `lstat` to disambiguate and raise `SymlinkRejected` (subclass of `OSError`) in either case.
- **No path-string reconstruction.** Every syscall uses `dir_fd=self.fd` with the bare component.
- **fd lifetime is via context manager only**; double-exit is harmless. The class deliberately does not expose a public `close()` to discourage leaks.

### API surface

- `SafeDir.open_root(path)` — factory
- `open_child(name, *, flags=O_RDONLY)` — generic open (always `O_NOFOLLOW`)
- `open_for_reader(name)` — canonical "pass to content reader" helper; pair with `os.fdopen(fd, "rb")`
- `open_subdir(name)` — returns a new `SafeDir` for a child directory
- `scandir()` — `os.scandir(self.fd)`
- `lstat(name)` — for inode-pinning workflows (PR4 / PR5)
- `mkdir`, `unlink`, `rename_into(name, other, other_name)`
- Context-manager protocol

### Platform

POSIX only. `open_root` raises `NotImplementedError` on Windows; companion tests skip there. Windows port deferred per #264.

## Test plan

- [x] `tests/utils/test_safedir.py` — **48 cases**, all pass
  - Name validation across every method (parametrized over `/`, `..`, `.`, `""`, NUL, `\`, absolute paths)
  - Happy paths for every operation (open, scandir, lstat, unlink, mkdir, `rename_into` same-dir + cross-dir, `open_subdir` chaining)
  - Symlink rejection on file open, dir open, and root open
  - Predicate-T10 negatives — entries named "link" / "documents_link" that are actually regular files/dirs must succeed
  - fd lifetime — 20-iteration loop verifies no leak via `/proc/self/fd`
  - Missing-entry semantics — `FileNotFoundError`, not generic `OSError`
- [x] CI subset (`pytest -m ci`) — 4400 passed, 7 skipped, plus the 2 pre-existing unrelated failures confirmed from PR #271
- [x] `ruff check` + `ruff format --check` clean
- [x] Advisory baseline of `scripts/check_safedir_required.py` unchanged at 48 call sites — `src/utils/safedir.py` is already allowlisted (set up in PR #271)

## What this is NOT

This PR adds the primitive but does not migrate any existing call sites. None of the 48 advisory-mode rail violations are resolved here — those come down in:

- #267 (PR3) — Read-side ingestion migration (closes LLM-exfiltration vector)
- #268 (PR4) — Inode-pin dedupe
- #269 (PR5) — History `(dev, ino)` + undo verification
- #270 (PR6) — Watcher + move-destination hardening

https://claude.ai/code/session_01EnPpeovvetPSR8Vwhxsn9j

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnPpeovvetPSR8Vwhxsn9j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure directory operations with automatic symlink attack prevention for POSIX systems.

* **Improvements**
  * Enhanced error handling for file operations with improved support for permission-sensitive scenarios.
  * Expanded test coverage for edge cases and cross-platform conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->