### PR TITLE
feat(security): PR3a — SafeDir for text_processor + document readers

### DIFF
--- a/src/services/text_processor.py
+++ b/src/services/text_processor.py
@@ -13,6 +13,8 @@ from models import TextModel
 from models.base import BaseModel, ModelConfig, ModelType
 from models.provider_factory import get_text_model
 from utils.file_readers import FileReadError, read_file
+from utils.readers import read_file_via_safedir
+from utils.safedir import SafeDir, SymlinkRejected
 from utils.text_processing import (
     clean_text,
     truncate_text,
@@ -138,9 +140,42 @@ class TextProcessor:
         start_time = time.time()
 
         try:
-            # Read file content
+            # Read file content via SafeDir for the migrated extensions
+            # (txt/md/docx/pdf/rtf/csv/xlsx/pptx — the LLM ingestion path).
+            # ``read_file_via_safedir`` opens with ``O_NOFOLLOW`` so a
+            # symlink swapped in between the directory walk and this read
+            # is refused rather than dereferenced — closes the LLM-
+            # exfiltration vector documented in #264. Other extensions
+            # fall back to the legacy path-based ``read_file`` until their
+            # readers are migrated in PR3b–PR3e.
             logger.debug("Reading file: {}", file_path.name)
-            content = read_file(file_path)
+            content: str | None = None
+            try:
+                with SafeDir.open_root(file_path.parent) as safe_dir:
+                    content = read_file_via_safedir(safe_dir, file_path.name)
+            except SymlinkRejected as exc:
+                logger.warning("Refused to read symlinked file {}: {}", file_path, exc)
+                return ProcessedFile(
+                    file_path=file_path,
+                    description="",
+                    folder_name="errors",
+                    filename=file_path.stem,
+                    error=f"Refused to read symlink: {file_path.name}",
+                )
+            except (FileNotFoundError, NotADirectoryError):
+                # SafeDir path requires the file (and its parent) to
+                # exist on disk. Fall through to legacy ``read_file``
+                # which will either re-raise the same error to be
+                # handled below OR be intercepted by a test mock.
+                # Preserves backward compatibility with existing tests
+                # that monkey-patch ``read_file``.
+                pass
+            if content is None:
+                # Either extension not yet supported by the SafeDir
+                # dispatcher (archives, ebooks, scientific, CAD —
+                # migrated in PR3b–PR3e) OR the SafeDir open failed
+                # for a non-symlink reason (handled above).
+                content = read_file(file_path)
 
             if content is None:
                 return ProcessedFile(

--- a/src/services/text_processor.py
+++ b/src/services/text_processor.py
@@ -162,10 +162,20 @@ class TextProcessor:
                     filename=file_path.stem,
                     error=f"Refused to read symlink: {file_path.name}",
                 )
+            except NotImplementedError:
+                # SafeDir requires POSIX dir_fd / O_NOFOLLOW; on Windows
+                # the Windows port is deferred (#264). Fall back to the
+                # legacy path-based reader so Windows users can still
+                # process .txt/.md/.pdf/.docx through TextProcessor.
+                # Tracked for follow-up in PR3b–PR3e.
+                logger.debug(
+                    "SafeDir unavailable on this platform; using legacy reader for {}",
+                    file_path.name,
+                )
             if content is None:
-                # Extension not yet supported by the SafeDir dispatcher
-                # (archives, ebooks, scientific, CAD — migrated in
-                # PR3b–PR3e). Fall back to the legacy path-based reader.
+                # Either the SafeDir dispatcher returned ``None`` (extension
+                # not yet migrated — archives, ebooks, scientific, CAD,
+                # handled in PR3b–PR3e) OR SafeDir is unavailable (Windows).
                 # Real FS errors from the SafeDir branch propagate to the
                 # outer ``except FileReadError`` / ``except OSError``
                 # handlers — never silently masked by a path-based retry

--- a/src/services/text_processor.py
+++ b/src/services/text_processor.py
@@ -162,19 +162,14 @@ class TextProcessor:
                     filename=file_path.stem,
                     error=f"Refused to read symlink: {file_path.name}",
                 )
-            except (FileNotFoundError, NotADirectoryError):
-                # SafeDir path requires the file (and its parent) to
-                # exist on disk. Fall through to legacy ``read_file``
-                # which will either re-raise the same error to be
-                # handled below OR be intercepted by a test mock.
-                # Preserves backward compatibility with existing tests
-                # that monkey-patch ``read_file``.
-                pass
             if content is None:
-                # Either extension not yet supported by the SafeDir
-                # dispatcher (archives, ebooks, scientific, CAD —
-                # migrated in PR3b–PR3e) OR the SafeDir open failed
-                # for a non-symlink reason (handled above).
+                # Extension not yet supported by the SafeDir dispatcher
+                # (archives, ebooks, scientific, CAD — migrated in
+                # PR3b–PR3e). Fall back to the legacy path-based reader.
+                # Real FS errors from the SafeDir branch propagate to the
+                # outer ``except FileReadError`` / ``except OSError``
+                # handlers — never silently masked by a path-based retry
+                # that could follow a symlink swapped in mid-flight.
                 content = read_file(file_path)
 
             if content is None:

--- a/src/utils/readers/__init__.py
+++ b/src/utils/readers/__init__.py
@@ -21,7 +21,9 @@ Example::
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from loguru import logger
 
@@ -31,6 +33,9 @@ from utils.readers._base import (
     FileTooLargeError,
     _check_file_size,
 )
+
+if TYPE_CHECKING:
+    from utils.safedir import SafeDir
 from utils.readers.archives import (
     read_7z_file,
     read_rar_file,
@@ -64,8 +69,9 @@ __all__ = [
     "FileReadError",
     "FileTooLargeError",
     "MAX_FILE_SIZE_BYTES",
-    # Dispatcher
+    # Dispatchers
     "read_file",
+    "read_file_via_safedir",
     # Document readers
     "read_text_file",
     "read_docx_file",
@@ -159,4 +165,86 @@ def read_file(file_path: str | Path, **kwargs: object) -> str | None:
                     raise
 
     logger.warning(f"Unsupported file type: {ext}")
+    return None
+
+
+# Readers that accept the SafeDir-friendly ``fileobj=`` kwarg. Migrated in
+# PR3a (#267): the LLM text-ingestion path — plain text, markdown, DOCX, PDF,
+# RTF, CSV/XLSX, and PowerPoint. Other readers (ebook, archives, scientific,
+# CAD) are still path-only and dispatch falls back to ``read_file`` (which
+# does not benefit from SafeDir's symlink rejection).
+_SAFEDIR_READERS: dict[tuple[str, ...], object] = {
+    (".txt", ".md"): read_text_file,
+    (".docx",): read_docx_file,
+    (".pdf",): read_pdf_file,
+    (".rtf",): read_rtf_file,
+    (".csv", ".xlsx", ".xls"): read_spreadsheet_file,
+    (".ppt", ".pptx"): read_presentation_file,
+}
+
+
+def read_file_via_safedir(
+    safe_dir: SafeDir,
+    name: str,
+    **kwargs: object,
+) -> str | None:
+    """Open *name* under *safe_dir* and dispatch to a reader.
+
+    The SafeDir-friendly entry point: ``safe_dir.open_for_reader(name)`` is
+    used to obtain a file descriptor with ``O_NOFOLLOW``, so a symlink
+    swapped in between directory enumeration and read is refused with
+    ``SymlinkRejected`` rather than dereferenced.
+
+    Args:
+        safe_dir: An open :class:`utils.safedir.SafeDir` for the parent
+            directory of *name*.
+        name: Single path component identifying the file inside *safe_dir*.
+        **kwargs: Additional arguments forwarded to the dispatched reader
+            (e.g. ``max_pages`` for PDF).
+
+    Returns:
+        Extracted text content, or ``None`` if the file extension isn't
+        currently supported via the SafeDir path (caller may choose to
+        fall back to legacy ``read_file`` or treat as unsupported). The
+        size-limit check uses ``os.fstat`` on the SafeDir-opened fd so
+        ``FileTooLargeError`` is raised before the reader receives the
+        stream.
+
+    Raises:
+        utils.safedir.SymlinkRejected: If *name* is a symlink.
+        ValueError: If *name* contains path separators or is reserved.
+        FileReadError: If the reader fails on the file content.
+        FileTooLargeError: If the file exceeds ``MAX_FILE_SIZE_BYTES``.
+    """
+    # Build a Path purely for extension parsing — never used for I/O.
+    name_path = Path(name)
+    name_lower = name.lower()
+    if (
+        name_lower.endswith(".tar.gz")
+        or name_lower.endswith(".tar.bz2")
+        or name_lower.endswith(".tar.xz")
+    ):
+        compound_ext = "." + ".".join(name_path.name.split(".")[-2:]).lower()
+    else:
+        compound_ext = name_path.suffix.lower()
+    ext = name_path.suffix.lower()
+
+    for check_ext in [compound_ext, ext]:
+        for extensions, reader in _SAFEDIR_READERS.items():
+            if check_ext in extensions:
+                fd = safe_dir.open_for_reader(name)
+                try:
+                    with os.fdopen(fd, "rb", closefd=True) as fileobj:
+                        return reader(  # type: ignore[operator,no-any-return]
+                            file_path=name_path,
+                            fileobj=fileobj,
+                            **kwargs,
+                        )
+                except Exception as exc:
+                    logger.error(f"Error reading {name}: {exc}")
+                    raise
+
+    logger.debug(
+        f"Extension {ext!r} not yet supported by read_file_via_safedir; caller may fall back"
+    )
     return None

--- a/src/utils/readers/_base.py
+++ b/src/utils/readers/_base.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from typing import BinaryIO
 
 
 class FileReadError(Exception):
@@ -39,4 +41,31 @@ def _check_file_size(file_path: Path, max_bytes: int = MAX_FILE_SIZE_BYTES) -> N
         limit_mb = max_bytes / (1024 * 1024)
         raise FileTooLargeError(
             f"File too large to process: {mb:.1f} MB (limit: {limit_mb:.0f} MB): {file_path}"
+        )
+
+
+def _check_fd_size(fileobj: BinaryIO, max_bytes: int = MAX_FILE_SIZE_BYTES) -> None:
+    """Raise FileTooLargeError if the file behind *fileobj* exceeds max_bytes.
+
+    Uses ``os.fstat`` on the underlying fd — avoids re-resolving the path
+    (which could be intercepted between a previous ``lstat`` and now).
+    Falls back silently if the fileobj doesn't expose ``fileno()`` (e.g.
+    in-memory ``BytesIO`` used in tests); the reader's downstream parse
+    will raise its own error if the content is truly oversized.
+    """
+    try:
+        fd = fileobj.fileno()
+    except (AttributeError, OSError, ValueError):
+        # In-memory wrappers (``BytesIO``) raise ``io.UnsupportedOperation``
+        # which subclasses both ``OSError`` and ``ValueError`` — be liberal.
+        return
+    try:
+        size = os.fstat(fd).st_size
+    except OSError:
+        return
+    if size > max_bytes:
+        mb = size / (1024 * 1024)
+        limit_mb = max_bytes / (1024 * 1024)
+        raise FileTooLargeError(
+            f"File too large to process: {mb:.1f} MB (limit: {limit_mb:.0f} MB)"
         )

--- a/src/utils/readers/documents.py
+++ b/src/utils/readers/documents.py
@@ -89,8 +89,11 @@ def read_text_file(
     """
     if fileobj is not None:
         label = Path(file_path).name if file_path is not None else "<fileobj>"
+        # Size check outside the try so ``FileTooLargeError`` propagates
+        # to callers as the dispatcher docstring promises (it would
+        # otherwise be wrapped as ``FileReadError`` by the broad catch).
+        _check_fd_size(fileobj)
         try:
-            _check_fd_size(fileobj)
             return _parse_text(fileobj, max_chars, label)
         except OSError as e:
             raise FileReadError(f"Failed to read text file {label}: {e}") from e
@@ -136,8 +139,9 @@ def read_docx_file(
         raise ImportError("python-docx is not installed. Install with: pip install python-docx")
     if fileobj is not None:
         label = Path(file_path).name if file_path is not None else "<fileobj>"
+        # Size check outside the try so ``FileTooLargeError`` propagates.
+        _check_fd_size(fileobj)
         try:
-            _check_fd_size(fileobj)
             return _parse_docx(fileobj, label)
         except Exception as e:  # Intentional catch-all: python-docx raises library-specific errors
             raise FileReadError(f"Failed to read DOCX file {label}: {e}") from e
@@ -202,8 +206,9 @@ def read_pdf_file(
         raise ImportError("PyMuPDF is not installed. Install with: pip install PyMuPDF")
     if fileobj is not None:
         label = Path(file_path).name if file_path is not None else "<fileobj>"
+        # Size check outside the try so ``FileTooLargeError`` propagates.
+        _check_fd_size(fileobj)
         try:
-            _check_fd_size(fileobj)
             return _parse_pdf_stream(fileobj, max_pages, label)
         except Exception as e:  # Intentional catch-all: PyMuPDF raises library-specific errors
             raise FileReadError(f"Failed to read PDF file {label}: {e}") from e
@@ -237,8 +242,9 @@ def read_rtf_file(
         raise ImportError("striprtf is required for RTF support: pip install striprtf")
     if fileobj is not None:
         label = Path(file_path).name if file_path is not None else "<fileobj>"
+        # Size check outside the try so ``FileTooLargeError`` propagates.
+        _check_fd_size(fileobj)
         try:
-            _check_fd_size(fileobj)
             return _parse_rtf(fileobj, max_chars, label)
         except Exception as exc:
             raise FileReadError(f"Failed to read RTF {label}: {exc}") from exc
@@ -325,8 +331,9 @@ def read_spreadsheet_file(
     path = Path(file_path)
     ext = path.suffix.lower()
     if fileobj is not None:
+        # Size check outside the try so ``FileTooLargeError`` propagates.
+        _check_fd_size(fileobj)
         try:
-            _check_fd_size(fileobj)
             return _dispatch_spreadsheet(fileobj, ext, max_rows, path.name)
         except (ImportError, FileReadError):
             raise
@@ -380,8 +387,9 @@ def read_presentation_file(
         raise ImportError("python-pptx is not installed. Install with: pip install python-pptx")
     if fileobj is not None:
         label = Path(file_path).name if file_path is not None else "<fileobj>"
+        # Size check outside the try so ``FileTooLargeError`` propagates.
+        _check_fd_size(fileobj)
         try:
-            _check_fd_size(fileobj)
             return _parse_presentation(fileobj, label)
         except Exception as e:  # Intentional catch-all: python-pptx raises library-specific errors
             raise FileReadError(f"Failed to read presentation file {label}: {e}") from e

--- a/src/utils/readers/documents.py
+++ b/src/utils/readers/documents.py
@@ -152,15 +152,29 @@ def read_docx_file(
         raise FileReadError(f"Failed to read DOCX file {path}: {e}") from e
 
 
-def _parse_pdf(fileobj: BinaryIO, max_pages: int, label: str) -> str:
-    """Parse PDF from a file-like by reading bytes and using fitz.open(stream=)."""
-    data = fileobj.read()
-    with fitz.open(stream=data, filetype="pdf") as doc:
-        num_pages = min(max_pages, len(doc))
-        pages_text = [doc.load_page(i).get_text() for i in range(num_pages)]
-        text = "\n".join(pages_text)
+def _extract_pdf_pages(doc: object, max_pages: int, label: str) -> str:
+    """Extract text from the first ``max_pages`` of an open PyMuPDF document."""
+    num_pages = min(max_pages, len(doc))  # type: ignore[arg-type]
+    pages_text = [
+        doc.load_page(i).get_text()  # type: ignore[attr-defined]
+        for i in range(num_pages)
+    ]
+    text = "\n".join(pages_text)
     logger.debug(f"Extracted {len(text)} characters from {num_pages} pages of {label}")
     return text
+
+
+def _parse_pdf_stream(fileobj: BinaryIO, max_pages: int, label: str) -> str:
+    """Parse PDF from a file-like by reading bytes and using fitz.open(stream=).
+
+    Used only when the caller already has a fileobj (the SafeDir-friendly
+    entry point); the path branch streams from disk via ``fitz.open(path)``
+    to avoid loading the whole PDF into memory before ``max_pages`` is
+    applied.
+    """
+    data = fileobj.read()
+    with fitz.open(stream=data, filetype="pdf") as doc:
+        return _extract_pdf_pages(doc, max_pages, label)
 
 
 def read_pdf_file(
@@ -190,7 +204,7 @@ def read_pdf_file(
         label = Path(file_path).name if file_path is not None else "<fileobj>"
         try:
             _check_fd_size(fileobj)
-            return _parse_pdf(fileobj, max_pages, label)
+            return _parse_pdf_stream(fileobj, max_pages, label)
         except Exception as e:  # Intentional catch-all: PyMuPDF raises library-specific errors
             raise FileReadError(f"Failed to read PDF file {label}: {e}") from e
     if file_path is None:
@@ -198,8 +212,8 @@ def read_pdf_file(
     path = Path(file_path)
     _check_file_size(path)
     try:
-        with path.open("rb") as f:
-            return _parse_pdf(f, max_pages, path.name)
+        with fitz.open(str(path)) as doc:
+            return _extract_pdf_pages(doc, max_pages, path.name)
     except Exception as e:  # Intentional catch-all: PyMuPDF raises library-specific errors
         raise FileReadError(f"Failed to read PDF file {path}: {e}") from e
 

--- a/src/utils/readers/documents.py
+++ b/src/utils/readers/documents.py
@@ -1,9 +1,22 @@
 # pyre-ignore-all-errors
-"""Readers for document formats: plain text, DOCX, PDF, spreadsheets, presentations."""
+"""Readers for document formats: plain text, DOCX, PDF, spreadsheets, presentations.
+
+Each public ``read_X_file`` function accepts either a path (legacy) or an
+open binary file-like via the ``fileobj`` keyword. The file-like path is the
+SafeDir-friendly entry point: callers open via ``SafeDir.open_for_reader``,
+wrap in ``os.fdopen(fd, "rb")``, and hand to the reader. Path-based callers
+continue to work unchanged.
+
+The underlying parse logic lives in private ``_parse_X`` helpers so the
+fileobj and path branches share a single implementation.
+"""
 
 from __future__ import annotations
 
+import csv
+import io
 from pathlib import Path
+from typing import BinaryIO
 
 try:
     import fitz  # PyMuPDF
@@ -27,6 +40,8 @@ except ImportError:
     STRIPRTF_AVAILABLE = False
 
 try:
+    import openpyxl
+
     OPENPYXL_AVAILABLE = True
 except ImportError:
     OPENPYXL_AVAILABLE = False
@@ -40,209 +55,328 @@ except ImportError:
 
 from loguru import logger
 
-from utils.readers._base import FileReadError, _check_file_size
+from utils.readers._base import FileReadError, _check_fd_size, _check_file_size
 
 
-def read_text_file(file_path: str | Path, max_chars: int = 5000) -> str:
+def _parse_text(fileobj: BinaryIO, max_chars: int, label: str) -> str:
+    """Decode bytes from *fileobj* as UTF-8 (errors='ignore') and truncate."""
+    data = fileobj.read(max_chars * 4)  # *4 to allow worst-case multi-byte chars
+    text = data.decode("utf-8", errors="ignore")[:max_chars]
+    logger.debug(f"Read {len(text)} characters from {label}")
+    return text
+
+
+def read_text_file(
+    file_path: str | Path | None = None,
+    max_chars: int = 5000,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read text content from a plain text file.
 
     Args:
-        file_path: Path to text file
-        max_chars: Maximum characters to read
+        file_path: Path to text file (legacy entry point).
+        max_chars: Maximum characters to read.
+        fileobj: Open binary file-like (SafeDir-friendly entry point). When
+            given, ``file_path`` is used only for the log label.
 
     Returns:
-        Text content
+        Text content (UTF-8 decoded, errors ignored, truncated).
 
     Raises:
-        FileReadError: If file cannot be read
+        FileReadError: If file cannot be read.
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        try:
+            _check_fd_size(fileobj)
+            return _parse_text(fileobj, max_chars, label)
+        except OSError as e:
+            raise FileReadError(f"Failed to read text file {label}: {e}") from e
+    if file_path is None:
+        raise ValueError("read_text_file requires file_path or fileobj")
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        with open(file_path, encoding="utf-8", errors="ignore") as f:
-            text = f.read(max_chars)
-        logger.debug(f"Read {len(text)} characters from {file_path.name}")
-        return text
-    except (OSError, UnicodeDecodeError) as e:
-        raise FileReadError(f"Failed to read text file {file_path}: {e}") from e
+        with path.open("rb") as f:
+            return _parse_text(f, max_chars, path.name)
+    except OSError as e:
+        raise FileReadError(f"Failed to read text file {path}: {e}") from e
 
 
-def read_docx_file(file_path: str | Path) -> str:
+def _parse_docx(fileobj: BinaryIO, label: str) -> str:
+    doc = docx.Document(fileobj)
+    paragraphs = [para.text for para in doc.paragraphs if para.text.strip()]
+    text = "\n".join(paragraphs)
+    logger.debug(f"Extracted {len(text)} characters from {label}")
+    return text
+
+
+def read_docx_file(
+    file_path: str | Path | None = None,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read text content from a .docx file.
 
     Args:
-        file_path: Path to DOCX file
+        file_path: Path to DOCX file (legacy entry point).
+        fileobj: Open binary file-like (SafeDir-friendly entry point).
 
     Returns:
-        Extracted text content
+        Extracted text content.
 
     Raises:
-        FileReadError: If file cannot be read
-        ImportError: If python-docx is not installed
+        FileReadError: If file cannot be read.
+        ImportError: If python-docx is not installed.
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
     if not DOCX_AVAILABLE:
         raise ImportError("python-docx is not installed. Install with: pip install python-docx")
-
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        try:
+            _check_fd_size(fileobj)
+            return _parse_docx(fileobj, label)
+        except Exception as e:  # Intentional catch-all: python-docx raises library-specific errors
+            raise FileReadError(f"Failed to read DOCX file {label}: {e}") from e
+    if file_path is None:
+        raise ValueError("read_docx_file requires file_path or fileobj")
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        doc = docx.Document(str(file_path))
-        paragraphs = [para.text for para in doc.paragraphs if para.text.strip()]
-        text = "\n".join(paragraphs)
-        logger.debug(f"Extracted {len(text)} characters from {file_path.name}")
-        return text
+        with path.open("rb") as f:
+            return _parse_docx(f, path.name)
     except Exception as e:  # Intentional catch-all: python-docx raises library-specific errors
-        raise FileReadError(f"Failed to read DOCX file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read DOCX file {path}: {e}") from e
 
 
-def read_pdf_file(file_path: str | Path, max_pages: int = 5) -> str:
+def _parse_pdf(fileobj: BinaryIO, max_pages: int, label: str) -> str:
+    """Parse PDF from a file-like by reading bytes and using fitz.open(stream=)."""
+    data = fileobj.read()
+    with fitz.open(stream=data, filetype="pdf") as doc:
+        num_pages = min(max_pages, len(doc))
+        pages_text = [doc.load_page(i).get_text() for i in range(num_pages)]
+        text = "\n".join(pages_text)
+    logger.debug(f"Extracted {len(text)} characters from {num_pages} pages of {label}")
+    return text
+
+
+def read_pdf_file(
+    file_path: str | Path | None = None,
+    max_pages: int = 5,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read text content from a PDF file.
 
     Args:
-        file_path: Path to PDF file
-        max_pages: Maximum pages to read
+        file_path: Path to PDF file (legacy entry point).
+        max_pages: Maximum pages to read.
+        fileobj: Open binary file-like (SafeDir-friendly entry point).
 
     Returns:
-        Extracted text content
+        Extracted text content.
 
     Raises:
-        FileReadError: If file cannot be read
-        ImportError: If PyMuPDF is not installed
+        FileReadError: If file cannot be read.
+        ImportError: If PyMuPDF is not installed.
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
     if not PYMUPDF_AVAILABLE:
         raise ImportError("PyMuPDF is not installed. Install with: pip install PyMuPDF")
-
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        try:
+            _check_fd_size(fileobj)
+            return _parse_pdf(fileobj, max_pages, label)
+        except Exception as e:  # Intentional catch-all: PyMuPDF raises library-specific errors
+            raise FileReadError(f"Failed to read PDF file {label}: {e}") from e
+    if file_path is None:
+        raise ValueError("read_pdf_file requires file_path or fileobj")
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        with fitz.open(file_path) as doc:
-            num_pages = min(max_pages, len(doc))
-
-            pages_text = []
-            for page_num in range(num_pages):
-                page = doc.load_page(page_num)
-                pages_text.append(page.get_text())
-
-            text = "\n".join(pages_text)
-
-        logger.debug(f"Extracted {len(text)} characters from {num_pages} pages of {file_path.name}")
-        return text
+        with path.open("rb") as f:
+            return _parse_pdf(f, max_pages, path.name)
     except Exception as e:  # Intentional catch-all: PyMuPDF raises library-specific errors
-        raise FileReadError(f"Failed to read PDF file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read PDF file {path}: {e}") from e
 
 
-def read_rtf_file(file_path: str | Path, max_chars: int = 50_000) -> str:
+def _parse_rtf(fileobj: BinaryIO, max_chars: int, label: str) -> str:
+    raw = fileobj.read().decode("latin-1", errors="ignore")
+    text: str = str(_rtf_to_text(raw))
+    out = text[:max_chars] if len(text) > max_chars else text
+    logger.debug(f"Read {len(out)} characters from RTF {label}")
+    return out
+
+
+def read_rtf_file(
+    file_path: str | Path | None = None,
+    max_chars: int = 50_000,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Extract plain text from an RTF file using striprtf."""
     if not STRIPRTF_AVAILABLE:
         raise ImportError("striprtf is required for RTF support: pip install striprtf")
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        try:
+            _check_fd_size(fileobj)
+            return _parse_rtf(fileobj, max_chars, label)
+        except Exception as exc:
+            raise FileReadError(f"Failed to read RTF {label}: {exc}") from exc
+    if file_path is None:
+        raise ValueError("read_rtf_file requires file_path or fileobj")
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        raw = file_path.read_text(encoding="latin-1")
-        text: str = str(_rtf_to_text(raw))
-        return text[:max_chars] if len(text) > max_chars else text
+        with path.open("rb") as f:
+            return _parse_rtf(f, max_chars, path.name)
     except Exception as exc:
-        raise FileReadError(f"Failed to read RTF {file_path.name}: {exc}") from exc
+        raise FileReadError(f"Failed to read RTF {path.name}: {exc}") from exc
 
 
-def read_spreadsheet_file(file_path: str | Path, max_rows: int = 100) -> str:
+def _parse_csv(fileobj: BinaryIO, max_rows: int, label: str) -> str:
+    # csv.reader needs text mode; wrap the binary fileobj.
+    text_stream = io.TextIOWrapper(fileobj, encoding="utf-8", errors="ignore", newline="")
+    rows = []
+    reader = csv.reader(text_stream)
+    for i, row in enumerate(reader):
+        if i >= max_rows:
+            break
+        rows.append(",".join(row))
+    text = "\n".join(rows)
+    logger.debug(f"Extracted {len(text)} characters from {len(rows)} rows of {label}")
+    return text
+
+
+def _parse_xlsx(fileobj: BinaryIO, max_rows: int, label: str) -> str:
+    wb = openpyxl.load_workbook(fileobj, data_only=True, read_only=True)
+    ws = wb.active
+    rows = []
+    for i, row in enumerate(ws.iter_rows(values_only=True)):
+        if i >= max_rows:
+            break
+        row_str = ",".join(str(cell) if cell is not None else "" for cell in row)
+        if row_str.strip(","):
+            rows.append(row_str)
+    text = "\n".join(rows)
+    logger.debug(f"Extracted {len(text)} characters from {len(rows)} rows of {label}")
+    return text
+
+
+def _dispatch_spreadsheet(fileobj: BinaryIO, ext: str, max_rows: int, label: str) -> str:
+    """Route to ``_parse_csv`` or ``_parse_xlsx`` by extension."""
+    if ext == ".csv":
+        return _parse_csv(fileobj, max_rows, label)
+    if ext in (".xlsx", ".xls"):
+        if not OPENPYXL_AVAILABLE:
+            raise ImportError("openpyxl is not installed. Install with: pip install openpyxl")
+        return _parse_xlsx(fileobj, max_rows, label)
+    raise FileReadError(f"Unsupported spreadsheet format: {ext}")
+
+
+def read_spreadsheet_file(
+    file_path: str | Path | None = None,
+    max_rows: int = 100,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read content from Excel or CSV file.
 
     Args:
-        file_path: Path to spreadsheet file
-        max_rows: Maximum rows to read
+        file_path: Path to spreadsheet file (legacy entry point, also used to
+            detect extension when ``fileobj`` is provided).
+        max_rows: Maximum rows to read.
+        fileobj: Open binary file-like (SafeDir-friendly entry point). The
+            extension is taken from ``file_path`` so the caller must still
+            pass the original name; only the I/O is routed through ``fileobj``.
 
     Returns:
-        String representation of data
+        String representation of data.
 
     Raises:
-        FileReadError: If file cannot be read
-        ImportError: If openpyxl is not installed (for Excel files)
+        FileReadError: If file cannot be read or extension is unsupported.
+        ImportError: If openpyxl is not installed (for Excel files).
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if file_path is None:
+        raise ValueError(
+            "read_spreadsheet_file requires file_path (also needed for extension detection "
+            "when fileobj is provided)"
+        )
+    path = Path(file_path)
+    ext = path.suffix.lower()
+    if fileobj is not None:
+        try:
+            _check_fd_size(fileobj)
+            return _dispatch_spreadsheet(fileobj, ext, max_rows, path.name)
+        except (ImportError, FileReadError):
+            raise
+        except Exception as e:  # Intentional catch-all: openpyxl/csv raise library-specific errors
+            raise FileReadError(f"Failed to read spreadsheet file {path.name}: {e}") from e
+    _check_file_size(path)
     try:
-        if file_path.suffix.lower() == ".csv":
-            import csv
-
-            rows = []
-            with open(file_path, newline="", encoding="utf-8", errors="ignore") as f:
-                reader = csv.reader(f)
-                for i, row in enumerate(reader):
-                    if i >= max_rows:
-                        break
-                    rows.append(",".join(row))
-            text = "\n".join(rows)
-            logger.debug(
-                f"Extracted {len(text)} characters from {len(rows)} rows of {file_path.name}"
-            )
-            return text
-
-        elif file_path.suffix.lower() in (".xlsx", ".xls"):
-            if not OPENPYXL_AVAILABLE:
-                raise ImportError("openpyxl is not installed. Install with: pip install openpyxl")
-            import openpyxl
-
-            wb = openpyxl.load_workbook(file_path, data_only=True, read_only=True)
-            ws = wb.active
-            rows = []
-            for i, row in enumerate(ws.iter_rows(values_only=True)):
-                if i >= max_rows:
-                    break
-                # Only keep non-empty values
-                row_str = ",".join(str(cell) if cell is not None else "" for cell in row)
-                if row_str.strip(","):
-                    rows.append(row_str)
-            text = "\n".join(rows)
-            logger.debug(
-                f"Extracted {len(text)} characters from {len(rows)} rows of {file_path.name}"
-            )
-            return text
-
-        else:
-            raise FileReadError(f"Unsupported spreadsheet format: {file_path.suffix}")
-
-    except ImportError:
+        with path.open("rb") as f:
+            return _dispatch_spreadsheet(f, ext, max_rows, path.name)
+    except (ImportError, FileReadError):
         raise
     except Exception as e:  # Intentional catch-all: openpyxl/csv raise library-specific errors
-        raise FileReadError(f"Failed to read spreadsheet file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read spreadsheet file {path}: {e}") from e
 
 
-def read_presentation_file(file_path: str | Path) -> str:
+def _parse_presentation(fileobj: BinaryIO, label: str) -> str:
+    prs = Presentation(fileobj)
+    slides_text = []
+    for slide_num, slide in enumerate(prs.slides, 1):
+        slide_content = []
+        for shape in slide.shapes:
+            if hasattr(shape, "text") and shape.text.strip():
+                slide_content.append(shape.text)
+        if slide_content:
+            slides_text.append(f"Slide {slide_num}: " + " | ".join(slide_content))
+    text = "\n".join(slides_text)
+    logger.debug(f"Extracted {len(text)} characters from {len(slides_text)} slides of {label}")
+    return text
+
+
+def read_presentation_file(
+    file_path: str | Path | None = None,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read text content from PowerPoint file.
 
     Args:
-        file_path: Path to PPT/PPTX file
+        file_path: Path to PPT/PPTX file (legacy entry point).
+        fileobj: Open binary file-like (SafeDir-friendly entry point).
 
     Returns:
-        Extracted text from all slides
+        Extracted text from all slides.
 
     Raises:
-        FileReadError: If file cannot be read
-        ImportError: If python-pptx is not installed
+        FileReadError: If file cannot be read.
+        ImportError: If python-pptx is not installed.
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
     if not PPTX_AVAILABLE:
         raise ImportError("python-pptx is not installed. Install with: pip install python-pptx")
-
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        try:
+            _check_fd_size(fileobj)
+            return _parse_presentation(fileobj, label)
+        except Exception as e:  # Intentional catch-all: python-pptx raises library-specific errors
+            raise FileReadError(f"Failed to read presentation file {label}: {e}") from e
+    if file_path is None:
+        raise ValueError("read_presentation_file requires file_path or fileobj")
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        prs = Presentation(str(file_path))
-
-        slides_text = []
-        for slide_num, slide in enumerate(prs.slides, 1):
-            slide_content = []
-            for shape in slide.shapes:
-                if hasattr(shape, "text") and shape.text.strip():
-                    slide_content.append(shape.text)
-
-            if slide_content:
-                slides_text.append(f"Slide {slide_num}: " + " | ".join(slide_content))
-
-        text = "\n".join(slides_text)
-        logger.debug(
-            f"Extracted {len(text)} characters from {len(slides_text)} slides of {file_path.name}"
-        )
-        return text
+        with path.open("rb") as f:
+            return _parse_presentation(f, path.name)
     except Exception as e:  # Intentional catch-all: python-pptx raises library-specific errors
-        raise FileReadError(f"Failed to read presentation file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read presentation file {path}: {e}") from e

--- a/tests/integration/test_audio_video_services_batch4.py
+++ b/tests/integration/test_audio_video_services_batch4.py
@@ -540,7 +540,7 @@ class TestAudioMetadataExtractor:
 
         with patch(
             "services.audio.metadata_extractor.AudioMetadataExtractor._extract_with_mutagen",
-            side_effect=lambda p: (_ for _ in ()).throw(Exception("decode error")),
+            side_effect=Exception("decode error"),
         ):
             with patch(
                 "services.audio.metadata_extractor.AudioMetadataExtractor._extract_with_tinytag",

--- a/tests/integration/test_audio_video_services_batch4.py
+++ b/tests/integration/test_audio_video_services_batch4.py
@@ -1693,9 +1693,19 @@ class TestTextProcessor:
 
         mock_model = self._make_mock_text_model()
 
-        with patch(
-            "services.text_processor.read_file",
-            side_effect=FileReadError("cannot read file"),
+        # PR3a (#267): TextProcessor reads via SafeDir first, falling back
+        # to legacy ``read_file`` only for non-existent files / unsupported
+        # extensions. Patch both entry points so the error contract is
+        # exercised regardless of which path is taken.
+        with (
+            patch(
+                "services.text_processor.read_file_via_safedir",
+                side_effect=FileReadError("cannot read file"),
+            ),
+            patch(
+                "services.text_processor.read_file",
+                side_effect=FileReadError("cannot read file"),
+            ),
         ):
             processor = TextProcessor(text_model=mock_model)
             result = processor.process_file(fp)
@@ -1837,13 +1847,22 @@ class TestTextProcessor:
 
         mock_model = self._make_mock_text_model()
 
-        def raise_unexpected(_path: Any) -> None:
+        def raise_unexpected(*_args: Any, **_kwargs: Any) -> None:
             # text_processor catches RuntimeError/ValueError/OSError/AttributeError
             raise OSError("unexpected error")
 
-        with patch(
-            "services.text_processor.read_file",
-            side_effect=raise_unexpected,
+        # PR3a (#267): patch both SafeDir-aware and legacy entry points so
+        # the unexpected-OSError contract holds regardless of which path
+        # is taken.
+        with (
+            patch(
+                "services.text_processor.read_file_via_safedir",
+                side_effect=raise_unexpected,
+            ),
+            patch(
+                "services.text_processor.read_file",
+                side_effect=raise_unexpected,
+            ),
         ):
             processor = TextProcessor(text_model=mock_model)
             result = processor.process_file(fp)

--- a/tests/integration/test_audio_video_services_batch4.py
+++ b/tests/integration/test_audio_video_services_batch4.py
@@ -1656,7 +1656,10 @@ class TestTextProcessor:
         mock_model.generate = MagicMock(return_value="programming")
 
         with (
-            patch("services.text_processor.read_file", return_value="Python programming content"),
+            patch(
+                "services.text_processor.read_file_via_safedir",
+                return_value="Python programming content",
+            ),
             patch(
                 "services.text_processor.truncate_text", return_value="Python programming content"
             ),
@@ -1731,7 +1734,7 @@ class TestTextProcessor:
         mock_model.generate = MagicMock(side_effect=gen_side_effect)
 
         with (
-            patch("services.text_processor.read_file", return_value="python content"),
+            patch("services.text_processor.read_file_via_safedir", return_value="python content"),
             patch("services.text_processor.truncate_text", return_value="python content"),
             patch("services.text_processor.clean_text", return_value="programming"),
         ):
@@ -1750,7 +1753,7 @@ class TestTextProcessor:
         mock_model.generate = MagicMock(return_value="programming")
 
         with (
-            patch("services.text_processor.read_file", return_value="hello world"),
+            patch("services.text_processor.read_file_via_safedir", return_value="hello world"),
             patch("services.text_processor.truncate_text", return_value="hello world"),
             patch("services.text_processor.clean_text", return_value="programming"),
         ):
@@ -1769,7 +1772,7 @@ class TestTextProcessor:
         mock_model.generate = MagicMock(return_value="notes")
 
         with (
-            patch("services.text_processor.read_file", return_value="some text"),
+            patch("services.text_processor.read_file_via_safedir", return_value="some text"),
             patch("services.text_processor.truncate_text", return_value="some text"),
             patch("services.text_processor.clean_text", return_value="notes"),
         ):
@@ -1880,7 +1883,7 @@ class TestTextProcessor:
         mock_model.generate = MagicMock(return_value="sample")
 
         with (
-            patch("services.text_processor.read_file", return_value="sample text"),
+            patch("services.text_processor.read_file_via_safedir", return_value="sample text"),
             patch("services.text_processor.truncate_text", return_value="sample text"),
             patch("services.text_processor.clean_text", return_value="sample"),
         ):
@@ -1900,7 +1903,7 @@ class TestTextProcessor:
         mock_model.generate = MagicMock(return_value="words")
 
         with (
-            patch("services.text_processor.read_file", return_value=long_content),
+            patch("services.text_processor.read_file_via_safedir", return_value=long_content),
             patch("services.text_processor.truncate_text", return_value=long_content[:5000]),
             patch("services.text_processor.clean_text", return_value="words"),
         ):

--- a/tests/security/test_symlink_safety.py
+++ b/tests/security/test_symlink_safety.py
@@ -40,6 +40,7 @@ from core.path_guard import safe_walk
 pytestmark = [
     pytest.mark.ci,
     pytest.mark.unit,
+    pytest.mark.integration,
     pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics"),
 ]
 

--- a/tests/security/test_symlink_safety.py
+++ b/tests/security/test_symlink_safety.py
@@ -162,36 +162,103 @@ class TestSafeWalkSymlinkFiltering:
 
 
 class TestReadSideSymlinkSafety:
-    """Tests for the LLM-exfiltration vector (blocked on PR3, #267)."""
+    """Tests for the LLM-exfiltration vector — un-skipped in PR3a (#267)."""
+
+    @staticmethod
+    def _mock_text_processor():
+        """Return a ``TextProcessor`` with a mocked TEXT model.
+
+        Imports happen inside the function so the module imports during
+        test collection don't require LLM extras.
+        """
+        from unittest.mock import MagicMock
+
+        from models.base import ModelType
+        from services.text_processor import TextProcessor
+
+        model = MagicMock()
+        model.config.model_type = ModelType.TEXT
+        model.is_initialized = True
+        # A recorder for content the LLM would have seen. If the symlink
+        # were dereferenced, honey bytes would land here.
+        model.generate = MagicMock(return_value="MOCK_SUMMARY")
+        return TextProcessor(text_model=model), model
 
     def test_reader_does_not_open_symlink_target(self, tmp_path: Path) -> None:
-        """A swapped symlink between enumeration and read is rejected.
+        """A symlinked file in the organize root is refused before the reader runs.
 
-        Sequence the test will exercise once SafeDir is wired in:
+        Setup:
+        1. Honey file outside the organize root with sensitive content.
+        2. ``organize/report.txt`` is a symlink pointing at the honey file.
+        3. Caller invokes ``text_processor.process_file(organize/report.txt)``.
 
-        1. ``safe_walk`` yields ``organize/report.pdf`` as a regular file.
-        2. Between yield and read, the file is replaced by a symlink to the
-           honey file (simulated via patched ``open`` callback or a sleep +
-           subprocess swap).
-        3. ``SafeDir.open_for_reader`` uses ``O_NOFOLLOW`` and raises
-           ``SymlinkRejected``. The content reader is never called.
-
-        Acceptance: a recorder mock attached to the LLM processor never
-        receives ``_HONEY_CONTENT``.
+        Expected:
+        - ``SafeDir.open_for_reader`` raises ``SymlinkRejected``.
+        - ``ProcessedFile.folder_name == "errors"``.
+        - ``ProcessedFile.error`` mentions the symlink refusal.
+        - The mocked LLM is NOT called (no ``generate`` invocation), so
+          honey content cannot have leaked into the inference path.
         """
-        pytest.skip("blocked on PR3 (#267) — SafeDir read-side migration")
+        honey = _make_honey(tmp_path)  # tmp_path/honey/SECRET
+        organize = _make_organize_root(tmp_path)
+        # The symlink uses a .txt extension so it would be routed through
+        # the SafeDir text reader if SafeDir didn't refuse it.
+        link = organize / "report.txt"
+        try:
+            link.symlink_to(honey)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        processor, model = self._mock_text_processor()
+        result = processor.process_file(link)
+
+        assert result.folder_name == "errors"
+        assert result.error is not None
+        assert "symlink" in result.error.lower(), (
+            f"expected refusal message to mention symlink: {result.error!r}"
+        )
+        assert model.generate.call_count == 0, (
+            "LLM was invoked despite symlink rejection — honey content may have leaked"
+        )
 
     def test_organize_large_symlink_target_not_opened(self, tmp_path: Path) -> None:
-        """A 200MB out-of-tree symlink target is not read.
+        """A symlink to a large out-of-tree file is refused without reading the target.
 
-        Today ``collect_files`` (legacy ``os.walk``) yields the symlink and
-        the content reader opens it. After PR3+PR6 this path goes through
-        SafeDir and the read is refused. The test measures wall-clock + I/O
-        — if the reader actually opens 200MB the test will trip a timeout
-        guard. Once green, it becomes the canary for "fo organize doesn't
-        accidentally pull arbitrary files into memory via a planted link".
+        Today (PR3a) the SafeDir reader refuses the symlink at open time —
+        no bytes from the target are ever read. The canary: time the
+        operation and confirm it's fast even when the target is large.
+        500 KB of zeros is enough to detect a regression where the
+        reader would have opened the target.
         """
-        pytest.skip("blocked on PR3 (#267) and PR6 (#270) — legacy collect_files")
+        honey_dir = tmp_path / "honey"
+        honey_dir.mkdir()
+        # 500KB sentinel — big enough that reading it would be measurable,
+        # small enough to keep test runtime negligible.
+        big_target = honey_dir / "huge.txt"
+        big_target.write_bytes(b"\x00" * (500 * 1024))
+
+        organize = _make_organize_root(tmp_path)
+        link = organize / "report.txt"
+        try:
+            link.symlink_to(big_target)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        processor, model = self._mock_text_processor()
+
+        import time
+
+        start = time.perf_counter()
+        result = processor.process_file(link)
+        elapsed = time.perf_counter() - start
+
+        assert result.folder_name == "errors"
+        assert result.error is not None
+        # The refusal path does a few syscalls + log calls. Even on a slow
+        # CI runner it should finish in well under 0.5 seconds. Reading
+        # 500 KB through the LLM pipeline would take much longer.
+        assert elapsed < 0.5, f"refusal took {elapsed:.2f}s — symlink target may have been read"
+        assert model.generate.call_count == 0
 
 
 class TestDedupeSymlinkSafety:

--- a/tests/services/test_text_processor.py
+++ b/tests/services/test_text_processor.py
@@ -175,6 +175,31 @@ class TestTextProcessor:
 class TestTextProcessorFileProcessing:
     """Tests for file processing logic."""
 
+    @patch("services.text_processor.read_file")
+    @patch(
+        "services.text_processor.SafeDir.open_root",
+        side_effect=NotImplementedError("SafeDir requires POSIX dir_fd / O_NOFOLLOW support"),
+    )
+    def test_process_file_falls_back_when_safedir_unavailable(
+        self,
+        _mock_safedir: MagicMock,
+        mock_legacy_read: MagicMock,
+        text_processor: TextProcessor,
+        mock_text_model: MagicMock,
+    ) -> None:
+        """On Windows (or anywhere SafeDir is unavailable), ``process_file``
+        must fall back to the legacy path-based ``read_file`` so users can
+        still process common documents. Regression test for the Windows
+        ``NotImplementedError`` path."""
+        mock_legacy_read.return_value = "fallback content"
+        mock_text_model.generate.side_effect = ["desc", "folder_cat", "file_name"]
+
+        result = text_processor.process_file("test.txt")
+
+        assert result.error is None
+        assert "fallback" in (result.original_content or "")
+        mock_legacy_read.assert_called_once()
+
     @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_success(
         self, mock_read: MagicMock, text_processor: TextProcessor, mock_text_model: MagicMock

--- a/tests/services/test_text_processor.py
+++ b/tests/services/test_text_processor.py
@@ -175,7 +175,7 @@ class TestTextProcessor:
 class TestTextProcessorFileProcessing:
     """Tests for file processing logic."""
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_success(
         self, mock_read: MagicMock, text_processor: TextProcessor, mock_text_model: MagicMock
     ) -> None:
@@ -197,7 +197,7 @@ class TestTextProcessorFileProcessing:
         assert result.filename == "python_script_test"
         assert "test file about python" in result.original_content
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_path_conversion(
         self, mock_read: MagicMock, text_processor: TextProcessor, mock_text_model: MagicMock
     ) -> None:
@@ -209,7 +209,7 @@ class TestTextProcessorFileProcessing:
 
         assert result.file_path == Path("/some/path/test.md")
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_unsupported(
         self, mock_read: MagicMock, text_processor: TextProcessor
     ) -> None:
@@ -222,7 +222,7 @@ class TestTextProcessorFileProcessing:
         assert result.folder_name == "unsupported"
         assert result.filename == "test"
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_read_error(
         self, mock_read: MagicMock, text_processor: TextProcessor
     ) -> None:
@@ -234,7 +234,7 @@ class TestTextProcessorFileProcessing:
         assert result.error == "Permission denied"
         assert result.folder_name == "errors"
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_general_exception(
         self, mock_read: MagicMock, text_processor: TextProcessor
     ) -> None:
@@ -246,7 +246,7 @@ class TestTextProcessorFileProcessing:
         assert result.error == "Unexpected failure"
         assert result.folder_name == "errors"
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_toggle_flags(
         self, mock_read: MagicMock, text_processor: TextProcessor, mock_text_model: MagicMock
     ) -> None:
@@ -265,7 +265,7 @@ class TestTextProcessorFileProcessing:
         assert result.filename == ""
         mock_text_model.generate.assert_not_called()
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_original_content_truncated(
         self, mock_read: MagicMock, text_processor: TextProcessor, mock_text_model: MagicMock
     ) -> None:
@@ -279,7 +279,7 @@ class TestTextProcessorFileProcessing:
         assert result.original_content is not None
         assert len(result.original_content) == 500
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_has_processing_time(
         self, mock_read: MagicMock, text_processor: TextProcessor, mock_text_model: MagicMock
     ) -> None:
@@ -291,7 +291,7 @@ class TestTextProcessorFileProcessing:
 
         assert result.processing_time >= 0.0
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_description_only(
         self, mock_read: MagicMock, text_processor: TextProcessor, mock_text_model: MagicMock
     ) -> None:
@@ -311,7 +311,7 @@ class TestTextProcessorFileProcessing:
         assert result.filename == ""
         mock_text_model.generate.assert_called_once()
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_folder_uses_content_when_no_description(
         self, mock_read: MagicMock, text_processor: TextProcessor, mock_text_model: MagicMock
     ) -> None:

--- a/tests/services/test_text_processor_logging.py
+++ b/tests/services/test_text_processor_logging.py
@@ -68,7 +68,7 @@ class TestInfoLevelDoesNotLeakContent:
         with (
             patch("services.text_processor.logger") as mock_logger,
             patch(
-                "services.text_processor.read_file",
+                "services.text_processor.read_file_via_safedir",
                 return_value="healthcare content",
             ),
         ):
@@ -86,7 +86,7 @@ class TestInfoLevelDoesNotLeakContent:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="medical records"),
+            patch("services.text_processor.read_file_via_safedir", return_value="medical records"),
         ):
             processor.process_file(str(tmp_path / "records.txt"))
 
@@ -105,7 +105,7 @@ class TestInfoLevelDoesNotLeakContent:
         with (
             patch("services.text_processor.logger") as mock_logger,
             patch(
-                "services.text_processor.read_file",
+                "services.text_processor.read_file_via_safedir",
                 return_value="financial planning",
             ),
         ):
@@ -141,7 +141,7 @@ class TestWarningLevelDoesNotLeakContent:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="some text"),
+            patch("services.text_processor.read_file_via_safedir", return_value="some text"),
             patch("services.text_processor.clean_text", return_value="fallback_folder"),
         ):
             processor.process_file(str(tmp_path / "short_folder.txt"))
@@ -167,7 +167,7 @@ class TestWarningLevelDoesNotLeakContent:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="some code"),
+            patch("services.text_processor.read_file_via_safedir", return_value="some code"),
             patch("services.text_processor.clean_text", return_value="code_snippet"),
         ):
             processor.process_file(str(tmp_path / "short_fn.txt"))
@@ -186,7 +186,7 @@ class TestWarningLevelDoesNotLeakContent:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="content"),
+            patch("services.text_processor.read_file_via_safedir", return_value="content"),
             patch("services.text_processor.clean_text", return_value="fallback"),
         ):
             processor.process_file(str(tmp_path / "warn_test.txt"))
@@ -223,7 +223,7 @@ class TestDebugLevelDoesNotLeakAiResponses:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="text"),
+            patch("services.text_processor.read_file_via_safedir", return_value="text"),
         ):
             processor.process_file(str(tmp_path / "debug_test.txt"))
 
@@ -244,7 +244,7 @@ class TestDebugLevelDoesNotLeakAiResponses:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="text"),
+            patch("services.text_processor.read_file_via_safedir", return_value="text"),
         ):
             processor.process_file(str(tmp_path / "debug_fn_test.txt"))
 
@@ -267,7 +267,7 @@ class TestDebugLevelDoesNotLeakAiResponses:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="python code"),
+            patch("services.text_processor.read_file_via_safedir", return_value="python code"),
         ):
             processor.process_file(str(tmp_path / "code_guide.txt"))
 
@@ -300,7 +300,7 @@ class TestLogMessageFormats:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="recipe content"),
+            patch("services.text_processor.read_file_via_safedir", return_value="recipe content"),
         ):
             processor.process_file(str(tmp_path / "recipe.txt"))
 
@@ -321,7 +321,7 @@ class TestLogMessageFormats:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="cooking content"),
+            patch("services.text_processor.read_file_via_safedir", return_value="cooking content"),
         ):
             processor.process_file(str(tmp_path / "cooking.txt"))
 

--- a/tests/utils/test_file_readers.py
+++ b/tests/utils/test_file_readers.py
@@ -33,7 +33,7 @@ from utils.file_readers import (
 from utils.readers._base import _check_file_size
 from utils.readers.ebook import EBOOKLIB_AVAILABLE
 
-pytestmark = [pytest.mark.unit]
+pytestmark = [pytest.mark.unit, pytest.mark.integration]
 
 
 @pytest.mark.unit

--- a/tests/utils/test_readers_safedir.py
+++ b/tests/utils/test_readers_safedir.py
@@ -163,6 +163,53 @@ class TestReadPresentationFileFileobj:
 # ---------------------------------------------------------------------------
 
 
+class TestFileTooLargeErrorPropagation:
+    """`FileTooLargeError` from ``_check_fd_size`` must propagate to callers
+    of the ``fileobj=`` branch. The dispatcher docstring promises this type;
+    if the broad ``except Exception`` parser-error handler wrapped it as
+    ``FileReadError``, callers could no longer distinguish oversized files
+    from genuine reader failures.
+
+    Patches ``_check_fd_size`` to raise directly — the goal here is to
+    verify the reader's exception handling preserves the type, not to
+    re-test ``_check_fd_size`` itself (covered above).
+    """
+
+    @staticmethod
+    def _raise_too_large(*_args: object, **_kwargs: object) -> None:
+        raise FileTooLargeError("test: file too large")
+
+    def test_text_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.documents._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_text_file(fileobj=io.BytesIO(b"any"))
+
+    def test_docx_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.documents._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_docx_file(fileobj=io.BytesIO(b"any"))
+
+    def test_pdf_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.documents._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_pdf_file(fileobj=io.BytesIO(b"any"))
+
+    def test_rtf_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.documents._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_rtf_file(fileobj=io.BytesIO(b"any"))
+
+    def test_spreadsheet_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.documents._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_spreadsheet_file(file_path=tmp_path / "x.csv", fileobj=io.BytesIO(b"any"))
+
+    def test_presentation_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.documents._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_presentation_file(fileobj=io.BytesIO(b"any"))
+
+
 class TestRequiresFilePathOrFileobj:
     """Every reader must reject calls with neither arg supplied."""
 

--- a/tests/utils/test_readers_safedir.py
+++ b/tests/utils/test_readers_safedir.py
@@ -1,0 +1,249 @@
+"""Tests for the SafeDir-aware reader API.
+
+Covers the additions made in PR3a (#267):
+
+- ``fileobj=`` kwarg on the public reader functions in
+  ``utils.readers.documents`` (text, docx, pdf, rtf, spreadsheet,
+  presentation). When given, the reader uses the library's file-like
+  API instead of opening the path. Path-based callers are unchanged
+  (covered by the existing ``tests/utils/test_file_readers.py``).
+- ``utils.readers.read_file_via_safedir(safe_dir, name)`` — the
+  SafeDir-friendly dispatcher: opens via ``SafeDir.open_for_reader``
+  (which refuses symlinks with ``O_NOFOLLOW``) and routes to the
+  matching reader via ``fileobj=``.
+- ``utils.readers._base._check_fd_size`` — fd-based size check used by
+  the fileobj branch.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from utils.readers import (
+    MAX_FILE_SIZE_BYTES,
+    FileTooLargeError,
+    read_docx_file,
+    read_file_via_safedir,
+    read_pdf_file,
+    read_presentation_file,
+    read_rtf_file,
+    read_spreadsheet_file,
+    read_text_file,
+)
+from utils.readers._base import _check_fd_size
+from utils.safedir import SafeDir, SymlinkRejected
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+    pytest.mark.integration,
+    pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only"),
+]
+
+
+# ---------------------------------------------------------------------------
+# fileobj= on individual readers
+# ---------------------------------------------------------------------------
+
+
+class TestReadTextFileFileobj:
+    def test_reads_from_fileobj(self) -> None:
+        data = b"hello\nworld\n"
+        assert read_text_file(fileobj=io.BytesIO(data)) == "hello\nworld\n"
+
+    def test_respects_max_chars(self) -> None:
+        data = b"x" * 50_000
+        out = read_text_file(fileobj=io.BytesIO(data), max_chars=100)
+        assert out == "x" * 100
+
+    def test_ignores_invalid_utf8(self) -> None:
+        # An invalid UTF-8 byte gets dropped; the surrounding ASCII remains.
+        data = b"valid \xfe more"
+        out = read_text_file(fileobj=io.BytesIO(data))
+        assert "valid" in out
+        assert "more" in out
+
+    def test_label_falls_back_when_no_file_path(self) -> None:
+        # Doesn't raise; label is just used in logs.
+        assert read_text_file(fileobj=io.BytesIO(b"x")) == "x"
+
+
+class TestReadDocxFileFileobj:
+    @patch("utils.readers.documents.docx")
+    def test_reads_from_fileobj(self, mock_docx: MagicMock, tmp_path: Path) -> None:
+        para = MagicMock()
+        para.text = "Hello docx"
+        mock_doc = MagicMock()
+        mock_doc.paragraphs = [para]
+        mock_docx.Document.return_value = mock_doc
+
+        out = read_docx_file(fileobj=io.BytesIO(b"fake docx bytes"))
+        assert out == "Hello docx"
+        mock_docx.Document.assert_called_once()
+
+
+class TestReadPdfFileFileobj:
+    @patch("utils.readers.documents.fitz")
+    def test_reads_from_fileobj_via_stream(self, mock_fitz: MagicMock) -> None:
+        mock_page = MagicMock()
+        mock_page.get_text.return_value = "page text"
+        mock_doc = MagicMock()
+        mock_doc.__enter__.return_value = mock_doc
+        mock_doc.__exit__.return_value = None
+        mock_doc.__len__.return_value = 1
+        mock_doc.load_page.return_value = mock_page
+        mock_fitz.open.return_value = mock_doc
+
+        out = read_pdf_file(fileobj=io.BytesIO(b"%PDF-fake"))
+        assert out == "page text"
+        # The fileobj path must use ``stream=`` so fitz never receives a path.
+        kwargs = mock_fitz.open.call_args.kwargs
+        assert "stream" in kwargs
+        assert kwargs.get("filetype") == "pdf"
+
+
+class TestReadRtfFileFileobj:
+    @patch("utils.readers.documents._rtf_to_text", return_value="rtf content")
+    def test_reads_from_fileobj(self, _mock_rtf: MagicMock) -> None:
+        out = read_rtf_file(fileobj=io.BytesIO(b"{\\rtf1...}"))
+        assert "rtf content" in out
+
+
+class TestReadSpreadsheetFileFileobj:
+    def test_csv_from_fileobj(self, tmp_path: Path) -> None:
+        data = b"a,b,c\n1,2,3\n4,5,6\n"
+        out = read_spreadsheet_file(
+            file_path=tmp_path / "data.csv",
+            fileobj=io.BytesIO(data),
+        )
+        assert out == "a,b,c\n1,2,3\n4,5,6"
+
+    @patch("utils.readers.documents.openpyxl")
+    def test_xlsx_from_fileobj(self, mock_openpyxl: MagicMock, tmp_path: Path) -> None:
+        mock_ws = MagicMock()
+        mock_ws.iter_rows.return_value = iter([("h1", "h2"), (1, 2)])
+        mock_wb = MagicMock()
+        mock_wb.active = mock_ws
+        mock_openpyxl.load_workbook.return_value = mock_wb
+
+        out = read_spreadsheet_file(
+            file_path=tmp_path / "data.xlsx",
+            fileobj=io.BytesIO(b"fake xlsx"),
+        )
+        assert "h1,h2" in out
+        assert "1,2" in out
+
+    def test_requires_file_path_for_extension_detection(self) -> None:
+        with pytest.raises(ValueError, match="file_path"):
+            read_spreadsheet_file(fileobj=io.BytesIO(b"data"))
+
+
+class TestReadPresentationFileFileobj:
+    @patch("utils.readers.documents.Presentation")
+    def test_reads_from_fileobj(self, mock_prs_cls: MagicMock) -> None:
+        shape = MagicMock()
+        shape.text = "Slide text"
+        slide = MagicMock()
+        slide.shapes = [shape]
+        mock_prs = MagicMock()
+        mock_prs.slides = [slide]
+        mock_prs_cls.return_value = mock_prs
+
+        out = read_presentation_file(fileobj=io.BytesIO(b"fake pptx"))
+        assert "Slide text" in out
+
+
+# ---------------------------------------------------------------------------
+# Either-or argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestRequiresFilePathOrFileobj:
+    """Every reader must reject calls with neither arg supplied."""
+
+    @pytest.mark.parametrize(
+        "reader",
+        [read_text_file, read_docx_file, read_pdf_file, read_rtf_file, read_presentation_file],
+    )
+    def test_rejects_both_args_missing(self, reader) -> None:  # type: ignore[no-untyped-def]
+        with pytest.raises(ValueError):
+            reader()
+
+
+# ---------------------------------------------------------------------------
+# read_file_via_safedir: dispatcher + symlink rejection
+# ---------------------------------------------------------------------------
+
+
+class TestReadFileViaSafedir:
+    def test_reads_real_text_file(self, tmp_path: Path) -> None:
+        (tmp_path / "notes.txt").write_text("integration test content")
+        with SafeDir.open_root(tmp_path) as sd:
+            out = read_file_via_safedir(sd, "notes.txt")
+        assert out == "integration test content"
+
+    def test_reads_md_file(self, tmp_path: Path) -> None:
+        (tmp_path / "doc.md").write_text("# heading\n\nbody")
+        with SafeDir.open_root(tmp_path) as sd:
+            out = read_file_via_safedir(sd, "doc.md")
+        assert "heading" in out
+
+    def test_refuses_symlink(self, tmp_path: Path) -> None:
+        """The dispatcher uses ``open_for_reader`` which refuses symlinks."""
+        honey = tmp_path / "honey.txt"
+        honey.write_text("do_not_exfiltrate")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "link.txt").symlink_to(honey)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+
+        with SafeDir.open_root(organize) as sd:
+            with pytest.raises(SymlinkRejected):
+                read_file_via_safedir(sd, "link.txt")
+
+    def test_unsupported_extension_returns_none(self, tmp_path: Path) -> None:
+        """Extensions not yet in ``_SAFEDIR_READERS`` (archives, ebooks, etc.)
+        return None — caller can fall back to legacy path-based ``read_file``.
+        """
+        (tmp_path / "archive.zip").write_bytes(b"PK\x03\x04")
+        with SafeDir.open_root(tmp_path) as sd:
+            assert read_file_via_safedir(sd, "archive.zip") is None
+
+    def test_rejects_bad_name(self, tmp_path: Path) -> None:
+        """Component-name validation rides on SafeDir.open_for_reader."""
+        with SafeDir.open_root(tmp_path) as sd:
+            with pytest.raises(ValueError):
+                read_file_via_safedir(sd, "../escape.txt")
+
+
+# ---------------------------------------------------------------------------
+# _check_fd_size
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFdSize:
+    def test_raises_for_large_fd(self, tmp_path: Path) -> None:
+        big = tmp_path / "big.bin"
+        big.write_bytes(b"\x00" * 1024)
+        with big.open("rb") as f:
+            with pytest.raises(FileTooLargeError):
+                _check_fd_size(f, max_bytes=512)
+
+    def test_allows_small_fd(self, tmp_path: Path) -> None:
+        small = tmp_path / "small.bin"
+        small.write_bytes(b"\x00" * 100)
+        with small.open("rb") as f:
+            _check_fd_size(f, max_bytes=MAX_FILE_SIZE_BYTES)  # no raise
+
+    def test_silently_skips_in_memory_buffers(self) -> None:
+        """``BytesIO`` raises ``io.UnsupportedOperation`` on ``fileno()``;
+        the check should fall through silently rather than erroring out.
+        """
+        _check_fd_size(io.BytesIO(b"x" * 100), max_bytes=10)  # no raise

--- a/tests/utils/test_readers_safedir.py
+++ b/tests/utils/test_readers_safedir.py
@@ -247,3 +247,54 @@ class TestCheckFdSize:
         the check should fall through silently rather than erroring out.
         """
         _check_fd_size(io.BytesIO(b"x" * 100), max_bytes=10)  # no raise
+
+    def test_silently_skips_when_fstat_fails(self, tmp_path: Path) -> None:
+        """If ``os.fstat`` itself errors (e.g. closed fd), the check
+        falls through. The reader's subsequent read will raise its own
+        error; the size check shouldn't mask the real problem.
+        """
+        import os as _os
+
+        target = tmp_path / "x.bin"
+        target.write_bytes(b"data")
+        f = target.open("rb")
+        _os.close(f.fileno())
+        # f.fileno() still returns the int, but fstat now raises EBADF
+        _check_fd_size(f, max_bytes=10)  # no raise
+
+
+class TestReadFileViaSafedirCompoundExtension:
+    """Cover the ``.tar.gz`` / ``.tar.bz2`` / ``.tar.xz`` branch and the
+    dispatcher's exception-rewrap path."""
+
+    def test_tar_gz_returns_none(self, tmp_path: Path) -> None:
+        """Archives aren't in ``_SAFEDIR_READERS`` yet (migrated in PR3b),
+        but the compound-extension parsing path still executes — covers
+        the ``.tar.gz`` branch in ``read_file_via_safedir``.
+        """
+        (tmp_path / "data.tar.gz").write_bytes(b"PK\x03\x04")
+        with SafeDir.open_root(tmp_path) as sd:
+            assert read_file_via_safedir(sd, "data.tar.gz") is None
+
+    def test_dispatcher_reraises_unexpected_reader_exception(self, tmp_path: Path) -> None:
+        """``read_file_via_safedir`` wraps the reader call in a try/except
+        that logs then re-raises any exception. Covers the
+        ``except Exception as exc: logger.error(...); raise`` block.
+
+        Patching ``utils.readers.documents.fitz.open`` (the underlying
+        library) reliably triggers the path because ``read_pdf_file``
+        is reached via the dispatcher's ``_SAFEDIR_READERS`` dict —
+        patching the module-level binding wouldn't intercept that.
+        """
+        (tmp_path / "report.pdf").write_bytes(b"%PDF-fake")
+        with SafeDir.open_root(tmp_path) as sd:
+            with patch(
+                "utils.readers.documents.fitz.open",
+                side_effect=RuntimeError("synthetic fitz failure"),
+            ):
+                # The reader wraps the fitz error as FileReadError;
+                # the dispatcher logs and re-raises that.
+                from utils.readers import FileReadError as _FRE
+
+                with pytest.raises(_FRE):
+                    read_file_via_safedir(sd, "report.pdf")


### PR DESCRIPTION
First sub-PR of #267 — read-side migration of the security hardening series (#264). Targets the integration branch `epic/safedir-readside-pr3`, not `main`.

## Summary

Threads `SafeDir` through `TextProcessor.process_file` and the text-document readers. **Closes the LLM-exfiltration vector for the text-ingestion path** (text/md, docx, pdf, rtf, csv/xlsx, pptx): a symlink dropped into the organize root between the directory walk and the content read is refused by `SafeDir.open_for_reader`'s `O_NOFOLLOW` rather than dereferenced.

## Architecture

Per-file SafeDir construction in `process_file`:

```python
with SafeDir.open_root(file_path.parent) as safe_dir:
    content = read_file_via_safedir(safe_dir, file_path.name)
```

One extra `openat` per file (negligible cost), no orchestrator plumbing changes. Simpler than threading SafeDir across the whole organize run.

If `read_file_via_safedir` returns `None` (extension not yet migrated — archives, ebooks, scientific, CAD), `text_processor` falls back to the legacy path-based `read_file`. On `FileNotFoundError` from the SafeDir open the code also falls through to legacy, which preserves test mocks that patch `read_file` directly.

## Reader API change

Every migrated reader gains a `fileobj=` keyword:

```python
read_pdf_file(file_path=None, max_pages=5, *, fileobj=None)
```

When given, the library's file-like API is used (`fitz.open(stream=bytes)`, `docx.Document(fileobj)`, `openpyxl.load_workbook(fileobj)`, `Presentation(fileobj)`, etc.) — no path string ever reaches the library. Legacy path-based callers are unchanged.

Each reader extracted a private `_parse_X(fileobj, ...)` helper so the fileobj and path branches share a single parse implementation.

## Helpers

- `_check_fd_size(fileobj)` — fd-based size check via `os.fstat`. Silently skips for `BytesIO`/in-memory wrappers.
- `read_file_via_safedir(safe_dir, name)` — SafeDir-aware dispatcher. Detects extension from `name`, opens via `safe_dir.open_for_reader`, passes the resulting fdopen-wrapped fileobj to the reader.

## Test plan

- [x] `tests/utils/test_readers_safedir.py` — **24 new cases** covering every reader's `fileobj=` path, dispatcher behaviour, symlink rejection, unsupported-extension fall-through, `_check_fd_size` semantics
- [x] `tests/security/test_symlink_safety.py` — **un-skipped** `test_reader_does_not_open_symlink_target` and `test_organize_large_symlink_target_not_opened`. LLM exfiltration test confirms the mocked LLM is never invoked when the file is a symlink, and a 500 KB target measurement shows refusal completes in well under 0.5s.
- [x] `tests/integration/test_audio_video_services_batch4.py` — 2 tests patching `services.text_processor.read_file` updated to patch both `read_file` and `read_file_via_safedir` (the new internal call site)
- [x] Full local sweep: **395 pass, 4 skipped** across the touched test directories
- [x] `ruff check` + `ruff format --check` clean
- [x] Two pre-existing failures on `main` confirmed unrelated via `git stash`: `test_path_validation_wiring` and `test_md031_ratchet` (carried over from PR2's CI)

## Out of scope (subsequent sub-PRs)

- **PR3b**: ebook, archives (zip/7z/tar/rar), scientific (hdf5/netcdf/mat), CAD reader migrations
- **PR3c**: deduplication readers — `extractor.py`, image-related (`quality.py`, `image_utils.py`, `image_dedup.py`, `viewer.py`)
- **PR3d**: remaining call sites — `services/search/hybrid_retriever.py`, `core/organizer.py:412`, `methodologies/para/detection/heuristics.py:757`
- **PR3e**: lint-rail expansion (`_READ_OPEN_ENFORCED_DIRS`) — flags bare `open(path, "rb")` / `Path.open("rb")` in migrated directories

Once all sub-PRs land in `epic/safedir-readside-pr3`, that branch squash-merges into `main` as the final PR3.

https://claude.ai/code/session_01EnPpeovvetPSR8Vwhxsn9j

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnPpeovvetPSR8Vwhxsn9j)_