### PR TITLE
feat(security): PR3e — SafeDir for dedup DocumentExtractor

### DIFF
--- a/src/services/deduplication/extractor.py
+++ b/src/services/deduplication/extractor.py
@@ -3,12 +3,27 @@
 
 Extracts text content from various document formats for semantic analysis.
 Supports PDF, DOCX, TXT, RTF, ODT, and Markdown document formats.
+
+The public ``extract_text(file_path)`` entry point opens the file via
+:class:`utils.safedir.SafeDir` so a symlink swapped into the organize root
+between the directory walk and the read is refused with
+``SymlinkRejected`` rather than dereferenced. On Windows (where SafeDir's
+POSIX-only ``dir_fd`` + ``O_NOFOLLOW`` primitives are not available) the
+legacy path-based extraction is used instead.
+
+The underlying extractor methods now each accept either ``fileobj=`` (the
+SafeDir-friendly entry point) or a path (the legacy entry point).
 """
 
 from __future__ import annotations
 
 import logging
+import os
+import sys
 from pathlib import Path
+from typing import BinaryIO
+
+from utils.safedir import SafeDir, SymlinkRejected
 
 logger = logging.getLogger(__name__)
 
@@ -32,15 +47,24 @@ class DocumentExtractor:
     def extract_text(self, file_path: Path) -> str:
         """Extract text from a single document.
 
+        Opens the file via ``SafeDir.open_for_reader`` so a symlink swapped
+        into the organize root between the directory walk and this read is
+        refused — closes the symlink-following surface in the dedup
+        ingestion pipeline (#264). On Windows the path-based fallback is
+        used because SafeDir is POSIX-only.
+
         Args:
             file_path: Path to document file
 
         Returns:
-            Extracted text content
+            Extracted text content, or empty string on read failure.
+            A refused symlink returns ``""`` rather than raising — matches
+            the legacy contract that returns ``""`` for any unrecoverable
+            extraction error.
 
         Raises:
             ValueError: If file format not supported
-            OSError: If file cannot be read
+            OSError: If file does not exist
         """
         if not file_path.exists():
             raise OSError(f"File not found: {file_path}")
@@ -50,24 +74,68 @@ class DocumentExtractor:
         if not self.supports_format(file_path):
             raise ValueError(f"Unsupported format: {extension}")
 
-        try:
-            if extension == ".pdf":
-                return self._extract_pdf(file_path)
-            elif extension == ".docx":
-                return self._extract_docx(file_path)
-            elif extension == ".txt" or extension == ".md":
-                return self._extract_text(file_path)
-            elif extension == ".rtf":
-                return self._extract_rtf(file_path)
-            elif extension == ".odt":
-                return self._extract_odt(file_path)
-            else:
-                logger.warning(f"No extractor for {extension}, treating as text")
-                return self._extract_text(file_path)
+        # Try the SafeDir path first; fall back to the legacy path-branch
+        # only when SafeDir is unavailable (Windows) — never on real FS
+        # errors, which must propagate so the caller sees them.
+        if sys.platform != "win32":
+            try:
+                with SafeDir.open_root(file_path.parent) as safe_dir:
+                    fd = safe_dir.open_for_reader(file_path.name)
+                    try:
+                        with os.fdopen(fd, "rb", closefd=True) as fileobj:
+                            return self._extract_from_fileobj(extension, fileobj, file_path.name)
+                    except SymlinkRejected:
+                        raise
+            except SymlinkRejected as exc:
+                logger.warning("Refused to read symlinked file %s: %s", file_path, exc)
+                return ""
+            except NotImplementedError:
+                # SafeDir's POSIX primitives unavailable; fall through to
+                # the path-based extraction below.
+                logger.debug("SafeDir unavailable; using legacy reader for %s", file_path.name)
+            except (OSError, ValueError, ImportError) as e:
+                logger.error(f"Error extracting text from {file_path}: {e}")
+                return ""
 
+        # Legacy path-based fallback (Windows) — preserves the original
+        # API contract.
+        try:
+            return self._extract_via_path(extension, file_path)
         except (OSError, ValueError, ImportError) as e:
             logger.error(f"Error extracting text from {file_path}: {e}")
             return ""
+
+    def _extract_from_fileobj(self, extension: str, fileobj: BinaryIO, label: str) -> str:
+        """Dispatch extraction to the right ``_extract_X`` with a fileobj."""
+        if extension == ".pdf":
+            return self._extract_pdf(fileobj=fileobj, label=label)
+        if extension == ".docx":
+            return self._extract_docx(fileobj=fileobj, label=label)
+        if extension in (".txt", ".md"):
+            return self._extract_text(fileobj=fileobj, label=label)
+        if extension == ".rtf":
+            return self._extract_rtf(fileobj=fileobj, label=label)
+        if extension == ".odt":
+            return self._extract_odt(fileobj=fileobj, label=label)
+        logger.warning("No extractor for %s, treating as text", extension)
+        return self._extract_text(fileobj=fileobj, label=label)
+
+    def _extract_via_path(self, extension: str, file_path: Path) -> str:
+        """Dispatch extraction to the right ``_extract_X`` with a path
+        (legacy fallback used only when SafeDir is unavailable).
+        """
+        if extension == ".pdf":
+            return self._extract_pdf(file_path=file_path)
+        if extension == ".docx":
+            return self._extract_docx(file_path=file_path)
+        if extension in (".txt", ".md"):
+            return self._extract_text(file_path=file_path)
+        if extension == ".rtf":
+            return self._extract_rtf(file_path=file_path)
+        if extension == ".odt":
+            return self._extract_odt(file_path=file_path)
+        logger.warning("No extractor for %s, treating as text", extension)
+        return self._extract_text(file_path=file_path)
 
     def extract_batch(self, file_paths: list[Path]) -> dict[Path, str]:
         """Extract text from multiple documents in batch.
@@ -112,14 +180,18 @@ class DocumentExtractor:
         """
         return sorted(self.supported_extensions)
 
-    def _extract_pdf(self, file_path: Path) -> str:
+    def _extract_pdf(
+        self,
+        file_path: Path | None = None,
+        *,
+        fileobj: BinaryIO | None = None,
+        label: str | None = None,
+    ) -> str:
         """Extract text from PDF file.
 
-        Args:
-            file_path: Path to PDF file
-
-        Returns:
-            Extracted text
+        Either ``file_path`` (legacy) or ``fileobj`` (SafeDir-friendly) must
+        be supplied. The ``label`` arg is used in log messages when only a
+        fileobj is given.
         """
         try:
             import pypdf
@@ -129,20 +201,28 @@ class DocumentExtractor:
             except (ImportError, AttributeError):
                 PyPdfError = Exception  # type: ignore[misc,assignment]  # fallback when pypdf.errors unavailable
 
-            text_parts = []
+            text_parts: list[str] = []
+            display = label or (file_path.name if file_path is not None else "<fileobj>")
 
-            with open(file_path, "rb") as f:
-                pdf_reader = pypdf.PdfReader(f)
-
-                # Extract text from each page
+            if fileobj is not None:
+                pdf_reader = pypdf.PdfReader(fileobj)
                 for page_num in range(len(pdf_reader.pages)):
                     page = pdf_reader.pages[page_num]
                     text = page.extract_text()
                     if text:
                         text_parts.append(text)
+            else:
+                assert file_path is not None
+                with open(file_path, "rb") as f:
+                    pdf_reader = pypdf.PdfReader(f)
+                    for page_num in range(len(pdf_reader.pages)):
+                        page = pdf_reader.pages[page_num]
+                        text = page.extract_text()
+                        if text:
+                            text_parts.append(text)
 
             full_text = "\n".join(text_parts)
-            logger.debug(f"Extracted {len(full_text)} chars from PDF: {file_path.name}")
+            logger.debug(f"Extracted {len(full_text)} chars from PDF: {display}")
 
             return full_text
 
@@ -150,34 +230,37 @@ class DocumentExtractor:
             logger.error("pypdf not installed. Install with: pip install pypdf")
             return ""
         except (PyPdfError, OSError, ValueError, KeyError, IndexError) as e:
-            logger.error(f"Error extracting PDF {file_path}: {e}")
+            display = label or (file_path.name if file_path is not None else "<fileobj>")
+            logger.error(f"Error extracting PDF {display}: {e}")
             return ""
 
-    def _extract_docx(self, file_path: Path) -> str:
-        """Extract text from DOCX file.
-
-        Args:
-            file_path: Path to DOCX file
-
-        Returns:
-            Extracted text
-        """
+    def _extract_docx(
+        self,
+        file_path: Path | None = None,
+        *,
+        fileobj: BinaryIO | None = None,
+        label: str | None = None,
+    ) -> str:
+        """Extract text from DOCX file."""
         try:
             import docx
 
-            doc = docx.Document(str(file_path))
+            if fileobj is not None:
+                doc = docx.Document(fileobj)
+            else:
+                assert file_path is not None
+                doc = docx.Document(str(file_path))
 
-            # Extract text from all paragraphs
             text_parts = [paragraph.text for paragraph in doc.paragraphs]
 
-            # Also extract text from tables
             for table in doc.tables:
                 for row in table.rows:
                     for cell in row.cells:
                         text_parts.append(cell.text)
 
             full_text = "\n".join(text_parts)
-            logger.debug(f"Extracted {len(full_text)} chars from DOCX: {file_path.name}")
+            display = label or (file_path.name if file_path is not None else "<fileobj>")
+            logger.debug(f"Extracted {len(full_text)} chars from DOCX: {display}")
 
             return full_text
 
@@ -185,27 +268,45 @@ class DocumentExtractor:
             logger.error("python-docx not installed. Install with: pip install python-docx")
             return ""
         except (OSError, ValueError, KeyError) as e:
-            logger.error(f"Error extracting DOCX {file_path}: {e}")
+            display = label or (file_path.name if file_path is not None else "<fileobj>")
+            logger.error(f"Error extracting DOCX {display}: {e}")
             return ""
 
-    def _extract_text(self, file_path: Path) -> str:
-        """Extract text from plain text file.
+    def _extract_text(
+        self,
+        file_path: Path | None = None,
+        *,
+        fileobj: BinaryIO | None = None,
+        label: str | None = None,
+    ) -> str:
+        """Extract text from plain text file."""
+        encodings = ["utf-8", "latin-1", "cp1252", "ascii"]
+        display = label or (file_path.name if file_path is not None else "<fileobj>")
 
-        Args:
-            file_path: Path to text file
+        if fileobj is not None:
+            # Read all bytes once; try each encoding in turn.
+            try:
+                raw = fileobj.read()
+            except OSError as e:
+                logger.error(f"Error reading text file {display}: {e}")
+                return ""
+            for encoding in encodings:
+                try:
+                    text = raw.decode(encoding)
+                    logger.debug(f"Read {len(text)} chars from text file: {display}")
+                    return text
+                except UnicodeDecodeError:
+                    continue
+            # All strict decodes failed — fall back to ignore errors.
+            return raw.decode("utf-8", errors="ignore")
 
-        Returns:
-            File contents
-        """
+        assert file_path is not None
         try:
-            # Try multiple encodings
-            encodings = ["utf-8", "latin-1", "cp1252", "ascii"]
-
             for encoding in encodings:
                 try:
                     with open(file_path, encoding=encoding) as f:
                         text = f.read()
-                    logger.debug(f"Read {len(text)} chars from text file: {file_path.name}")
+                    logger.debug(f"Read {len(text)} chars from text file: {display}")
                     return text
                 except UnicodeDecodeError:
                     continue
@@ -217,74 +318,72 @@ class DocumentExtractor:
             return text
 
         except OSError as e:
-            logger.error(f"Error reading text file {file_path}: {e}")
+            logger.error(f"Error reading text file {display}: {e}")
             return ""
 
-    def _extract_rtf(self, file_path: Path) -> str:
-        """Extract text from RTF file.
+    def _extract_rtf(
+        self,
+        file_path: Path | None = None,
+        *,
+        fileobj: BinaryIO | None = None,
+        label: str | None = None,
+    ) -> str:
+        """Extract text from RTF file."""
+        display = label or (file_path.name if file_path is not None else "<fileobj>")
 
-        Args:
-            file_path: Path to RTF file
-
-        Returns:
-            Extracted text
-        """
         try:
+            if fileobj is not None:
+                rtf_content = fileobj.read().decode("utf-8", errors="ignore")
+            else:
+                assert file_path is not None
+                with open(file_path, encoding="utf-8", errors="ignore") as f:
+                    rtf_content = f.read()
+
             # Try using striprtf if available
             try:
                 from striprtf.striprtf import rtf_to_text
 
-                with open(file_path, encoding="utf-8", errors="ignore") as f:
-                    rtf_content = f.read()
-
                 text = str(rtf_to_text(rtf_content))
-                logger.debug(f"Extracted {len(text)} chars from RTF: {file_path.name}")
-
+                logger.debug(f"Extracted {len(text)} chars from RTF: {display}")
                 return text
 
             except ImportError:
                 # Fallback: simple RTF stripping
                 logger.warning("striprtf not installed, using basic extraction")
-
-                with open(file_path, encoding="utf-8", errors="ignore") as f:
-                    content = f.read()
-
-                # Very basic RTF stripping (removes control words)
                 import re
 
-                text = re.sub(r"\\[a-z]+\d*\s?", "", content)
+                text = re.sub(r"\\[a-z]+\d*\s?", "", rtf_content)
                 text = re.sub(r"[{}]", "", text)
                 text = text.strip()
-
                 return text
 
         except (OSError, ValueError, ImportError) as e:
-            logger.error(f"Error extracting RTF {file_path}: {e}")
+            logger.error(f"Error extracting RTF {display}: {e}")
             return ""
 
-    def _extract_odt(self, file_path: Path) -> str:
-        """Extract text from ODT file.
+    def _extract_odt(
+        self,
+        file_path: Path | None = None,
+        *,
+        fileobj: BinaryIO | None = None,
+        label: str | None = None,
+    ) -> str:
+        """Extract text from ODT file."""
+        display = label or (file_path.name if file_path is not None else "<fileobj>")
 
-        Args:
-            file_path: Path to ODT file
-
-        Returns:
-            Extracted text
-        """
         try:
             import xml.etree.ElementTree as ET
             import zipfile
 
-            # ODT files are ZIP archives
-            with zipfile.ZipFile(file_path, "r") as odt_zip:
-                # Extract content.xml
+            # ODT files are ZIP archives — zipfile.ZipFile accepts both
+            # paths and file-like objects.
+            source = fileobj if fileobj is not None else file_path
+            assert source is not None
+            with zipfile.ZipFile(source, "r") as odt_zip:
                 content_xml = odt_zip.read("content.xml")
 
-            # Parse XML
             root = ET.fromstring(content_xml)
 
-            # Extract all text nodes
-            # ODT uses OpenDocument namespace
             namespaces = {
                 "text": "urn:oasis:names:tc:opendocument:xmlns:text:1.0",
                 "office": "urn:oasis:names:tc:opendocument:xmlns:office:1.0",
@@ -292,12 +391,10 @@ class DocumentExtractor:
 
             text_parts = []
 
-            # Find all text:p (paragraph) elements
             for paragraph in root.findall(".//text:p", namespaces):
                 if paragraph.text:
                     text_parts.append(paragraph.text)
 
-                # Also get text from child elements
                 for child in paragraph:
                     if child.text:
                         text_parts.append(child.text)
@@ -305,12 +402,12 @@ class DocumentExtractor:
                         text_parts.append(child.tail)
 
             full_text = "\n".join(text_parts)
-            logger.debug(f"Extracted {len(full_text)} chars from ODT: {file_path.name}")
+            logger.debug(f"Extracted {len(full_text)} chars from ODT: {display}")
 
             return full_text
 
         except (OSError, KeyError, ValueError, zipfile.BadZipFile) as e:
-            logger.error(f"Error extracting ODT {file_path}: {e}")
+            logger.error(f"Error extracting ODT {display}: {e}")
             return ""
 
     def _check_dependencies(self) -> None:

--- a/src/services/deduplication/extractor.py
+++ b/src/services/deduplication/extractor.py
@@ -87,14 +87,16 @@ class DocumentExtractor:
                     except SymlinkRejected:
                         raise
             except SymlinkRejected as exc:
-                logger.warning("Refused to read symlinked file %s: %s", file_path, exc)
+                logger.warning(
+                    "Refused to read symlinked file %s: %s", file_path, exc, exc_info=True
+                )
                 return ""
             except NotImplementedError:
                 # SafeDir's POSIX primitives unavailable; fall through to
                 # the path-based extraction below.
                 logger.debug("SafeDir unavailable; using legacy reader for %s", file_path.name)
             except (OSError, ValueError, ImportError) as e:
-                logger.error(f"Error extracting text from {file_path}: {e}")
+                logger.error("Error extracting text from %s: %s", file_path, e, exc_info=True)
                 return ""
 
         # Legacy path-based fallback (Windows) — preserves the original
@@ -102,7 +104,7 @@ class DocumentExtractor:
         try:
             return self._extract_via_path(extension, file_path)
         except (OSError, ValueError, ImportError) as e:
-            logger.error(f"Error extracting text from {file_path}: {e}")
+            logger.error("Error extracting text from %s: %s", file_path, e, exc_info=True)
             return ""
 
     def _extract_from_fileobj(self, extension: str, fileobj: BinaryIO, label: str) -> str:
@@ -121,8 +123,9 @@ class DocumentExtractor:
         return self._extract_text(fileobj=fileobj, label=label)
 
     def _extract_via_path(self, extension: str, file_path: Path) -> str:
-        """Dispatch extraction to the right ``_extract_X`` with a path
-        (legacy fallback used only when SafeDir is unavailable).
+        """Dispatch extraction to the right ``_extract_X`` with a path.
+
+        Legacy fallback used only when SafeDir is unavailable.
         """
         if extension == ".pdf":
             return self._extract_pdf(file_path=file_path)

--- a/src/services/deduplication/extractor.py
+++ b/src/services/deduplication/extractor.py
@@ -57,14 +57,23 @@ class DocumentExtractor:
             file_path: Path to document file
 
         Returns:
-            Extracted text content, or empty string on read failure.
-            A refused symlink returns ``""`` rather than raising — matches
-            the legacy contract that returns ``""`` for any unrecoverable
-            extraction error.
+            Extracted text content, or ``""`` when extraction fails for
+            *any* reason — including a refused symlink (``SymlinkRejected``),
+            an underlying ``OSError`` during the read, a malformed file, or
+            a missing optional library. The empty-string contract is
+            preserved from the pre-SafeDir implementation so consumers
+            (``document_dedup`` etc.) behave identically: a file that
+            can't be read simply contributes no text to the dedup corpus.
+
+            **Read failures are NOT raised** — callers cannot rely on
+            ``OSError`` to detect read problems. Only the missing-file
+            and unsupported-format pre-checks raise.
 
         Raises:
-            ValueError: If file format not supported
-            OSError: If file does not exist
+            OSError: If the file does not exist (pre-flight check before
+                any SafeDir / library work).
+            ValueError: If the file's extension is not in
+                ``supported_extensions``.
         """
         if not file_path.exists():
             raise OSError(f"File not found: {file_path}")
@@ -81,11 +90,16 @@ class DocumentExtractor:
             try:
                 with SafeDir.open_root(file_path.parent) as safe_dir:
                     fd = safe_dir.open_for_reader(file_path.name)
+                    # fdopen takes ownership only once it returns; close the
+                    # bare fd explicitly if fdopen itself raises (e.g. on
+                    # a closed dir_fd race), otherwise the fd would leak.
                     try:
-                        with os.fdopen(fd, "rb", closefd=True) as fileobj:
-                            return self._extract_from_fileobj(extension, fileobj, file_path.name)
-                    except SymlinkRejected:
+                        fileobj = os.fdopen(fd, "rb", closefd=True)
+                    except OSError:
+                        os.close(fd)
                         raise
+                    with fileobj:
+                        return self._extract_from_fileobj(extension, fileobj, file_path.name)
             except SymlinkRejected as exc:
                 logger.warning(
                     "Refused to read symlinked file %s: %s", file_path, exc, exc_info=True
@@ -215,7 +229,8 @@ class DocumentExtractor:
                     if text:
                         text_parts.append(text)
             else:
-                assert file_path is not None
+                if file_path is None:
+                    raise TypeError("path-branch requires file_path")
                 with open(file_path, "rb") as f:
                     pdf_reader = pypdf.PdfReader(f)
                     for page_num in range(len(pdf_reader.pages)):
@@ -251,7 +266,8 @@ class DocumentExtractor:
             if fileobj is not None:
                 doc = docx.Document(fileobj)
             else:
-                assert file_path is not None
+                if file_path is None:
+                    raise TypeError("path-branch requires file_path")
                 doc = docx.Document(str(file_path))
 
             text_parts = [paragraph.text for paragraph in doc.paragraphs]
@@ -303,7 +319,8 @@ class DocumentExtractor:
             # All strict decodes failed — fall back to ignore errors.
             return raw.decode("utf-8", errors="ignore")
 
-        assert file_path is not None
+        if file_path is None:
+            raise TypeError("path-branch requires file_path")
         try:
             for encoding in encodings:
                 try:
@@ -338,7 +355,8 @@ class DocumentExtractor:
             if fileobj is not None:
                 rtf_content = fileobj.read().decode("utf-8", errors="ignore")
             else:
-                assert file_path is not None
+                if file_path is None:
+                    raise TypeError("path-branch requires file_path")
                 with open(file_path, encoding="utf-8", errors="ignore") as f:
                     rtf_content = f.read()
 
@@ -381,7 +399,8 @@ class DocumentExtractor:
             # ODT files are ZIP archives — zipfile.ZipFile accepts both
             # paths and file-like objects.
             source = fileobj if fileobj is not None else file_path
-            assert source is not None
+            if source is None:
+                raise TypeError("_extract_odt requires file_path or fileobj")
             with zipfile.ZipFile(source, "r") as odt_zip:
                 content_xml = odt_zip.read("content.xml")
 

--- a/tests/services/deduplication/test_extractor_safedir.py
+++ b/tests/services/deduplication/test_extractor_safedir.py
@@ -1,0 +1,290 @@
+"""Tests for the SafeDir-aware branch of ``DocumentExtractor.extract_text``.
+
+PR3e of #267 wires ``utils.safedir.SafeDir`` into the dedup ingestion
+``extract_text`` entry point so a symlink swapped into the organize root
+between the directory walk and the read is refused with
+``SymlinkRejected`` rather than dereferenced.
+
+Verifies:
+
+- Plain ``.txt`` / ``.md`` extraction round-trips through SafeDir
+- Symlinks under the SafeDir root are refused (extractor returns ``""``)
+- DOCX / PDF / RTF / ODT exercise the ``fileobj=`` branch of the private
+  ``_extract_X`` helpers (mocked underlying libs so the tests don't need
+  the full optional-dep matrix)
+- On Windows the ``NotImplementedError`` fallback uses the legacy
+  path-based extraction
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services.deduplication.extractor import DocumentExtractor
+from utils.safedir import SafeDir
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+    pytest.mark.integration,
+    pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only"),
+]
+
+
+@pytest.fixture
+def extractor() -> DocumentExtractor:
+    return DocumentExtractor()
+
+
+class TestSafeDirBranchPlainText:
+    """The simplest path: ``.txt`` / ``.md`` round-trip via SafeDir."""
+
+    def test_extracts_txt_via_safedir(self, extractor: DocumentExtractor, tmp_path: Path) -> None:
+        target = tmp_path / "notes.txt"
+        target.write_text("first line\nsecond line\n")
+        out = extractor.extract_text(target)
+        assert "first line" in out
+        assert "second line" in out
+
+    def test_extracts_md_via_safedir(self, extractor: DocumentExtractor, tmp_path: Path) -> None:
+        target = tmp_path / "doc.md"
+        target.write_text("# Heading\n\nbody text\n")
+        out = extractor.extract_text(target)
+        assert "Heading" in out
+        assert "body text" in out
+
+    def test_refuses_symlinked_file_and_returns_empty(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        """A symlink in the organize root is refused via SafeDir.open_for_reader;
+        the extractor returns ``""`` instead of dereferencing to the real
+        target. Matches the legacy contract of returning ``""`` for any
+        unrecoverable extraction error.
+        """
+        real = tmp_path / "secret.txt"
+        real.write_text("DO_NOT_EXFILTRATE_THIS_CONTENT")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "decoy.txt").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        out = extractor.extract_text(organize / "decoy.txt")
+        assert out == ""
+
+    def test_file_not_found_still_raises(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        """File-not-found is a caller-level error, not a SafeDir issue —
+        the public contract still raises OSError. (Matches legacy behavior.)
+        """
+        with pytest.raises(OSError, match="File not found"):
+            extractor.extract_text(tmp_path / "missing.txt")
+
+
+class TestSafeDirBranchPdf:
+    """PDF extraction via the ``fileobj=`` branch of ``_extract_pdf``."""
+
+    def test_pdf_extraction_uses_pypdf_with_fileobj(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        p = tmp_path / "report.pdf"
+        p.write_bytes(b"%PDF-fake content\n")
+
+        mock_page = MagicMock()
+        mock_page.extract_text.return_value = "page text"
+        mock_reader = MagicMock()
+        mock_reader.pages = [mock_page]
+
+        with patch("pypdf.PdfReader", return_value=mock_reader) as mock_ctor:
+            out = extractor.extract_text(p)
+
+        assert out == "page text"
+        # The SafeDir branch passes a fileobj, not a path.
+        call_args, _ = mock_ctor.call_args
+        assert hasattr(call_args[0], "read"), "PdfReader should receive a file-like"
+
+
+class TestSafeDirBranchDocx:
+    """DOCX extraction via the ``fileobj=`` branch of ``_extract_docx``."""
+
+    def test_docx_extraction_uses_docx_with_fileobj(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        p = tmp_path / "report.docx"
+        p.write_bytes(b"fake docx bytes")
+
+        mock_para = MagicMock()
+        mock_para.text = "Hello docx"
+        mock_doc = MagicMock()
+        mock_doc.paragraphs = [mock_para]
+        mock_doc.tables = []
+
+        with patch("docx.Document", return_value=mock_doc) as mock_ctor:
+            out = extractor.extract_text(p)
+
+        assert out == "Hello docx"
+        # The SafeDir branch passes a fileobj, not a path string.
+        call_args, _ = mock_ctor.call_args
+        assert hasattr(call_args[0], "read")
+
+
+class TestSafeDirBranchRtf:
+    """RTF extraction via the ``fileobj=`` branch of ``_extract_rtf``."""
+
+    def test_rtf_extraction_uses_striprtf_on_fileobj_bytes(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        p = tmp_path / "letter.rtf"
+        p.write_bytes(b"{\\rtf1\\ansi this is rtf}")
+
+        with patch("striprtf.striprtf.rtf_to_text", return_value="this is rtf") as mock_strip:
+            out = extractor.extract_text(p)
+
+        assert "this is rtf" in out
+        mock_strip.assert_called_once()
+
+
+class TestSafeDirBranchOdt:
+    """ODT extraction via the ``fileobj=`` branch of ``_extract_odt``."""
+
+    def test_odt_extraction_reads_zip_from_fileobj(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        p = tmp_path / "doc.odt"
+        # Build a minimal ODT (zip with content.xml)
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr(
+                "content.xml",
+                (
+                    '<?xml version="1.0"?>'
+                    '<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" '
+                    'xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0">'
+                    "<office:body><office:text>"
+                    "<text:p>ODT paragraph one</text:p>"
+                    "<text:p>ODT paragraph two</text:p>"
+                    "</office:text></office:body></office:document-content>"
+                ),
+            )
+
+        out = extractor.extract_text(p)
+        assert "ODT paragraph one" in out
+        assert "ODT paragraph two" in out
+
+
+class TestSafeDirFallbackOnNotImplemented:
+    """When SafeDir raises ``NotImplementedError`` (Windows-style port not
+    available), the extractor falls back to the legacy path-based read so
+    the public contract still produces a result.
+    """
+
+    def test_falls_back_to_path_extraction(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "via_path.txt"
+        target.write_text("path-branch content")
+
+        with patch(
+            "services.deduplication.extractor.SafeDir.open_root",
+            side_effect=NotImplementedError("simulated platform without SafeDir"),
+        ):
+            out = extractor.extract_text(target)
+        assert "path-branch content" in out
+
+    def test_real_oserror_does_not_silently_fall_back(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        """A real OS error from SafeDir (e.g. permission denied) is logged
+        and ``""`` is returned — not silently routed to the path branch
+        that would defeat the SafeDir hardening.
+        """
+        target = tmp_path / "x.txt"
+        target.write_text("data")
+
+        with patch(
+            "services.deduplication.extractor.SafeDir.open_root",
+            side_effect=OSError("simulated permission denied"),
+        ):
+            out = extractor.extract_text(target)
+        assert out == ""
+
+
+class TestExtractorFileobjUnitMethods:
+    """Direct unit tests on the new ``fileobj=`` branches of each helper."""
+
+    def test_extract_pdf_fileobj(self, extractor: DocumentExtractor) -> None:
+        mock_page = MagicMock()
+        mock_page.extract_text.return_value = "p1 text"
+        mock_reader = MagicMock()
+        mock_reader.pages = [mock_page]
+        with patch("pypdf.PdfReader", return_value=mock_reader):
+            out = extractor._extract_pdf(fileobj=io.BytesIO(b"%PDF-fake"), label="t.pdf")
+        assert out == "p1 text"
+
+    def test_extract_docx_fileobj(self, extractor: DocumentExtractor) -> None:
+        mock_para = MagicMock()
+        mock_para.text = "hello"
+        mock_doc = MagicMock()
+        mock_doc.paragraphs = [mock_para]
+        mock_doc.tables = []
+        with patch("docx.Document", return_value=mock_doc):
+            out = extractor._extract_docx(fileobj=io.BytesIO(b"data"), label="t.docx")
+        assert out == "hello"
+
+    def test_extract_text_fileobj_utf8(self, extractor: DocumentExtractor) -> None:
+        out = extractor._extract_text(fileobj=io.BytesIO(b"hello world"), label="t.txt")
+        assert out == "hello world"
+
+    def test_extract_text_fileobj_falls_back_to_latin1(self, extractor: DocumentExtractor) -> None:
+        # Byte 0xff is invalid UTF-8 but valid latin-1
+        out = extractor._extract_text(fileobj=io.BytesIO(b"hello \xff world"), label="t.txt")
+        # Either latin-1 (preferred fallback) or utf-8 with errors=ignore
+        assert "hello" in out
+        assert "world" in out
+
+    def test_extract_rtf_fileobj(self, extractor: DocumentExtractor) -> None:
+        with patch("striprtf.striprtf.rtf_to_text", return_value="plain text"):
+            out = extractor._extract_rtf(fileobj=io.BytesIO(b"{\\rtf1}"), label="t.rtf")
+        assert "plain text" in out
+
+    def test_extract_odt_fileobj(self, extractor: DocumentExtractor, tmp_path: Path) -> None:
+        # Build the ODT bytes in memory.
+        zip_bytes = io.BytesIO()
+        with zipfile.ZipFile(zip_bytes, "w") as zf:
+            zf.writestr(
+                "content.xml",
+                '<?xml version="1.0"?><office:document-content '
+                'xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" '
+                'xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0">'
+                "<office:body><office:text><text:p>odt content</text:p>"
+                "</office:text></office:body></office:document-content>",
+            )
+        zip_bytes.seek(0)
+        out = extractor._extract_odt(fileobj=zip_bytes, label="t.odt")
+        assert "odt content" in out
+
+
+class TestSafeDirRouteSelected:
+    """Locks in the routing: the SafeDir branch is the default on POSIX."""
+
+    def test_safedir_open_root_is_called(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        """The non-Windows code path always tries SafeDir.open_root before
+        any fallback. Regression-locks the wire-up.
+        """
+        target = tmp_path / "x.txt"
+        target.write_text("data")
+        with patch(
+            "services.deduplication.extractor.SafeDir.open_root",
+            wraps=SafeDir.open_root,
+        ) as mock_open_root:
+            extractor.extract_text(target)
+        mock_open_root.assert_called_once_with(tmp_path)


### PR DESCRIPTION
First non-reader call-site migration of #267. PR3a–PR3d (#273-#276) covered every reader under `src/utils/readers/`; this PR migrates `DocumentExtractor.extract_text` in `src/services/deduplication/extractor.py` — the dedup ingestion entry point that #267 item 4 explicitly calls out (`pypdf` + `docx.Document` + `zipfile.ZipFile` sites).

## Approach

Mirrors `text_processor`'s PR3a wire-up:

- Public `extract_text(file_path)` entry point tries `SafeDir.open_root` + `SafeDir.open_for_reader` first.
- Dispatches to a new `fileobj=` branch of each `_extract_X` helper.
- Falls back to the legacy path-based extraction only on Windows (where SafeDir's POSIX `dir_fd` / `O_NOFOLLOW` primitives raise `NotImplementedError`).
- `SymlinkRejected` → log WARNING, return `""` — matches the legacy contract of returning `""` for any unrecoverable extraction error, so `document_dedup.py` and other callers behave identically (a refused symlink simply doesn't contribute text to the dedup corpus).
- **Real OS errors are NOT silently routed to the path-branch fallback** — they're logged and returned as `""`, same as pre-PR. Closes the symlink-exfiltration vector for the dedup pipeline.

Each `_extract_X` method now accepts either `file_path=` (legacy) or `fileobj=` (SafeDir-friendly) plus an optional `label=` for log messages. Underlying library calls:

| Helper | fileobj-branch library call |
|---|---|
| `_extract_pdf` | `pypdf.PdfReader(fileobj)` |
| `_extract_docx` | `docx.Document(fileobj)` (accepts file-likes since python-docx 0.8.x) |
| `_extract_text` | read bytes, try utf-8 / latin-1 / cp1252 / ascii in turn |
| `_extract_rtf` | decode bytes, hand to `striprtf` |
| `_extract_odt` | `zipfile.ZipFile(fileobj)` (stdlib accepts file-likes) |

**No caller changes**: `document_dedup.py` and other consumers of `DocumentExtractor` work unchanged — the public API contract is preserved.

## Tests

17 new cases in `tests/services/deduplication/test_extractor_safedir.py`:

- Plain `.txt` / `.md` SafeDir round-trip
- **Symlink refusal returns `""`** — closes the dedup-ingestion exfiltration vector
- File-not-found still raises `OSError` (legacy contract preserved)
- PDF / DOCX / RTF / ODT each verify the `fileobj=` path is taken (mocked underlying libs; call args asserted to be file-likes)
- `NotImplementedError` fallback uses path-based extraction
- **Real `OSError` from SafeDir does NOT silently fall back** — locks in the contract that we don't bypass SafeDir on transient errors
- Direct unit tests on each `_extract_X` fileobj branch
- Routing lock-in: `SafeDir.open_root` is called on POSIX

## Coverage / Rail

- `src/services/deduplication/extractor.py`: 78% (baseline 75%) ✓
- SafeDir advisory rail: 49 → 51 (+2). Expected: my refactor split the `pypdf.PdfReader` and `docx.Document` call sites into fileobj + path branches; each branch still matches the rail's name-based detection. Flipping the rail to enforcing for migrated dirs (with opt-out markers on the SafeDir-safe fileobj branches) is deferred to a later PR.

## Out of scope (next sub-PRs)

- `services/deduplication/{image_utils,image_dedup,viewer}.py` — Pillow `Image.open` sites (#267 item 5)
- `services/search/hybrid_retriever.py` — corpus `path.open("rb")` (#267 item 6)
- `core/organizer.py`, `methodologies/para/detection/heuristics.py` — bare `path.open("rb")` (#267 items 7-8)
- Lint-rail flip to enforcing for `src/utils/readers/` and `src/services/deduplication/`

## Test plan

- [x] Local integration suite: 7650 pass, 0 fail
- [x] Full dedup test suite: 645 pass, 0 fail (no regressions in document_dedup or downstream consumers)
- [x] mypy clean on modified files
- [x] ruff check + format clean
- [x] Coverage above baseline floor for extractor.py
- [x] SafeDir advisory rail still passing (count +2 from fileobj+path branch split, expected)

Targets `epic/safedir-readside-pr3`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnPpeovvetPSR8Vwhxsn9j)_