### PR TITLE
feat(security): PR3i — promote bare-open detection to enforcing for PR3a–PR3h files

### DIFF
--- a/scripts/check_safedir_required.py
+++ b/scripts/check_safedir_required.py
@@ -108,13 +108,46 @@ _MARKER_WINDOW_ABOVE = 2
 _MARKER_WINDOW_BELOW = 6
 
 
-# Directories where bare ``open(path, "r"...)`` / ``Path.open("r"...)`` /
-# ``io.open(path, "r"...)`` read calls are also flagged (deferred from
-# #271 / per CodeRabbit review on PR1). Empty for now — PR3i flips the
-# already-migrated reader and dedup dirs into this set with opt-out
-# markers on the legitimate post-migration sites. Adding a directory
-# here is what turns the bare-open detection on for files inside it.
-_READ_OPEN_ENFORCED_DIRS: frozenset[str] = frozenset()
+# Directories / files where bare ``open(path, "r"...)`` / ``Path.open("r"...)`` /
+# ``io.open(path, "r"...)`` read calls are also flagged. Populated by PR3i for
+# every PR3a–PR3h migration target. New bare-open reads in these locations need
+# a ``# safedir: ok — <reason>`` opt-out marker; the legitimate post-migration
+# sites (Windows / NotImplementedError fallback branches, dual-API path
+# branches in the reader libraries) are already marked.
+#
+# Entries can be either directory prefixes (matched via ``startswith(d/)``) or
+# specific file paths (matched via exact equality).
+#
+# Per #267, expanding this set to ``services/deduplication/{hasher,backup,
+# embedder}`` is PR4 scope; ``undo/`` is PR5; ``watcher/`` / ``daemon/`` /
+# ``pipeline/stages/{writer,postprocessor}`` / ``core/file_ops`` is PR6.
+_READ_OPEN_ENFORCED_DIRS: frozenset[str] = frozenset(
+    {
+        # PR3a — text processor + document readers
+        "src/services/text_processor.py",
+        "src/utils/readers/documents.py",
+        # PR3b — archive readers (zip / 7z / tar / rar)
+        "src/utils/readers/archives.py",
+        # PR3c — ebook + scientific readers
+        "src/utils/readers/ebook.py",
+        "src/utils/readers/scientific.py",
+        # PR3d — CAD readers
+        "src/utils/readers/cad.py",
+        # PR3e — dedup document extractor
+        "src/services/deduplication/extractor.py",
+        # PR3f — dedup image readers
+        "src/services/deduplication/image_dedup.py",
+        "src/services/deduplication/image_utils.py",
+        "src/services/deduplication/viewer.py",
+        "src/services/deduplication/quality.py",
+        # PR3g — EPUB enhanced reader
+        "src/utils/epub_enhanced.py",
+        # PR3h — search / organize / PARA detection
+        "src/services/search/hybrid_retriever.py",
+        "src/core/organizer.py",
+        "src/methodologies/para/detection/heuristics.py",
+    }
+)
 
 # Read-mode characters. ``open(...)`` defaults to ``"r"`` so a call with
 # no mode argument is also a read. ``"r+"`` / ``"w+"`` / ``"a+"`` are

--- a/src/services/deduplication/extractor.py
+++ b/src/services/deduplication/extractor.py
@@ -231,7 +231,9 @@ class DocumentExtractor:
             else:
                 if file_path is None:
                     raise TypeError("path-branch requires file_path")
-                with open(file_path, "rb") as f:
+                with open(
+                    file_path, "rb"
+                ) as f:  # safedir: ok — Windows / NotImplementedError fallback
                     pdf_reader = pypdf.PdfReader(f)
                     for page_num in range(len(pdf_reader.pages)):
                         page = pdf_reader.pages[page_num]
@@ -324,7 +326,9 @@ class DocumentExtractor:
         try:
             for encoding in encodings:
                 try:
-                    with open(file_path, encoding=encoding) as f:
+                    with open(
+                        file_path, encoding=encoding
+                    ) as f:  # safedir: ok — Windows / NotImplementedError fallback
                         text = f.read()
                     logger.debug(f"Read {len(text)} chars from text file: {display}")
                     return text
@@ -332,7 +336,7 @@ class DocumentExtractor:
                     continue
 
             # If all encodings fail, read as binary and decode with errors='ignore'
-            with open(file_path, "rb") as f:
+            with open(file_path, "rb") as f:  # safedir: ok — Windows / NotImplementedError fallback
                 text = f.read().decode("utf-8", errors="ignore")
 
             return text
@@ -357,7 +361,9 @@ class DocumentExtractor:
             else:
                 if file_path is None:
                     raise TypeError("path-branch requires file_path")
-                with open(file_path, encoding="utf-8", errors="ignore") as f:
+                with open(
+                    file_path, encoding="utf-8", errors="ignore"
+                ) as f:  # safedir: ok — Windows / NotImplementedError fallback
                     rtf_content = f.read()
 
             # Try using striprtf if available

--- a/src/services/deduplication/extractor.py
+++ b/src/services/deduplication/extractor.py
@@ -231,6 +231,11 @@ class DocumentExtractor:
             else:
                 if file_path is None:
                     raise TypeError("path-branch requires file_path")
+                # The opt-out marker below covers BOTH the bare open and the
+                # nearby ``pypdf.PdfReader(f)`` call (within
+                # ``_MARKER_WINDOW_BELOW=6``). Both belong to the same legacy
+                # fallback block — when SafeDir is unavailable we accept the
+                # path-based read end-to-end.
                 with open(
                     file_path, "rb"
                 ) as f:  # safedir: ok — Windows / NotImplementedError fallback

--- a/src/utils/readers/archives.py
+++ b/src/utils/readers/archives.py
@@ -114,7 +114,9 @@ def read_zip_file(
         raise ValueError("read_zip_file requires file_path or fileobj")
     path = Path(file_path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _parse_zip(f, max_files, path.name)
     except Exception as e:  # Intentional catch-all: zipfile raises library-specific errors
         raise FileReadError(f"Failed to read ZIP file {path}: {e}") from e
@@ -198,7 +200,9 @@ def read_7z_file(
         raise ValueError("read_7z_file requires file_path or fileobj")
     path = Path(file_path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _parse_7z(f, max_files, path.name)
     except Exception as e:  # Intentional catch-all: py7zr raises library-specific errors
         raise FileReadError(f"Failed to read 7Z file {path}: {e}") from e
@@ -302,7 +306,9 @@ def read_tar_file(
         raise ValueError("read_tar_file requires file_path or fileobj")
     path = Path(file_path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _parse_tar(f, max_files, path.name)
     except Exception as e:  # Intentional catch-all: tarfile raises library-specific errors
         raise FileReadError(f"Failed to read TAR file {path}: {e}") from e
@@ -394,7 +400,9 @@ def read_rar_file(
         raise ValueError("read_rar_file requires file_path or fileobj")
     path = Path(file_path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _parse_rar(f, max_files, path.name)
     except rarfile.RarCannotExec as e:
         raise FileReadError(

--- a/src/utils/readers/cad.py
+++ b/src/utils/readers/cad.py
@@ -358,7 +358,9 @@ def read_step_file(
     path = Path(file_path)
     _check_file_size(path)
     try:
-        with path.open(encoding="utf-8", errors="ignore") as f:
+        with path.open(
+            encoding="utf-8", errors="ignore"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             content = f.read(10000)
         size_kb = path.stat().st_size / 1024
         return _parse_step_text(content, path.name, size_kb)
@@ -471,7 +473,9 @@ def read_iges_file(
     path = Path(file_path)
     _check_file_size(path)
     try:
-        with path.open(encoding="utf-8", errors="ignore") as f:
+        with path.open(
+            encoding="utf-8", errors="ignore"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             lines = [f.readline() for _ in range(max_lines)]
         size_kb = path.stat().st_size / 1024
         return _parse_iges_lines(lines, path.name, size_kb)

--- a/src/utils/readers/documents.py
+++ b/src/utils/readers/documents.py
@@ -102,7 +102,9 @@ def read_text_file(
     path = Path(file_path)
     _check_file_size(path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _parse_text(f, max_chars, path.name)
     except OSError as e:
         raise FileReadError(f"Failed to read text file {path}: {e}") from e
@@ -150,7 +152,9 @@ def read_docx_file(
     path = Path(file_path)
     _check_file_size(path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _parse_docx(f, path.name)
     except Exception as e:  # Intentional catch-all: python-docx raises library-specific errors
         raise FileReadError(f"Failed to read DOCX file {path}: {e}") from e
@@ -253,7 +257,9 @@ def read_rtf_file(
     path = Path(file_path)
     _check_file_size(path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _parse_rtf(f, max_chars, path.name)
     except Exception as exc:
         raise FileReadError(f"Failed to read RTF {path.name}: {exc}") from exc
@@ -341,7 +347,9 @@ def read_spreadsheet_file(
             raise FileReadError(f"Failed to read spreadsheet file {path.name}: {e}") from e
     _check_file_size(path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _dispatch_spreadsheet(f, ext, max_rows, path.name)
     except (ImportError, FileReadError):
         raise
@@ -398,7 +406,9 @@ def read_presentation_file(
     path = Path(file_path)
     _check_file_size(path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _parse_presentation(f, path.name)
     except Exception as e:  # Intentional catch-all: python-pptx raises library-specific errors
         raise FileReadError(f"Failed to read presentation file {path}: {e}") from e

--- a/tests/ci/test_symlink_safety_lints.py
+++ b/tests/ci/test_symlink_safety_lints.py
@@ -32,6 +32,7 @@ sys.path.insert(0, str(_FO_ROOT / "scripts"))
 from check_safedir_required import (  # noqa: E402  — sys.path manipulation above
     _ALLOWLISTED_FILES,
     _FLAGGED_CALLS,
+    _READ_OPEN_ENFORCED_DIRS,
     _call_name,
     _collect_marker_comment_lines,
     _has_opt_out_in_window,
@@ -263,9 +264,17 @@ class TestLiveTreeAdvisory:
         If this fails, either a new bare-open read was added to a
         migrated file (route it through SafeDir or add a marker) or
         an existing marker has drifted out of the matching window.
-        """
-        from check_safedir_required import _READ_OPEN_ENFORCED_DIRS
 
+        Implicit contract: ``find_violations`` (the function that
+        backs ``scan_tree``) only emits Pass 2 detections when the
+        file is in ``_READ_OPEN_ENFORCED_DIRS`` — see
+        ``_file_under_enforced_dir`` in the checker script. So
+        filtering by call name alone is sufficient here; the
+        path-scope guard is inherited from the detector. If
+        ``find_violations`` is ever refactored to decouple path-scope
+        from emission, add an explicit ``_file_under_enforced_dir(path)``
+        guard below.
+        """
         # Sanity: enforcement is actually on (PR3i populated the set).
         assert _READ_OPEN_ENFORCED_DIRS, (
             "expected _READ_OPEN_ENFORCED_DIRS to be populated by PR3i; "

--- a/tests/ci/test_symlink_safety_lints.py
+++ b/tests/ci/test_symlink_safety_lints.py
@@ -251,6 +251,38 @@ class TestLiveTreeAdvisory:
         assert "Breakdown by callee:" in result.stderr
         assert "ADVISORY mode" in result.stderr
 
+    def test_no_bare_open_violations_in_enforced_dirs(self) -> None:
+        """PR3i populates ``_READ_OPEN_ENFORCED_DIRS`` with every PR3a–PR3h
+        migration target. Every bare ``open(...)`` / ``Path.open(...)`` /
+        ``io.open(...)`` site in those files must either be migrated to
+        SafeDir OR carry a ``# safedir: ok — <reason>`` opt-out marker
+        (legacy / Windows / NotImplementedError fallback branches).
+
+        This test reads the live tree and asserts Pass 2 (bare-open
+        detection) finds zero unmarked violations in the enforced dirs.
+        If this fails, either a new bare-open read was added to a
+        migrated file (route it through SafeDir or add a marker) or
+        an existing marker has drifted out of the matching window.
+        """
+        from check_safedir_required import _READ_OPEN_ENFORCED_DIRS
+
+        # Sanity: enforcement is actually on (PR3i populated the set).
+        assert _READ_OPEN_ENFORCED_DIRS, (
+            "expected _READ_OPEN_ENFORCED_DIRS to be populated by PR3i; "
+            "if you cleared it intentionally, update this test"
+        )
+
+        violations = scan_tree()
+        bare_call_names = {"open", "io.open", "Path.open"}
+        bare = [
+            (path, lineno, name)
+            for path, lineno, name, _excerpt in violations
+            if name in bare_call_names
+        ]
+        assert not bare, "unmarked bare-open reads found in enforced dirs:\n" + "\n".join(
+            f"  {path.relative_to(_FO_ROOT)}:{lineno}  {name}" for path, lineno, name in bare
+        )
+
     def test_allowlist_files_not_scanned(self) -> None:
         """Allowlisted implementation files don't generate self-flags."""
         violations = scan_tree()


### PR DESCRIPTION
Ninth sub-PR of #267. Promotes the bare-open detection class (introduced in PR3g, #282) from purely advisory to **actively enforcing** for the 15 files that PR3a–PR3h migrated to SafeDir.

## What changes

### `scripts/check_safedir_required.py` — populate `_READ_OPEN_ENFORCED_DIRS`

Adds file-level entries for every PR3a–PR3h migration target:

| Sub-PR | File |
|---|---|
| PR3a | `src/services/text_processor.py`, `src/utils/readers/documents.py` |
| PR3b | `src/utils/readers/archives.py` |
| PR3c | `src/utils/readers/ebook.py`, `src/utils/readers/scientific.py` |
| PR3d | `src/utils/readers/cad.py` |
| PR3e | `src/services/deduplication/extractor.py` |
| PR3f | `src/services/deduplication/image_dedup.py`, `image_utils.py`, `viewer.py`, `quality.py` |
| PR3g | `src/utils/epub_enhanced.py` |
| PR3h | `src/services/search/hybrid_retriever.py`, `src/core/organizer.py`, `src/methodologies/para/detection/heuristics.py` |

Per #267, expanding the set further is **PR4** scope (`services/deduplication/{hasher,backup,embedder}`), **PR5** scope (`undo/`), **PR6** scope (`watcher/`, `daemon/`, `pipeline/stages/{writer,postprocessor}`, `core/file_ops`).

### Opt-out markers on legitimate post-migration sites

15 bare-open reads in the enforced files get `# safedir: ok — <reason>` markers:

- **4 sites in `extractor.py`** — `Windows / NotImplementedError fallback`. Inside `_extract_via_path`, reached only when SafeDir is unavailable. SafeDir-aware callers use the fileobj branch (`_extract_from_fileobj`).
- **4 sites in `archives.py`** (zip/7z/tar/rar) + **5 sites in `documents.py`** (text/docx/rtf/spreadsheet/presentation) + **2 sites in `cad.py`** (STEP/IGES) — `legacy path-branch; SafeDir-aware callers pass fileobj=`. Each reader is a dual-API helper `read_X_file(file_path=..., fileobj=...)`; the file_path branch is the legacy / non-SafeDir caller path.

## Tests

New regression test `test_no_bare_open_violations_in_enforced_dirs` in `tests/ci/test_symlink_safety_lints.py`:

- Asserts `_READ_OPEN_ENFORCED_DIRS` is populated (catches accidental revert).
- Runs `scan_tree()` against the live tree.
- Filters to Pass 2 (bare-open) violations.
- Asserts zero unmarked bare-open reads in any enforced file.

If a future PR adds a new bare-open read to a migrated file without either routing through SafeDir or adding an opt-out marker, this test fails at PR review.

## Rail counts

| | Before | After |
|---|---|---|
| Advisory violations | 45 | 44 |
| Pass 1 (library-call surface) | 45 | 44 |
| Pass 2 (bare-open in enforced dirs) | 0 | 0 |

The single Pass 1 drop is `extractor.py:235 pypdf.PdfReader(f)`, which sat inside the same legacy fallback block as the `open(file_path, "rb")` call at line 234 — the opt-out marker on 234 correctly suppresses both detections within the `_MARKER_WINDOW_BELOW=6` line window.

## Out of scope (next sub-PR)

- **PR3j** — `shutil.copystat` / `shutil.copyfile` audit + streaming-vs-stat decision doc (#267 closeout).
- **#283** — alias-aware module-style `.open` detection (parallel epic).
- **#286** — anchored-traversal hardening: thread `trusted_root` through all read-side migrations (parallel epic, applies to PR3a–PR3h sites).

## Test plan

- [x] 54/54 tests in `test_symlink_safety_lints.py` pass (including the new regression test).
- [x] `python scripts/check_safedir_required.py` exits **1** with 44 violations on the live tree (down from 45) — Pass 1 baseline only, no Pass 2 unmarked sites.
- [x] `python scripts/check_safedir_required.py --advisory` exits **0**.
- [x] `pre-commit run --all-files` clean.
- [x] No new bare-open reads detectable in enforced files via `scan_tree()`.

Targets `epic/safedir-readside-pr3`.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnPpeovvetPSR8Vwhxsn9j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new CI validation to ensure file handling compliance across the codebase.

* **Chores**
  * Updated file handling patterns in core modules to conform to safety standards.
  * Enabled enforcement checks for file operations in populated source directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->