### PR TITLE
feat(security): PR3d — SafeDir for CAD readers (dxf/dwg/step/iges)

### DIFF
--- a/src/utils/readers/__init__.py
+++ b/src/utils/readers/__init__.py
@@ -181,8 +181,10 @@ def read_file(file_path: str | Path, **kwargs: object) -> str | None:
 # netCDF4 C extension doesn't accept file-likes directly; size is capped by
 # ``_check_fd_size`` before the buffer is materialised.
 #
-# Remaining path-only readers (CAD) dispatch falls back to ``read_file`` and
-# does not benefit from SafeDir's symlink rejection.
+# Migrated in PR3d (#267): CAD readers — DXF, DWG, STEP, IGES. ezdxf takes a
+# text stream via ``ezdxf.read()`` (binary fileobj is wrapped in
+# ``io.TextIOWrapper``); STEP and IGES are ASCII text formats decoded the
+# same way.
 _SAFEDIR_READERS: dict[tuple[str, ...], object] = {
     (".txt", ".md"): read_text_file,
     (".docx",): read_docx_file,
@@ -198,6 +200,10 @@ _SAFEDIR_READERS: dict[tuple[str, ...], object] = {
     (".hdf5", ".h5", ".hdf"): read_hdf5_file,
     (".nc", ".nc4", ".netcdf"): read_netcdf_file,
     (".mat",): read_mat_file,
+    (".dxf",): read_dxf_file,
+    (".dwg",): read_dwg_file,
+    (".step", ".stp"): read_step_file,
+    (".iges", ".igs"): read_iges_file,
 }
 
 

--- a/src/utils/readers/cad.py
+++ b/src/utils/readers/cad.py
@@ -118,9 +118,19 @@ def _read_dxf_from_fileobj(fileobj: BinaryIO) -> Any:
     ``ezdxf.read`` takes a ``TextIO``; SafeDir hands us a binary fd. The
     ``surrogateescape`` errors handler matches ``ezdxf.readfile``'s default
     so non-UTF-8 byte sequences in headers round-trip cleanly.
+
+    The wrapper is ``detach()``'d on every exit path — including
+    exceptions — so the caller's underlying binary stream survives the
+    wrapper's garbage collection (``TextIOWrapper`` otherwise closes
+    its source on ``__del__``). This both preserves the caller-owned
+    ``fileobj=`` contract and lets the DWG fallback path below still
+    ``os.fstat`` the same fd after a parse failure.
     """
     text_stream = io.TextIOWrapper(fileobj, encoding="utf-8", errors="surrogateescape")
-    return ezdxf.read(text_stream)  # type: ignore[attr-defined]  # ezdxf stubs incomplete
+    try:
+        return ezdxf.read(text_stream)  # type: ignore[attr-defined]  # ezdxf stubs incomplete
+    finally:
+        text_stream.detach()
 
 
 def read_dxf_file(
@@ -441,8 +451,14 @@ def read_iges_file(
         label = Path(file_path).name if file_path is not None else "<fileobj>"
         _check_fd_size(fileobj)
         try:
+            # ``TextIOWrapper`` closes its source stream on GC; detach the
+            # underlying binary fd before the wrapper goes out of scope so
+            # the caller-owned ``fileobj`` survives this call.
             text_stream = io.TextIOWrapper(fileobj, encoding="utf-8", errors="ignore")
-            lines = [text_stream.readline() for _ in range(max_lines)]
+            try:
+                lines = [text_stream.readline() for _ in range(max_lines)]
+            finally:
+                text_stream.detach()
             try:
                 size_kb = os.fstat(fileobj.fileno()).st_size / 1024
             except (OSError, AttributeError, ValueError):

--- a/src/utils/readers/cad.py
+++ b/src/utils/readers/cad.py
@@ -1,10 +1,27 @@
 # pyre-ignore-all-errors
-"""Readers for CAD formats: DXF, DWG, STEP, IGES."""
+"""Readers for CAD formats: DXF, DWG, STEP, IGES.
+
+Each public ``read_X_file`` function accepts either a path (legacy) or an
+open binary file-like via the ``fileobj`` keyword. The file-like path is
+the SafeDir-friendly entry point: callers open via
+``SafeDir.open_for_reader``, wrap in ``os.fdopen(fd, "rb")``, and hand to
+the reader.
+
+Library-specific notes:
+
+- ``ezdxf.readfile`` takes a path; ``ezdxf.read`` takes a **text** stream.
+  The fileobj branch wraps the binary fileobj in ``io.TextIOWrapper``
+  before handing it to ``ezdxf.read``.
+- STEP and IGES are plain ASCII text formats; the fileobj branch wraps
+  the binary fileobj in ``io.TextIOWrapper`` and reads as text.
+"""
 
 from __future__ import annotations
 
+import io
+import os
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO
 
 try:
     import ezdxf
@@ -15,18 +32,19 @@ except ImportError:
 
 from loguru import logger
 
-from utils.readers._base import FileReadError, _check_file_size
+from utils.readers._base import FileReadError, _check_fd_size, _check_file_size
 
 
-def _process_dxf_doc(doc: Any, file_path: Path, max_layers: int = 20) -> str:
+def _process_dxf_doc(doc: Any, label: str, max_layers: int = 20) -> str:
     """Extract metadata from an already-loaded ezdxf document.
 
     Shared by :func:`read_dxf_file` and :func:`read_dwg_file` so the file is
     opened only once even when a DWG read falls back to the DXF path.
 
     Args:
-        doc: An ezdxf document object returned by ``ezdxf.readfile()``.
-        file_path: Original file path (used only for the log message).
+        doc: An ezdxf document object returned by ``ezdxf.readfile()`` or
+            ``ezdxf.read()``.
+        label: Filename (or ``<fileobj>``) used in the log message.
         max_layers: Maximum number of layers to list.
 
     Returns:
@@ -43,9 +61,7 @@ def _process_dxf_doc(doc: Any, file_path: Path, max_layers: int = 20) -> str:
             if title:
                 metadata_parts.append(f"Title: {title}")
         except Exception:  # Intentional catch-all: ezdxf header raises library-specific errors
-            logger.opt(exception=True).debug(
-                "Failed to read DXF $TITLE header for {}", file_path.name
-            )
+            logger.opt(exception=True).debug("Failed to read DXF $TITLE header for {}", label)
 
         try:
             author = doc.header.get("$AUTHOR", "")
@@ -53,14 +69,10 @@ def _process_dxf_doc(doc: Any, file_path: Path, max_layers: int = 20) -> str:
                 author = doc.header.get("$LASTSAVEDBY", "Unknown")
             metadata_parts.append(f"Author: {author}")
         except Exception:  # Intentional catch-all: ezdxf header raises library-specific errors
-            logger.opt(exception=True).debug(
-                "Failed to read DXF author metadata for {}", file_path.name
-            )
+            logger.opt(exception=True).debug("Failed to read DXF author metadata for {}", label)
 
-    # DXF version
     metadata_parts.append(f"DXF Version: {doc.dxfversion}")
 
-    # Layer information
     if doc.layers:
         layer_count = len(doc.layers)
         metadata_parts.append(f"\n=== Layers ({layer_count} total) ===")
@@ -75,7 +87,6 @@ def _process_dxf_doc(doc: Any, file_path: Path, max_layers: int = 20) -> str:
                 layer_info += f" (Color: {layer.dxf.color})"
             metadata_parts.append(layer_info)
 
-    # Entity statistics
     modelspace = doc.modelspace()
     entity_types: dict[str, int] = {}
 
@@ -90,7 +101,6 @@ def _process_dxf_doc(doc: Any, file_path: Path, max_layers: int = 20) -> str:
         for entity_type, count in sorted(entity_types.items()):
             metadata_parts.append(f"  {entity_type}: {count}")
 
-    # Blocks
     if doc.blocks:
         block_count = len([b for b in doc.blocks if not b.name.startswith("*")])
         if block_count > 0:
@@ -98,75 +108,148 @@ def _process_dxf_doc(doc: Any, file_path: Path, max_layers: int = 20) -> str:
             metadata_parts.append(f"Block definitions: {block_count}")
 
     text = "\n".join(metadata_parts)
-    logger.debug(f"Extracted {len(text)} characters from DXF file {file_path.name}")
+    logger.debug(f"Extracted {len(text)} characters from DXF file {label}")
     return text
 
 
-def read_dxf_file(file_path: str | Path, max_layers: int = 20) -> str:
+def _read_dxf_from_fileobj(fileobj: BinaryIO) -> Any:
+    """Hand a binary fileobj to ``ezdxf.read`` via a text wrapper.
+
+    ``ezdxf.read`` takes a ``TextIO``; SafeDir hands us a binary fd. The
+    ``surrogateescape`` errors handler matches ``ezdxf.readfile``'s default
+    so non-UTF-8 byte sequences in headers round-trip cleanly.
+    """
+    text_stream = io.TextIOWrapper(fileobj, encoding="utf-8", errors="surrogateescape")
+    return ezdxf.read(text_stream)  # type: ignore[attr-defined]  # ezdxf stubs incomplete
+
+
+def read_dxf_file(
+    file_path: str | Path | None = None,
+    max_layers: int = 20,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read metadata and content from a DXF CAD file.
 
     Args:
-        file_path: Path to DXF file
+        file_path: Path to DXF file (legacy entry point).
         max_layers: Maximum number of layers to list
+        fileobj: Open binary file-like (SafeDir-friendly entry point). When
+            given, ``file_path`` is used only for the log label.
 
     Returns:
         Extracted metadata and layer information
 
     Raises:
         FileReadError: If file cannot be read
+        FileTooLargeError: If the file behind ``fileobj`` exceeds the limit.
         ImportError: If ezdxf is not installed
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
+    if fileobj is None and file_path is None:
+        raise ValueError("read_dxf_file requires file_path or fileobj")
     if not EZDXF_AVAILABLE:
         raise ImportError("ezdxf is not installed. Install with: pip install ezdxf")
 
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        _check_fd_size(fileobj)
+        try:
+            doc = _read_dxf_from_fileobj(fileobj)
+            return _process_dxf_doc(doc, label, max_layers)
+        except Exception as e:  # Intentional catch-all: ezdxf raises library-specific errors
+            raise FileReadError(f"Failed to read DXF file {label}: {e}") from e
+    assert file_path is not None  # narrowed above
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        doc = ezdxf.readfile(file_path)  # type: ignore[attr-defined]  # ezdxf stubs incomplete
-        return _process_dxf_doc(doc, file_path, max_layers)
+        doc = ezdxf.readfile(path)  # type: ignore[attr-defined]  # ezdxf stubs incomplete
+        return _process_dxf_doc(doc, path.name, max_layers)
     except Exception as e:  # Intentional catch-all: ezdxf raises library-specific errors
-        raise FileReadError(f"Failed to read DXF file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read DXF file {path}: {e}") from e
 
 
-def read_dwg_file(file_path: str | Path) -> str:
+def read_dwg_file(
+    file_path: str | Path | None = None,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read metadata from a DWG CAD file.
 
-    Note: DWG is a proprietary format. This function attempts to read it using ezdxf,
-    which has limited DWG support. For full DWG support, consider using ODA File Converter
-    to convert DWG to DXF first.
+    Note: DWG is a proprietary format. This function attempts to read it
+    using ezdxf, which has limited DWG support. For full DWG support,
+    consider using ODA File Converter to convert DWG to DXF first.
 
     Args:
-        file_path: Path to DWG file
+        file_path: Path to DWG file (legacy entry point).
+        fileobj: Open binary file-like (SafeDir-friendly entry point). When
+            given, ``file_path`` is used only for the log label and the
+            file-info fallback message; the fallback that displays
+            ``Size: ... KB`` uses ``os.fstat`` on the fd.
 
     Returns:
         Extracted metadata or basic file information
 
     Raises:
         FileReadError: If file cannot be read
+        FileTooLargeError: If the file behind ``fileobj`` exceeds the limit.
         ImportError: If ezdxf is not installed
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
+    if fileobj is None and file_path is None:
+        raise ValueError("read_dwg_file requires file_path or fileobj")
     if not EZDXF_AVAILABLE:
         raise ImportError("ezdxf is not installed. Install with: pip install ezdxf")
 
-    file_path = Path(file_path)
-    _check_file_size(file_path)
-    try:
-        # Try to read with ezdxf (limited support).
-        # Capture the returned document and pass it through to avoid re-opening the file.
-        doc = ezdxf.readfile(file_path)  # type: ignore[attr-defined]  # ezdxf stubs incomplete
-        return _process_dxf_doc(doc, file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        _check_fd_size(fileobj)
+        try:
+            doc = _read_dxf_from_fileobj(fileobj)
+            return _process_dxf_doc(doc, label)
+        except Exception as e:  # Intentional catch-all: ezdxf raises library-specific errors
+            logger.warning(f"Could not parse DWG file with ezdxf: {e}")
+            # Path-based fallback inspected the file with ``file_path.stat()``;
+            # for the fileobj branch we use the fd size, which avoids a
+            # second filesystem call that could race against SafeDir's
+            # symlink rejection.
+            try:
+                size_bytes = os.fstat(fileobj.fileno()).st_size
+                size_kb = size_bytes / 1024
+            except (OSError, AttributeError, ValueError):
+                size_kb = -1.0
 
+            metadata_parts = [
+                "=== DWG File Information ===",
+                f"File: {label}",
+            ]
+            if size_kb >= 0:
+                metadata_parts.append(f"Size: {size_kb:.2f} KB")
+            metadata_parts.extend(
+                [
+                    "",
+                    "Note: Full DWG parsing requires additional tools.",
+                    "Consider using ODA File Converter to convert DWG to DXF for better support.",
+                ]
+            )
+            return "\n".join(metadata_parts)
+
+    assert file_path is not None  # narrowed above
+    path = Path(file_path)
+    _check_file_size(path)
+    try:
+        doc = ezdxf.readfile(path)  # type: ignore[attr-defined]  # ezdxf stubs incomplete
+        return _process_dxf_doc(doc, path.name)
     except Exception as e:  # Intentional catch-all: ezdxf raises library-specific errors
-        # If ezdxf can't read it, provide basic file info
         logger.warning(f"Could not parse DWG file with ezdxf: {e}")
 
-        if not file_path.exists():
-            raise FileReadError(f"File not found: {file_path}") from e
+        if not path.exists():
+            raise FileReadError(f"File not found: {path}") from e
 
         metadata_parts = [
             "=== DWG File Information ===",
-            f"File: {file_path.name}",
-            f"Size: {file_path.stat().st_size / 1024:.2f} KB",
+            f"File: {path.name}",
+            f"Size: {path.stat().st_size / 1024:.2f} KB",
             "",
             "Note: Full DWG parsing requires additional tools.",
             "Consider using ODA File Converter to convert DWG to DXF for better support.",
@@ -175,162 +258,219 @@ def read_dwg_file(file_path: str | Path) -> str:
         return "\n".join(metadata_parts)
 
 
-def read_step_file(file_path: str | Path, max_lines: int = 100) -> str:
+def _parse_step_text(content: str, label: str, size_kb: float) -> str:
+    """Extract STEP metadata from the first 10 KB of the file content."""
+    metadata_parts = ["=== STEP File Information ===", f"File: {label}"]
+    if size_kb >= 0:
+        metadata_parts.append(f"Size: {size_kb:.2f} KB")
+
+    # Extract header section (between HEADER; and ENDSEC;)
+    if "HEADER;" in content and "ENDSEC;" in content:
+        header_start = content.find("HEADER;")
+        header_end = content.find("ENDSEC;", header_start)
+        header = content[header_start:header_end]
+
+        metadata_parts.append("\n=== Header Information ===")
+
+        if "FILE_DESCRIPTION" in header:
+            desc_start = header.find("FILE_DESCRIPTION")
+            desc_end = header.find(");", desc_start)
+            if desc_end > desc_start:
+                desc = header[desc_start : desc_end + 2]
+                metadata_parts.append(desc.strip())
+
+        if "FILE_NAME" in header:
+            name_start = header.find("FILE_NAME")
+            name_end = header.find(");", name_start)
+            if name_end > name_start:
+                name_info = header[name_start : name_end + 2]
+                metadata_parts.append(name_info.strip())
+
+        if "FILE_SCHEMA" in header:
+            schema_start = header.find("FILE_SCHEMA")
+            schema_end = header.find(");", schema_start)
+            if schema_end > schema_start:
+                schema = header[schema_start : schema_end + 2]
+                metadata_parts.append(schema.strip())
+
+    if "DATA;" in content:
+        entity_count = content.count("\n#")
+        metadata_parts.append(f"\nApproximate entity count: {entity_count}")
+
+    text = "\n".join(metadata_parts)
+    logger.debug(f"Extracted {len(text)} characters from STEP file {label}")
+    return text
+
+
+def read_step_file(
+    file_path: str | Path | None = None,
+    max_lines: int = 100,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read metadata from a STEP (.step, .stp) CAD file.
 
     STEP files are ISO 10303 standard format for 3D CAD data exchange.
-    This function extracts basic header information.
+    This function extracts basic header information from the first 10 KB.
 
     Args:
-        file_path: Path to STEP file
-        max_lines: Maximum lines to read from header
+        file_path: Path to STEP file (legacy entry point).
+        max_lines: Unused (kept for backward compat).
+        fileobj: Open binary file-like (SafeDir-friendly entry point).
+            STEP is plain ASCII; the binary stream is decoded UTF-8 with
+            errors ignored, matching the legacy path-branch behavior.
 
     Returns:
         Extracted header information
 
     Raises:
         FileReadError: If file cannot be read
+        FileTooLargeError: If the file behind ``fileobj`` exceeds the limit.
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if fileobj is None and file_path is None:
+        raise ValueError("read_step_file requires file_path or fileobj")
+
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        _check_fd_size(fileobj)
+        try:
+            content = fileobj.read(10000).decode("utf-8", errors="ignore")
+            try:
+                size_kb = os.fstat(fileobj.fileno()).st_size / 1024
+            except (OSError, AttributeError, ValueError):
+                size_kb = -1.0
+            return _parse_step_text(content, label, size_kb)
+        except (OSError, UnicodeDecodeError, ValueError) as e:
+            raise FileReadError(f"Failed to read STEP file {label}: {e}") from e
+
+    assert file_path is not None  # narrowed above
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        with open(file_path, encoding="utf-8", errors="ignore") as f:
-            content = f.read(10000)  # Read first 10KB
-
-        metadata_parts = ["=== STEP File Information ==="]
-        metadata_parts.append(f"File: {file_path.name}")
-        metadata_parts.append(f"Size: {file_path.stat().st_size / 1024:.2f} KB")
-
-        # Extract header section (between HEADER; and ENDSEC;)
-        if "HEADER;" in content and "ENDSEC;" in content:
-            header_start = content.find("HEADER;")
-            header_end = content.find("ENDSEC;", header_start)
-            header = content[header_start:header_end]
-
-            metadata_parts.append("\n=== Header Information ===")
-
-            # Extract file description
-            if "FILE_DESCRIPTION" in header:
-                desc_start = header.find("FILE_DESCRIPTION")
-                desc_end = header.find(");", desc_start)
-                if desc_end > desc_start:
-                    desc = header[desc_start : desc_end + 2]
-                    metadata_parts.append(desc.strip())
-
-            # Extract file name
-            if "FILE_NAME" in header:
-                name_start = header.find("FILE_NAME")
-                name_end = header.find(");", name_start)
-                if name_end > name_start:
-                    name_info = header[name_start : name_end + 2]
-                    metadata_parts.append(name_info.strip())
-
-            # Extract schema
-            if "FILE_SCHEMA" in header:
-                schema_start = header.find("FILE_SCHEMA")
-                schema_end = header.find(");", schema_start)
-                if schema_end > schema_start:
-                    schema = header[schema_start : schema_end + 2]
-                    metadata_parts.append(schema.strip())
-
-        # Count entities in DATA section
-        if "DATA;" in content:
-            # Count lines starting with # (entities)
-            entity_count = content.count("\n#")
-            metadata_parts.append(f"\nApproximate entity count: {entity_count}")
-
-        text = "\n".join(metadata_parts)
-        logger.debug(f"Extracted {len(text)} characters from STEP file {file_path.name}")
-        return text
-
+        with path.open(encoding="utf-8", errors="ignore") as f:
+            content = f.read(10000)
+        size_kb = path.stat().st_size / 1024
+        return _parse_step_text(content, path.name, size_kb)
     except (OSError, UnicodeDecodeError, ValueError) as e:
-        raise FileReadError(f"Failed to read STEP file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read STEP file {path}: {e}") from e
 
 
-def read_iges_file(file_path: str | Path, max_lines: int = 50) -> str:
+def _parse_iges_lines(lines: list[str], label: str, size_kb: float) -> str:
+    """Extract IGES metadata from the first N lines of the file."""
+    metadata_parts = ["=== IGES File Information ===", f"File: {label}"]
+    if size_kb >= 0:
+        metadata_parts.append(f"Size: {size_kb:.2f} KB")
+
+    # IGES files have structured sections marked in column 73
+    # S = Start, G = Global, D = Directory Entry, P = Parameter Data, T = Terminate
+
+    start_section = []
+    global_section = []
+
+    for line in lines:
+        if len(line) >= 73:
+            section_type = line[72]
+            content = line[:72].strip()
+
+            if section_type == "S" and content:
+                start_section.append(content)
+            elif section_type == "G" and content:
+                global_section.append(content)
+
+    if start_section:
+        metadata_parts.append("\n=== Start Section ===")
+        metadata_parts.extend(start_section[:10])
+
+    if global_section:
+        metadata_parts.append("\n=== Global Parameters ===")
+        global_params = "".join(global_section)
+        params = global_params.split(",")[:5]
+
+        param_names = [
+            "Parameter delimiter",
+            "Record delimiter",
+            "Product ID from sender",
+            "File name",
+            "Native system ID",
+        ]
+
+        for name, value in zip(param_names, params, strict=False):
+            if value.strip():
+                metadata_parts.append(f"{name}: {value.strip()}")
+
+    entity_count = sum(1 for line in lines if len(line) >= 73 and line[72] == "D")
+    if entity_count > 0:
+        metadata_parts.append(f"\nDirectory entries found: {entity_count}")
+
+    text = "\n".join(metadata_parts)
+    logger.debug(f"Extracted {len(text)} characters from IGES file {label}")
+    return text
+
+
+def read_iges_file(
+    file_path: str | Path | None = None,
+    max_lines: int = 50,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read metadata from an IGES (.iges, .igs) CAD file.
 
-    IGES (Initial Graphics Exchange Specification) is a vendor-neutral file format
-    for 3D CAD data exchange.
+    IGES (Initial Graphics Exchange Specification) is a vendor-neutral file
+    format for 3D CAD data exchange.
 
     Args:
-        file_path: Path to IGES file
+        file_path: Path to IGES file (legacy entry point).
         max_lines: Maximum lines to read from header
+        fileobj: Open binary file-like (SafeDir-friendly entry point). The
+            binary stream is decoded UTF-8 line-by-line with errors ignored,
+            matching the legacy path-branch behavior.
 
     Returns:
         Extracted header information
 
     Raises:
         FileReadError: If file cannot be read
+        FileTooLargeError: If the file behind ``fileobj`` exceeds the limit.
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if fileobj is None and file_path is None:
+        raise ValueError("read_iges_file requires file_path or fileobj")
+
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        _check_fd_size(fileobj)
+        try:
+            text_stream = io.TextIOWrapper(fileobj, encoding="utf-8", errors="ignore")
+            lines = [text_stream.readline() for _ in range(max_lines)]
+            try:
+                size_kb = os.fstat(fileobj.fileno()).st_size / 1024
+            except (OSError, AttributeError, ValueError):
+                size_kb = -1.0
+            return _parse_iges_lines(lines, label, size_kb)
+        except (OSError, UnicodeDecodeError, ValueError) as e:
+            raise FileReadError(f"Failed to read IGES file {label}: {e}") from e
+
+    assert file_path is not None  # narrowed above
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        with open(file_path, encoding="utf-8", errors="ignore") as f:
+        with path.open(encoding="utf-8", errors="ignore") as f:
             lines = [f.readline() for _ in range(max_lines)]
-
-        metadata_parts = ["=== IGES File Information ==="]
-        metadata_parts.append(f"File: {file_path.name}")
-        metadata_parts.append(f"Size: {file_path.stat().st_size / 1024:.2f} KB")
-
-        # IGES files have structured sections marked in column 73
-        # S = Start, G = Global, D = Directory Entry, P = Parameter Data, T = Terminate
-
-        start_section = []
-        global_section = []
-
-        for line in lines:
-            if len(line) >= 73:
-                section_type = line[72]
-                content = line[:72].strip()
-
-                if section_type == "S" and content:
-                    start_section.append(content)
-                elif section_type == "G" and content:
-                    global_section.append(content)
-
-        # Display start section (usually contains file description)
-        if start_section:
-            metadata_parts.append("\n=== Start Section ===")
-            metadata_parts.extend(start_section[:10])  # First 10 lines
-
-        # Display global section (contains parameters)
-        if global_section:
-            metadata_parts.append("\n=== Global Parameters ===")
-            # Join and split by commas to get parameters
-            global_params = "".join(global_section)
-            params = global_params.split(",")[:5]  # First 5 parameters
-
-            # Parameter meanings (typical order)
-            param_names = [
-                "Parameter delimiter",
-                "Record delimiter",
-                "Product ID from sender",
-                "File name",
-                "Native system ID",
-            ]
-
-            for name, value in zip(param_names, params, strict=False):
-                if value.strip():
-                    metadata_parts.append(f"{name}: {value.strip()}")
-
-        # Count entities
-        entity_count = sum(1 for line in lines if len(line) >= 73 and line[72] == "D")
-        if entity_count > 0:
-            metadata_parts.append(f"\nDirectory entries found: {entity_count}")
-
-        text = "\n".join(metadata_parts)
-        logger.debug(f"Extracted {len(text)} characters from IGES file {file_path.name}")
-        return text
-
+        size_kb = path.stat().st_size / 1024
+        return _parse_iges_lines(lines, path.name, size_kb)
     except (OSError, UnicodeDecodeError, ValueError) as e:
-        raise FileReadError(f"Failed to read IGES file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read IGES file {path}: {e}") from e
 
 
 def read_cad_file(file_path: str | Path, **kwargs: object) -> str:
-    """Read content from any CAD file format.
+    """Read content from any CAD file format (path-only convenience dispatcher).
 
-    Auto-detects CAD file type and uses appropriate reader.
+    Auto-detects CAD file type and uses appropriate reader. This is the
+    legacy path-based entry point; the SafeDir dispatcher in
+    ``utils.readers.read_file_via_safedir`` registers each extension
+    directly against the per-format readers so the fileobj branch is
+    reached without going through this function.
 
     Args:
         file_path: Path to CAD file
@@ -356,6 +496,6 @@ def read_cad_file(file_path: str | Path, **kwargs: object) -> str:
 
     reader = cad_readers.get(ext)
     if reader:
-        return reader(file_path, **kwargs)  # type: ignore[operator,no-any-return]  # Union dict value; see pyproject.toml [[tool.mypy.overrides]]
+        return reader(file_path, **kwargs)  # type: ignore[operator,no-any-return,arg-type]  # Union dict value; see pyproject.toml [[tool.mypy.overrides]]
     else:
         raise FileReadError(f"Unsupported CAD file format: {ext}")

--- a/tests/utils/test_readers_safedir.py
+++ b/tests/utils/test_readers_safedir.py
@@ -674,6 +674,25 @@ class TestReadDxfFileFileobj:
         with pytest.raises(ValueError, match="file_path or fileobj"):
             read_dxf_file()
 
+    def test_fileobj_not_closed_after_return(self, tmp_path: Path) -> None:
+        """The fileobj= contract preserves caller ownership. ``ezdxf.read``
+        is fed via ``io.TextIOWrapper``, which closes its source stream
+        on GC unless ``detach()`` is called — verify the underlying
+        binary stream survives the call.
+        """
+        mock_doc = _build_mocked_ezdxf_doc()
+        fileobj = io.BytesIO(b"0\nSECTION\n")
+        with (
+            patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+            patch("utils.readers.cad.ezdxf", create=True) as mock_ezdxf,
+        ):
+            mock_ezdxf.read.return_value = mock_doc
+            read_dxf_file(file_path=tmp_path / "x.dxf", fileobj=fileobj)
+        import gc
+
+        gc.collect()  # force TextIOWrapper finalisation
+        assert not fileobj.closed
+
 
 class TestReadDwgFileFileobj:
     """DWG falls back to a basic file-info message when ezdxf can't parse —
@@ -797,6 +816,18 @@ class TestReadIgesFileFileobj:
     def test_requires_arg(self) -> None:
         with pytest.raises(ValueError, match="file_path or fileobj"):
             read_iges_file()
+
+    def test_fileobj_not_closed_after_return(self, tmp_path: Path) -> None:
+        """IGES wraps the binary fileobj in ``TextIOWrapper`` to read text
+        lines; verify ``detach()`` releases ownership so the caller's
+        stream isn't closed when the wrapper goes out of scope.
+        """
+        fileobj = io.BytesIO(b" " * 80 + b"S\n" + b" " * 80 + b"G\n")
+        read_iges_file(file_path=tmp_path / "x.iges", fileobj=fileobj)
+        import gc
+
+        gc.collect()
+        assert not fileobj.closed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_readers_safedir.py
+++ b/tests/utils/test_readers_safedir.py
@@ -29,9 +29,12 @@ from utils.readers import (
     FileTooLargeError,
     read_7z_file,
     read_docx_file,
+    read_dwg_file,
+    read_dxf_file,
     read_ebook_file,
     read_file_via_safedir,
     read_hdf5_file,
+    read_iges_file,
     read_mat_file,
     read_netcdf_file,
     read_pdf_file,
@@ -39,6 +42,7 @@ from utils.readers import (
     read_rar_file,
     read_rtf_file,
     read_spreadsheet_file,
+    read_step_file,
     read_tar_file,
     read_text_file,
     read_zip_file,
@@ -595,6 +599,207 @@ class TestReadMatFileFileobj:
 
 
 # ---------------------------------------------------------------------------
+# CAD readers — fileobj= branch (PR3d)
+# ---------------------------------------------------------------------------
+
+
+def _build_mocked_ezdxf_doc() -> MagicMock:
+    """Return a MagicMock that quacks like an ezdxf Drawing.
+
+    Shared by the DXF / DWG fileobj tests so the mock surface stays
+    consistent — ``_process_dxf_doc`` iterates layers, modelspace
+    entities, and blocks; the mock provides one of each.
+    """
+    mock_header = MagicMock()
+    mock_header.get.return_value = "Test Drawing"
+
+    mock_layer = MagicMock()
+    mock_layer.dxf.name = "Layer0"
+    mock_layer.dxf.color = 7
+
+    mock_entity = MagicMock()
+    mock_entity.dxftype.return_value = "LINE"
+
+    mock_modelspace = MagicMock()
+    mock_modelspace.__iter__ = MagicMock(return_value=iter([mock_entity]))
+
+    mock_block = MagicMock()
+    mock_block.name = "MyBlock"
+
+    mock_doc = MagicMock()
+    mock_doc.header = mock_header
+    mock_doc.dxfversion = "AC1032"
+    mock_doc.layers = [mock_layer]
+    mock_doc.modelspace.return_value = mock_modelspace
+    mock_doc.blocks = [mock_block]
+    return mock_doc
+
+
+class TestReadDxfFileFileobj:
+    """``ezdxf`` is in the ``cad`` optional extra (not in ``.[dev,search]``).
+    Mocked so the reader's Python code paths are exercised on CI without
+    the library installed.
+    """
+
+    def test_reads_from_fileobj(self, tmp_path: Path) -> None:
+        mock_doc = _build_mocked_ezdxf_doc()
+        with (
+            patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+            patch("utils.readers.cad.ezdxf", create=True) as mock_ezdxf,
+        ):
+            mock_ezdxf.read.return_value = mock_doc
+            out = read_dxf_file(
+                file_path=tmp_path / "model.dxf", fileobj=io.BytesIO(b"0\nSECTION\n")
+            )
+        assert "DXF Document Metadata" in out
+        assert "AC1032" in out
+        assert "Layer0" in out
+        # The fileobj branch must use ``ezdxf.read`` (text-stream API),
+        # not ``ezdxf.readfile`` (path API).
+        mock_ezdxf.read.assert_called_once()
+        mock_ezdxf.readfile.assert_not_called()
+
+    def test_fileobj_error_wraps_as_file_read_error(self, tmp_path: Path) -> None:
+        from utils.readers import FileReadError as _FRE
+
+        with (
+            patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+            patch("utils.readers.cad.ezdxf", create=True) as mock_ezdxf,
+        ):
+            mock_ezdxf.read.side_effect = RuntimeError("synthetic ezdxf failure")
+            with pytest.raises(_FRE, match="DXF"):
+                read_dxf_file(file_path=tmp_path / "bad.dxf", fileobj=io.BytesIO(b"not dxf"))
+
+    def test_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="file_path or fileobj"):
+            read_dxf_file()
+
+
+class TestReadDwgFileFileobj:
+    """DWG falls back to a basic file-info message when ezdxf can't parse —
+    the fileobj branch uses ``os.fstat`` for size instead of ``Path.stat()``.
+    """
+
+    def test_reads_from_fileobj_when_ezdxf_parses(self, tmp_path: Path) -> None:
+        mock_doc = _build_mocked_ezdxf_doc()
+        with (
+            patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+            patch("utils.readers.cad.ezdxf", create=True) as mock_ezdxf,
+        ):
+            mock_ezdxf.read.return_value = mock_doc
+            out = read_dwg_file(file_path=tmp_path / "model.dwg", fileobj=io.BytesIO(b"00000"))
+        assert "AC1032" in out
+        mock_ezdxf.read.assert_called_once()
+
+    def test_fileobj_fallback_when_ezdxf_fails(self, tmp_path: Path) -> None:
+        """``ezdxf`` can't always parse DWG; the reader catches and emits
+        a basic file-info message. The fileobj branch derives size from
+        ``os.fstat`` rather than touching the path.
+        """
+        p = tmp_path / "blob.dwg"
+        p.write_bytes(b"binary dwg content here")
+        with (
+            patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+            patch("utils.readers.cad.ezdxf", create=True) as mock_ezdxf,
+        ):
+            mock_ezdxf.read.side_effect = RuntimeError("cannot parse DWG")
+            with p.open("rb") as f:
+                out = read_dwg_file(file_path=p, fileobj=f)
+        assert "DWG File Information" in out
+        assert "blob.dwg" in out
+        assert "ODA File Converter" in out
+        # Size came from os.fstat on the fileobj, not Path.stat.
+        assert "Size:" in out
+
+    def test_fileobj_fallback_handles_unstatable_stream(self, tmp_path: Path) -> None:
+        """``BytesIO`` raises on ``fileno()``; the size line is omitted."""
+        with (
+            patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+            patch("utils.readers.cad.ezdxf", create=True) as mock_ezdxf,
+        ):
+            mock_ezdxf.read.side_effect = RuntimeError("cannot parse")
+            out = read_dwg_file(file_path=tmp_path / "x.dwg", fileobj=io.BytesIO(b"binary"))
+        assert "DWG File Information" in out
+        # Size line is suppressed when fstat fails (BytesIO).
+        assert "Size:" not in out
+
+    def test_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="file_path or fileobj"):
+            read_dwg_file()
+
+
+class TestReadStepFileFileobj:
+    """STEP is plain ASCII; the fileobj branch decodes the first 10 KB."""
+
+    def test_reads_from_fileobj(self, tmp_path: Path) -> None:
+        step_content = (
+            "ISO-10303-21;\n"
+            "HEADER;\n"
+            "FILE_DESCRIPTION(('test description'),'2;1');\n"
+            "FILE_NAME('test.step','2026-01-01',('me'),('co'),'tool','sys','auth');\n"
+            "FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\n"
+            "ENDSEC;\n"
+            "DATA;\n"
+            "#1=POINT('',(0.,0.,0.));\n"
+            "#2=POINT('',(1.,1.,1.));\n"
+            "ENDSEC;\n"
+            "END-ISO-10303-21;\n"
+        )
+        p = tmp_path / "model.step"
+        p.write_text(step_content)
+        with p.open("rb") as f:
+            out = read_step_file(file_path=p, fileobj=f)
+        assert "STEP File Information" in out
+        assert "model.step" in out
+        assert "FILE_DESCRIPTION" in out
+        assert "Approximate entity count: 2" in out
+        assert "Size:" in out
+
+    def test_fileobj_size_omitted_for_unstatable_stream(self, tmp_path: Path) -> None:
+        """``BytesIO`` can't be ``fstat``ed; the Size line is omitted."""
+        out = read_step_file(
+            file_path=tmp_path / "x.step",
+            fileobj=io.BytesIO(b"ISO-10303-21;\nHEADER;\n"),
+        )
+        assert "STEP File Information" in out
+        assert "Size:" not in out
+
+    def test_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="file_path or fileobj"):
+            read_step_file()
+
+
+class TestReadIgesFileFileobj:
+    """IGES is column-structured ASCII; the fileobj branch reads N lines."""
+
+    def test_reads_from_fileobj(self, tmp_path: Path) -> None:
+        # Column 73 is the section marker (S=Start, G=Global, D=DirectoryEntry,
+        # P=ParameterData, T=Terminate). Pad each line to 72 chars + marker.
+        def line(content: str, marker: str) -> str:
+            return content.ljust(72) + marker + "      1\n"
+
+        iges_content = (
+            line("This is the start section", "S")
+            + line(",,3HMy ,4HFILE,1,,,,", "G")
+            + line("0", "D")
+            + line("0", "D")
+            + line("Terminate", "T")
+        )
+        p = tmp_path / "model.iges"
+        p.write_text(iges_content)
+        with p.open("rb") as f:
+            out = read_iges_file(file_path=p, fileobj=f)
+        assert "IGES File Information" in out
+        assert "model.iges" in out
+        assert "Start Section" in out
+        assert "Directory entries found: 2" in out
+
+    def test_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="file_path or fileobj"):
+            read_iges_file()
+
+
+# ---------------------------------------------------------------------------
 # Either-or argument validation
 # ---------------------------------------------------------------------------
 
@@ -696,6 +901,32 @@ class TestFileTooLargeErrorPropagation:
             with pytest.raises(FileTooLargeError):
                 read_mat_file(fileobj=io.BytesIO(b"any"))
 
+    def test_dxf_reader_propagates(self, tmp_path: Path) -> None:
+        with (
+            patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+            patch("utils.readers.cad._check_fd_size", side_effect=self._raise_too_large),
+        ):
+            with pytest.raises(FileTooLargeError):
+                read_dxf_file(fileobj=io.BytesIO(b"any"))
+
+    def test_dwg_reader_propagates(self, tmp_path: Path) -> None:
+        with (
+            patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+            patch("utils.readers.cad._check_fd_size", side_effect=self._raise_too_large),
+        ):
+            with pytest.raises(FileTooLargeError):
+                read_dwg_file(fileobj=io.BytesIO(b"any"))
+
+    def test_step_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.cad._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_step_file(fileobj=io.BytesIO(b"any"))
+
+    def test_iges_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.cad._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_iges_file(fileobj=io.BytesIO(b"any"))
+
 
 class TestRequiresFilePathOrFileobj:
     """Every reader must reject calls with neither arg supplied."""
@@ -716,6 +947,10 @@ class TestRequiresFilePathOrFileobj:
             read_hdf5_file,
             read_netcdf_file,
             read_mat_file,
+            read_dxf_file,
+            read_dwg_file,
+            read_step_file,
+            read_iges_file,
         ],
     )
     def test_rejects_both_args_missing(self, reader) -> None:  # type: ignore[no-untyped-def]
@@ -757,12 +992,15 @@ class TestReadFileViaSafedir:
                 read_file_via_safedir(sd, "link.txt")
 
     def test_unsupported_extension_returns_none(self, tmp_path: Path) -> None:
-        """Extensions not yet in ``_SAFEDIR_READERS`` (CAD) return None —
-        caller can fall back to legacy path-based ``read_file``.
+        """Extensions outside ``_SAFEDIR_READERS`` return None — caller can
+        fall back to legacy path-based ``read_file`` (which itself returns
+        None for genuinely unknown formats). After PR3d, every reader the
+        codebase supports has a SafeDir mapping, so this exercises the
+        truly-unsupported branch with a synthetic extension.
         """
-        (tmp_path / "model.dxf").write_text("dummy dxf")
+        (tmp_path / "data.unknownext").write_text("dummy")
         with SafeDir.open_root(tmp_path) as sd:
-            assert read_file_via_safedir(sd, "model.dxf") is None
+            assert read_file_via_safedir(sd, "data.unknownext") is None
 
     def test_rejects_bad_name(self, tmp_path: Path) -> None:
         """Component-name validation rides on SafeDir.open_for_reader."""
@@ -976,6 +1214,82 @@ class TestReadFileViaSafedir:
         # SafeDir-opened fileobj reached the underlying library.
         call_args, _kwargs = mock_loadmat.call_args
         assert hasattr(call_args[0], "read")
+
+    @pytest.mark.parametrize(
+        ("name", "reader_module_attr"),
+        [
+            ("model.dxf", "read"),
+            ("model.dwg", "read"),
+        ],
+    )
+    def test_dispatches_dxf_dwg_extensions(
+        self, tmp_path: Path, name: str, reader_module_attr: str
+    ) -> None:
+        """``.dxf`` and ``.dwg`` reach the ezdxf-based readers via the
+        dispatcher. Mocked because ``ezdxf`` is in the ``cad`` optional
+        extra (not in the default CI ``.[dev,search]`` install).
+        """
+        (tmp_path / name).write_text("0\nSECTION\nfake dxf content\n")
+
+        mock_doc = _build_mocked_ezdxf_doc()
+        with SafeDir.open_root(tmp_path) as sd:
+            with (
+                patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+                patch("utils.readers.cad.ezdxf", create=True) as mock_ezdxf,
+            ):
+                mock_ezdxf.read.return_value = mock_doc
+                out = read_file_via_safedir(sd, name)
+        assert out is not None
+        assert "AC1032" in out
+        # ezdxf.read (text-stream API) called, not readfile (path API).
+        getattr(mock_ezdxf, reader_module_attr).assert_called_once()
+
+    @pytest.mark.parametrize("name", ["model.step", "model.stp"])
+    def test_dispatches_step_extensions(self, tmp_path: Path, name: str) -> None:
+        """Both ``.step`` and ``.stp`` reach ``read_step_file`` via the
+        dispatcher.
+        """
+        (tmp_path / name).write_text(
+            "ISO-10303-21;\nHEADER;\nFILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\nENDSEC;\nDATA;\n"
+            "#1=POINT('',(0.,0.,0.));\nENDSEC;\nEND-ISO-10303-21;\n"
+        )
+        with SafeDir.open_root(tmp_path) as sd:
+            out = read_file_via_safedir(sd, name)
+        assert out is not None
+        assert "STEP File Information" in out
+        assert name in out
+
+    @pytest.mark.parametrize("name", ["model.iges", "model.igs"])
+    def test_dispatches_iges_extensions(self, tmp_path: Path, name: str) -> None:
+        """Both ``.iges`` and ``.igs`` reach ``read_iges_file`` via the
+        dispatcher.
+        """
+        line = lambda content, marker: content.ljust(72) + marker + "      1\n"  # noqa: E731
+        (tmp_path / name).write_text(
+            line("Start info", "S") + line(",,3HMy,4HFILE,", "G") + line("0", "D")
+        )
+        with SafeDir.open_root(tmp_path) as sd:
+            out = read_file_via_safedir(sd, name)
+        assert out is not None
+        assert "IGES File Information" in out
+        assert name in out
+
+    def test_refuses_symlinked_step(self, tmp_path: Path) -> None:
+        """Symlinked CAD files are refused by the dispatcher — exercises
+        the SafeDir O_NOFOLLOW path for one of the new extensions.
+        """
+        real = tmp_path / "real.step"
+        real.write_text("ISO-10303-21;\nHEADER;\nENDSEC;\n")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "decoy.step").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+
+        with SafeDir.open_root(organize) as sd:
+            with pytest.raises(SymlinkRejected):
+                read_file_via_safedir(sd, "decoy.step")
 
     def test_refuses_symlinked_epub(self, tmp_path: Path) -> None:
         """The dispatcher refuses a symlinked EPUB in the organize root —


### PR DESCRIPTION
Final reader-side sub-PR of #267. PR3a (#273) covered the LLM text path; PR3b (#274) archives; PR3c (#275) ebook + scientific. This PR migrates the four **CAD** readers — DXF, DWG, STEP, IGES — to the same SafeDir-friendly `fileobj=` pattern.

After this lands, **every reader the codebase supports is reachable via the SafeDir dispatcher**; the remaining work (PR3e and beyond) is the non-reader call sites in `deduplication/extractor.py`, `services/search/hybrid_retriever.py`, etc.

## Approach

Same shape as PR3a–PR3c:

- Each public `read_X_file` now accepts either a path (legacy) or an open binary file-like via the `fileobj=` keyword.
- `read_file_via_safedir` gains `.dxf` / `.dwg` / `.step` / `.stp` / `.iges` / `.igs` in `_SAFEDIR_READERS`.
- `read_cad_file` kept as the path-only convenience dispatcher used by the legacy `read_file()` entry point; the SafeDir dispatcher bypasses it by registering each extension directly against the per-format reader.

## Library-specific notes

- **DXF / DWG**: `ezdxf.readfile` takes a path; `ezdxf.read` takes a **text** stream. The fileobj branch wraps the binary fileobj in `io.TextIOWrapper(encoding="utf-8", errors="surrogateescape")` — `surrogateescape` matches the legacy `ezdxf.readfile` default so non-UTF-8 byte sequences in headers round-trip cleanly.
- **DWG** falls back to a basic file-info message when `ezdxf` can't parse the proprietary format. The fileobj branch derives `Size: ... KB` from `os.fstat(fileobj.fileno())` instead of `file_path.stat()` — avoids a second filesystem call that could race against SafeDir's symlink rejection. Falls through silently when `fstat` fails (e.g. `BytesIO`).
- **STEP / IGES** are plain ASCII; the fileobj branch decodes via `io.TextIOWrapper` or `fileobj.read().decode(...)` (matching legacy `errors="ignore"` behavior).
- All four readers follow the standard arg-check order (`ValueError` on missing args before `ImportError` on missing dep, same as PR3c).

## Tests

27 net new cases (151 total in `test_readers_safedir.py`):

- `fileobj=` round-trips for all 4 CAD readers (mocked `ezdxf` for DXF/DWG, real ASCII content for STEP/IGES).
- DWG fallback path with and without fstat-able streams.
- `FileTooLargeError` propagation from the `fileobj=` branch (4 readers).
- Either-or argument validation extended to all 4 new readers.
- End-to-end SafeDir dispatch parametrized across all 6 CAD extensions (`.dxf` / `.dwg` / `.step` / `.stp` / `.iges` / `.igs`).
- Symlink refusal for `.step` via the dispatcher.

`test_unsupported_extension_returns_none` now uses `.unknownext` — after PR3d every supported format has a SafeDir mapping, so the test exercises the genuinely-unsupported branch with a synthetic extension.

## Coverage

- `src/utils/readers/cad.py`: 94% (baseline 91%)
- `src/utils/readers/__init__.py`: 100%

## Lint rail

SafeDir advisory rail baseline unchanged at 49. The detector matches by call name, not argument source — `ezdxf.readfile` / `ezdxf.read` continue to count.

## Out of scope (next sub-PR)

- PR3e: non-reader call sites — `deduplication/extractor.py`, `services/search/hybrid_retriever.py`, `core/organizer.py`, `methodologies/para/detection/heuristics.py`, etc.

## Test plan

- [x] Local integration suite: 7631 pass, 0 fail
- [x] Verified locally with scientific + cad deps uninstalled: 124 reader tests pass (no library mocks broken)
- [x] mypy clean on modified files
- [x] ruff check + format clean
- [x] SafeDir lint rail baseline unchanged at 49
- [x] Coverage above baseline floor for cad.py

Targets `epic/safedir-readside-pr3`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnPpeovvetPSR8Vwhxsn9j)_