### PR TITLE
feat(security): PR3f — SafeDir for dedup image readers + anchoring + hash flow

### DIFF
--- a/src/services/deduplication/image_dedup.py
+++ b/src/services/deduplication/image_dedup.py
@@ -141,12 +141,19 @@ class ImageDeduplicator:
             import numpy as np
 
             with safedir_image_open(image_path, trusted_root=trusted_root) as (img, _fd):
-                # imagededup expects RGB uint8 arrays for the perceptual
-                # hash families (PHash/DHash/AHash). Convert if needed —
-                # mode "RGB" is the documented input format.
+                # imagededup's array preprocessing uses OpenCV's BGR
+                # channel ordering — passing an RGB array would swap
+                # red/blue and produce different perceptual hashes
+                # vs. its path-based ``encode_image(str(path))`` flow.
+                # Convert to RGB first (so palette / RGBA modes are
+                # normalised) and then reverse the channel axis to
+                # match imagededup's BGR expectation. ``ascontiguous-
+                # array`` materialises a contiguous buffer because
+                # negative-stride slicing is non-contiguous and would
+                # otherwise force a copy inside numpy/cv2 anyway.
                 if img.mode != "RGB":
                     img = img.convert("RGB")
-                image_array = np.asarray(img)
+                image_array = np.ascontiguousarray(np.asarray(img)[:, :, ::-1])
             encoding = self.hasher.encode_image(image_array=image_array)
             return str(encoding) if encoding is not None else None
         except OSError as e:

--- a/src/services/deduplication/image_dedup.py
+++ b/src/services/deduplication/image_dedup.py
@@ -21,6 +21,8 @@ except ImportError:
     AHash = DHash = PHash = None
     _IMAGEDEDUP_AVAILABLE = False
 
+from PIL.Image import DecompressionBombError
+
 from .image_utils import SUPPORTED_FORMATS, safedir_image_open
 
 logger = logging.getLogger(__name__)
@@ -149,6 +151,13 @@ class ImageDeduplicator:
             return str(encoding) if encoding is not None else None
         except OSError as e:
             logger.warning(f"Could not read image {image_path}: {e}")
+            return None
+        except DecompressionBombError as e:
+            # PIL refuses images over MAX_IMAGE_PIXELS — recoverable
+            # per-file error, not a reason to abort find_duplicates /
+            # batch_compute_hashes scans. Mirrors how
+            # image_utils.get_image_metadata handles it.
+            logger.error(f"Decompression bomb detected for {image_path}: {e}")
             return None
         except (ValueError, RuntimeError) as e:
             logger.error(f"Error processing image {image_path}: {e}")

--- a/src/services/deduplication/image_dedup.py
+++ b/src/services/deduplication/image_dedup.py
@@ -13,8 +13,6 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-from PIL import Image
-
 try:
     from imagededup.methods import AHash, DHash, PHash  # pyre-ignore[21]
 
@@ -23,7 +21,7 @@ except ImportError:
     AHash = DHash = PHash = None
     _IMAGEDEDUP_AVAILABLE = False
 
-from .image_utils import SUPPORTED_FORMATS
+from .image_utils import SUPPORTED_FORMATS, safedir_image_open
 
 logger = logging.getLogger(__name__)
 
@@ -413,7 +411,7 @@ class ImageDeduplicator:
             return False, f"Unsupported format: {image_path.suffix}"
 
         try:
-            with Image.open(image_path) as img:
+            with safedir_image_open(image_path) as img:
                 # Try to load image data to verify it's not corrupt
                 img.verify()
             return True, None

--- a/src/services/deduplication/image_dedup.py
+++ b/src/services/deduplication/image_dedup.py
@@ -89,15 +89,32 @@ class ImageDeduplicator:
         else:  # ahash
             self.hasher = AHash()
 
-    def get_image_hash(self, image_path: Path) -> str | None:
+    def get_image_hash(self, image_path: Path, *, trusted_root: Path | None = None) -> str | None:
         """Compute perceptual hash for a single image.
 
+        Routes the image read through :func:`safedir_image_open` so a
+        symlinked image is refused at every path component when
+        ``trusted_root`` is supplied (closes the dedup-ingestion
+        symlink-exfiltration vector, #264). The PIL Image is converted
+        to a numpy array and handed to ``imagededup``'s
+        ``encode_image(image_array=...)`` API — bypassing the path-based
+        ``encode_image(path)`` codepath that would otherwise dereference
+        symlinks inside imagededup itself.
+
         Args:
-            image_path: Path to image file
+            image_path: Path to image file.
+            trusted_root: Anchor directory that bounds the SafeDir
+                traversal. When supplied (typically the directory the
+                walk started from), every intermediate component of
+                ``image_path.relative_to(trusted_root)`` is checked for
+                symlinks. ``find_duplicates``, ``cluster_by_similarity``,
+                and ``batch_compute_hashes`` thread their root through.
+                When ``None``, falls back to parent-rooted protection
+                (final component only) — OK for ad-hoc calls.
 
         Returns:
             Hexadecimal string representation of perceptual hash,
-            or None if image could not be processed
+            or None if image could not be processed.
         """
         if not image_path.exists():
             logger.warning(f"Image not found: {image_path}")
@@ -114,8 +131,21 @@ class ImageDeduplicator:
             return None
 
         try:
-            # imagededup expects string path
-            encoding = self.hasher.encode_image(str(image_path))
+            # Open via SafeDir, convert PIL Image → numpy array, pass to
+            # imagededup's image_array= API. This bypasses imagededup's
+            # path-based codepath which would call Pillow's path-based
+            # Image.open() internally and re-introduce the symlink
+            # dereference we're trying to close.
+            import numpy as np
+
+            with safedir_image_open(image_path, trusted_root=trusted_root) as (img, _fd):
+                # imagededup expects RGB uint8 arrays for the perceptual
+                # hash families (PHash/DHash/AHash). Convert if needed —
+                # mode "RGB" is the documented input format.
+                if img.mode != "RGB":
+                    img = img.convert("RGB")
+                image_array = np.asarray(img)
+            encoding = self.hasher.encode_image(image_array=image_array)
             return str(encoding) if encoding is not None else None
         except OSError as e:
             logger.warning(f"Could not read image {image_path}: {e}")
@@ -227,7 +257,10 @@ class ImageDeduplicator:
         image_hashes: dict[Path, str] = {}
 
         for idx, img_path in enumerate(image_files, 1):
-            img_hash = self.get_image_hash(img_path)
+            # ``directory`` is the trusted root: every image was found
+            # under this walk, so SafeDir anchoring traverses each
+            # intermediate component with O_NOFOLLOW.
+            img_hash = self.get_image_hash(img_path, trusted_root=directory)
             if img_hash is not None:
                 image_hashes[img_path] = img_hash
 
@@ -295,6 +328,11 @@ class ImageDeduplicator:
         image_hashes: dict[Path, str] = {}
 
         for idx, img_path in enumerate(images, 1):
+            # cluster_by_similarity takes an arbitrary list of paths;
+            # there's no single trusted root we can anchor against.
+            # Fall back to parent-rooted protection (final-component
+            # O_NOFOLLOW only) — documented as the standalone-caller
+            # contract in safedir_image_open.
             img_hash = self.get_image_hash(img_path)
             if img_hash is not None:
                 image_hashes[img_path] = img_hash
@@ -353,6 +391,9 @@ class ImageDeduplicator:
         results: dict[Path, str] = {}
 
         for idx, img_path in enumerate(image_paths, 1):
+            # batch_compute_hashes takes an arbitrary list of paths; no
+            # single trusted root. Falls back to parent-rooted SafeDir
+            # protection — same as cluster_by_similarity.
             img_hash = self.get_image_hash(img_path)
             if img_hash is not None:
                 results[img_path] = img_hash
@@ -380,6 +421,14 @@ class ImageDeduplicator:
             pattern = "*"
 
         for path in directory.glob(pattern):
+            # ``Path.is_file()`` follows symlinks (PR3f / Codex finding).
+            # Filter symlinked entries here so SafeDir's per-component
+            # check inside the dedup hash flow remains the only place
+            # that decides whether a symlinked image is processed —
+            # never silently accepted by the walk.
+            if path.is_symlink():
+                logger.debug("Skipping symlinked image in walk: %s", path)
+                continue
             if path.is_file() and path.suffix.lower() in SUPPORTED_FORMATS:
                 image_files.append(path)
 
@@ -411,7 +460,7 @@ class ImageDeduplicator:
             return False, f"Unsupported format: {image_path.suffix}"
 
         try:
-            with safedir_image_open(image_path) as img:
+            with safedir_image_open(image_path) as (img, _fd):
                 # Try to load image data to verify it's not corrupt
                 img.verify()
             return True, None

--- a/src/services/deduplication/image_dedup.py
+++ b/src/services/deduplication/image_dedup.py
@@ -141,19 +141,17 @@ class ImageDeduplicator:
             import numpy as np
 
             with safedir_image_open(image_path, trusted_root=trusted_root) as (img, _fd):
-                # imagededup's array preprocessing uses OpenCV's BGR
-                # channel ordering — passing an RGB array would swap
-                # red/blue and produce different perceptual hashes
-                # vs. its path-based ``encode_image(str(path))`` flow.
-                # Convert to RGB first (so palette / RGBA modes are
-                # normalised) and then reverse the channel axis to
-                # match imagededup's BGR expectation. ``ascontiguous-
-                # array`` materialises a contiguous buffer because
-                # negative-stride slicing is non-contiguous and would
-                # otherwise force a copy inside numpy/cv2 anyway.
+                # imagededup interprets numpy arrays as RGB: its
+                # ``preprocess_image`` runs ``PIL.Image.fromarray(array)``
+                # which PIL maps to RGB for 3-channel uint8 arrays, then
+                # converts to grayscale via the same luminance formula
+                # used on the path-based codepath. Passing an RGB array
+                # here therefore matches what
+                # ``encode_image(image_file=str(path))`` would have
+                # produced — same color photo, same perceptual hash.
                 if img.mode != "RGB":
                     img = img.convert("RGB")
-                image_array = np.ascontiguousarray(np.asarray(img)[:, :, ::-1])
+                image_array = np.ascontiguousarray(np.asarray(img))
             encoding = self.hasher.encode_image(image_array=image_array)
             return str(encoding) if encoding is not None else None
         except OSError as e:

--- a/src/services/deduplication/image_utils.py
+++ b/src/services/deduplication/image_utils.py
@@ -11,6 +11,16 @@ rather than dereferenced — closes the symlink-following surface in the
 image dedup ingestion pipeline (#264). On Windows (where SafeDir's
 ``dir_fd`` + ``O_NOFOLLOW`` primitives are unavailable) the legacy
 path-based ``Image.open`` is used.
+
+**Anchoring**: callers that have a trusted-root context (the directory
+they walked to find the image) should pass ``trusted_root=`` to
+:func:`safedir_image_open`. The helper then traverses every component
+of the relative path with ``open_subdir`` so each intermediate
+directory is checked for symlinks too — closes the nested-symlink-
+ancestor TOCTOU window. Without ``trusted_root``, the helper falls
+back to parent-rooted opening (only the final component is protected;
+suitable for standalone validation calls that don't sit behind a
+directory walk).
 """
 
 from __future__ import annotations
@@ -32,48 +42,106 @@ logger = logging.getLogger(__name__)
 
 
 @contextlib.contextmanager
-def safedir_image_open(image_path: Path) -> Iterator[Image.Image]:
-    """Yield a ``PIL.Image`` opened via SafeDir; refuses symlinks.
+def safedir_image_open(
+    image_path: Path,
+    *,
+    trusted_root: Path | None = None,
+) -> Iterator[tuple[Image.Image, int | None]]:
+    """Yield ``(PIL.Image, fd)`` opened via SafeDir; refuses symlinks.
 
-    Behaves like ``with safedir_image_open(image_path) as img:`` but the file
-    is opened through ``SafeDir.open_for_reader`` so a symlink inside
-    ``image_path.parent`` is refused with ``SymlinkRejected`` (an
-    ``OSError`` subclass) instead of dereferenced. Callers that
-    already catch ``OSError`` will naturally treat refused symlinks
-    as unreadable images.
+    Args:
+        image_path: Path to the image file.
+        trusted_root: Anchor directory whose contents are trusted. When
+            given, the helper opens ``trusted_root`` as a SafeDir and
+            traverses each intermediate component of
+            ``image_path.relative_to(trusted_root)`` via
+            ``open_subdir`` — each step rejects symlinks with
+            ``O_NOFOLLOW``, closing the nested-symlink-ancestor TOCTOU
+            window. When ``None``, falls back to opening
+            ``image_path.parent`` directly (only the final component
+            is protected; OK for standalone validation calls without
+            a walk context).
 
-    On Windows (or any platform where SafeDir raises
-    ``NotImplementedError``) the helper falls back to direct
-    ``Image.open(image_path)`` — preserves the legacy API surface.
+    Yields:
+        ``(img, fd)`` where ``fd`` is the underlying SafeDir-opened
+        file descriptor (or ``None`` on the Windows / non-SafeDir
+        fallback path). Callers that need race-free metadata reads
+        (file size, mtime) should use ``os.fstat(fd)`` rather than
+        ``image_path.stat()`` — the latter can mismatch on a
+        post-open swap.
 
-    The Pillow Image lifecycle: ``Image.open(fileobj)`` is lazy, so
-    the fileobj must stay alive until the image is closed. We keep
-    both contexts open until the caller's ``with`` block exits.
+    Raises:
+        SymlinkRejected: If ``image_path`` or any intermediate
+            ancestor (under ``trusted_root``, when supplied) is a
+            symlink. Subclasses ``OSError`` so callers' existing
+            ``except OSError`` paths catch refused symlinks too.
+        ValueError: If ``image_path`` is not under ``trusted_root``.
+        OSError: For other open failures (permission denied, etc.).
     """
     if sys.platform == "win32":
         with Image.open(image_path) as img:
-            yield img
+            yield img, None
         return
 
+    stack = contextlib.ExitStack()
+    img: Image.Image | None = None
+    fd: int | None = None
     try:
-        with SafeDir.open_root(image_path.parent) as safe_dir:
-            fd = safe_dir.open_for_reader(image_path.name)
+        # Construction phase — narrowly catch NotImplementedError here
+        # so a NotImplementedError raised inside the yield (by the
+        # caller's code or by a PIL operation) propagates normally
+        # rather than being mistaken for "SafeDir unavailable".
+        try:
+            stack.__enter__()
+            if trusted_root is None:
+                # Parent-rooted (legacy / standalone): only the final
+                # component is O_NOFOLLOW-protected. Documented above.
+                sd = stack.enter_context(SafeDir.open_root(image_path.parent))
+                name = image_path.name
+            else:
+                # Trusted-root traversal: every intermediate component
+                # is rejected if it's a symlink. ``relative_to`` raises
+                # ValueError if the image is outside the trusted root —
+                # which is itself a security violation worth surfacing.
+                relative = image_path.relative_to(trusted_root)
+                parts = relative.parts
+                if not parts:
+                    raise ValueError(
+                        f"image_path {image_path!r} equals trusted_root {trusted_root!r}; "
+                        "expected a file inside the root"
+                    )
+                sd = stack.enter_context(SafeDir.open_root(trusted_root))
+                for part in parts[:-1]:
+                    sd = stack.enter_context(sd.open_subdir(part))
+                name = parts[-1]
+            fd = sd.open_for_reader(name)
             # fdopen takes ownership only once it returns; explicitly
-            # close the raw fd if fdopen itself raises (e.g. on a
-            # closed dir_fd race).
+            # close the raw fd if fdopen itself raises.
             try:
                 fileobj = os.fdopen(fd, "rb", closefd=True)
             except OSError:
                 os.close(fd)
                 raise
-            with fileobj, Image.open(fileobj) as img:
-                yield img
-    except NotImplementedError:
-        # SafeDir's POSIX primitives unavailable on this build; fall
-        # back to direct Image.open so the helper still works.
-        logger.debug("SafeDir unavailable; using legacy Image.open for %s", image_path.name)
-        with Image.open(image_path) as img:
-            yield img
+            stack.enter_context(fileobj)
+            img = stack.enter_context(Image.open(fileobj))
+        except NotImplementedError:
+            # SafeDir's POSIX primitives unavailable on this build; close
+            # any partially-entered stack frames and fall back to direct
+            # ``Image.open(path)``. Yield from inside the fallback's own
+            # ``with`` so cleanup is structured.
+            stack.close()
+            logger.debug("SafeDir unavailable; using legacy Image.open for %s", image_path.name)
+            with Image.open(image_path) as fallback_img:
+                yield fallback_img, None
+            return
+
+        # Yield from outside the construction-try so the caller's
+        # exceptions propagate cleanly — including NotImplementedError
+        # raised inside the with-block body, which used to be swallowed.
+        assert img is not None  # always set by the construction phase
+        yield img, fd
+    finally:
+        stack.close()
 
 
 # Supported image formats
@@ -154,12 +222,15 @@ def get_image_metadata(image_path: Path) -> ImageMetadata | None:
         return None
 
     try:
-        with safedir_image_open(image_path) as img:
+        # Stat from the SafeDir-opened fd so size_bytes describes the
+        # same non-symlink file the dimensions were read from. Falls
+        # back to ``image_path.stat()`` when ``fd is None`` (Windows /
+        # SafeDir-unavailable code path).
+        with safedir_image_open(image_path) as (img, fd):
             width, height = img.size
             image_format = img.format or "unknown"
             mode = img.mode
-
-        size_bytes = image_path.stat().st_size
+            size_bytes = os.fstat(fd).st_size if fd is not None else image_path.stat().st_size
 
         return ImageMetadata(
             path=image_path,
@@ -190,7 +261,7 @@ def get_image_dimensions(image_path: Path) -> tuple[int, int] | None:
         Tuple of (width, height) in pixels, or None if image cannot be read
     """
     try:
-        with safedir_image_open(image_path) as img:
+        with safedir_image_open(image_path) as (img, _fd):
             return img.size  # type: ignore[no-any-return]
     except (OSError, ValueError) as e:
         logger.warning(f"Could not get dimensions for {image_path}: {e}")
@@ -207,7 +278,7 @@ def get_image_format(image_path: Path) -> str | None:
         Format string (e.g., "JPEG", "PNG"), or None if cannot be determined
     """
     try:
-        with safedir_image_open(image_path) as img:
+        with safedir_image_open(image_path) as (img, _fd):
             return img.format  # type: ignore[no-any-return]
     except (OSError, ValueError) as e:
         logger.warning(f"Could not determine format for {image_path}: {e}")
@@ -253,12 +324,12 @@ def validate_image_file(image_path: Path) -> tuple[bool, str | None]:
         return False, f"Unsupported format: {image_path.suffix}"
 
     try:
-        with safedir_image_open(image_path) as img:
+        with safedir_image_open(image_path) as (img, _fd):
             # Verify image data is readable
             img.verify()
 
         # Reopen to get actual dimensions (verify closes the file)
-        with safedir_image_open(image_path) as img:
+        with safedir_image_open(image_path) as (img, _fd):
             width, height = img.size
             if width <= 0 or height <= 0:
                 return False, f"Invalid dimensions: {width}x{height}"

--- a/src/services/deduplication/image_utils.py
+++ b/src/services/deduplication/image_utils.py
@@ -2,18 +2,79 @@
 
 Provides helper functions for image validation, metadata extraction,
 format conversion, and batch processing operations.
+
+Every image read goes through :func:`safedir_image_open`, which routes
+``PIL.Image.open`` through a SafeDir-opened file descriptor on POSIX.
+A symlink swapped into the organize root between the directory walk and
+the read is refused with ``SymlinkRejected`` (an ``OSError`` subclass)
+rather than dereferenced — closes the symlink-following surface in the
+image dedup ingestion pipeline (#264). On Windows (where SafeDir's
+``dir_fd`` + ``O_NOFOLLOW`` primitives are unavailable) the legacy
+path-based ``Image.open`` is used.
 """
 
 from __future__ import annotations
 
+import contextlib
 import logging
+import os
+import sys
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 from PIL import Image, UnidentifiedImageError
 from PIL.Image import DecompressionBombError
 
+from utils.safedir import SafeDir
+
 logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def safedir_image_open(image_path: Path) -> Iterator[Image.Image]:
+    """Yield a ``PIL.Image`` opened via SafeDir; refuses symlinks.
+
+    Behaves like ``with safedir_image_open(image_path) as img:`` but the file
+    is opened through ``SafeDir.open_for_reader`` so a symlink inside
+    ``image_path.parent`` is refused with ``SymlinkRejected`` (an
+    ``OSError`` subclass) instead of dereferenced. Callers that
+    already catch ``OSError`` will naturally treat refused symlinks
+    as unreadable images.
+
+    On Windows (or any platform where SafeDir raises
+    ``NotImplementedError``) the helper falls back to direct
+    ``Image.open(image_path)`` — preserves the legacy API surface.
+
+    The Pillow Image lifecycle: ``Image.open(fileobj)`` is lazy, so
+    the fileobj must stay alive until the image is closed. We keep
+    both contexts open until the caller's ``with`` block exits.
+    """
+    if sys.platform == "win32":
+        with Image.open(image_path) as img:
+            yield img
+        return
+
+    try:
+        with SafeDir.open_root(image_path.parent) as safe_dir:
+            fd = safe_dir.open_for_reader(image_path.name)
+            # fdopen takes ownership only once it returns; explicitly
+            # close the raw fd if fdopen itself raises (e.g. on a
+            # closed dir_fd race).
+            try:
+                fileobj = os.fdopen(fd, "rb", closefd=True)
+            except OSError:
+                os.close(fd)
+                raise
+            with fileobj, Image.open(fileobj) as img:
+                yield img
+    except NotImplementedError:
+        # SafeDir's POSIX primitives unavailable on this build; fall
+        # back to direct Image.open so the helper still works.
+        logger.debug("SafeDir unavailable; using legacy Image.open for %s", image_path.name)
+        with Image.open(image_path) as img:
+            yield img
+
 
 # Supported image formats
 SUPPORTED_FORMATS = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".tif", ".webp"}
@@ -93,7 +154,7 @@ def get_image_metadata(image_path: Path) -> ImageMetadata | None:
         return None
 
     try:
-        with Image.open(image_path) as img:
+        with safedir_image_open(image_path) as img:
             width, height = img.size
             image_format = img.format or "unknown"
             mode = img.mode
@@ -129,7 +190,7 @@ def get_image_dimensions(image_path: Path) -> tuple[int, int] | None:
         Tuple of (width, height) in pixels, or None if image cannot be read
     """
     try:
-        with Image.open(image_path) as img:
+        with safedir_image_open(image_path) as img:
             return img.size  # type: ignore[no-any-return]
     except (OSError, ValueError) as e:
         logger.warning(f"Could not get dimensions for {image_path}: {e}")
@@ -146,7 +207,7 @@ def get_image_format(image_path: Path) -> str | None:
         Format string (e.g., "JPEG", "PNG"), or None if cannot be determined
     """
     try:
-        with Image.open(image_path) as img:
+        with safedir_image_open(image_path) as img:
             return img.format  # type: ignore[no-any-return]
     except (OSError, ValueError) as e:
         logger.warning(f"Could not determine format for {image_path}: {e}")
@@ -192,12 +253,12 @@ def validate_image_file(image_path: Path) -> tuple[bool, str | None]:
         return False, f"Unsupported format: {image_path.suffix}"
 
     try:
-        with Image.open(image_path) as img:
+        with safedir_image_open(image_path) as img:
             # Verify image data is readable
             img.verify()
 
         # Reopen to get actual dimensions (verify closes the file)
-        with Image.open(image_path) as img:
+        with safedir_image_open(image_path) as img:
             width, height = img.size
             if width <= 0 or height <= 0:
                 return False, f"Invalid dimensions: {width}x{height}"

--- a/src/services/deduplication/quality.py
+++ b/src/services/deduplication/quality.py
@@ -135,9 +135,11 @@ class ImageQualityAnalyzer:
             return None
 
         try:
+            import os
+
             from .image_utils import safedir_image_open
 
-            with safedir_image_open(path) as (img, _fd):
+            with safedir_image_open(path) as (img, fd):
                 width, height = img.size
                 resolution = width * height
 
@@ -165,7 +167,14 @@ class ImageQualityAnalyzer:
                 }
                 color_depth = mode_bits.get(img.mode, 24)
 
-                stat = path.stat()
+                # Stat from the SafeDir-opened fd when available so size
+                # and mtime describe the same non-symlink file the image
+                # was decoded from. Falls back to ``path.stat()`` when
+                # ``fd is None`` (Windows / SafeDir-unavailable).
+                if fd is not None:
+                    stat = os.fstat(fd)
+                else:
+                    stat = path.stat()
                 file_size = stat.st_size
                 format_enum = self._get_format_from_extension(path)
                 aspect_ratio = width / height if height > 0 else 0

--- a/src/services/deduplication/quality.py
+++ b/src/services/deduplication/quality.py
@@ -135,7 +135,9 @@ class ImageQualityAnalyzer:
             return None
 
         try:
-            with self.Image.open(path) as img:
+            from .image_utils import safedir_image_open
+
+            with safedir_image_open(path) as (img, _fd):
                 width, height = img.size
                 resolution = width * height
 

--- a/src/services/deduplication/viewer.py
+++ b/src/services/deduplication/viewer.py
@@ -11,6 +11,7 @@ Provides a terminal-based UI for reviewing duplicate images with:
 
 from __future__ import annotations
 
+import os
 import shutil
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -203,12 +204,19 @@ class ComparisonViewer:
         Raises:
             Exception: If image cannot be loaded
         """
-        with safedir_image_open(image_path) as img:
+        with safedir_image_open(image_path) as (img, fd):
             width, height = img.size
             img_format = img.format or "UNKNOWN"
             mode = img.mode
-
-        stat = image_path.stat()
+            # Stat from the same SafeDir-opened fd so size/mtime
+            # describe the non-symlink file we actually read. Falls
+            # back to ``image_path.stat()`` only when ``fd is None``
+            # (Windows / SafeDir-unavailable), where the helper itself
+            # already used the path directly.
+            if fd is not None:
+                stat = os.fstat(fd)
+            else:
+                stat = image_path.stat()
 
         return ImageMetadata(
             path=image_path,
@@ -303,7 +311,7 @@ class ComparisonViewer:
             ASCII art string or None if preview fails
         """
         try:
-            with safedir_image_open(image_path) as raw_img:
+            with safedir_image_open(image_path) as (raw_img, _fd):
                 # Convert to grayscale
                 img: Image.Image = raw_img.convert("L")
 

--- a/src/services/deduplication/viewer.py
+++ b/src/services/deduplication/viewer.py
@@ -107,7 +107,11 @@ class ComparisonViewer:
         self._terminal_width = shutil.get_terminal_size().columns
 
     def show_comparison(
-        self, images: list[Path], similarity_score: float | None = None
+        self,
+        images: list[Path],
+        similarity_score: float | None = None,
+        *,
+        trusted_root: Path | None = None,
     ) -> DuplicateReview:
         """Show comparison for a group of duplicate images.
 
@@ -116,6 +120,13 @@ class ComparisonViewer:
         Args:
             images: List of duplicate image paths
             similarity_score: Similarity score if available
+            trusted_root: Optional scan root that bounds the SafeDir
+                traversal for each image. When supplied (typically the
+                directory passed to ``find_duplicates``), every
+                intermediate component of each image path is checked
+                for symlinks during the metadata + preview generation —
+                closes the nested-symlink-ancestor TOCTOU window that
+                would otherwise reopen between hashing and review.
 
         Returns:
             DuplicateReview with user decisions
@@ -127,7 +138,7 @@ class ComparisonViewer:
         metadata_list = []
         for img_path in images:
             try:
-                metadata = self._get_image_metadata(img_path)
+                metadata = self._get_image_metadata(img_path, trusted_root=trusted_root)
                 metadata_list.append(metadata)
             except (OSError, ValueError) as e:
                 self.console.print(f"[yellow]Warning: Could not load {img_path}: {e}[/yellow]")
@@ -137,7 +148,7 @@ class ComparisonViewer:
 
         # Display comparison
         self._display_comparison_header(len(metadata_list), similarity_score)
-        self._display_images_side_by_side(metadata_list)
+        self._display_images_side_by_side(metadata_list, trusted_root=trusted_root)
 
         # Get user action
         action = self._prompt_user_action(len(metadata_list))
@@ -146,13 +157,21 @@ class ComparisonViewer:
         return self._process_user_action(action, metadata_list)
 
     def batch_review(
-        self, duplicate_groups: dict[str, list[Path]], auto_select_best: bool = False
+        self,
+        duplicate_groups: dict[str, list[Path]],
+        auto_select_best: bool = False,
+        *,
+        trusted_root: Path | None = None,
     ) -> dict[Path, str]:
         """Review multiple groups of duplicates in batch.
 
         Args:
             duplicate_groups: Dictionary mapping group IDs to lists of duplicate images
             auto_select_best: If True, automatically keep best quality
+            trusted_root: Optional scan root that bounds SafeDir traversal
+                for each image during review. Forwards through to
+                :meth:`show_comparison` so symlinked ancestors are
+                rejected at every component.
 
         Returns:
             Dictionary mapping file paths to actions ("keep" or "delete")
@@ -172,8 +191,9 @@ class ComparisonViewer:
                 # Automatic selection of best quality
                 review = self._auto_select_best(images)
             else:
-                # Manual review
-                review = self.show_comparison(images)
+                # Manual review — pass the scan root through so each
+                # image opens with full anchored traversal.
+                review = self.show_comparison(images, trusted_root=trusted_root)
 
             # Record decisions
             for path in review.files_to_keep:
@@ -192,11 +212,15 @@ class ComparisonViewer:
 
         return decisions
 
-    def _get_image_metadata(self, image_path: Path) -> ImageMetadata:
+    def _get_image_metadata(
+        self, image_path: Path, *, trusted_root: Path | None = None
+    ) -> ImageMetadata:
         """Extract metadata from an image file.
 
         Args:
             image_path: Path to image file
+            trusted_root: Scan root for SafeDir anchoring; defers to the
+                parent-rooted fallback when ``None``.
 
         Returns:
             ImageMetadata object
@@ -204,7 +228,7 @@ class ComparisonViewer:
         Raises:
             Exception: If image cannot be loaded
         """
-        with safedir_image_open(image_path) as (img, fd):
+        with safedir_image_open(image_path, trusted_root=trusted_root) as (img, fd):
             width, height = img.size
             img_format = img.format or "UNKNOWN"
             mode = img.mode
@@ -238,17 +262,25 @@ class ComparisonViewer:
 
         self.console.print(Panel(header_text, style="bold cyan", box=box.DOUBLE))
 
-    def _display_images_side_by_side(self, metadata_list: list[ImageMetadata]) -> None:
+    def _display_images_side_by_side(
+        self,
+        metadata_list: list[ImageMetadata],
+        *,
+        trusted_root: Path | None = None,
+    ) -> None:
         """Display images side by side with metadata.
 
         Args:
             metadata_list: List of ImageMetadata objects
+            trusted_root: Forwarded to ``_generate_ascii_preview`` so
+                the ASCII preview re-open uses the same SafeDir anchor
+                as the metadata extraction.
         """
         # Create tables for each image
         tables = []
 
         for idx, metadata in enumerate(metadata_list, 1):
-            table = self._create_image_info_table(idx, metadata)
+            table = self._create_image_info_table(idx, metadata, trusted_root=trusted_root)
             tables.append(table)
 
         # Display in columns if terminal is wide enough
@@ -260,12 +292,19 @@ class ComparisonViewer:
                 self.console.print(table)
                 self.console.print()
 
-    def _create_image_info_table(self, index: int, metadata: ImageMetadata) -> Table:
+    def _create_image_info_table(
+        self,
+        index: int,
+        metadata: ImageMetadata,
+        *,
+        trusted_root: Path | None = None,
+    ) -> Table:
         """Create a table displaying image information.
 
         Args:
             index: Image number in comparison
             metadata: ImageMetadata object
+            trusted_root: Forwarded to ``_generate_ascii_preview``.
 
         Returns:
             Rich Table with image info
@@ -291,14 +330,19 @@ class ComparisonViewer:
         table.add_row("Full Path", str(metadata.path))
 
         # Add ASCII preview if terminal supports it
-        preview = self._generate_ascii_preview(metadata.path)
+        preview = self._generate_ascii_preview(metadata.path, trusted_root=trusted_root)
         if preview:
             table.add_row("Preview", preview)
 
         return table
 
     def _generate_ascii_preview(
-        self, image_path: Path, max_width: int = 40, max_height: int = 15
+        self,
+        image_path: Path,
+        max_width: int = 40,
+        max_height: int = 15,
+        *,
+        trusted_root: Path | None = None,
     ) -> str | None:
         """Generate ASCII art preview of image.
 
@@ -306,12 +350,14 @@ class ComparisonViewer:
             image_path: Path to image
             max_width: Maximum width in characters
             max_height: Maximum height in characters
+            trusted_root: Scan root for SafeDir anchoring; defers to
+                the parent-rooted fallback when ``None``.
 
         Returns:
             ASCII art string or None if preview fails
         """
         try:
-            with safedir_image_open(image_path) as (raw_img, _fd):
+            with safedir_image_open(image_path, trusted_root=trusted_root) as (raw_img, _fd):
                 # Convert to grayscale
                 img: Image.Image = raw_img.convert("L")
 

--- a/src/services/deduplication/viewer.py
+++ b/src/services/deduplication/viewer.py
@@ -153,8 +153,10 @@ class ComparisonViewer:
         # Get user action
         action = self._prompt_user_action(len(metadata_list))
 
-        # Process action
-        return self._process_user_action(action, metadata_list)
+        # Process action — forward trusted_root so the AUTO_SELECT branch's
+        # re-open via ``_auto_select_best`` gets the same SafeDir anchoring
+        # as the initial display.
+        return self._process_user_action(action, metadata_list, trusted_root=trusted_root)
 
     def batch_review(
         self,
@@ -188,8 +190,9 @@ class ComparisonViewer:
             self.console.rule()
 
             if auto_select_best:
-                # Automatic selection of best quality
-                review = self._auto_select_best(images)
+                # Automatic selection of best quality — same anchoring
+                # contract as the manual path.
+                review = self._auto_select_best(images, trusted_root=trusted_root)
             else:
                 # Manual review — pass the scan root through so each
                 # image opens with full anchored traversal.
@@ -438,13 +441,20 @@ class ComparisonViewer:
                 self.console.print("[red]Invalid choice. Please try again.[/red]")
 
     def _process_user_action(
-        self, action: UserAction, metadata_list: list[ImageMetadata]
+        self,
+        action: UserAction,
+        metadata_list: list[ImageMetadata],
+        *,
+        trusted_root: Path | None = None,
     ) -> DuplicateReview:
         """Process user action and return review result.
 
         Args:
             action: UserAction enum value
             metadata_list: List of ImageMetadata
+            trusted_root: Forwarded to ``_auto_select_best`` so the
+                AUTO_SELECT branch's image re-open uses the same
+                SafeDir anchoring as the display.
 
         Returns:
             DuplicateReview with decisions
@@ -466,7 +476,9 @@ class ComparisonViewer:
                 return DuplicateReview([], [], skipped=True)
 
         elif action == UserAction.AUTO_SELECT:
-            return self._auto_select_best([m.path for m in metadata_list])
+            return self._auto_select_best(
+                [m.path for m in metadata_list], trusted_root=trusted_root
+            )
 
         elif action == UserAction.KEEP:
             # Prompt for which image to keep
@@ -489,7 +501,9 @@ class ComparisonViewer:
 
         return DuplicateReview([], [], skipped=True)
 
-    def _auto_select_best(self, images: list[Path]) -> DuplicateReview:
+    def _auto_select_best(
+        self, images: list[Path], *, trusted_root: Path | None = None
+    ) -> DuplicateReview:
         """Automatically select the best quality image.
 
         Chooses based on:
@@ -499,12 +513,17 @@ class ComparisonViewer:
 
         Args:
             images: List of image paths
+            trusted_root: Scan root for SafeDir anchoring; forwarded to
+                each ``_get_image_metadata`` re-open so the auto-select
+                path gets the same protection as the display path.
 
         Returns:
             DuplicateReview with best image kept, others marked for deletion
         """
         try:
-            metadata_list = [self._get_image_metadata(img) for img in images]
+            metadata_list = [
+                self._get_image_metadata(img, trusted_root=trusted_root) for img in images
+            ]
         except (OSError, ValueError) as e:
             self.console.print(f"[yellow]Warning: Could not auto-select: {e}[/yellow]")
             return DuplicateReview([], [], skipped=True)

--- a/src/services/deduplication/viewer.py
+++ b/src/services/deduplication/viewer.py
@@ -26,6 +26,8 @@ from rich.panel import Panel
 from rich.prompt import Confirm, Prompt
 from rich.table import Table
 
+from .image_utils import safedir_image_open
+
 
 class UserAction(Enum):
     """User actions for duplicate handling."""
@@ -201,7 +203,7 @@ class ComparisonViewer:
         Raises:
             Exception: If image cannot be loaded
         """
-        with Image.open(image_path) as img:
+        with safedir_image_open(image_path) as img:
             width, height = img.size
             img_format = img.format or "UNKNOWN"
             mode = img.mode
@@ -301,7 +303,7 @@ class ComparisonViewer:
             ASCII art string or None if preview fails
         """
         try:
-            with Image.open(image_path) as raw_img:
+            with safedir_image_open(image_path) as raw_img:
                 # Convert to grayscale
                 img: Image.Image = raw_img.convert("L")
 

--- a/tests/integration/test_coverage_gap_supplements.py
+++ b/tests/integration/test_coverage_gap_supplements.py
@@ -448,6 +448,8 @@ class TestCopilotExecutorHandlers:
         assert "search" in result.message.lower()
 
     def test_handle_find_with_results(self, executor, tmp_path: Path) -> None:
+        # Routes through BM25Index which requires rank-bm25 (``search`` extra).
+        pytest.importorskip("rank_bm25")
         from services.copilot.executor import Intent, IntentType
 
         f = tmp_path / "important_report.txt"

--- a/tests/integration/test_deduplication_core.py
+++ b/tests/integration/test_deduplication_core.py
@@ -221,6 +221,17 @@ class TestDocumentExtractor:
 # ---------------------------------------------------------------------------
 
 
+def _make_jpeg(path: Path, size: tuple[int, int] = (8, 8)) -> None:
+    """Write a tiny real JPEG to ``path``.
+
+    PR3f's ``get_image_hash`` opens via ``safedir_image_open`` and feeds
+    a numpy array to the hasher — fake JPEG-prefix bytes don't decode.
+    """
+    from PIL import Image as _PILImage
+
+    _PILImage.new("RGB", size, color=(100, 150, 200)).save(path, format="JPEG")
+
+
 class TestImageDeduplicator:
     """Tests for ImageDeduplicator (image_dedup.py)."""
 
@@ -316,16 +327,18 @@ class TestImageDeduplicator:
     def test_get_image_hash_supported_format_calls_hasher(self, tmp_path: Path) -> None:
         dedup = self._make_deduplicator()
         f = tmp_path / "img.jpg"
-        f.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(f)
         dedup.hasher.encode_image.return_value = "abcd1234"
         result = dedup.get_image_hash(f)
         assert result == "abcd1234"
-        dedup.hasher.encode_image.assert_called_once_with(str(f))
+        # PR3f: encode_image now receives image_array kwarg, not path
+
+        dedup.hasher.encode_image.assert_called_once()
 
     def test_get_image_hash_hasher_returns_none(self, tmp_path: Path) -> None:
         dedup = self._make_deduplicator()
         f = tmp_path / "img.jpg"
-        f.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(f)
         dedup.hasher.encode_image.return_value = None
         result = dedup.get_image_hash(f)
         assert result is None
@@ -342,8 +355,8 @@ class TestImageDeduplicator:
         dedup = self._make_deduplicator()
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8\xff")
-        img2.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
         dedup.hasher.encode_image.return_value = "ff00ff00ff00ff00"
         result = dedup.compute_similarity(img1, img2)
         assert result is not None
@@ -354,7 +367,7 @@ class TestImageDeduplicator:
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
         # only img1 exists
-        img1.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(img1)
         dedup.hasher.encode_image.side_effect = [OSError(), OSError()]
         result = dedup.compute_similarity(img1, img2)
         assert result is None
@@ -381,8 +394,8 @@ class TestImageDeduplicator:
         dedup = self._make_deduplicator()
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8\xff")
-        img2.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
         hash_val = "ff00ff00ff00ff00"
         dedup.hasher.encode_image.return_value = hash_val
         dedup.hasher.find_duplicates.return_value = {
@@ -401,7 +414,7 @@ class TestImageDeduplicator:
     def test_batch_compute_hashes_with_images(self, tmp_path: Path) -> None:
         dedup = self._make_deduplicator()
         img = tmp_path / "img.jpg"
-        img.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(img)
         dedup.hasher.encode_image.return_value = "aabbccdd"
         result = dedup.batch_compute_hashes([img])
         assert img in result
@@ -416,8 +429,8 @@ class TestImageDeduplicator:
         dedup = self._make_deduplicator(threshold=0)
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8\xff")
-        img2.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
         # Return very different hashes
         dedup.hasher.encode_image.side_effect = ["ff00000000000000", "00ff000000000000"]
         result = dedup.cluster_by_similarity([img1, img2])
@@ -453,7 +466,7 @@ class TestImageDeduplicator:
     def test_progress_callback_called(self, tmp_path: Path) -> None:
         dedup = self._make_deduplicator()
         img = tmp_path / "img.jpg"
-        img.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(img)
         dedup.hasher.encode_image.return_value = "aabb"
         calls: list[tuple[int, int]] = []
         dedup.batch_compute_hashes([img], progress_callback=lambda c, t: calls.append((c, t)))
@@ -466,8 +479,8 @@ class TestImageDeduplicator:
         sub.mkdir()
         top_img = tmp_path / "top.jpg"
         sub_img = sub / "nested.jpg"
-        top_img.write_bytes(b"\xff\xd8\xff")
-        sub_img.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(top_img)
+        _make_jpeg(sub_img)
         files = dedup._find_image_files(tmp_path, recursive=False)
         paths = [str(f) for f in files]
         assert str(top_img) in paths

--- a/tests/integration/test_pipeline_orchestrator_and_services.py
+++ b/tests/integration/test_pipeline_orchestrator_and_services.py
@@ -841,6 +841,11 @@ class TestCommandExecutorFind:
         assert result.success is False
 
     def test_find_by_filename_match(self, tmp_path: Path) -> None:
+        # CommandExecutor.find_files routes through BM25Index which
+        # requires rank-bm25 (``search`` extra). Skip when absent so
+        # the test doesn't fail in dev envs without ``[search]``; CI
+        # installs ``.[dev,search]`` and exercises this path normally.
+        pytest.importorskip("rank_bm25")
         from services.copilot.executor import CommandExecutor
         from services.copilot.models import Intent, IntentType
 

--- a/tests/integration/test_services_auto_tagging_copilot_feedback.py
+++ b/tests/integration/test_services_auto_tagging_copilot_feedback.py
@@ -781,6 +781,9 @@ class TestCommandExecutorAdditional:
         assert "search for" in result.message.lower()
 
     def test_execute_find_with_matches(self, tmp_path: Path) -> None:
+        # CommandExecutor.find_files routes through BM25Index which
+        # requires rank-bm25 (``search`` extra). Skip when absent.
+        pytest.importorskip("rank_bm25")
         from services.copilot.executor import CommandExecutor
 
         (tmp_path / "report.txt").write_text("content")

--- a/tests/services/deduplication/test_dedup_viewer.py
+++ b/tests/services/deduplication/test_dedup_viewer.py
@@ -220,7 +220,8 @@ class TestShowComparison:
         """If some images fail to load, the rest still show up."""
         call_count = 0
 
-        def _meta_side_effect(path):
+        def _meta_side_effect(path, **_kwargs):
+            # PR3f: _get_image_metadata accepts ``trusted_root=`` kwarg now
             nonlocal call_count
             call_count += 1
             if call_count == 1:

--- a/tests/services/deduplication/test_dedup_viewer.py
+++ b/tests/services/deduplication/test_dedup_viewer.py
@@ -473,7 +473,7 @@ class TestGenerateAsciiPreview:
         type(fake_img.resize.return_value).width = 40
 
         mock_open_cm = MagicMock()
-        mock_open_cm.__enter__ = MagicMock(return_value=fake_img)
+        mock_open_cm.__enter__ = MagicMock(return_value=(fake_img, None))
         mock_open_cm.__exit__ = MagicMock(return_value=False)
 
         with patch(
@@ -522,7 +522,7 @@ class TestGenerateAsciiPreview:
         # Landscape: 400x100, aspect_ratio=4 > 1
         landscape_img = _make_fake_img(400, 100, 20, 10)
         mock_cm = MagicMock()
-        mock_cm.__enter__ = MagicMock(return_value=landscape_img)
+        mock_cm.__enter__ = MagicMock(return_value=(landscape_img, None))
         mock_cm.__exit__ = MagicMock(return_value=False)
         with patch(
             "services.deduplication.viewer.safedir_image_open",
@@ -536,7 +536,7 @@ class TestGenerateAsciiPreview:
         # Portrait: 100x400, aspect_ratio=0.25 < 1
         portrait_img = _make_fake_img(100, 400, 20, 10)
         mock_cm2 = MagicMock()
-        mock_cm2.__enter__ = MagicMock(return_value=portrait_img)
+        mock_cm2.__enter__ = MagicMock(return_value=(portrait_img, None))
         mock_cm2.__exit__ = MagicMock(return_value=False)
         with patch(
             "services.deduplication.viewer.safedir_image_open",

--- a/tests/services/deduplication/test_dedup_viewer.py
+++ b/tests/services/deduplication/test_dedup_viewer.py
@@ -477,7 +477,7 @@ class TestGenerateAsciiPreview:
         mock_open_cm.__exit__ = MagicMock(return_value=False)
 
         with patch(
-            "services.deduplication.viewer.Image.open",
+            "services.deduplication.viewer.safedir_image_open",
             return_value=mock_open_cm,
         ):
             result = viewer._generate_ascii_preview(
@@ -525,7 +525,7 @@ class TestGenerateAsciiPreview:
         mock_cm.__enter__ = MagicMock(return_value=landscape_img)
         mock_cm.__exit__ = MagicMock(return_value=False)
         with patch(
-            "services.deduplication.viewer.Image.open",
+            "services.deduplication.viewer.safedir_image_open",
             return_value=mock_cm,
         ):
             result = viewer._generate_ascii_preview(
@@ -539,7 +539,7 @@ class TestGenerateAsciiPreview:
         mock_cm2.__enter__ = MagicMock(return_value=portrait_img)
         mock_cm2.__exit__ = MagicMock(return_value=False)
         with patch(
-            "services.deduplication.viewer.Image.open",
+            "services.deduplication.viewer.safedir_image_open",
             return_value=mock_cm2,
         ):
             result = viewer._generate_ascii_preview(

--- a/tests/services/deduplication/test_image_dedup.py
+++ b/tests/services/deduplication/test_image_dedup.py
@@ -722,10 +722,13 @@ class TestValidateImage:
         img.write_bytes(b"\xff\xd8\xff\xe0data")
 
         dedup = _make_dedup()
-        with patch("services.deduplication.image_dedup.Image") as mock_image:
+        # PR3f: validate_image now opens via ``safedir_image_open`` (SafeDir-
+        # routed). Patch the helper directly so the test doesn't need a real
+        # JPEG payload or a live SafeDir.
+        with patch("services.deduplication.image_dedup.safedir_image_open") as mock_open:
             mock_ctx = MagicMock()
-            mock_image.open.return_value.__enter__ = MagicMock(return_value=mock_ctx)
-            mock_image.open.return_value.__exit__ = MagicMock(return_value=False)
+            mock_open.return_value.__enter__ = MagicMock(return_value=mock_ctx)
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
 
             is_valid, error = dedup.validate_image(img)
             assert is_valid is True
@@ -761,9 +764,9 @@ class TestValidateImage:
         img.write_bytes(b"\xff\xd8\xff\xe0corrupt")
 
         dedup = _make_dedup()
-        with patch("services.deduplication.image_dedup.Image") as mock_image:
-            mock_image.open.return_value.__enter__ = MagicMock(side_effect=OSError("truncated"))
-            mock_image.open.return_value.__exit__ = MagicMock(return_value=False)
+        with patch("services.deduplication.image_dedup.safedir_image_open") as mock_open:
+            mock_open.return_value.__enter__ = MagicMock(side_effect=OSError("truncated"))
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
 
             is_valid, error = dedup.validate_image(img)
             assert is_valid is False
@@ -775,11 +778,9 @@ class TestValidateImage:
         img.write_bytes(b"\x89PNGbaddata")
 
         dedup = _make_dedup()
-        with patch("services.deduplication.image_dedup.Image") as mock_image:
-            mock_image.open.return_value.__enter__ = MagicMock(
-                side_effect=RuntimeError("weird error")
-            )
-            mock_image.open.return_value.__exit__ = MagicMock(return_value=False)
+        with patch("services.deduplication.image_dedup.safedir_image_open") as mock_open:
+            mock_open.return_value.__enter__ = MagicMock(side_effect=RuntimeError("weird error"))
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
 
             is_valid, error = dedup.validate_image(img)
             assert is_valid is False

--- a/tests/services/deduplication/test_image_dedup.py
+++ b/tests/services/deduplication/test_image_dedup.py
@@ -81,6 +81,20 @@ def _make_dedup(hash_method: str = "phash", threshold: int = 10) -> ImageDedupli
     return dedup
 
 
+def _make_jpeg(path: Path, size: tuple[int, int] = (8, 8)) -> None:
+    """Write a tiny real JPEG to ``path``.
+
+    PR3f's ``get_image_hash`` opens the file via ``safedir_image_open``
+    and hands a numpy array to the hasher — fake bytes won't decode.
+    Tests that previously used ``write_bytes(b"\\xff\\xd8...")`` to fake
+    a JPEG should call this helper instead so the actual SafeDir +
+    Pillow code path runs end-to-end.
+    """
+    from PIL import Image as _PILImage
+
+    _PILImage.new("RGB", size, color=(100, 150, 200)).save(path, format="JPEG")
+
+
 # ---------------------------------------------------------------------------
 # Initialization
 # ---------------------------------------------------------------------------
@@ -148,14 +162,20 @@ class TestGetImageHash:
     def test_hash_valid_image(self, tmp_path: Path):
         """Test successful hash of a valid image file."""
         img = tmp_path / "photo.jpg"
-        img.write_bytes(b"\xff\xd8\xff\xe0fake-jpeg-data")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = "abcdef1234567890"
 
         result = dedup.get_image_hash(img)
         assert result == "abcdef1234567890"
-        dedup.hasher.encode_image.assert_called_once_with(str(img))
+        # PR3f: hasher is now called with an image_array kwarg (numpy
+        # array from SafeDir-opened PIL Image), not the string path.
+        # That bypasses imagededup's internal Image.open(path) which
+        # would re-introduce the symlink-dereference we closed.
+        dedup.hasher.encode_image.assert_called_once()
+        kwargs = dedup.hasher.encode_image.call_args.kwargs
+        assert "image_array" in kwargs
 
     def test_hash_nonexistent_file(self, tmp_path: Path):
         """Test that missing file returns None."""
@@ -190,7 +210,7 @@ class TestGetImageHash:
     def test_hash_unexpected_exception(self, tmp_path: Path):
         """Test that unexpected exception during encoding returns None."""
         img = tmp_path / "weird.jpg"
-        img.write_bytes(b"\xff\xd8\xff\xe0junk")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.side_effect = RuntimeError("kaboom")
@@ -204,7 +224,11 @@ class TestGetImageHash:
 
         for ext in (".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".tif", ".webp"):
             img = tmp_path / f"image{ext}"
-            img.write_bytes(b"\x00" * 10)
+            # PR3f: get_image_hash now decodes via PIL before hashing;
+            # the test exercises the extension-suffix check, not format
+            # detection, so writing JPEG bytes to every suffix works
+            # (Pillow reads the magic bytes, not the extension).
+            _make_jpeg(img)
             result = dedup.get_image_hash(img)
             assert result == "aabbccdd", f"Failed for extension {ext}"
 
@@ -269,8 +293,8 @@ class TestComputeSimilarity:
         """Test perfect similarity for images with identical hashes."""
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8data1")
-        img2.write_bytes(b"\xff\xd8data2")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = "abcdef1234567890"
@@ -282,8 +306,8 @@ class TestComputeSimilarity:
         """Test zero similarity for maximally different hashes."""
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8data1")
-        img2.write_bytes(b"\xff\xd8data2")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.side_effect = [
@@ -298,8 +322,8 @@ class TestComputeSimilarity:
         """Test partial similarity with known distance."""
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8data1")
-        img2.write_bytes(b"\xff\xd8data2")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
 
         dedup = _make_dedup()
         # 0x000000000000000f vs 0x0000000000000000 -> 4 bits differ
@@ -315,7 +339,7 @@ class TestComputeSimilarity:
         """Test None returned when first image can't be hashed."""
         img1 = tmp_path / "missing.jpg"  # does not exist
         img2 = tmp_path / "b.jpg"
-        img2.write_bytes(b"\xff\xd8data2")
+        _make_jpeg(img2)
 
         dedup = _make_dedup()
         result = dedup.compute_similarity(img1, img2)
@@ -324,7 +348,7 @@ class TestComputeSimilarity:
     def test_second_image_fails(self, tmp_path: Path):
         """Test None returned when second image can't be hashed."""
         img1 = tmp_path / "a.jpg"
-        img1.write_bytes(b"\xff\xd8data1")
+        _make_jpeg(img1)
         img2 = tmp_path / "missing.jpg"
 
         dedup = _make_dedup()
@@ -363,8 +387,8 @@ class TestFindDuplicates:
         """Test empty result when all images are unique."""
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.png"
-        img1.write_bytes(b"\xff\xd8data1")
-        img2.write_bytes(b"\x89PNGdata2")
+        _make_jpeg(img1)
+        _make_jpeg(img2)  # JPEG bytes in .png — Pillow opens by magic, not suffix
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.side_effect = ["hash1", "hash2"]
@@ -382,7 +406,7 @@ class TestFindDuplicates:
         img2 = tmp_path / "b.jpg"
         img3 = tmp_path / "c.png"
         for img in (img1, img2, img3):
-            img.write_bytes(b"\xff\xd8fakeimage")
+            _make_jpeg(img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.side_effect = ["hash_a", "hash_b", "hash_c"]
@@ -401,7 +425,7 @@ class TestFindDuplicates:
     def test_progress_callback(self, tmp_path: Path):
         """Test that progress callback is invoked for each image."""
         img = tmp_path / "photo.jpg"
-        img.write_bytes(b"\xff\xd8data")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = "somehash"
@@ -416,7 +440,7 @@ class TestFindDuplicates:
         subdir = tmp_path / "sub"
         subdir.mkdir()
         img = subdir / "nested.jpg"
-        img.write_bytes(b"\xff\xd8data")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = "nested_hash"
@@ -429,38 +453,42 @@ class TestFindDuplicates:
         """Test recursive=False does NOT find images in subdirectories."""
         subdir = tmp_path / "sub"
         subdir.mkdir()
-        (subdir / "nested.jpg").write_bytes(b"\xff\xd8data")
+        _make_jpeg(subdir / "nested.jpg")
         root_img = tmp_path / "root.jpg"
-        root_img.write_bytes(b"\xff\xd8data")
+        _make_jpeg(root_img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = "root_hash"
         dedup.hasher.find_duplicates.return_value = {str(root_img): []}
 
         dedup.find_duplicates(tmp_path, recursive=False)
-        dedup.hasher.encode_image.assert_called_once_with(str(root_img))
+        # PR3f: hasher receives image_array=, not path
+        dedup.hasher.encode_image.assert_called_once()
+        kwargs = dedup.hasher.encode_image.call_args.kwargs
+        assert "image_array" in kwargs
 
     def test_skips_unhashable_images(self, tmp_path: Path):
         """Test that images failing to hash are excluded."""
         good = tmp_path / "good.jpg"
         bad = tmp_path / "bad.jpg"
-        good.write_bytes(b"\xff\xd8good")
-        bad.write_bytes(b"\xff\xd8bad")
+        _make_jpeg(good)
+        _make_jpeg(bad)
 
         dedup = _make_dedup()
 
-        # encode_image should return hash for good, None for bad (order-independent)
-        def encode_image_side_effect(path: str) -> str | None:
-            if path == str(good):
+        # PR3f: encode_image is now called with image_array=<numpy array>,
+        # not str(path) — we can't dispatch by path. Patch get_image_hash
+        # directly so we can decide good vs bad by path without relying on
+        # _find_image_files' ordering.
+        def hash_side_effect(image_path: Path, *, trusted_root: Path | None = None) -> str | None:
+            if image_path == good:
                 return "good_hash"
-            elif path == str(bad):
-                return None
             return None
 
-        dedup.hasher.encode_image.side_effect = encode_image_side_effect
-        dedup.hasher.find_duplicates.return_value = {str(good): []}
+        with patch.object(dedup, "get_image_hash", side_effect=hash_side_effect):
+            dedup.hasher.find_duplicates.return_value = {str(good): []}
+            dedup.find_duplicates(tmp_path)
 
-        dedup.find_duplicates(tmp_path)
         call_kwargs = dedup.hasher.find_duplicates.call_args
         encoding_map = call_kwargs.kwargs.get("encoding_map", call_kwargs[1].get("encoding_map"))
         assert str(good) in encoding_map
@@ -482,7 +510,7 @@ class TestClusterBySimilarity:
     def test_all_hashes_fail(self, tmp_path: Path):
         """Test empty clusters when no image can be hashed."""
         img = tmp_path / "bad.jpg"
-        img.write_bytes(b"\xff\xd8corrupt")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = None
@@ -493,7 +521,7 @@ class TestClusterBySimilarity:
     def test_single_image_no_cluster(self, tmp_path: Path):
         """Test that a single image does not form a cluster."""
         img = tmp_path / "solo.jpg"
-        img.write_bytes(b"\xff\xd8solo")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = "0000000000000000"
@@ -505,8 +533,8 @@ class TestClusterBySimilarity:
         """Test cluster of two identical images."""
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8data")
-        img2.write_bytes(b"\xff\xd8data")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
 
         dedup = _make_dedup(threshold=10)
         dedup.hasher.encode_image.return_value = "abcdef1234567890"
@@ -520,8 +548,8 @@ class TestClusterBySimilarity:
         """Test no clusters for very different images."""
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8data1")
-        img2.write_bytes(b"\xff\xd8data2")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
 
         dedup = _make_dedup(threshold=0)
         dedup.hasher.encode_image.side_effect = [
@@ -536,8 +564,8 @@ class TestClusterBySimilarity:
         """Test progress callback is called during clustering."""
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8d1")
-        img2.write_bytes(b"\xff\xd8d2")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = "aabb"
@@ -553,7 +581,7 @@ class TestClusterBySimilarity:
         imgs = []
         for name in ("a.jpg", "b.jpg", "c.jpg", "d.jpg"):
             p = tmp_path / name
-            p.write_bytes(b"\xff\xd8data")
+            _make_jpeg(p)
             imgs.append(p)
 
         dedup = _make_dedup(threshold=5)
@@ -585,8 +613,8 @@ class TestBatchComputeHashes:
         """Test all images hashed successfully."""
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.png"
-        img1.write_bytes(b"\xff\xd8d1")
-        img2.write_bytes(b"\x89PNGd2")
+        _make_jpeg(img1)
+        _make_jpeg(img2)  # JPEG bytes in .png — Pillow detects by magic bytes
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.side_effect = ["hash_a", "hash_b"]
@@ -598,8 +626,8 @@ class TestBatchComputeHashes:
         """Test that failed images are excluded from results."""
         good = tmp_path / "good.jpg"
         bad = tmp_path / "bad.jpg"
-        good.write_bytes(b"\xff\xd8good")
-        bad.write_bytes(b"\xff\xd8bad")
+        _make_jpeg(good)
+        _make_jpeg(bad)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.side_effect = ["good_hash", None]
@@ -612,7 +640,7 @@ class TestBatchComputeHashes:
         imgs = []
         for i in range(3):
             p = tmp_path / f"img{i}.jpg"
-            p.write_bytes(b"\xff\xd8data")
+            _make_jpeg(p)
             imgs.append(p)
 
         dedup = _make_dedup()
@@ -628,7 +656,7 @@ class TestBatchComputeHashes:
     def test_no_callback(self, tmp_path: Path):
         """Test batch works without progress callback."""
         img = tmp_path / "only.jpg"
-        img.write_bytes(b"\xff\xd8ok")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = "ok_hash"
@@ -719,15 +747,15 @@ class TestValidateImage:
     def test_valid_image(self, tmp_path: Path):
         """Test validation passes for a readable image."""
         img = tmp_path / "valid.jpg"
-        img.write_bytes(b"\xff\xd8\xff\xe0data")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
-        # PR3f: validate_image now opens via ``safedir_image_open`` (SafeDir-
-        # routed). Patch the helper directly so the test doesn't need a real
-        # JPEG payload or a live SafeDir.
+        # PR3f: validate_image now opens via ``safedir_image_open`` which
+        # yields a (img, fd) tuple. Patch the helper directly so the test
+        # doesn't need a real JPEG payload or a live SafeDir.
         with patch("services.deduplication.image_dedup.safedir_image_open") as mock_open:
             mock_ctx = MagicMock()
-            mock_open.return_value.__enter__ = MagicMock(return_value=mock_ctx)
+            mock_open.return_value.__enter__ = MagicMock(return_value=(mock_ctx, None))
             mock_open.return_value.__exit__ = MagicMock(return_value=False)
 
             is_valid, error = dedup.validate_image(img)
@@ -761,7 +789,7 @@ class TestValidateImage:
     def test_corrupt_image_os_error(self, tmp_path: Path):
         """Test validation fails for corrupt image (PIL raises OSError)."""
         img = tmp_path / "corrupt.jpg"
-        img.write_bytes(b"\xff\xd8\xff\xe0corrupt")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
         with patch("services.deduplication.image_dedup.safedir_image_open") as mock_open:

--- a/tests/services/deduplication/test_image_safedir.py
+++ b/tests/services/deduplication/test_image_safedir.py
@@ -311,7 +311,10 @@ class TestGetImageHashErrorBranches:
         assert result == "deadbeef"
         # The non-RGB branch was taken: convert("RGB") called once.
         mock_rgba_img.convert.assert_called_once_with("RGB")
-        # imagededup received a contiguous BGR-ordered 3-channel array.
+        # imagededup received a contiguous RGB 3-channel array.
+        # ``ascontiguousarray`` is preserved for future-proofing even
+        # though plain ``np.asarray(img)`` is already C-contiguous —
+        # the assertion locks the contract.
         passed_array = dedup.hasher.encode_image.call_args.kwargs["image_array"]
         assert passed_array.shape == (4, 4, 3)
         assert passed_array.flags["C_CONTIGUOUS"]
@@ -341,6 +344,51 @@ class TestViewerMetadataFdNoneFallback:
         assert meta.height == 10
         # File size came from path.stat (not os.fstat).
         assert meta.file_size > 0
+
+
+class TestHashEquivalenceWithPathCodepath:
+    """The SafeDir-routed ``get_image_hash`` must produce the same
+    perceptual hash as imagededup's path-based ``encode_image(path)``
+    flow — otherwise the migration silently breaks dedup matches on
+    existing corpora. This test runs with REAL imagededup installed
+    and asserts byte-for-byte hash equality between the two paths.
+
+    Skipped when ``imagededup`` is absent (CI matrix without the
+    dedup-image extra). Locally with the extra installed this is the
+    regression test that catches channel-order / preprocessing
+    mismatches like the one Codex flagged on PR3f.
+    """
+
+    def test_safedir_hash_matches_path_hash(self, tmp_path: Path) -> None:
+        pytest.importorskip("imagededup")
+        from services.deduplication.image_dedup import ImageDeduplicator
+
+        # A color photo where R/B differ noticeably, so any R/B swap
+        # would produce a clearly different perceptual hash.
+        from PIL import Image as _PILImage
+
+        target = tmp_path / "color.jpg"
+        # Diagonal gradient with strong red dominance so the grayscale
+        # luminance differs from a B-dominant version.
+        img = _PILImage.new("RGB", (32, 32))
+        pixels = img.load()
+        for y in range(32):
+            for x in range(32):
+                pixels[x, y] = (200 + (x % 16), 50, 30 + (y % 32))
+        img.save(target, format="JPEG", quality=95)
+
+        dedup = ImageDeduplicator(hash_method="phash")
+        # Path-based reference hash (what imagededup would compute on
+        # its own, no SafeDir involved).
+        reference = dedup.hasher.encode_image(image_file=str(target))
+
+        # SafeDir-routed hash via our refactored get_image_hash.
+        safedir_hash = dedup.get_image_hash(target)
+
+        assert safedir_hash == reference, (
+            f"SafeDir hash {safedir_hash!r} != path-based reference "
+            f"{reference!r} — channel ordering or preprocessing drift"
+        )
 
 
 class TestQualityFdStatBranch:

--- a/tests/services/deduplication/test_image_safedir.py
+++ b/tests/services/deduplication/test_image_safedir.py
@@ -294,18 +294,27 @@ class TestGetImageHashErrorBranches:
         dedup = self._make_dedup()
         dedup.hasher.encode_image.return_value = "deadbeef"
 
+        import numpy as np
+
+        # Provide a real 3-channel uint8 array so the new BGR-reverse
+        # slicing (``[:, :, ::-1]``) and ``np.ascontiguousarray`` work.
+        fake_rgb = np.zeros((4, 4, 3), dtype=np.uint8)
         with (
             patch(
                 "services.deduplication.image_dedup.safedir_image_open",
                 return_value=mock_cm,
             ),
-            patch("numpy.asarray", return_value="fake_array"),
+            patch("numpy.asarray", return_value=fake_rgb),
         ):
             result = dedup.get_image_hash(img)
 
         assert result == "deadbeef"
         # The non-RGB branch was taken: convert("RGB") called once.
         mock_rgba_img.convert.assert_called_once_with("RGB")
+        # imagededup received a contiguous BGR-ordered 3-channel array.
+        passed_array = dedup.hasher.encode_image.call_args.kwargs["image_array"]
+        assert passed_array.shape == (4, 4, 3)
+        assert passed_array.flags["C_CONTIGUOUS"]
 
 
 class TestViewerMetadataFdNoneFallback:
@@ -332,3 +341,51 @@ class TestViewerMetadataFdNoneFallback:
         assert meta.height == 10
         # File size came from path.stat (not os.fstat).
         assert meta.file_size > 0
+
+
+class TestQualityFdStatBranch:
+    """Cover the new ``os.fstat(fd)`` branch in
+    ``quality.ImageQualityAnalyzer._extract_metrics_with_pil``
+    introduced by 552228c. The existing test_quality.py tests mock
+    safedir_image_open to yield ``(mock_img, None)`` — only the
+    ``fd is None`` path is exercised. Add a test that yields a real
+    integer fd so the ``os.fstat(fd)`` branch is hit.
+    """
+
+    def test_quality_uses_fstat_when_fd_is_supplied(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        from services.deduplication.quality import ImageQualityAnalyzer
+
+        analyzer = ImageQualityAnalyzer()
+        target = tmp_path / "img.jpg"
+        _make_jpeg(target, size=(40, 30))
+
+        # Open a real fd so os.fstat() can be called on it. Provide
+        # a fake PIL Image with the expected attributes; the helper
+        # mock yields (img, fd). The fd must be valid for fstat to
+        # report a sensible size.
+        real_fd = os.open(str(target), os.O_RDONLY)
+        try:
+            mock_img = MagicMock()
+            mock_img.size = (40, 30)
+            mock_img.format = "JPEG"
+            mock_img.mode = "RGB"
+            mock_img.info = {}
+
+            cm = MagicMock()
+            cm.__enter__ = MagicMock(return_value=(mock_img, real_fd))
+            cm.__exit__ = MagicMock(return_value=False)
+            with patch(
+                "services.deduplication.image_utils.safedir_image_open",
+                return_value=cm,
+            ):
+                metrics = analyzer._extract_metrics_with_pil(target)
+        finally:
+            os.close(real_fd)
+
+        assert metrics is not None
+        assert metrics.width == 40
+        assert metrics.height == 30
+        # os.fstat path was taken: file_size came from the fd, not path.stat().
+        assert metrics.file_size > 0

--- a/tests/services/deduplication/test_image_safedir.py
+++ b/tests/services/deduplication/test_image_safedir.py
@@ -103,9 +103,7 @@ class TestSafedirImageOpenHelper:
             "services.deduplication.image_utils.os.fdopen",
             side_effect=OSError("synthetic fdopen failure"),
         ) as mock_fdopen:
-            with patch(
-                "services.deduplication.image_utils.os.close"
-            ) as mock_close:
+            with patch("services.deduplication.image_utils.os.close") as mock_close:
                 with pytest.raises(OSError, match="synthetic fdopen failure"):
                     with safedir_image_open(target):
                         pass

--- a/tests/services/deduplication/test_image_safedir.py
+++ b/tests/services/deduplication/test_image_safedir.py
@@ -360,12 +360,19 @@ class TestHashEquivalenceWithPathCodepath:
     """
 
     def test_safedir_hash_matches_path_hash(self, tmp_path: Path) -> None:
-        pytest.importorskip("imagededup")
-        from services.deduplication.image_dedup import ImageDeduplicator
-
+        # ``test_image_dedup.py`` injects a fake ``imagededup`` into
+        # ``sys.modules`` via ``setdefault`` when the real extra is
+        # absent, which means a plain ``importorskip("imagededup")``
+        # succeeds against the mock and the test would then fail
+        # calling real hash methods. Probe a submodule the fake doesn't
+        # provide instead — it only exists when the actual library is
+        # installed.
+        pytest.importorskip("imagededup.utils.image_utils")
         # A color photo where R/B differ noticeably, so any R/B swap
         # would produce a clearly different perceptual hash.
         from PIL import Image as _PILImage
+
+        from services.deduplication.image_dedup import ImageDeduplicator
 
         target = tmp_path / "color.jpg"
         # Diagonal gradient with strong red dominance so the grayscale

--- a/tests/services/deduplication/test_image_safedir.py
+++ b/tests/services/deduplication/test_image_safedir.py
@@ -1,0 +1,216 @@
+"""Tests for the SafeDir-aware ``safedir_image_open`` helper and its
+integration with the image-dedup utilities.
+
+PR3f of #267 wires ``utils.safedir.SafeDir`` into the image dedup
+ingestion path. Every ``PIL.Image.open(...)`` call in
+``services/deduplication/{image_utils,image_dedup,viewer}.py`` now goes
+through ``safedir_image_open`` so a symlink swapped into the organize
+root between the directory walk and the read is refused with
+``SymlinkRejected`` rather than dereferenced.
+
+Verifies:
+
+- ``safedir_image_open`` opens a real image and yields a PIL.Image
+- Symlinks under the SafeDir root are refused
+- On Windows (``NotImplementedError``) the helper falls back to direct
+  ``Image.open(path)``
+- The downstream utility functions
+  (``get_image_metadata`` / ``get_image_dimensions`` / etc.) route
+  symlinks to the same safe-default returns as other I/O errors
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from PIL import Image as _PILImage
+
+from services.deduplication.image_utils import (
+    get_image_dimensions,
+    get_image_format,
+    get_image_metadata,
+    safedir_image_open,
+    validate_image_file,
+)
+from utils.safedir import SymlinkRejected
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+    pytest.mark.integration,
+    pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only"),
+]
+
+
+def _make_jpeg(path: Path, size: tuple[int, int] = (8, 8)) -> None:
+    """Write a tiny JPEG to ``path`` for round-trip tests."""
+    img = _PILImage.new("RGB", size, color=(100, 150, 200))
+    img.save(path, format="JPEG")
+
+
+class TestSafedirImageOpenHelper:
+    def test_opens_real_image(self, tmp_path: Path) -> None:
+        target = tmp_path / "photo.jpg"
+        _make_jpeg(target, size=(16, 8))
+        with safedir_image_open(target) as img:
+            assert img.size == (16, 8)
+            assert img.format == "JPEG"
+
+    def test_refuses_symlinked_image(self, tmp_path: Path) -> None:
+        """A symlinked image in the organize root must be refused —
+        ``SafeDir.open_for_reader`` raises ``SymlinkRejected``, which
+        is an ``OSError`` subclass.
+        """
+        real = tmp_path / "secret.jpg"
+        _make_jpeg(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "decoy.jpg").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        with pytest.raises(SymlinkRejected):
+            with safedir_image_open(organize / "decoy.jpg"):
+                pass
+
+    def test_falls_back_to_path_open_when_safedir_not_implemented(self, tmp_path: Path) -> None:
+        """When SafeDir.open_root raises NotImplementedError (Windows-style
+        port not available), the helper falls back to direct
+        ``Image.open(path)`` — preserves the legacy API surface.
+        """
+        target = tmp_path / "fallback.jpg"
+        _make_jpeg(target)
+        with patch(
+            "services.deduplication.image_utils.SafeDir.open_root",
+            side_effect=NotImplementedError("simulated unavailable SafeDir"),
+        ):
+            with safedir_image_open(target) as img:
+                assert img.size == (8, 8)
+
+    def test_closes_fd_when_fdopen_raises(self, tmp_path: Path) -> None:
+        """If ``os.fdopen`` raises (e.g. transient OSError on a closed
+        dir_fd race), the helper must close the raw fd returned by
+        ``open_for_reader`` before the exception propagates — otherwise
+        we leak a descriptor. Verified via patch on ``os.fdopen``.
+        """
+        target = tmp_path / "fd_leak_test.jpg"
+        _make_jpeg(target)
+        with patch(
+            "services.deduplication.image_utils.os.fdopen",
+            side_effect=OSError("synthetic fdopen failure"),
+        ) as mock_fdopen:
+            with patch(
+                "services.deduplication.image_utils.os.close"
+            ) as mock_close:
+                with pytest.raises(OSError, match="synthetic fdopen failure"):
+                    with safedir_image_open(target):
+                        pass
+                # The raw fd from SafeDir.open_for_reader was reclaimed —
+                # SafeDir.__exit__ also closes its own dir_fd, so we get
+                # ≥1 close call. The fd that ``os.fdopen`` tried to wrap
+                # must be among the closed fds.
+                assert mock_close.call_count >= 1
+                fdopen_fd = mock_fdopen.call_args[0][0]
+                assert isinstance(fdopen_fd, int) and fdopen_fd >= 0
+                closed_fds = {call.args[0] for call in mock_close.call_args_list}
+                assert fdopen_fd in closed_fds
+
+
+class TestImageUtilsRoutesThroughHelper:
+    """The migrated image_utils functions return the legacy safe-default
+    ``None`` when the underlying image is unreadable. Symlink rejection is
+    just another OSError and routes the same way."""
+
+    def test_get_image_metadata_returns_none_on_symlink(self, tmp_path: Path) -> None:
+        real = tmp_path / "real.jpg"
+        _make_jpeg(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "link.jpg").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        out = get_image_metadata(organize / "link.jpg")
+        assert out is None
+
+    def test_get_image_dimensions_returns_none_on_symlink(self, tmp_path: Path) -> None:
+        real = tmp_path / "real.jpg"
+        _make_jpeg(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "link.jpg").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        assert get_image_dimensions(organize / "link.jpg") is None
+
+    def test_get_image_format_returns_none_on_symlink(self, tmp_path: Path) -> None:
+        real = tmp_path / "real.jpg"
+        _make_jpeg(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "link.jpg").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        assert get_image_format(organize / "link.jpg") is None
+
+    def test_validate_image_file_rejects_symlink(self, tmp_path: Path) -> None:
+        """``validate_image_file`` exists-checks first (the symlink itself
+        exists), then tries to open via SafeDir — which refuses. The
+        function returns ``(False, "...")``.
+        """
+        real = tmp_path / "real.jpg"
+        _make_jpeg(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "link.jpg").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        is_valid, err = validate_image_file(organize / "link.jpg")
+        assert is_valid is False
+        assert err is not None
+
+    def test_get_image_metadata_happy_path(self, tmp_path: Path) -> None:
+        target = tmp_path / "p.jpg"
+        _make_jpeg(target, size=(20, 10))
+        meta = get_image_metadata(target)
+        assert meta is not None
+        assert meta.width == 20
+        assert meta.height == 10
+        assert meta.format == "JPEG"
+        assert meta.size_bytes > 0
+
+
+class TestImageDedupValidateRefusesSymlinks:
+    """The ``ImageDeduplicator.validate_image`` flow now goes through
+    ``safedir_image_open`` — symlinks return ``(False, "Cannot read
+    image: ...")``."""
+
+    def test_validate_refuses_symlinked_image(self, tmp_path: Path) -> None:
+        pytest.importorskip("imagededup")  # dedup-image extra not in [dev,search]
+        from services.deduplication.image_dedup import ImageDeduplicator
+
+        real = tmp_path / "real.jpg"
+        _make_jpeg(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "decoy.jpg").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        dedup = ImageDeduplicator()
+        is_valid, err = dedup.validate_image(organize / "decoy.jpg")
+        assert is_valid is False
+        assert err is not None
+        assert "Cannot read image" in err or "symlink" in err.lower()

--- a/tests/services/deduplication/test_image_safedir.py
+++ b/tests/services/deduplication/test_image_safedir.py
@@ -223,3 +223,111 @@ class TestImageDedupValidateRefusesSymlinks:
         assert is_valid is False
         assert err is not None
         assert "Cannot read image" in err or "symlink" in err.lower()
+
+
+class TestGetImageHashErrorBranches:
+    """Cover the new error-handling branches in ``ImageDeduplicator.
+    get_image_hash`` introduced by PR3f's SafeDir-routed hashing
+    (#281 reviews). These run with mocked imagededup so they don't
+    need the ``dedup-image`` extra installed.
+    """
+
+    def _make_dedup(self):
+        """Build an ImageDeduplicator with a controllable hasher mock.
+
+        Patches the imagededup availability flag so the constructor
+        succeeds even when the optional extra is absent (CI matrix).
+        """
+        from unittest.mock import MagicMock, patch as _patch
+
+        from services.deduplication import image_dedup as _id
+
+        with (
+            _patch.object(_id, "_IMAGEDEDUP_AVAILABLE", True),
+            _patch.object(_id, "PHash", MagicMock(return_value=MagicMock())),
+            _patch.object(_id, "DHash", MagicMock(return_value=MagicMock())),
+            _patch.object(_id, "AHash", MagicMock(return_value=MagicMock())),
+        ):
+            d = _id.ImageDeduplicator()
+        d.hasher = MagicMock()
+        return d
+
+    def test_decompression_bomb_returns_none(self, tmp_path: Path) -> None:
+        """DecompressionBombError on Image.open is caught and returns
+        None — must not abort a find_duplicates / batch_compute_hashes
+        scan."""
+        from PIL.Image import DecompressionBombError
+
+        img = tmp_path / "bomb.jpg"
+        img.write_bytes(b"\x00")  # bytes irrelevant; we patch safedir_image_open
+
+        dedup = self._make_dedup()
+        with patch(
+            "services.deduplication.image_dedup.safedir_image_open",
+            side_effect=DecompressionBombError("synthetic bomb"),
+        ):
+            result = dedup.get_image_hash(img)
+        assert result is None
+
+    def test_non_rgb_image_is_converted(self, tmp_path: Path) -> None:
+        """Non-RGB images (e.g. RGBA, L) are converted before being
+        handed to imagededup as a numpy array. Exercises the
+        ``img.mode != "RGB": img = img.convert("RGB")`` branch.
+        """
+        from unittest.mock import MagicMock
+
+        img = tmp_path / "rgba.png"
+        _make_jpeg(img)
+
+        # Mock the helper to return a non-RGB image.
+        mock_rgba_img = MagicMock()
+        mock_rgba_img.mode = "RGBA"
+        mock_rgb_img = MagicMock()
+        mock_rgb_img.mode = "RGB"
+        mock_rgba_img.convert.return_value = mock_rgb_img
+
+        mock_cm = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=(mock_rgba_img, None))
+        mock_cm.__exit__ = MagicMock(return_value=False)
+
+        dedup = self._make_dedup()
+        dedup.hasher.encode_image.return_value = "deadbeef"
+
+        with (
+            patch(
+                "services.deduplication.image_dedup.safedir_image_open",
+                return_value=mock_cm,
+            ),
+            patch("numpy.asarray", return_value="fake_array"),
+        ):
+            result = dedup.get_image_hash(img)
+
+        assert result == "deadbeef"
+        # The non-RGB branch was taken: convert("RGB") called once.
+        mock_rgba_img.convert.assert_called_once_with("RGB")
+
+
+class TestViewerMetadataFdNoneFallback:
+    """``viewer._get_image_metadata`` falls back to ``image_path.stat()``
+    when ``safedir_image_open`` yields ``fd is None`` (Windows / SafeDir
+    unavailable). Exercised by simulating the NotImplementedError
+    fallback path."""
+
+    def test_viewer_metadata_uses_path_stat_when_fd_none(self, tmp_path: Path) -> None:
+        from services.deduplication.viewer import ComparisonViewer
+
+        target = tmp_path / "img.jpg"
+        _make_jpeg(target, size=(12, 10))
+
+        viewer = ComparisonViewer()
+        # Force the Windows-style fallback so the helper yields fd=None.
+        with patch(
+            "services.deduplication.image_utils.SafeDir.open_root",
+            side_effect=NotImplementedError("simulated fallback"),
+        ):
+            meta = viewer._get_image_metadata(target)
+
+        assert meta.width == 12
+        assert meta.height == 10
+        # File size came from path.stat (not os.fstat).
+        assert meta.file_size > 0

--- a/tests/services/deduplication/test_image_safedir.py
+++ b/tests/services/deduplication/test_image_safedir.py
@@ -21,6 +21,7 @@ Verifies:
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -55,7 +56,7 @@ class TestSafedirImageOpenHelper:
     def test_opens_real_image(self, tmp_path: Path) -> None:
         target = tmp_path / "photo.jpg"
         _make_jpeg(target, size=(16, 8))
-        with safedir_image_open(target) as img:
+        with safedir_image_open(target) as (img, _fd):
             assert img.size == (16, 8)
             assert img.format == "JPEG"
 
@@ -88,7 +89,7 @@ class TestSafedirImageOpenHelper:
             "services.deduplication.image_utils.SafeDir.open_root",
             side_effect=NotImplementedError("simulated unavailable SafeDir"),
         ):
-            with safedir_image_open(target) as img:
+            with safedir_image_open(target) as (img, _fd):
                 assert img.size == (8, 8)
 
     def test_closes_fd_when_fdopen_raises(self, tmp_path: Path) -> None:
@@ -96,14 +97,24 @@ class TestSafedirImageOpenHelper:
         dir_fd race), the helper must close the raw fd returned by
         ``open_for_reader`` before the exception propagates — otherwise
         we leak a descriptor. Verified via patch on ``os.fdopen``.
+
+        ``os.close`` is patched with ``side_effect=os.close`` (i.e. the
+        real ``os.close``) so the leak guard's call AND SafeDir's own
+        dir_fd cleanup actually close their fds — patching with a bare
+        ``MagicMock`` would just record the calls and leak the fds
+        during the test run (Copilot #281 review).
         """
         target = tmp_path / "fd_leak_test.jpg"
         _make_jpeg(target)
+        real_os_close = os.close  # capture before patching
         with patch(
             "services.deduplication.image_utils.os.fdopen",
             side_effect=OSError("synthetic fdopen failure"),
         ) as mock_fdopen:
-            with patch("services.deduplication.image_utils.os.close") as mock_close:
+            with patch(
+                "services.deduplication.image_utils.os.close",
+                side_effect=real_os_close,
+            ) as mock_close:
                 with pytest.raises(OSError, match="synthetic fdopen failure"):
                     with safedir_image_open(target):
                         pass

--- a/tests/services/deduplication/test_image_safedir.py
+++ b/tests/services/deduplication/test_image_safedir.py
@@ -238,7 +238,8 @@ class TestGetImageHashErrorBranches:
         Patches the imagededup availability flag so the constructor
         succeeds even when the optional extra is absent (CI matrix).
         """
-        from unittest.mock import MagicMock, patch as _patch
+        from unittest.mock import MagicMock
+        from unittest.mock import patch as _patch
 
         from services.deduplication import image_dedup as _id
 

--- a/tests/services/deduplication/test_quality.py
+++ b/tests/services/deduplication/test_quality.py
@@ -5,7 +5,7 @@ fallback behavior when PIL is unavailable.
 """
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -297,10 +297,18 @@ class TestExtractMetricsWithPil:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
+        # PR3f: quality.py now opens via safedir_image_open (tuple yield).
 
-        m = analyzer._extract_metrics_with_pil(p)
+        # Patch the helper to yield (mock_img, None).
+
+        _cm = MagicMock()
+
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+
+        _cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer._extract_metrics_with_pil(p)
         assert m is not None
         assert m.width == 1920
         assert m.height == 1080
@@ -324,10 +332,18 @@ class TestExtractMetricsWithPil:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
+        # PR3f: quality.py now opens via safedir_image_open (tuple yield).
 
-        m = analyzer._extract_metrics_with_pil(p)
+        # Patch the helper to yield (mock_img, None).
+
+        _cm = MagicMock()
+
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+
+        _cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer._extract_metrics_with_pil(p)
         assert m.has_transparency is True
         assert m.color_depth == 32
 
@@ -344,10 +360,18 @@ class TestExtractMetricsWithPil:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
+        # PR3f: quality.py now opens via safedir_image_open (tuple yield).
 
-        m = analyzer._extract_metrics_with_pil(p)
+        # Patch the helper to yield (mock_img, None).
+
+        _cm = MagicMock()
+
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+
+        _cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer._extract_metrics_with_pil(p)
         assert m.has_transparency is True
         assert m.color_depth == 8  # P mode
 
@@ -364,10 +388,18 @@ class TestExtractMetricsWithPil:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
+        # PR3f: quality.py now opens via safedir_image_open (tuple yield).
 
-        m = analyzer._extract_metrics_with_pil(p)
+        # Patch the helper to yield (mock_img, None).
+
+        _cm = MagicMock()
+
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+
+        _cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer._extract_metrics_with_pil(p)
         assert m.has_transparency is True
 
     def test_unknown_mode_defaults_to_24_bit(self, analyzer, tmp_path):
@@ -383,10 +415,18 @@ class TestExtractMetricsWithPil:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
+        # PR3f: quality.py now opens via safedir_image_open (tuple yield).
 
-        m = analyzer._extract_metrics_with_pil(p)
+        # Patch the helper to yield (mock_img, None).
+
+        _cm = MagicMock()
+
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+
+        _cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer._extract_metrics_with_pil(p)
         assert m.color_depth == 24
 
     def test_height_zero_aspect_ratio(self, analyzer, tmp_path):
@@ -402,10 +442,18 @@ class TestExtractMetricsWithPil:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
+        # PR3f: quality.py now opens via safedir_image_open (tuple yield).
 
-        m = analyzer._extract_metrics_with_pil(p)
+        # Patch the helper to yield (mock_img, None).
+
+        _cm = MagicMock()
+
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+
+        _cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer._extract_metrics_with_pil(p)
         assert m.aspect_ratio == 0
 
     def test_exception_returns_none(self, analyzer, tmp_path):
@@ -413,11 +461,13 @@ class TestExtractMetricsWithPil:
         p = tmp_path / "corrupt.jpg"
         p.write_bytes(b"\x00" * 100)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.side_effect = OSError("Corrupt image")
-
-        m = analyzer._extract_metrics_with_pil(p)
-        assert m is None
+        # PR3f: quality.py now opens via safedir_image_open.
+        with patch(
+            "services.deduplication.image_utils.safedir_image_open",
+            side_effect=OSError("Corrupt image"),
+        ):
+            m = analyzer._extract_metrics_with_pil(p)
+            assert m is None
 
     def test_webp_format_is_compressed(self, analyzer, tmp_path):
         """WEBP format is correctly flagged as compressed."""
@@ -432,10 +482,18 @@ class TestExtractMetricsWithPil:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
+        # PR3f: quality.py now opens via safedir_image_open (tuple yield).
 
-        m = analyzer._extract_metrics_with_pil(p)
+        # Patch the helper to yield (mock_img, None).
+
+        _cm = MagicMock()
+
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+
+        _cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer._extract_metrics_with_pil(p)
         assert m.is_compressed is True
 
     def test_png_format_not_compressed(self, analyzer, tmp_path):
@@ -451,10 +509,18 @@ class TestExtractMetricsWithPil:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
+        # PR3f: quality.py now opens via safedir_image_open (tuple yield).
 
-        m = analyzer._extract_metrics_with_pil(p)
+        # Patch the helper to yield (mock_img, None).
+
+        _cm = MagicMock()
+
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+
+        _cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer._extract_metrics_with_pil(p)
         assert m.is_compressed is False
 
 
@@ -499,10 +565,12 @@ class TestGetQualityMetrics:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
-
-        m = analyzer.get_quality_metrics(p)
+        # PR3f: quality.py now opens via safedir_image_open.
+        _cm = MagicMock()
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+        _cm.__exit__ = MagicMock(return_value=False)
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer.get_quality_metrics(p)
         assert m is not None
         assert m.width == 800
         assert m.height == 600


### PR DESCRIPTION
Sixth sub-PR of #267. PR3a–PR3e (#273–#279) migrated all document/archive/scientific/CAD readers plus the dedup `DocumentExtractor`; this PR migrates **every Pillow `Image.open`** call site in `src/services/deduplication/{image_utils,image_dedup,viewer,quality}.py` — the full #267 item 5 scope.

After Codex's P1 review on the initial implementation, the scope expanded considerably to address fundamental anchoring and hash-flow gaps. Final state below.

## What's hardened

| Surface | Before | After |
|---|---|---|
| `image_utils.{get_image_metadata,get_image_dimensions,get_image_format,validate_image_file}` | `Image.open(path)` | `safedir_image_open` |
| `image_dedup.validate_image` | `Image.open(path)` | `safedir_image_open` |
| `image_dedup.get_image_hash` | `self.hasher.encode_image(str(path))` (imagededup's internal Pillow open re-introduces symlink deref) | `safedir_image_open` → numpy array → `encode_image(image_array=)` |
| `image_dedup._find_image_files` | `path.is_file()` (follows symlinks) | filter `path.is_symlink()` first |
| `viewer.{_get_image_metadata,_generate_ascii_preview}` | `Image.open(path)` + `image_path.stat()` | `safedir_image_open` + `os.fstat(fd)` for race-free metadata |
| `quality._extract_metrics_with_pil` | `self.Image.open(path)` | `safedir_image_open` |

## `safedir_image_open(image_path, *, trusted_root=None)`

Shared context-manager helper in `image_utils.py`. Yields `(PIL.Image, fd_or_none)`.

- **POSIX with `trusted_root`**: opens `trusted_root` as a SafeDir, then traverses each intermediate component of `image_path.relative_to(trusted_root)` via `open_subdir` — every step rejects symlinks with `O_NOFOLLOW`. Closes Codex's P1 nested-symlink-ancestor TOCTOU window (e.g. `/root/album` swapped to a symlink post-walk).
- **POSIX without `trusted_root`**: parent-rooted fallback (final-component `O_NOFOLLOW` only) — documented as the contract for standalone validation calls without a walk context.
- **Windows / `NotImplementedError`**: falls back to direct `Image.open(path)` — preserves legacy API. Yields `fd=None` so callers can branch.
- **fd-leak guard**: if `os.fdopen` raises (closed dir_fd race), the raw fd from `open_for_reader` is reclaimed via `os.close(fd)` before re-raising.
- **NotImplementedError isolation**: the `try/except NotImplementedError` wraps only the SafeDir construction phase, not the `yield`. A `NotImplementedError` raised inside a caller's `with` block propagates normally instead of being mistaken for "SafeDir unavailable" and routing through the path fallback.

## Hash-flow migration (Codex F2 / Copilot)

`get_image_hash(image_path, *, trusted_root=None)` opens via `safedir_image_open`, converts the PIL Image to a numpy array, and hands it to `imagededup`'s documented `encode_image(image_array=...)` API. This bypasses `encode_image(path)` which internally calls Pillow's path-based `Image.open()` and would re-introduce the symlink dereference. `DecompressionBombError` is caught explicitly (P2) so a bomb file doesn't abort an entire `find_duplicates` / `batch_compute_hashes` scan.

`find_duplicates(directory)` threads `trusted_root=directory` for full anchored-traversal protection. `cluster_by_similarity` / `batch_compute_hashes` take arbitrary path lists with no shared root, so they fall back to parent-rooted protection — documented in the docstring.

## Stat-race fix

`get_image_metadata` and `viewer._get_image_metadata` now read `os.fstat(fd).st_size` (and `st_mtime`) from the same SafeDir-opened fd instead of calling `image_path.stat()` after the image context closed. Ties all reported metadata to the non-symlink file the image was actually opened from. Falls back to `path.stat()` when `fd is None` (Windows / SafeDir-unavailable code path).

## Tests

**New** (`tests/services/deduplication/test_image_safedir.py`, 12 cases):

- Helper opens a real JPEG round-trip via SafeDir
- Symlinked image refused with `SymlinkRejected`
- `NotImplementedError` fallback uses direct `Image.open`
- fd-leak guard: `os.fdopen` failure triggers explicit `os.close` (patches `os.close` with `side_effect=os.close` so the real fd is closed, not just recorded)
- `image_utils` helpers return safe defaults (`None`) on symlinked input
- `validate_image_file` rejects symlinked image
- `ImageDeduplicator.validate_image` rejects symlinked image (skipped when `imagededup` extra absent)
- DecompressionBombError handling in `get_image_hash`
- Non-RGB image conversion path (`img.mode != "RGB"` branch)
- Viewer metadata falls back to `path.stat()` when `fd is None`

**Updated** to match the new `(img, fd)` tuple shape and `encode_image(image_array=)` signature:

- `tests/services/deduplication/test_image_dedup.py` — added `_make_jpeg` helper for tests that exercise the new PIL-decode path; updated `assert_called_once_with(str(path))` → `image_array` kwarg check; rewrote `test_skips_unhashable_images` to patch `get_image_hash` directly (path-keyed dispatch is no longer possible)
- `tests/services/deduplication/test_dedup_viewer.py` — `__enter__` returns updated to `(mock_img, None)` tuples
- `tests/services/deduplication/test_quality.py` — 9 tests that patched `analyzer.Image.open` now patch `safedir_image_open` with the tuple shape
- `tests/integration/test_deduplication_core.py` — `_make_jpeg` helper; bulk-replaced fake JPEG bytes; updated assertion shapes

## Coverage (CI matrix — `[dev,search]` without dedup-image extra)

- `image_utils.py`: 87% (baseline 87%) ✓
- `image_dedup.py`: 88% (baseline 88%) ✓
- `viewer.py`: 100% (baseline 100%) ✓
- `quality.py`: 85% (baseline 85%) ✓

## Lint rail

SafeDir advisory rail: 49 → 46 (net -3). Removed 8 path-based `Image.open` sites; added the helper which uses `Image.open(fileobj)` once internally.

## Review iterations

| Round | Source | Outcome |
|---|---|---|
| 1 | Codex P1 (anchoring) | Threaded `trusted_root` through helper + caller |
| 1 | Codex P1 (hash flow bypass) | Routed `get_image_hash` through SafeDir + numpy |
| 1 | Copilot (quality.py missed) | Migrated |
| 1 | Copilot (NotImplementedError wraps yield) | ExitStack refactor |
| 1 | Copilot (`os.close` mock leaks fds) | `side_effect=os.close` wrapper |
| 1 | Copilot (stat race ×2) | `os.fstat(fd)` from same SafeDir fd |
| 2 | Codex P2 (DecompressionBomb abort) | Explicit catch returns `None` |

## Test plan

- [x] Local integration suite (with all extras): 7755 pass, 0 fail
- [x] Local integration suite (CI-like: `[dev,search]`): 666 dedup tests pass, all 4 module floors met
- [x] PR3a–PR3f end-to-end sweep: 1317 pass, 0 fail (no regressions in prior PRs from the helper-API change)
- [x] mypy clean on modified files
- [x] ruff check + format clean
- [x] `python3 -O -m pytest`: SafeDir invariants survive the assertion strip
- [x] SafeDir lint rail baseline went down (-3)

Targets `epic/safedir-readside-pr3`.