### PR TITLE
feat(security): SafeDir read-side hardening (PR3 rollup, closes #267)

### DIFF
--- a/.github/workflows/ci-extras.yml
+++ b/.github/workflows/ci-extras.yml
@@ -12,7 +12,7 @@ name: Extras Validation
 
 on:
   pull_request:
-    branches: [main, epic/flatten-src-fo]
+    branches: [main, epic/flatten-src-fo, epic/safedir-readside-pr3]
     paths-ignore:
       - ".claude/**"
       - "docs/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
       - ".claude/rules/**"
       - ".claude/README.md"
   pull_request:
-    branches: [main, epic/flatten-src-fo]
+    branches: [main, epic/flatten-src-fo, epic/safedir-readside-pr3]
     paths-ignore:
       - ".claude/agents/**"
       - ".claude/commands/**"

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, epic/flatten-src-fo]
+    branches: [main, epic/flatten-src-fo, epic/safedir-readside-pr3]
 
 permissions:
   contents: read

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, epic/flatten-src-fo]
+    branches: [main, epic/flatten-src-fo, epic/safedir-readside-pr3]
 
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on:
     branches: [main, develop]
     paths: ['docs/**', 'mkdocs.yml', '.github/workflows/docs.yml']
   pull_request:
-    branches: [main, epic/flatten-src-fo]
+    branches: [main, epic/flatten-src-fo, epic/safedir-readside-pr3]
     paths: ['docs/**', 'mkdocs.yml', '.github/workflows/docs.yml']
 
 jobs:

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -19,7 +19,7 @@ name: PR Integration Tests
 
 on:
   pull_request:
-    branches: [main, epic/flatten-src-fo]
+    branches: [main, epic/flatten-src-fo, epic/safedir-readside-pr3]
     types: [opened, reopened, ready_for_review, synchronize]
     paths-ignore:
       - ".claude/**"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 6 * * 1"  # Weekly on Monday at 06:00 UTC
   pull_request:
-    branches: [main, epic/flatten-src-fo]
+    branches: [main, epic/flatten-src-fo, epic/safedir-readside-pr3]
     paths-ignore:
       - ".claude/agents/**"
       - ".claude/commands/**"

--- a/docs/internal/safedir-shutil-audit-pr3j.md
+++ b/docs/internal/safedir-shutil-audit-pr3j.md
@@ -1,0 +1,306 @@
+# SafeDir read-side closeout — `shutil` audit + streaming-vs-stat decision
+
+**PR3j of #267**. Final deliverable in the read-side hardening epic.
+Documents the audit findings for `shutil.copystat` / `shutil.copyfile`
+plus the streaming-vs-stat decision adopted across PR3a–PR3i.
+
+## Audit: `shutil.copystat` and `shutil.copyfile` in `src/`
+
+### Findings
+
+A repository scan for `shutil.copystat` and `shutil.copyfile` produces
+exactly two callsites, both in the same function in `src/undo/durable_move.py`:
+
+| Site | Call | Context |
+|---|---|---|
+| `src/undo/durable_move.py:417` | `shutil.copyfile(src, tmp_path)` | Inside `_durable_cross_device_move`, in the `else:` branch of `if src.is_symlink():`. Regular files only — symlinks take the dedicated `os.replace(tmp_path, dst)` branch. |
+| `src/undo/durable_move.py:422` | `shutil.copystat(src, tmp_path)` | Same `else:` branch. Wrapped in `try / except OSError` (non-fatal — see comment at line 423). |
+
+[VERIFIED in: src/undo/durable_move.py:417,422]
+
+### Risk assessment
+
+`shutil.copyfile(src, dst)` with the default `follow_symlinks=True`
+**does** follow symlinks at `src` — it dereferences the symlink and
+copies the content of whatever it resolves to. Only
+`follow_symlinks=False` preserves a symlink as a symlink. CPython
+implements this by opening `src` with the builtin `open()`, which
+follows symlinks at every path component (final + intermediate).
+
+That sounds dangerous, but the `durable_move.py` call is protected
+upstream by a deliberate symlink branch:
+
+```python
+if src.is_symlink():
+    # symlink path: os.replace the tmp ENTRY (which the caller pre-
+    # populated as a symlink). shutil.copyfile is NEVER reached on
+    # this branch.
+    os.replace(tmp_path, dst)
+    fsync_directory(dst)
+else:
+    shutil.copyfile(src, tmp_path)  # regular file at check-time
+    try:
+        shutil.copystat(src, tmp_path)
+    except OSError:
+        ...
+```
+
+[FROM: src/undo/durable_move.py:410-428] [VERIFIED in: src/undo/durable_move.py:417,422]
+
+`src.is_symlink()` uses `lstat` semantics — it correctly identifies
+a symlink at `src` **at the moment of the check** and routes it to
+the `os.replace()` branch. **But the check and the subsequent
+`shutil.copyfile(src, ...)` are both path-based**: the latter
+re-opens `src` by path, so an attacker who can write into `src`'s
+parent directory between the check and the copy can swap `src` for
+a symlink (or replace the regular file with a different inode).
+This is a TOCTOU race window at the **final component**, in addition
+to the well-known race at **intermediate components** (#286 anchored-
+traversal epic).
+
+In other words, the upstream `is_symlink()` guard does NOT prove
+that the inode `copyfile` opens is the same inode that
+`_durable_cross_device_move`'s caller intended to move. The audit
+finding is: **both the final-component and the ancestor-component
+symlink-swap windows are open at this callsite**. Closing them
+requires switching to an fd-pinned operation (open `src` once with
+`O_NOFOLLOW`, then stream from that fd into `tmp_path`) and lives
+in **PR5** (`undo/` migration) per #267.
+
+Why is the file still allowlisted today? The risk model for the
+undo subsystem is narrower than the organize-time content readers
+this epic targeted:
+
+- `durable_move` only operates on paths the caller previously
+  produced via undo's own state (journal entries reference paths
+  the daemon owns). User-controlled paths reach `durable_move` only
+  through the daemon's path-validation layer, not directly.
+- The trash/journal directories that `durable_move` writes into are
+  app-owned, not user-organize-root.
+
+That risk-model boundary is what the `_ALLOWLISTED_FILES` entry is
+recording — not a security proof. PR5's anchored-traversal migration
+upgrades it to a real proof.
+
+### Conclusion
+
+- Both callsites are correctly allowlisted in
+  `scripts/check_safedir_required.py` via
+  `_ALLOWLISTED_FILES = frozenset({..., "src/undo/durable_move.py"})`.
+  [VERIFIED in: scripts/check_safedir_required.py:64]
+- The `is_symlink()` guard at line 410 routes confirmed-symlink-at-
+  check-time inputs to the `os.replace()` branch. It does NOT prove
+  the file `copyfile` opens by path is the same inode that the
+  check examined — both the final-component and intermediate-component
+  symlink-swap windows are open.
+- Allowlisting is justified by the **undo-subsystem risk model**
+  (paths only reach `durable_move` through the daemon's
+  validation layer, not directly from user-organize-root) — not by
+  a TOCTOU-free proof at the syscall level.
+- Closing both windows requires fd-pinned (`O_NOFOLLOW`) handling
+  in `durable_move` itself. Tracked in **#286** for the broader
+  anchored-traversal effort and scheduled for **PR5** (`undo/`
+  migration) per #267.
+- No PR3j-scope code changes required for these callsites.
+
+## Decision: streaming from fd vs stat-then-open from path
+
+### Context
+
+Every PR3a–PR3h migration replaced a path-based reader with a
+SafeDir-aware reader that:
+
+1. Opens the file's parent with `SafeDir.open_root(parent)`.
+2. Gets a raw fd via `safe_dir.open_for_reader(name)` (uses `O_NOFOLLOW`).
+3. Wraps the fd with `os.fdopen(fd, "rb")`.
+4. Hands the resulting fileobj to the content-extraction library.
+
+A natural question: when the same code path also needs file metadata
+(size, mtime, mode), where should it come from?
+
+- **Stream from the SafeDir-opened fd**: `os.fstat(fd)`.
+- **Stat-then-open from path**: `path.stat()` then SafeDir-open for content.
+
+### Decision
+
+**Stream from the SafeDir-opened fd whenever possible.** Use `os.fstat(fd)`
+to obtain `st_size`, `st_mtime`, `st_mode`, etc. The path-based
+`path.stat()` MUST NOT precede a SafeDir open in production code.
+
+### Rationale
+
+1. **TOCTOU**. `path.stat()` resolves the path through every
+   intermediate symlink, then a subsequent `SafeDir.open_root + open_for_reader`
+   re-resolves through the (possibly attacker-swapped) tree. The
+   metadata seen by `stat()` and the bytes seen by the open may
+   belong to **different files**. Reading `st_size` from one and
+   the content from another is a classic confusion vector — an
+   attacker swaps the file at a known size between the two calls
+   and bypasses size-based defenses.
+
+2. **`os.fstat(fd)` is TOCTOU-free for the file already open**.
+   Once `open_for_reader(name)` returns an fd, that fd identifies a
+   single open file description in the kernel. `os.fstat(fd)` reads
+   metadata from the same inode that subsequent `read(fd)` calls
+   will read content from. No racing window.
+
+3. **`O_NOFOLLOW` only protects the final component**. The point of
+   SafeDir is that the open refuses a symlink **at that final
+   component**. A subsequent `path.stat()` on the same path
+   re-traverses every intermediate, defeating the protection.
+
+4. **Operational simplicity**. Streaming from the fd is the same
+   number of syscalls (or fewer — no second open), and the code is
+   linearly readable: "open via SafeDir, read everything I need
+   from that fd, close".
+
+### Precedent in PR3a–PR3h
+
+| Sub-PR | File | Pattern |
+|---|---|---|
+| PR3a | `services/text_processor.py` | Streams text content from SafeDir fd. |
+| PR3b–PR3d | `utils/readers/{archives,documents,cad,ebook,scientific}.py` | Each reader takes a `fileobj=` parameter; size check (`_check_file_size`) is path-based at the *legacy* entry only, not the SafeDir-aware caller. |
+| PR3e | `services/deduplication/extractor.py` | Streams content; size limits enforced from `_extract_from_fileobj` via `fileobj.read(n)` caps, not `path.stat()`. |
+| PR3f | `services/deduplication/{image_dedup,image_utils,viewer,quality}.py` | `os.fstat(fd)` used in `viewer.py` for `file_size` / `mtime` display — the explicit precedent for this decision. |
+| PR3g | `utils/epub_enhanced.py` | EPUB is read as a stream from the SafeDir fd; no metadata-then-content split. |
+| PR3h | `services/search/hybrid_retriever.py`, `core/organizer.py`, `methodologies/para/detection/heuristics.py` | All three new helpers read a bounded byte range from the SafeDir fd directly (`fileobj.read(limit)`). No `path.stat()` precedes the open. |
+
+### Exceptions (with rationale)
+
+A few sites legitimately use `path.stat()` before a SafeDir open. The
+**only** acceptable rationale is that the stat result is used purely
+for **logging / display** — never as input to any decision that
+affects what bytes are read, what limit is enforced, or what action
+is taken. A path-based stat by definition re-traverses the path; if
+its result fed into any program decision (size cap, skip-or-process,
+permission check, mtime cache key), the swap-between-syscalls race is
+open and the decision applies to the wrong inode.
+
+What is **not** sufficient rationale, even if the check feels like a
+UX nicety:
+
+- **Size gates** — "skip files larger than N MB" via `path.stat()`
+  before opening content. This is a security decision (it bounds
+  reader resource use); the project's pattern is `_check_fd_size`
+  on the opened fd (`src/utils/readers/_base.py:47`), exactly so the
+  stat and the content read see the same inode.
+- **mtime-based caches** — "skip files unchanged since last scan"
+  via `path.stat().st_mtime`. The cache key must come from the fd
+  (`os.fstat(fd).st_mtime`) or it can be poisoned by a swap.
+- **"The path came from a SafeDir-aware enumeration"** — `safe_walk`
+  (and similar enumerators) yield lexical `Path` objects, not
+  inode-pinned handles. A writable parent can swap an entry between
+  enumeration and a later `path.stat()`, and the post-enumeration
+  path is no more trust-bounded for follow-up syscalls than any
+  other path string. The documented contract on `SafeDir` says
+  callers must route subsequent operations through `lstat` /
+  `open_for_reader` for that reason.
+
+Each surviving exception (purely informational `path.stat()` for a
+log line, etc.) carries (or will carry) an inline comment explaining
+why the dual-stat pattern is non-security-relevant in that context.
+
+### What this rules out
+
+- Path-based size validation before opening content. Wrong: the
+  stat and the content read can see different inodes. Use
+  `_check_fd_size(fileobj, …)` (`src/utils/readers/_base.py:47`)
+  on the SafeDir-opened fd.
+- Path-based mtime caching before reading. Wrong for the same
+  reason. Use `os.fstat(fd).st_mtime`.
+- Any "check this file is OK to read by stat-ing it first" pattern.
+
+### What this rules in
+
+- `os.fstat(safe_dir.open_for_reader(name))` for size / mtime / mode
+  when the file is already SafeDir-opened.
+- `safe_dir.lstat(name)` (no-follow) when only the metadata is needed
+  and no content read follows. The SafeDir primitive exposes `lstat`
+  precisely for this case (#266).
+
+## Closeout
+
+This document concludes the read-side hardening epic (#267) for
+**Phase 3** (read-side). PR3a–PR3h migrated 18 content-reading sites
+to SafeDir; PR3i flipped the bare-open detection from advisory to
+enforcing for every migrated file; PR3j (this PR) confirms the
+remaining `shutil.copystat` / `shutil.copyfile` callsites are
+already correctly handled and codifies the streaming-vs-stat
+decision that applied across the epic.
+
+Subsequent phases:
+
+- **PR4** (#268) — `services/deduplication/{hasher, backup, embedder}` migrations.
+- **PR5** (#269) — `undo/{durable_move, rollback}` migrations.
+  Addresses the anchored-traversal gap (#286) for the `shutil.copyfile`
+  callsite identified in this audit.
+- **PR6** (#270) — `watcher/`, `daemon/`, `pipeline/stages/{writer, postprocessor}`,
+  `core/file_ops` migrations.
+
+Parallel tracking issues that remain after PR3 closes:
+
+- **#283** — alias-aware module-style `.open` detection.
+- **#286** — anchored-traversal hardening across all read-side migrations.
+
+## References
+
+- #264 — original LLM-exfiltration vector documented by Codex.
+- #267 — read-side SafeDir hardening epic.
+- #271 — original bare-open detection requirement.
+- #266 — SafeDir primitive design.
+
+## Verification metadata
+
+All concrete claims in this document were cross-checked against the
+live tree at the head of this PR's base branch (`epic/safedir-readside-pr3`).
+
+### Sources verified
+
+- `src/undo/durable_move.py` — both callsites and the `is_symlink()`
+  branch guard.
+- `scripts/check_safedir_required.py` — the `_ALLOWLISTED_FILES`
+  entry covering `src/undo/durable_move.py`.
+- `src/utils/readers/_base.py` — `_check_fd_size` fd-based size cap
+  cited as the project's pattern in "What this rules out".
+
+### Callsites / line references
+
+| Claim | Source |
+|---|---|
+| `shutil.copyfile(src, tmp_path)` callsite | `src/undo/durable_move.py:417` |
+| `shutil.copystat(src, tmp_path)` callsite | `src/undo/durable_move.py:422` |
+| `if src.is_symlink():` branch guard | `src/undo/durable_move.py:410` |
+| `copystat` `try/except OSError` non-fatal | `src/undo/durable_move.py:423-430` |
+| `_ALLOWLISTED_FILES` entry | `scripts/check_safedir_required.py:64` |
+| `_check_fd_size` fd-based size cap | `src/utils/readers/_base.py:47` |
+| Rail advisory count (44 sites after PR3i) | `python scripts/check_safedir_required.py --advisory` |
+
+### Contradiction checklist
+
+- Audit findings (2 callsites, both allowlisted under the undo
+  subsystem's risk model, with both final-component and intermediate-
+  component TOCTOU windows open and tracked for PR5) vs the
+  Conclusion section ("no PR3j-scope code changes required"): **consistent**.
+- "Streaming-vs-stat" decision section vs the "Exceptions" subsection
+  (logging / display only, never security-relevant): **consistent** —
+  exceptions are bounded by the explicit rule that they MUST NOT be
+  security-relevant. Size gates and mtime caches are listed as
+  examples of what is NOT a sufficient rationale, and "What this
+  rules out" cites `_check_fd_size` as the fd-based replacement.
+- Audit claim "shutil.copyfile follows source symlinks by default"
+  vs conclusion "the callsite is allowlisted under the undo
+  risk-model boundary": **consistent** — the `is_symlink()` guard
+  doesn't TOCTOU-pin the inode (final-component swap window is
+  open), so the allowlist is justified by the upstream
+  path-validation guarantee, not by syscall-level safety. PR5
+  migrates to fd-pinned handling for a real proof.
+
+### Cross-reference checks
+
+- `shutil.copyfile` symlink semantics (Python docs, `Lib/shutil.py`):
+  `follow_symlinks=True` (default) follows source symlinks; verified
+  against CPython's `shutil.copyfile` implementation and the existing
+  `tests/undo/test_durable_move.py` test fixtures that exercise the
+  dereference behavior.
+- Sub-PR per-row entries in the streaming-vs-stat precedent table
+  match the merged commits for PR3a–PR3h on `epic/safedir-readside-pr3`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "python-docx~=1.0",        # DOCX parsing
     "openpyxl~=3.1",           # XLSX parsing
     "python-pptx>=0.6.0,<2",   # PPTX parsing
-    "ebooklib>=0.18,<1",        # EPUB parsing
+    "ebooklib>=0.20,<1",        # EPUB parsing — 0.20 added isinstance guard around os.path.isdir, required for the SafeDir fileobj branch (PR3c / #267)
     "beautifulsoup4~=4.12",    # HTML/XML parsing
     "lxml~=6.1",               # XML backend for BS4
 

--- a/scripts/check_safedir_required.py
+++ b/scripts/check_safedir_required.py
@@ -108,6 +108,107 @@ _MARKER_WINDOW_ABOVE = 2
 _MARKER_WINDOW_BELOW = 6
 
 
+# Directories where bare ``open(path, "r"...)`` / ``Path.open("r"...)`` /
+# ``io.open(path, "r"...)`` read calls are also flagged (deferred from
+# #271 / per CodeRabbit review on PR1). Empty for now — PR3i flips the
+# already-migrated reader and dedup dirs into this set with opt-out
+# markers on the legitimate post-migration sites. Adding a directory
+# here is what turns the bare-open detection on for files inside it.
+_READ_OPEN_ENFORCED_DIRS: frozenset[str] = frozenset()
+
+# Read-mode characters. ``open(...)`` defaults to ``"r"`` so a call with
+# no mode argument is also a read. ``"r+"`` / ``"w+"`` / ``"a+"`` are
+# read-and-write — flagged because they open the underlying file (and
+# could still dereference a symlink). The detector flags any mode whose
+# letter set intersects ``{"r", "+"}`` and is not a pure write
+# (``"w"``/``"a"``/``"x"`` without ``"+"``).
+_WRITE_ONLY_MODE_LETTERS = frozenset("wax")
+
+
+def _is_read_mode(mode_str: str | None) -> bool:
+    """Return True if *mode_str* (or default-``"r"`` when None) reads."""
+    if mode_str is None:
+        return True  # default mode is "r"
+    letters = set(mode_str)
+    # Pure write/append/exclusive ("w", "wb", "a", "x") never reads.
+    if letters & {"r", "+"}:
+        return True
+    if letters & _WRITE_ONLY_MODE_LETTERS:
+        return False
+    # Mode like "b" (no r/w/+/a/x) is malformed; treat as read for safety.
+    return True
+
+
+def _mode_arg(node: ast.Call, mode_position: int) -> str | None:
+    """Extract the literal mode string from *node*, if statically known.
+
+    Args:
+        node: The call AST.
+        mode_position: 0-based index where ``mode`` appears positionally
+            (``Path.open(mode)`` → 0; ``open(file, mode)`` → 1).
+
+    Returns ``None`` when the mode is omitted (treated as default-read by
+    callers) or when it's a non-literal expression we can't reason about
+    statically (also treated conservatively as read).
+    """
+    if len(node.args) > mode_position:
+        arg = node.args[mode_position]
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            return arg.value
+        return None  # dynamic — caller treats as read
+    for kw in node.keywords:
+        if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+            value = kw.value.value
+            if isinstance(value, str):
+                return value
+    return None  # no mode argument → default "r"
+
+
+def _bare_open_violation(node: ast.Call) -> str | None:
+    """Return a synthetic name for a bare-open read, or ``None``.
+
+    Detects:
+      - ``open(path, "r"...)``           → ``"open"``
+      - ``io.open(path, "r"...)``        → ``"io.open"``
+      - ``<X>.open("r"...)`` on Path/file → ``"<receiver>.open"``  (any X
+        — the rail can't statically tell SafeDir from Path, so the
+        marker is the disambiguator)
+
+    The detector only returns a name; the caller checks
+    ``_READ_OPEN_ENFORCED_DIRS`` membership.
+    """
+    func = node.func
+    # `open(...)` builtin — Name node, id == "open"
+    if isinstance(func, ast.Name) and func.id == "open":
+        if _is_read_mode(_mode_arg(node, mode_position=1)):
+            return "open"
+        return None
+    # ``<receiver>.open(...)`` — Attribute node, attr == "open"
+    if isinstance(func, ast.Attribute) and func.attr == "open":
+        # io.open(path, "rb") — receiver is Name "io"
+        if isinstance(func.value, ast.Name) and func.value.id == "io":
+            if _is_read_mode(_mode_arg(node, mode_position=1)):
+                return "io.open"
+            return None
+        # ``path.open("rb")`` — any other receiver. Mode is positional
+        # arg 0 (the receiver doesn't appear in node.args).
+        if _is_read_mode(_mode_arg(node, mode_position=0)):
+            return "Path.open"
+        return None
+    return None
+
+
+def _file_under_enforced_dir(path: Path) -> bool:
+    """Return True if *path* is inside a directory in ``_READ_OPEN_ENFORCED_DIRS``."""
+    if not _READ_OPEN_ENFORCED_DIRS:
+        return False
+    try:
+        rel = path.resolve().relative_to(_SRC_DIR.resolve().parent).as_posix()
+    except (OSError, ValueError):
+        return False
+    return any(rel == d or rel.startswith(d.rstrip("/") + "/") for d in _READ_OPEN_ENFORCED_DIRS)
+
+
 def _call_name(node: ast.Call) -> str | None:
     """Return the dotted name of *node*'s callee, or ``None`` if dynamic.
 
@@ -150,7 +251,24 @@ def _has_opt_out_in_window(marker_lines: set[int], call_line: int, total_lines: 
 
 
 def find_violations(path: Path) -> list[tuple[int, str, str]]:
-    """Return ``[(line_no, call_name, line_text)]`` for each unexempted flagged call."""
+    """Return ``[(line_no, call_name, line_text)]`` for each unexempted flagged call.
+
+    Two detection passes:
+
+    1. Library-call surface (``_FLAGGED_CALLS``) — always-on, all dirs.
+       Catches ``fitz.open`` / ``Image.open`` / ``zipfile.ZipFile`` etc.
+       regardless of which directory the call lives in.
+    2. Bare-``open`` reads (``open`` / ``io.open`` / ``Path.open``) —
+       only flagged when *path* is inside a directory listed in
+       ``_READ_OPEN_ENFORCED_DIRS``. Empty by default for backwards
+       compatibility; PR3i populates it for the migrated reader and
+       dedup directories. Per-directory scoping keeps the baseline
+       count from ballooning when the bare-open class is enabled on
+       a fresh subsystem.
+
+    Opt-out markers (``# safedir: ok — <reason>``) apply to both
+    passes uniformly.
+    """
     try:
         source = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError):
@@ -162,17 +280,29 @@ def find_violations(path: Path) -> list[tuple[int, str, str]]:
     lines = source.splitlines()
     marker_lines = _collect_marker_comment_lines(source)
     total = len(lines)
+    bare_open_active = _file_under_enforced_dir(path)
     out: list[tuple[int, str, str]] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
+        # Pass 1: library-call surface
         name = _call_name(node)
-        if name is None or name not in _FLAGGED_CALLS:
+        if name is not None and name in _FLAGGED_CALLS:
+            if _has_opt_out_in_window(marker_lines, node.lineno, total):
+                continue
+            excerpt = lines[node.lineno - 1].rstrip() if 1 <= node.lineno <= total else ""
+            out.append((node.lineno, name, excerpt))
+            continue
+        # Pass 2: bare-open read (directory-scoped)
+        if not bare_open_active:
+            continue
+        bare_name = _bare_open_violation(node)
+        if bare_name is None:
             continue
         if _has_opt_out_in_window(marker_lines, node.lineno, total):
             continue
         excerpt = lines[node.lineno - 1].rstrip() if 1 <= node.lineno <= total else ""
-        out.append((node.lineno, name, excerpt))
+        out.append((node.lineno, bare_name, excerpt))
     return out
 
 

--- a/scripts/check_safedir_required.py
+++ b/scripts/check_safedir_required.py
@@ -108,13 +108,46 @@ _MARKER_WINDOW_ABOVE = 2
 _MARKER_WINDOW_BELOW = 6
 
 
-# Directories where bare ``open(path, "r"...)`` / ``Path.open("r"...)`` /
-# ``io.open(path, "r"...)`` read calls are also flagged (deferred from
-# #271 / per CodeRabbit review on PR1). Empty for now — PR3i flips the
-# already-migrated reader and dedup dirs into this set with opt-out
-# markers on the legitimate post-migration sites. Adding a directory
-# here is what turns the bare-open detection on for files inside it.
-_READ_OPEN_ENFORCED_DIRS: frozenset[str] = frozenset()
+# Directories / files where bare ``open(path, "r"...)`` / ``Path.open("r"...)`` /
+# ``io.open(path, "r"...)`` read calls are also flagged. Populated by PR3i for
+# every PR3a–PR3h migration target. New bare-open reads in these locations need
+# a ``# safedir: ok — <reason>`` opt-out marker; the legitimate post-migration
+# sites (Windows / NotImplementedError fallback branches, dual-API path
+# branches in the reader libraries) are already marked.
+#
+# Entries can be either directory prefixes (matched via ``startswith(d/)``) or
+# specific file paths (matched via exact equality).
+#
+# Per #267, expanding this set to ``services/deduplication/{hasher,backup,
+# embedder}`` is PR4 scope; ``undo/`` is PR5; ``watcher/`` / ``daemon/`` /
+# ``pipeline/stages/{writer,postprocessor}`` / ``core/file_ops`` is PR6.
+_READ_OPEN_ENFORCED_DIRS: frozenset[str] = frozenset(
+    {
+        # PR3a — text processor + document readers
+        "src/services/text_processor.py",
+        "src/utils/readers/documents.py",
+        # PR3b — archive readers (zip / 7z / tar / rar)
+        "src/utils/readers/archives.py",
+        # PR3c — ebook + scientific readers
+        "src/utils/readers/ebook.py",
+        "src/utils/readers/scientific.py",
+        # PR3d — CAD readers
+        "src/utils/readers/cad.py",
+        # PR3e — dedup document extractor
+        "src/services/deduplication/extractor.py",
+        # PR3f — dedup image readers
+        "src/services/deduplication/image_dedup.py",
+        "src/services/deduplication/image_utils.py",
+        "src/services/deduplication/viewer.py",
+        "src/services/deduplication/quality.py",
+        # PR3g — EPUB enhanced reader
+        "src/utils/epub_enhanced.py",
+        # PR3h — search / organize / PARA detection
+        "src/services/search/hybrid_retriever.py",
+        "src/core/organizer.py",
+        "src/methodologies/para/detection/heuristics.py",
+    }
+)
 
 # Read-mode characters. ``open(...)`` defaults to ``"r"`` so a call with
 # no mode argument is also a read. ``"r+"`` / ``"w+"`` / ``"a+"`` are

--- a/src/core/organizer.py
+++ b/src/core/organizer.py
@@ -15,6 +15,8 @@ delegates to extracted modules for specific concerns:
 from __future__ import annotations
 
 import hashlib
+import os
+import sys
 import time
 from pathlib import Path
 from typing import Any, ClassVar
@@ -39,6 +41,7 @@ from services import ProcessedFile, ProcessedImage, TextProcessor, VisionProcess
 from services.audio.metadata_extractor import AudioMetadataExtractor
 from services.video.metadata_extractor import VideoMetadataExtractor
 from undo import UndoManager
+from utils.safedir import SafeDir, SymlinkRejected
 
 
 class FileOrganizer:
@@ -407,13 +410,11 @@ class FileOrganizer:
         seen_hashes: set[str] = set()
         deduped: list[ProcessedFile | ProcessedImage] = []
         for pf in all_processed:
-            try:
-                hasher = hashlib.sha256()
-                with pf.file_path.open("rb") as f:
-                    for chunk in iter(lambda: f.read(65536), b""):
-                        hasher.update(chunk)
-                file_hash = hasher.hexdigest()
-            except OSError:
+            file_hash = self._sha256_via_safedir(pf.file_path)
+            if file_hash is None:
+                # I/O error or refused symlink — keep the file in the
+                # deduped output (we can't determine whether it's a
+                # duplicate without hashing).
                 deduped.append(pf)
                 continue
             if file_hash not in seen_hashes:
@@ -423,6 +424,58 @@ class FileOrganizer:
                 logger.info("Duplicate file detected by content: {}, skipping.", pf.file_path.name)
                 result.deduplicated_files += 1
         return deduped
+
+    @staticmethod
+    def _sha256_via_safedir(file_path: Path) -> str | None:
+        """Compute the SHA-256 hex digest of *file_path*, via SafeDir.
+
+        Opens through :class:`utils.safedir.SafeDir` on POSIX so a
+        symlink swapped in between organize-time enumeration and the
+        hash read is refused (closes the LLM-exfiltration vector in
+        #264). Windows / non-POSIX falls back to the legacy path-based
+        open until the SafeDir Windows port lands.
+
+        Returns ``None`` when the file is unreadable or the read is
+        refused — the caller treats that as "unknown hash" and keeps
+        the file in the deduplicated output rather than dropping it.
+        """
+        hasher = hashlib.sha256()
+        if sys.platform != "win32":
+            try:
+                with SafeDir.open_root(file_path.parent) as safe_dir:
+                    fd = safe_dir.open_for_reader(file_path.name)
+                    try:
+                        fileobj = os.fdopen(fd, "rb", closefd=True)
+                    except OSError:
+                        os.close(fd)
+                        raise
+                    with fileobj:
+                        for chunk in iter(lambda: fileobj.read(65536), b""):
+                            hasher.update(chunk)
+                return hasher.hexdigest()
+            except SymlinkRejected as exc:
+                logger.warning("Refused to hash symlinked file {}: {}", file_path, exc)
+                return None
+            except NotImplementedError:
+                logger.debug(
+                    "SafeDir unavailable; hashing {} via legacy reader",
+                    file_path.name,
+                )
+            except (OSError, ValueError):
+                # ValueError covers SafeDir's name-validation rejection
+                # (filenames with backslash / NUL / path separators);
+                # OSError covers normal I/O failures. Both are
+                # "file unreadable" outcomes — return None so the
+                # caller keeps the file in the dedup output.
+                return None
+        # Legacy path-based fallback (Windows / NotImplementedError).
+        try:
+            with file_path.open("rb") as f:  # safedir: ok — Windows / NotImplementedError fallback
+                for chunk in iter(lambda: f.read(65536), b""):
+                    hasher.update(chunk)
+            return hasher.hexdigest()
+        except OSError:
+            return None
 
     def _execute_organization(
         self,

--- a/src/methodologies/para/detection/heuristics.py
+++ b/src/methodologies/para/detection/heuristics.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import re
+import sys
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -27,6 +28,8 @@ try:
 except ImportError:
     ollama = None  # type: ignore[assignment]
     OLLAMA_AVAILABLE = False
+
+from utils.safedir import SafeDir, SymlinkRejected
 
 from ..categories import PARACategory
 from ..config import AIHeuristicConfig, CategoryThresholds
@@ -743,8 +746,14 @@ class AIHeuristic(Heuristic):
         """Extract text content from a file for the classification prompt.
 
         For text-readable files, reads the first ``max_content_chars``
-        characters. For binary or unreadable files, returns a summary
-        built from the file path and any supplied metadata.
+        characters via :class:`utils.safedir.SafeDir` on POSIX so a
+        symlink swapped in between detection and this read is refused
+        (closes the LLM-exfiltration vector in #264). Windows /
+        non-POSIX falls back to the legacy path-based open until the
+        SafeDir Windows port lands.
+
+        For binary or unreadable files (or refused symlinks), returns a
+        summary built from the file path and any supplied metadata.
 
         Args:
             file_path: Path to the file.
@@ -753,25 +762,25 @@ class AIHeuristic(Heuristic):
         Returns:
             A string suitable for inclusion in the LLM prompt.
         """
-        try:
-            with file_path.open("rb") as f:
-                raw = f.read(self.config.max_content_chars)
-            # Fast path: valid UTF-8 is text regardless of byte values.
+        raw = self._read_content_bytes(file_path, self.config.max_content_chars)
+        if raw is not None:
             try:
-                content = raw.decode("utf-8")
-            except UnicodeDecodeError:
-                # Not valid UTF-8 — count low control bytes (null + non-whitespace
-                # controls) as binary indicators.  Bytes ≥ 128 are NOT counted here
-                # because they appear in Latin-1 and other single-byte encodings
-                # that may still be human-readable.
-                non_text = sum(1 for b in raw if b == 0 or (b < 32 and b not in (9, 10, 13)))
-                if raw and non_text / len(raw) > 0.30:
-                    raise ValueError("binary content") from None
-                content = raw.decode("utf-8", errors="replace")
-            if content.strip():
-                return content
-        except (OSError, ValueError):
-            pass
+                # Fast path: valid UTF-8 is text regardless of byte values.
+                try:
+                    content = raw.decode("utf-8")
+                except UnicodeDecodeError:
+                    # Not valid UTF-8 — count low control bytes (null + non-whitespace
+                    # controls) as binary indicators.  Bytes ≥ 128 are NOT counted here
+                    # because they appear in Latin-1 and other single-byte encodings
+                    # that may still be human-readable.
+                    non_text = sum(1 for b in raw if b == 0 or (b < 32 and b not in (9, 10, 13)))
+                    if raw and non_text / len(raw) > 0.30:
+                        raise ValueError("binary content") from None
+                    content = raw.decode("utf-8", errors="replace")
+                if content.strip():
+                    return content
+            except ValueError:
+                pass
 
         # Fallback: describe the file from path and metadata
         parts = [f"[Binary or unreadable file: {file_path.name}]"]
@@ -779,6 +788,51 @@ class AIHeuristic(Heuristic):
             for key, value in metadata.items():
                 parts.append(f"{key}: {value}")
         return "\n".join(parts)
+
+    @staticmethod
+    def _read_content_bytes(file_path: Path, limit: int) -> bytes | None:
+        """Read up to *limit* bytes from *file_path* via SafeDir.
+
+        Falls back to a path-based open on Windows / when SafeDir is
+        unavailable. Returns ``None`` on any I/O error or refused symlink.
+
+        Defensive: a non-positive *limit* (from a misconfigured
+        ``max_content_chars``) would otherwise make ``read(limit)`` read
+        the whole file, defeating the preview cap. Treat it as "no
+        content to read".
+        """
+        if limit <= 0:
+            return None
+        if sys.platform != "win32":
+            try:
+                with SafeDir.open_root(file_path.parent) as safe_dir:
+                    fd = safe_dir.open_for_reader(file_path.name)
+                    try:
+                        fileobj = os.fdopen(fd, "rb", closefd=True)
+                    except OSError:
+                        os.close(fd)
+                        raise
+                    with fileobj:
+                        return fileobj.read(limit)
+            except SymlinkRejected as exc:
+                logger.warning(
+                    "Refused to read symlinked file %s: %s", file_path, exc, exc_info=True
+                )
+                return None
+            except NotImplementedError:
+                logger.debug(
+                    "SafeDir unavailable; reading %s via legacy reader",
+                    file_path.name,
+                )
+            except (OSError, ValueError):
+                # ValueError covers SafeDir's name-validation rejection
+                # (filenames with backslash / NUL / path separators).
+                return None
+        try:
+            with file_path.open("rb") as f:  # safedir: ok — Windows / NotImplementedError fallback
+                return f.read(limit)
+        except OSError:
+            return None
 
     def _build_prompt(self, file_path: Path, content: str) -> str:
         """Build the per-file user message for PARA classification.

--- a/src/methodologies/para/detection/heuristics.py
+++ b/src/methodologies/para/detection/heuristics.py
@@ -824,6 +824,10 @@ class AIHeuristic(Heuristic):
                     "SafeDir unavailable; reading %s via legacy reader",
                     file_path.name,
                 )
+                # Intentional fall-through to the legacy path-based open
+                # below — SafeDir's POSIX primitives aren't available, so
+                # we must read via path. Same shape as the other PR3
+                # migrations (organizer, text_processor, etc.).
             except (OSError, ValueError):
                 # ValueError covers SafeDir's name-validation rejection
                 # (filenames with backslash / NUL / path separators).

--- a/src/services/deduplication/extractor.py
+++ b/src/services/deduplication/extractor.py
@@ -231,7 +231,14 @@ class DocumentExtractor:
             else:
                 if file_path is None:
                     raise TypeError("path-branch requires file_path")
-                with open(file_path, "rb") as f:
+                # The opt-out marker below covers BOTH the bare open and the
+                # nearby ``pypdf.PdfReader(f)`` call (within
+                # ``_MARKER_WINDOW_BELOW=6``). Both belong to the same legacy
+                # fallback block — when SafeDir is unavailable we accept the
+                # path-based read end-to-end.
+                with open(
+                    file_path, "rb"
+                ) as f:  # safedir: ok — Windows / NotImplementedError fallback
                     pdf_reader = pypdf.PdfReader(f)
                     for page_num in range(len(pdf_reader.pages)):
                         page = pdf_reader.pages[page_num]
@@ -324,7 +331,9 @@ class DocumentExtractor:
         try:
             for encoding in encodings:
                 try:
-                    with open(file_path, encoding=encoding) as f:
+                    with open(
+                        file_path, encoding=encoding
+                    ) as f:  # safedir: ok — Windows / NotImplementedError fallback
                         text = f.read()
                     logger.debug(f"Read {len(text)} chars from text file: {display}")
                     return text
@@ -332,7 +341,7 @@ class DocumentExtractor:
                     continue
 
             # If all encodings fail, read as binary and decode with errors='ignore'
-            with open(file_path, "rb") as f:
+            with open(file_path, "rb") as f:  # safedir: ok — Windows / NotImplementedError fallback
                 text = f.read().decode("utf-8", errors="ignore")
 
             return text
@@ -357,7 +366,9 @@ class DocumentExtractor:
             else:
                 if file_path is None:
                     raise TypeError("path-branch requires file_path")
-                with open(file_path, encoding="utf-8", errors="ignore") as f:
+                with open(
+                    file_path, encoding="utf-8", errors="ignore"
+                ) as f:  # safedir: ok — Windows / NotImplementedError fallback
                     rtf_content = f.read()
 
             # Try using striprtf if available

--- a/src/services/deduplication/extractor.py
+++ b/src/services/deduplication/extractor.py
@@ -3,12 +3,27 @@
 
 Extracts text content from various document formats for semantic analysis.
 Supports PDF, DOCX, TXT, RTF, ODT, and Markdown document formats.
+
+The public ``extract_text(file_path)`` entry point opens the file via
+:class:`utils.safedir.SafeDir` so a symlink swapped into the organize root
+between the directory walk and the read is refused with
+``SymlinkRejected`` rather than dereferenced. On Windows (where SafeDir's
+POSIX-only ``dir_fd`` + ``O_NOFOLLOW`` primitives are not available) the
+legacy path-based extraction is used instead.
+
+The underlying extractor methods now each accept either ``fileobj=`` (the
+SafeDir-friendly entry point) or a path (the legacy entry point).
 """
 
 from __future__ import annotations
 
 import logging
+import os
+import sys
 from pathlib import Path
+from typing import BinaryIO
+
+from utils.safedir import SafeDir, SymlinkRejected
 
 logger = logging.getLogger(__name__)
 
@@ -32,15 +47,33 @@ class DocumentExtractor:
     def extract_text(self, file_path: Path) -> str:
         """Extract text from a single document.
 
+        Opens the file via ``SafeDir.open_for_reader`` so a symlink swapped
+        into the organize root between the directory walk and this read is
+        refused — closes the symlink-following surface in the dedup
+        ingestion pipeline (#264). On Windows the path-based fallback is
+        used because SafeDir is POSIX-only.
+
         Args:
             file_path: Path to document file
 
         Returns:
-            Extracted text content
+            Extracted text content, or ``""`` when extraction fails for
+            *any* reason — including a refused symlink (``SymlinkRejected``),
+            an underlying ``OSError`` during the read, a malformed file, or
+            a missing optional library. The empty-string contract is
+            preserved from the pre-SafeDir implementation so consumers
+            (``document_dedup`` etc.) behave identically: a file that
+            can't be read simply contributes no text to the dedup corpus.
+
+            **Read failures are NOT raised** — callers cannot rely on
+            ``OSError`` to detect read problems. Only the missing-file
+            and unsupported-format pre-checks raise.
 
         Raises:
-            ValueError: If file format not supported
-            OSError: If file cannot be read
+            OSError: If the file does not exist (pre-flight check before
+                any SafeDir / library work).
+            ValueError: If the file's extension is not in
+                ``supported_extensions``.
         """
         if not file_path.exists():
             raise OSError(f"File not found: {file_path}")
@@ -50,24 +83,76 @@ class DocumentExtractor:
         if not self.supports_format(file_path):
             raise ValueError(f"Unsupported format: {extension}")
 
-        try:
-            if extension == ".pdf":
-                return self._extract_pdf(file_path)
-            elif extension == ".docx":
-                return self._extract_docx(file_path)
-            elif extension == ".txt" or extension == ".md":
-                return self._extract_text(file_path)
-            elif extension == ".rtf":
-                return self._extract_rtf(file_path)
-            elif extension == ".odt":
-                return self._extract_odt(file_path)
-            else:
-                logger.warning(f"No extractor for {extension}, treating as text")
-                return self._extract_text(file_path)
+        # Try the SafeDir path first; fall back to the legacy path-branch
+        # only when SafeDir is unavailable (Windows) — never on real FS
+        # errors, which must propagate so the caller sees them.
+        if sys.platform != "win32":
+            try:
+                with SafeDir.open_root(file_path.parent) as safe_dir:
+                    fd = safe_dir.open_for_reader(file_path.name)
+                    # fdopen takes ownership only once it returns; close the
+                    # bare fd explicitly if fdopen itself raises (e.g. on
+                    # a closed dir_fd race), otherwise the fd would leak.
+                    try:
+                        fileobj = os.fdopen(fd, "rb", closefd=True)
+                    except OSError:
+                        os.close(fd)
+                        raise
+                    with fileobj:
+                        return self._extract_from_fileobj(extension, fileobj, file_path.name)
+            except SymlinkRejected as exc:
+                logger.warning(
+                    "Refused to read symlinked file %s: %s", file_path, exc, exc_info=True
+                )
+                return ""
+            except NotImplementedError:
+                # SafeDir's POSIX primitives unavailable; fall through to
+                # the path-based extraction below.
+                logger.debug("SafeDir unavailable; using legacy reader for %s", file_path.name)
+            except (OSError, ValueError, ImportError) as e:
+                logger.error("Error extracting text from %s: %s", file_path, e, exc_info=True)
+                return ""
 
+        # Legacy path-based fallback (Windows) — preserves the original
+        # API contract.
+        try:
+            return self._extract_via_path(extension, file_path)
         except (OSError, ValueError, ImportError) as e:
-            logger.error(f"Error extracting text from {file_path}: {e}")
+            logger.error("Error extracting text from %s: %s", file_path, e, exc_info=True)
             return ""
+
+    def _extract_from_fileobj(self, extension: str, fileobj: BinaryIO, label: str) -> str:
+        """Dispatch extraction to the right ``_extract_X`` with a fileobj."""
+        if extension == ".pdf":
+            return self._extract_pdf(fileobj=fileobj, label=label)
+        if extension == ".docx":
+            return self._extract_docx(fileobj=fileobj, label=label)
+        if extension in (".txt", ".md"):
+            return self._extract_text(fileobj=fileobj, label=label)
+        if extension == ".rtf":
+            return self._extract_rtf(fileobj=fileobj, label=label)
+        if extension == ".odt":
+            return self._extract_odt(fileobj=fileobj, label=label)
+        logger.warning("No extractor for %s, treating as text", extension)
+        return self._extract_text(fileobj=fileobj, label=label)
+
+    def _extract_via_path(self, extension: str, file_path: Path) -> str:
+        """Dispatch extraction to the right ``_extract_X`` with a path.
+
+        Legacy fallback used only when SafeDir is unavailable.
+        """
+        if extension == ".pdf":
+            return self._extract_pdf(file_path=file_path)
+        if extension == ".docx":
+            return self._extract_docx(file_path=file_path)
+        if extension in (".txt", ".md"):
+            return self._extract_text(file_path=file_path)
+        if extension == ".rtf":
+            return self._extract_rtf(file_path=file_path)
+        if extension == ".odt":
+            return self._extract_odt(file_path=file_path)
+        logger.warning("No extractor for %s, treating as text", extension)
+        return self._extract_text(file_path=file_path)
 
     def extract_batch(self, file_paths: list[Path]) -> dict[Path, str]:
         """Extract text from multiple documents in batch.
@@ -112,14 +197,18 @@ class DocumentExtractor:
         """
         return sorted(self.supported_extensions)
 
-    def _extract_pdf(self, file_path: Path) -> str:
+    def _extract_pdf(
+        self,
+        file_path: Path | None = None,
+        *,
+        fileobj: BinaryIO | None = None,
+        label: str | None = None,
+    ) -> str:
         """Extract text from PDF file.
 
-        Args:
-            file_path: Path to PDF file
-
-        Returns:
-            Extracted text
+        Either ``file_path`` (legacy) or ``fileobj`` (SafeDir-friendly) must
+        be supplied. The ``label`` arg is used in log messages when only a
+        fileobj is given.
         """
         try:
             import pypdf
@@ -129,20 +218,29 @@ class DocumentExtractor:
             except (ImportError, AttributeError):
                 PyPdfError = Exception  # type: ignore[misc,assignment]  # fallback when pypdf.errors unavailable
 
-            text_parts = []
+            text_parts: list[str] = []
+            display = label or (file_path.name if file_path is not None else "<fileobj>")
 
-            with open(file_path, "rb") as f:
-                pdf_reader = pypdf.PdfReader(f)
-
-                # Extract text from each page
+            if fileobj is not None:
+                pdf_reader = pypdf.PdfReader(fileobj)
                 for page_num in range(len(pdf_reader.pages)):
                     page = pdf_reader.pages[page_num]
                     text = page.extract_text()
                     if text:
                         text_parts.append(text)
+            else:
+                if file_path is None:
+                    raise TypeError("path-branch requires file_path")
+                with open(file_path, "rb") as f:
+                    pdf_reader = pypdf.PdfReader(f)
+                    for page_num in range(len(pdf_reader.pages)):
+                        page = pdf_reader.pages[page_num]
+                        text = page.extract_text()
+                        if text:
+                            text_parts.append(text)
 
             full_text = "\n".join(text_parts)
-            logger.debug(f"Extracted {len(full_text)} chars from PDF: {file_path.name}")
+            logger.debug(f"Extracted {len(full_text)} chars from PDF: {display}")
 
             return full_text
 
@@ -150,34 +248,38 @@ class DocumentExtractor:
             logger.error("pypdf not installed. Install with: pip install pypdf")
             return ""
         except (PyPdfError, OSError, ValueError, KeyError, IndexError) as e:
-            logger.error(f"Error extracting PDF {file_path}: {e}")
+            display = label or (file_path.name if file_path is not None else "<fileobj>")
+            logger.error(f"Error extracting PDF {display}: {e}")
             return ""
 
-    def _extract_docx(self, file_path: Path) -> str:
-        """Extract text from DOCX file.
-
-        Args:
-            file_path: Path to DOCX file
-
-        Returns:
-            Extracted text
-        """
+    def _extract_docx(
+        self,
+        file_path: Path | None = None,
+        *,
+        fileobj: BinaryIO | None = None,
+        label: str | None = None,
+    ) -> str:
+        """Extract text from DOCX file."""
         try:
             import docx
 
-            doc = docx.Document(str(file_path))
+            if fileobj is not None:
+                doc = docx.Document(fileobj)
+            else:
+                if file_path is None:
+                    raise TypeError("path-branch requires file_path")
+                doc = docx.Document(str(file_path))
 
-            # Extract text from all paragraphs
             text_parts = [paragraph.text for paragraph in doc.paragraphs]
 
-            # Also extract text from tables
             for table in doc.tables:
                 for row in table.rows:
                     for cell in row.cells:
                         text_parts.append(cell.text)
 
             full_text = "\n".join(text_parts)
-            logger.debug(f"Extracted {len(full_text)} chars from DOCX: {file_path.name}")
+            display = label or (file_path.name if file_path is not None else "<fileobj>")
+            logger.debug(f"Extracted {len(full_text)} chars from DOCX: {display}")
 
             return full_text
 
@@ -185,27 +287,46 @@ class DocumentExtractor:
             logger.error("python-docx not installed. Install with: pip install python-docx")
             return ""
         except (OSError, ValueError, KeyError) as e:
-            logger.error(f"Error extracting DOCX {file_path}: {e}")
+            display = label or (file_path.name if file_path is not None else "<fileobj>")
+            logger.error(f"Error extracting DOCX {display}: {e}")
             return ""
 
-    def _extract_text(self, file_path: Path) -> str:
-        """Extract text from plain text file.
+    def _extract_text(
+        self,
+        file_path: Path | None = None,
+        *,
+        fileobj: BinaryIO | None = None,
+        label: str | None = None,
+    ) -> str:
+        """Extract text from plain text file."""
+        encodings = ["utf-8", "latin-1", "cp1252", "ascii"]
+        display = label or (file_path.name if file_path is not None else "<fileobj>")
 
-        Args:
-            file_path: Path to text file
+        if fileobj is not None:
+            # Read all bytes once; try each encoding in turn.
+            try:
+                raw = fileobj.read()
+            except OSError as e:
+                logger.error(f"Error reading text file {display}: {e}")
+                return ""
+            for encoding in encodings:
+                try:
+                    text = raw.decode(encoding)
+                    logger.debug(f"Read {len(text)} chars from text file: {display}")
+                    return text
+                except UnicodeDecodeError:
+                    continue
+            # All strict decodes failed — fall back to ignore errors.
+            return raw.decode("utf-8", errors="ignore")
 
-        Returns:
-            File contents
-        """
+        if file_path is None:
+            raise TypeError("path-branch requires file_path")
         try:
-            # Try multiple encodings
-            encodings = ["utf-8", "latin-1", "cp1252", "ascii"]
-
             for encoding in encodings:
                 try:
                     with open(file_path, encoding=encoding) as f:
                         text = f.read()
-                    logger.debug(f"Read {len(text)} chars from text file: {file_path.name}")
+                    logger.debug(f"Read {len(text)} chars from text file: {display}")
                     return text
                 except UnicodeDecodeError:
                     continue
@@ -217,74 +338,74 @@ class DocumentExtractor:
             return text
 
         except OSError as e:
-            logger.error(f"Error reading text file {file_path}: {e}")
+            logger.error(f"Error reading text file {display}: {e}")
             return ""
 
-    def _extract_rtf(self, file_path: Path) -> str:
-        """Extract text from RTF file.
+    def _extract_rtf(
+        self,
+        file_path: Path | None = None,
+        *,
+        fileobj: BinaryIO | None = None,
+        label: str | None = None,
+    ) -> str:
+        """Extract text from RTF file."""
+        display = label or (file_path.name if file_path is not None else "<fileobj>")
 
-        Args:
-            file_path: Path to RTF file
-
-        Returns:
-            Extracted text
-        """
         try:
+            if fileobj is not None:
+                rtf_content = fileobj.read().decode("utf-8", errors="ignore")
+            else:
+                if file_path is None:
+                    raise TypeError("path-branch requires file_path")
+                with open(file_path, encoding="utf-8", errors="ignore") as f:
+                    rtf_content = f.read()
+
             # Try using striprtf if available
             try:
                 from striprtf.striprtf import rtf_to_text
 
-                with open(file_path, encoding="utf-8", errors="ignore") as f:
-                    rtf_content = f.read()
-
                 text = str(rtf_to_text(rtf_content))
-                logger.debug(f"Extracted {len(text)} chars from RTF: {file_path.name}")
-
+                logger.debug(f"Extracted {len(text)} chars from RTF: {display}")
                 return text
 
             except ImportError:
                 # Fallback: simple RTF stripping
                 logger.warning("striprtf not installed, using basic extraction")
-
-                with open(file_path, encoding="utf-8", errors="ignore") as f:
-                    content = f.read()
-
-                # Very basic RTF stripping (removes control words)
                 import re
 
-                text = re.sub(r"\\[a-z]+\d*\s?", "", content)
+                text = re.sub(r"\\[a-z]+\d*\s?", "", rtf_content)
                 text = re.sub(r"[{}]", "", text)
                 text = text.strip()
-
                 return text
 
         except (OSError, ValueError, ImportError) as e:
-            logger.error(f"Error extracting RTF {file_path}: {e}")
+            logger.error(f"Error extracting RTF {display}: {e}")
             return ""
 
-    def _extract_odt(self, file_path: Path) -> str:
-        """Extract text from ODT file.
+    def _extract_odt(
+        self,
+        file_path: Path | None = None,
+        *,
+        fileobj: BinaryIO | None = None,
+        label: str | None = None,
+    ) -> str:
+        """Extract text from ODT file."""
+        display = label or (file_path.name if file_path is not None else "<fileobj>")
 
-        Args:
-            file_path: Path to ODT file
-
-        Returns:
-            Extracted text
-        """
         try:
             import xml.etree.ElementTree as ET
             import zipfile
 
-            # ODT files are ZIP archives
-            with zipfile.ZipFile(file_path, "r") as odt_zip:
-                # Extract content.xml
+            # ODT files are ZIP archives — zipfile.ZipFile accepts both
+            # paths and file-like objects.
+            source = fileobj if fileobj is not None else file_path
+            if source is None:
+                raise TypeError("_extract_odt requires file_path or fileobj")
+            with zipfile.ZipFile(source, "r") as odt_zip:
                 content_xml = odt_zip.read("content.xml")
 
-            # Parse XML
             root = ET.fromstring(content_xml)
 
-            # Extract all text nodes
-            # ODT uses OpenDocument namespace
             namespaces = {
                 "text": "urn:oasis:names:tc:opendocument:xmlns:text:1.0",
                 "office": "urn:oasis:names:tc:opendocument:xmlns:office:1.0",
@@ -292,12 +413,10 @@ class DocumentExtractor:
 
             text_parts = []
 
-            # Find all text:p (paragraph) elements
             for paragraph in root.findall(".//text:p", namespaces):
                 if paragraph.text:
                     text_parts.append(paragraph.text)
 
-                # Also get text from child elements
                 for child in paragraph:
                     if child.text:
                         text_parts.append(child.text)
@@ -305,12 +424,12 @@ class DocumentExtractor:
                         text_parts.append(child.tail)
 
             full_text = "\n".join(text_parts)
-            logger.debug(f"Extracted {len(full_text)} chars from ODT: {file_path.name}")
+            logger.debug(f"Extracted {len(full_text)} chars from ODT: {display}")
 
             return full_text
 
         except (OSError, KeyError, ValueError, zipfile.BadZipFile) as e:
-            logger.error(f"Error extracting ODT {file_path}: {e}")
+            logger.error(f"Error extracting ODT {display}: {e}")
             return ""
 
     def _check_dependencies(self) -> None:

--- a/src/services/deduplication/image_dedup.py
+++ b/src/services/deduplication/image_dedup.py
@@ -13,8 +13,6 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
-from PIL import Image
-
 try:
     from imagededup.methods import AHash, DHash, PHash  # pyre-ignore[21]
 
@@ -23,7 +21,9 @@ except ImportError:
     AHash = DHash = PHash = None
     _IMAGEDEDUP_AVAILABLE = False
 
-from .image_utils import SUPPORTED_FORMATS
+from PIL.Image import DecompressionBombError
+
+from .image_utils import SUPPORTED_FORMATS, safedir_image_open
 
 logger = logging.getLogger(__name__)
 
@@ -91,15 +91,32 @@ class ImageDeduplicator:
         else:  # ahash
             self.hasher = AHash()
 
-    def get_image_hash(self, image_path: Path) -> str | None:
+    def get_image_hash(self, image_path: Path, *, trusted_root: Path | None = None) -> str | None:
         """Compute perceptual hash for a single image.
 
+        Routes the image read through :func:`safedir_image_open` so a
+        symlinked image is refused at every path component when
+        ``trusted_root`` is supplied (closes the dedup-ingestion
+        symlink-exfiltration vector, #264). The PIL Image is converted
+        to a numpy array and handed to ``imagededup``'s
+        ``encode_image(image_array=...)`` API — bypassing the path-based
+        ``encode_image(path)`` codepath that would otherwise dereference
+        symlinks inside imagededup itself.
+
         Args:
-            image_path: Path to image file
+            image_path: Path to image file.
+            trusted_root: Anchor directory that bounds the SafeDir
+                traversal. When supplied (typically the directory the
+                walk started from), every intermediate component of
+                ``image_path.relative_to(trusted_root)`` is checked for
+                symlinks. ``find_duplicates``, ``cluster_by_similarity``,
+                and ``batch_compute_hashes`` thread their root through.
+                When ``None``, falls back to parent-rooted protection
+                (final component only) — OK for ad-hoc calls.
 
         Returns:
             Hexadecimal string representation of perceptual hash,
-            or None if image could not be processed
+            or None if image could not be processed.
         """
         if not image_path.exists():
             logger.warning(f"Image not found: {image_path}")
@@ -116,11 +133,36 @@ class ImageDeduplicator:
             return None
 
         try:
-            # imagededup expects string path
-            encoding = self.hasher.encode_image(str(image_path))
+            # Open via SafeDir, convert PIL Image → numpy array, pass to
+            # imagededup's image_array= API. This bypasses imagededup's
+            # path-based codepath which would call Pillow's path-based
+            # Image.open() internally and re-introduce the symlink
+            # dereference we're trying to close.
+            import numpy as np
+
+            with safedir_image_open(image_path, trusted_root=trusted_root) as (img, _fd):
+                # imagededup interprets numpy arrays as RGB: its
+                # ``preprocess_image`` runs ``PIL.Image.fromarray(array)``
+                # which PIL maps to RGB for 3-channel uint8 arrays, then
+                # converts to grayscale via the same luminance formula
+                # used on the path-based codepath. Passing an RGB array
+                # here therefore matches what
+                # ``encode_image(image_file=str(path))`` would have
+                # produced — same color photo, same perceptual hash.
+                if img.mode != "RGB":
+                    img = img.convert("RGB")
+                image_array = np.ascontiguousarray(np.asarray(img))
+            encoding = self.hasher.encode_image(image_array=image_array)
             return str(encoding) if encoding is not None else None
         except OSError as e:
             logger.warning(f"Could not read image {image_path}: {e}")
+            return None
+        except DecompressionBombError as e:
+            # PIL refuses images over MAX_IMAGE_PIXELS — recoverable
+            # per-file error, not a reason to abort find_duplicates /
+            # batch_compute_hashes scans. Mirrors how
+            # image_utils.get_image_metadata handles it.
+            logger.error(f"Decompression bomb detected for {image_path}: {e}")
             return None
         except (ValueError, RuntimeError) as e:
             logger.error(f"Error processing image {image_path}: {e}")
@@ -229,7 +271,10 @@ class ImageDeduplicator:
         image_hashes: dict[Path, str] = {}
 
         for idx, img_path in enumerate(image_files, 1):
-            img_hash = self.get_image_hash(img_path)
+            # ``directory`` is the trusted root: every image was found
+            # under this walk, so SafeDir anchoring traverses each
+            # intermediate component with O_NOFOLLOW.
+            img_hash = self.get_image_hash(img_path, trusted_root=directory)
             if img_hash is not None:
                 image_hashes[img_path] = img_hash
 
@@ -297,6 +342,11 @@ class ImageDeduplicator:
         image_hashes: dict[Path, str] = {}
 
         for idx, img_path in enumerate(images, 1):
+            # cluster_by_similarity takes an arbitrary list of paths;
+            # there's no single trusted root we can anchor against.
+            # Fall back to parent-rooted protection (final-component
+            # O_NOFOLLOW only) — documented as the standalone-caller
+            # contract in safedir_image_open.
             img_hash = self.get_image_hash(img_path)
             if img_hash is not None:
                 image_hashes[img_path] = img_hash
@@ -355,6 +405,9 @@ class ImageDeduplicator:
         results: dict[Path, str] = {}
 
         for idx, img_path in enumerate(image_paths, 1):
+            # batch_compute_hashes takes an arbitrary list of paths; no
+            # single trusted root. Falls back to parent-rooted SafeDir
+            # protection — same as cluster_by_similarity.
             img_hash = self.get_image_hash(img_path)
             if img_hash is not None:
                 results[img_path] = img_hash
@@ -382,6 +435,14 @@ class ImageDeduplicator:
             pattern = "*"
 
         for path in directory.glob(pattern):
+            # ``Path.is_file()`` follows symlinks (PR3f / Codex finding).
+            # Filter symlinked entries here so SafeDir's per-component
+            # check inside the dedup hash flow remains the only place
+            # that decides whether a symlinked image is processed —
+            # never silently accepted by the walk.
+            if path.is_symlink():
+                logger.debug("Skipping symlinked image in walk: %s", path)
+                continue
             if path.is_file() and path.suffix.lower() in SUPPORTED_FORMATS:
                 image_files.append(path)
 
@@ -413,7 +474,7 @@ class ImageDeduplicator:
             return False, f"Unsupported format: {image_path.suffix}"
 
         try:
-            with Image.open(image_path) as img:
+            with safedir_image_open(image_path) as (img, _fd):
                 # Try to load image data to verify it's not corrupt
                 img.verify()
             return True, None

--- a/src/services/deduplication/image_utils.py
+++ b/src/services/deduplication/image_utils.py
@@ -2,18 +2,147 @@
 
 Provides helper functions for image validation, metadata extraction,
 format conversion, and batch processing operations.
+
+Every image read goes through :func:`safedir_image_open`, which routes
+``PIL.Image.open`` through a SafeDir-opened file descriptor on POSIX.
+A symlink swapped into the organize root between the directory walk and
+the read is refused with ``SymlinkRejected`` (an ``OSError`` subclass)
+rather than dereferenced — closes the symlink-following surface in the
+image dedup ingestion pipeline (#264). On Windows (where SafeDir's
+``dir_fd`` + ``O_NOFOLLOW`` primitives are unavailable) the legacy
+path-based ``Image.open`` is used.
+
+**Anchoring**: callers that have a trusted-root context (the directory
+they walked to find the image) should pass ``trusted_root=`` to
+:func:`safedir_image_open`. The helper then traverses every component
+of the relative path with ``open_subdir`` so each intermediate
+directory is checked for symlinks too — closes the nested-symlink-
+ancestor TOCTOU window. Without ``trusted_root``, the helper falls
+back to parent-rooted opening (only the final component is protected;
+suitable for standalone validation calls that don't sit behind a
+directory walk).
 """
 
 from __future__ import annotations
 
+import contextlib
 import logging
+import os
+import sys
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 from PIL import Image, UnidentifiedImageError
 from PIL.Image import DecompressionBombError
 
+from utils.safedir import SafeDir
+
 logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def safedir_image_open(
+    image_path: Path,
+    *,
+    trusted_root: Path | None = None,
+) -> Iterator[tuple[Image.Image, int | None]]:
+    """Yield ``(PIL.Image, fd)`` opened via SafeDir; refuses symlinks.
+
+    Args:
+        image_path: Path to the image file.
+        trusted_root: Anchor directory whose contents are trusted. When
+            given, the helper opens ``trusted_root`` as a SafeDir and
+            traverses each intermediate component of
+            ``image_path.relative_to(trusted_root)`` via
+            ``open_subdir`` — each step rejects symlinks with
+            ``O_NOFOLLOW``, closing the nested-symlink-ancestor TOCTOU
+            window. When ``None``, falls back to opening
+            ``image_path.parent`` directly (only the final component
+            is protected; OK for standalone validation calls without
+            a walk context).
+
+    Yields:
+        ``(img, fd)`` where ``fd`` is the underlying SafeDir-opened
+        file descriptor (or ``None`` on the Windows / non-SafeDir
+        fallback path). Callers that need race-free metadata reads
+        (file size, mtime) should use ``os.fstat(fd)`` rather than
+        ``image_path.stat()`` — the latter can mismatch on a
+        post-open swap.
+
+    Raises:
+        SymlinkRejected: If ``image_path`` or any intermediate
+            ancestor (under ``trusted_root``, when supplied) is a
+            symlink. Subclasses ``OSError`` so callers' existing
+            ``except OSError`` paths catch refused symlinks too.
+        ValueError: If ``image_path`` is not under ``trusted_root``.
+        OSError: For other open failures (permission denied, etc.).
+    """
+    if sys.platform == "win32":
+        with Image.open(image_path) as img:
+            yield img, None
+        return
+
+    stack = contextlib.ExitStack()
+    img: Image.Image | None = None
+    fd: int | None = None
+    try:
+        # Construction phase — narrowly catch NotImplementedError here
+        # so a NotImplementedError raised inside the yield (by the
+        # caller's code or by a PIL operation) propagates normally
+        # rather than being mistaken for "SafeDir unavailable".
+        try:
+            stack.__enter__()
+            if trusted_root is None:
+                # Parent-rooted (legacy / standalone): only the final
+                # component is O_NOFOLLOW-protected. Documented above.
+                sd = stack.enter_context(SafeDir.open_root(image_path.parent))
+                name = image_path.name
+            else:
+                # Trusted-root traversal: every intermediate component
+                # is rejected if it's a symlink. ``relative_to`` raises
+                # ValueError if the image is outside the trusted root —
+                # which is itself a security violation worth surfacing.
+                relative = image_path.relative_to(trusted_root)
+                parts = relative.parts
+                if not parts:
+                    raise ValueError(
+                        f"image_path {image_path!r} equals trusted_root {trusted_root!r}; "
+                        "expected a file inside the root"
+                    )
+                sd = stack.enter_context(SafeDir.open_root(trusted_root))
+                for part in parts[:-1]:
+                    sd = stack.enter_context(sd.open_subdir(part))
+                name = parts[-1]
+            fd = sd.open_for_reader(name)
+            # fdopen takes ownership only once it returns; explicitly
+            # close the raw fd if fdopen itself raises.
+            try:
+                fileobj = os.fdopen(fd, "rb", closefd=True)
+            except OSError:
+                os.close(fd)
+                raise
+            stack.enter_context(fileobj)
+            img = stack.enter_context(Image.open(fileobj))
+        except NotImplementedError:
+            # SafeDir's POSIX primitives unavailable on this build; close
+            # any partially-entered stack frames and fall back to direct
+            # ``Image.open(path)``. Yield from inside the fallback's own
+            # ``with`` so cleanup is structured.
+            stack.close()
+            logger.debug("SafeDir unavailable; using legacy Image.open for %s", image_path.name)
+            with Image.open(image_path) as fallback_img:
+                yield fallback_img, None
+            return
+
+        # Yield from outside the construction-try so the caller's
+        # exceptions propagate cleanly — including NotImplementedError
+        # raised inside the with-block body, which used to be swallowed.
+        assert img is not None  # always set by the construction phase
+        yield img, fd
+    finally:
+        stack.close()
+
 
 # Supported image formats
 SUPPORTED_FORMATS = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".tif", ".webp"}
@@ -93,12 +222,15 @@ def get_image_metadata(image_path: Path) -> ImageMetadata | None:
         return None
 
     try:
-        with Image.open(image_path) as img:
+        # Stat from the SafeDir-opened fd so size_bytes describes the
+        # same non-symlink file the dimensions were read from. Falls
+        # back to ``image_path.stat()`` when ``fd is None`` (Windows /
+        # SafeDir-unavailable code path).
+        with safedir_image_open(image_path) as (img, fd):
             width, height = img.size
             image_format = img.format or "unknown"
             mode = img.mode
-
-        size_bytes = image_path.stat().st_size
+            size_bytes = os.fstat(fd).st_size if fd is not None else image_path.stat().st_size
 
         return ImageMetadata(
             path=image_path,
@@ -129,7 +261,7 @@ def get_image_dimensions(image_path: Path) -> tuple[int, int] | None:
         Tuple of (width, height) in pixels, or None if image cannot be read
     """
     try:
-        with Image.open(image_path) as img:
+        with safedir_image_open(image_path) as (img, _fd):
             return img.size  # type: ignore[no-any-return]
     except (OSError, ValueError) as e:
         logger.warning(f"Could not get dimensions for {image_path}: {e}")
@@ -146,7 +278,7 @@ def get_image_format(image_path: Path) -> str | None:
         Format string (e.g., "JPEG", "PNG"), or None if cannot be determined
     """
     try:
-        with Image.open(image_path) as img:
+        with safedir_image_open(image_path) as (img, _fd):
             return img.format  # type: ignore[no-any-return]
     except (OSError, ValueError) as e:
         logger.warning(f"Could not determine format for {image_path}: {e}")
@@ -192,12 +324,12 @@ def validate_image_file(image_path: Path) -> tuple[bool, str | None]:
         return False, f"Unsupported format: {image_path.suffix}"
 
     try:
-        with Image.open(image_path) as img:
+        with safedir_image_open(image_path) as (img, _fd):
             # Verify image data is readable
             img.verify()
 
         # Reopen to get actual dimensions (verify closes the file)
-        with Image.open(image_path) as img:
+        with safedir_image_open(image_path) as (img, _fd):
             width, height = img.size
             if width <= 0 or height <= 0:
                 return False, f"Invalid dimensions: {width}x{height}"

--- a/src/services/deduplication/quality.py
+++ b/src/services/deduplication/quality.py
@@ -135,7 +135,11 @@ class ImageQualityAnalyzer:
             return None
 
         try:
-            with self.Image.open(path) as img:
+            import os
+
+            from .image_utils import safedir_image_open
+
+            with safedir_image_open(path) as (img, fd):
                 width, height = img.size
                 resolution = width * height
 
@@ -163,7 +167,14 @@ class ImageQualityAnalyzer:
                 }
                 color_depth = mode_bits.get(img.mode, 24)
 
-                stat = path.stat()
+                # Stat from the SafeDir-opened fd when available so size
+                # and mtime describe the same non-symlink file the image
+                # was decoded from. Falls back to ``path.stat()`` when
+                # ``fd is None`` (Windows / SafeDir-unavailable).
+                if fd is not None:
+                    stat = os.fstat(fd)
+                else:
+                    stat = path.stat()
                 file_size = stat.st_size
                 format_enum = self._get_format_from_extension(path)
                 aspect_ratio = width / height if height > 0 else 0

--- a/src/services/deduplication/viewer.py
+++ b/src/services/deduplication/viewer.py
@@ -11,6 +11,7 @@ Provides a terminal-based UI for reviewing duplicate images with:
 
 from __future__ import annotations
 
+import os
 import shutil
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -25,6 +26,8 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Confirm, Prompt
 from rich.table import Table
+
+from .image_utils import safedir_image_open
 
 
 class UserAction(Enum):
@@ -104,7 +107,11 @@ class ComparisonViewer:
         self._terminal_width = shutil.get_terminal_size().columns
 
     def show_comparison(
-        self, images: list[Path], similarity_score: float | None = None
+        self,
+        images: list[Path],
+        similarity_score: float | None = None,
+        *,
+        trusted_root: Path | None = None,
     ) -> DuplicateReview:
         """Show comparison for a group of duplicate images.
 
@@ -113,6 +120,13 @@ class ComparisonViewer:
         Args:
             images: List of duplicate image paths
             similarity_score: Similarity score if available
+            trusted_root: Optional scan root that bounds the SafeDir
+                traversal for each image. When supplied (typically the
+                directory passed to ``find_duplicates``), every
+                intermediate component of each image path is checked
+                for symlinks during the metadata + preview generation —
+                closes the nested-symlink-ancestor TOCTOU window that
+                would otherwise reopen between hashing and review.
 
         Returns:
             DuplicateReview with user decisions
@@ -124,7 +138,7 @@ class ComparisonViewer:
         metadata_list = []
         for img_path in images:
             try:
-                metadata = self._get_image_metadata(img_path)
+                metadata = self._get_image_metadata(img_path, trusted_root=trusted_root)
                 metadata_list.append(metadata)
             except (OSError, ValueError) as e:
                 self.console.print(f"[yellow]Warning: Could not load {img_path}: {e}[/yellow]")
@@ -134,22 +148,32 @@ class ComparisonViewer:
 
         # Display comparison
         self._display_comparison_header(len(metadata_list), similarity_score)
-        self._display_images_side_by_side(metadata_list)
+        self._display_images_side_by_side(metadata_list, trusted_root=trusted_root)
 
         # Get user action
         action = self._prompt_user_action(len(metadata_list))
 
-        # Process action
-        return self._process_user_action(action, metadata_list)
+        # Process action — forward trusted_root so the AUTO_SELECT branch's
+        # re-open via ``_auto_select_best`` gets the same SafeDir anchoring
+        # as the initial display.
+        return self._process_user_action(action, metadata_list, trusted_root=trusted_root)
 
     def batch_review(
-        self, duplicate_groups: dict[str, list[Path]], auto_select_best: bool = False
+        self,
+        duplicate_groups: dict[str, list[Path]],
+        auto_select_best: bool = False,
+        *,
+        trusted_root: Path | None = None,
     ) -> dict[Path, str]:
         """Review multiple groups of duplicates in batch.
 
         Args:
             duplicate_groups: Dictionary mapping group IDs to lists of duplicate images
             auto_select_best: If True, automatically keep best quality
+            trusted_root: Optional scan root that bounds SafeDir traversal
+                for each image during review. Forwards through to
+                :meth:`show_comparison` so symlinked ancestors are
+                rejected at every component.
 
         Returns:
             Dictionary mapping file paths to actions ("keep" or "delete")
@@ -166,11 +190,13 @@ class ComparisonViewer:
             self.console.rule()
 
             if auto_select_best:
-                # Automatic selection of best quality
-                review = self._auto_select_best(images)
+                # Automatic selection of best quality — same anchoring
+                # contract as the manual path.
+                review = self._auto_select_best(images, trusted_root=trusted_root)
             else:
-                # Manual review
-                review = self.show_comparison(images)
+                # Manual review — pass the scan root through so each
+                # image opens with full anchored traversal.
+                review = self.show_comparison(images, trusted_root=trusted_root)
 
             # Record decisions
             for path in review.files_to_keep:
@@ -189,11 +215,15 @@ class ComparisonViewer:
 
         return decisions
 
-    def _get_image_metadata(self, image_path: Path) -> ImageMetadata:
+    def _get_image_metadata(
+        self, image_path: Path, *, trusted_root: Path | None = None
+    ) -> ImageMetadata:
         """Extract metadata from an image file.
 
         Args:
             image_path: Path to image file
+            trusted_root: Scan root for SafeDir anchoring; defers to the
+                parent-rooted fallback when ``None``.
 
         Returns:
             ImageMetadata object
@@ -201,12 +231,19 @@ class ComparisonViewer:
         Raises:
             Exception: If image cannot be loaded
         """
-        with Image.open(image_path) as img:
+        with safedir_image_open(image_path, trusted_root=trusted_root) as (img, fd):
             width, height = img.size
             img_format = img.format or "UNKNOWN"
             mode = img.mode
-
-        stat = image_path.stat()
+            # Stat from the same SafeDir-opened fd so size/mtime
+            # describe the non-symlink file we actually read. Falls
+            # back to ``image_path.stat()`` only when ``fd is None``
+            # (Windows / SafeDir-unavailable), where the helper itself
+            # already used the path directly.
+            if fd is not None:
+                stat = os.fstat(fd)
+            else:
+                stat = image_path.stat()
 
         return ImageMetadata(
             path=image_path,
@@ -228,17 +265,25 @@ class ComparisonViewer:
 
         self.console.print(Panel(header_text, style="bold cyan", box=box.DOUBLE))
 
-    def _display_images_side_by_side(self, metadata_list: list[ImageMetadata]) -> None:
+    def _display_images_side_by_side(
+        self,
+        metadata_list: list[ImageMetadata],
+        *,
+        trusted_root: Path | None = None,
+    ) -> None:
         """Display images side by side with metadata.
 
         Args:
             metadata_list: List of ImageMetadata objects
+            trusted_root: Forwarded to ``_generate_ascii_preview`` so
+                the ASCII preview re-open uses the same SafeDir anchor
+                as the metadata extraction.
         """
         # Create tables for each image
         tables = []
 
         for idx, metadata in enumerate(metadata_list, 1):
-            table = self._create_image_info_table(idx, metadata)
+            table = self._create_image_info_table(idx, metadata, trusted_root=trusted_root)
             tables.append(table)
 
         # Display in columns if terminal is wide enough
@@ -250,12 +295,19 @@ class ComparisonViewer:
                 self.console.print(table)
                 self.console.print()
 
-    def _create_image_info_table(self, index: int, metadata: ImageMetadata) -> Table:
+    def _create_image_info_table(
+        self,
+        index: int,
+        metadata: ImageMetadata,
+        *,
+        trusted_root: Path | None = None,
+    ) -> Table:
         """Create a table displaying image information.
 
         Args:
             index: Image number in comparison
             metadata: ImageMetadata object
+            trusted_root: Forwarded to ``_generate_ascii_preview``.
 
         Returns:
             Rich Table with image info
@@ -281,14 +333,19 @@ class ComparisonViewer:
         table.add_row("Full Path", str(metadata.path))
 
         # Add ASCII preview if terminal supports it
-        preview = self._generate_ascii_preview(metadata.path)
+        preview = self._generate_ascii_preview(metadata.path, trusted_root=trusted_root)
         if preview:
             table.add_row("Preview", preview)
 
         return table
 
     def _generate_ascii_preview(
-        self, image_path: Path, max_width: int = 40, max_height: int = 15
+        self,
+        image_path: Path,
+        max_width: int = 40,
+        max_height: int = 15,
+        *,
+        trusted_root: Path | None = None,
     ) -> str | None:
         """Generate ASCII art preview of image.
 
@@ -296,12 +353,14 @@ class ComparisonViewer:
             image_path: Path to image
             max_width: Maximum width in characters
             max_height: Maximum height in characters
+            trusted_root: Scan root for SafeDir anchoring; defers to
+                the parent-rooted fallback when ``None``.
 
         Returns:
             ASCII art string or None if preview fails
         """
         try:
-            with Image.open(image_path) as raw_img:
+            with safedir_image_open(image_path, trusted_root=trusted_root) as (raw_img, _fd):
                 # Convert to grayscale
                 img: Image.Image = raw_img.convert("L")
 
@@ -382,13 +441,20 @@ class ComparisonViewer:
                 self.console.print("[red]Invalid choice. Please try again.[/red]")
 
     def _process_user_action(
-        self, action: UserAction, metadata_list: list[ImageMetadata]
+        self,
+        action: UserAction,
+        metadata_list: list[ImageMetadata],
+        *,
+        trusted_root: Path | None = None,
     ) -> DuplicateReview:
         """Process user action and return review result.
 
         Args:
             action: UserAction enum value
             metadata_list: List of ImageMetadata
+            trusted_root: Forwarded to ``_auto_select_best`` so the
+                AUTO_SELECT branch's image re-open uses the same
+                SafeDir anchoring as the display.
 
         Returns:
             DuplicateReview with decisions
@@ -410,7 +476,9 @@ class ComparisonViewer:
                 return DuplicateReview([], [], skipped=True)
 
         elif action == UserAction.AUTO_SELECT:
-            return self._auto_select_best([m.path for m in metadata_list])
+            return self._auto_select_best(
+                [m.path for m in metadata_list], trusted_root=trusted_root
+            )
 
         elif action == UserAction.KEEP:
             # Prompt for which image to keep
@@ -433,7 +501,9 @@ class ComparisonViewer:
 
         return DuplicateReview([], [], skipped=True)
 
-    def _auto_select_best(self, images: list[Path]) -> DuplicateReview:
+    def _auto_select_best(
+        self, images: list[Path], *, trusted_root: Path | None = None
+    ) -> DuplicateReview:
         """Automatically select the best quality image.
 
         Chooses based on:
@@ -443,12 +513,17 @@ class ComparisonViewer:
 
         Args:
             images: List of image paths
+            trusted_root: Scan root for SafeDir anchoring; forwarded to
+                each ``_get_image_metadata`` re-open so the auto-select
+                path gets the same protection as the display path.
 
         Returns:
             DuplicateReview with best image kept, others marked for deletion
         """
         try:
-            metadata_list = [self._get_image_metadata(img) for img in images]
+            metadata_list = [
+                self._get_image_metadata(img, trusted_root=trusted_root) for img in images
+            ]
         except (OSError, ValueError) as e:
             self.console.print(f"[yellow]Warning: Could not auto-select: {e}[/yellow]")
             return DuplicateReview([], [], skipped=True)

--- a/src/services/search/hybrid_retriever.py
+++ b/src/services/search/hybrid_retriever.py
@@ -13,6 +13,8 @@ building.
 
 from __future__ import annotations
 
+import os
+import sys
 import threading
 from pathlib import Path
 
@@ -21,6 +23,7 @@ from loguru import logger
 from interfaces.search import RetrieverProtocol
 from services.search.bm25_index import BM25Index
 from services.search.vector_index import VectorIndex
+from utils.safedir import SafeDir, SymlinkRejected
 
 # ---------------------------------------------------------------------------
 # Corpus helpers (shared by API router and CLI)
@@ -39,20 +42,60 @@ def read_text_safe(path: Path, limit: int = CORPUS_TEXT_LIMIT) -> str:
     *limit* bytes, inspects the first :data:`CORPUS_BINARY_PEEK` bytes for
     null bytes (binary sentinel), then decodes.
 
+    The read goes through :class:`utils.safedir.SafeDir` on POSIX so a
+    symlink swapped in between corpus enumeration and this content read
+    is refused rather than dereferenced (closes the LLM-exfiltration
+    vector documented in #264). Windows / non-POSIX platforms fall back
+    to the legacy path-based open until the SafeDir Windows port lands.
+
     Args:
         path: File to read.
         limit: Maximum number of bytes to read (may yield fewer characters for
             multi-byte encodings).
 
     Returns:
-        Decoded text content, or an empty string if the file is binary or
-        unreadable.
+        Decoded text content, or an empty string if the file is binary,
+        unreadable, or a refused symlink.
     """
-    try:
-        with path.open("rb") as fh:
-            raw = fh.read(limit)
-    except OSError:
+    # Defensive clamp: a non-positive limit would make the underlying
+    # ``read(n)`` calls read the whole file, bypassing the corpus cap
+    # (search-generation-patterns S3). Callers today pass
+    # ``CORPUS_TEXT_LIMIT`` or smaller, but the guard keeps the API
+    # safe against future regressions.
+    if limit <= 0:
         return ""
+    limit = min(limit, CORPUS_TEXT_LIMIT)
+    raw: bytes | None = None
+    if sys.platform != "win32":
+        try:
+            with SafeDir.open_root(path.parent) as safe_dir:
+                fd = safe_dir.open_for_reader(path.name)
+                # fdopen takes ownership only once it returns; explicitly
+                # close the bare fd if fdopen itself raises.
+                try:
+                    fileobj = os.fdopen(fd, "rb", closefd=True)
+                except OSError:
+                    os.close(fd)
+                    raise
+                with fileobj:
+                    raw = fileobj.read(limit)
+        except SymlinkRejected as exc:
+            logger.warning("Refused to read symlinked file {}: {}", path, exc)
+            return ""
+        except NotImplementedError:
+            # SafeDir's POSIX primitives unavailable; fall through to
+            # legacy path-based open below.
+            logger.debug("SafeDir unavailable; using legacy reader for {}", path.name)
+        except (OSError, ValueError):
+            # ValueError covers SafeDir's name-validation rejection
+            # (filenames with backslash / NUL / path separators).
+            return ""
+    if raw is None:
+        try:
+            with path.open("rb") as fh:  # safedir: ok — Windows / NotImplementedError fallback
+                raw = fh.read(limit)
+        except OSError:
+            return ""
     peek_size = min(CORPUS_BINARY_PEEK, len(raw))
     if b"\x00" in raw[:peek_size]:
         return ""  # binary file — skip content extraction

--- a/src/services/text_processor.py
+++ b/src/services/text_processor.py
@@ -13,7 +13,7 @@ from models import TextModel
 from models.base import BaseModel, ModelConfig, ModelType
 from models.provider_factory import get_text_model
 from utils.file_readers import FileReadError, read_file
-from utils.readers import read_file_via_safedir
+from utils.readers import read_file_via_safedir, read_file_via_safedir_anchored
 from utils.safedir import SafeDir, SymlinkRejected
 from utils.text_processing import (
     clean_text,
@@ -122,6 +122,7 @@ class TextProcessor:
         generate_description: bool = True,
         generate_folder: bool = True,
         generate_filename: bool = True,
+        scan_root: str | Path | None = None,
     ) -> ProcessedFile:
         """Process a single text file.
 
@@ -130,6 +131,18 @@ class TextProcessor:
             generate_description: Whether to generate description
             generate_folder: Whether to generate folder name
             generate_filename: Whether to generate filename
+            scan_root: Optional anchor directory the caller walked to
+                find *file_path*. When provided, the SafeDir read uses
+                anchored traversal — every intermediate path component
+                between *scan_root* and *file_path* is opened with
+                ``O_NOFOLLOW`` so a symlink swapped into an ancestor
+                between the walk and this read is refused with
+                ``SymlinkRejected``. Closes the nested-ancestor TOCTOU
+                window (#286) that parent-rooted opening leaves open.
+                When ``None`` (default), falls back to parent-rooted
+                opening: only the final component is symlink-protected.
+                Pass *scan_root* whenever the caller has a meaningful
+                trusted root (the directory tree it walked).
 
         Returns:
             ProcessedFile with metadata
@@ -137,22 +150,28 @@ class TextProcessor:
         import time
 
         file_path = Path(file_path)
+        scan_root_path = Path(scan_root) if scan_root is not None else None
         start_time = time.time()
 
         try:
             # Read file content via SafeDir for the migrated extensions
             # (txt/md/docx/pdf/rtf/csv/xlsx/pptx — the LLM ingestion path).
-            # ``read_file_via_safedir`` opens with ``O_NOFOLLOW`` so a
-            # symlink swapped in between the directory walk and this read
-            # is refused rather than dereferenced — closes the LLM-
-            # exfiltration vector documented in #264. Other extensions
-            # fall back to the legacy path-based ``read_file`` until their
-            # readers are migrated in PR3b–PR3e.
+            # When ``scan_root`` is provided, ``read_file_via_safedir_anchored``
+            # walks each intermediate component with ``O_NOFOLLOW`` so a
+            # symlink swapped into ANY ancestor between the walk and this
+            # read is refused — closes both the final-component and the
+            # nested-ancestor TOCTOU windows for the LLM-exfiltration
+            # vector documented in #264. Without ``scan_root``, falls back
+            # to parent-rooted ``read_file_via_safedir`` (final-component
+            # protection only — same as PR3a–PR3i behaviour).
             logger.debug("Reading file: {}", file_path.name)
             content: str | None = None
             try:
-                with SafeDir.open_root(file_path.parent) as safe_dir:
-                    content = read_file_via_safedir(safe_dir, file_path.name)
+                if scan_root_path is not None:
+                    content = read_file_via_safedir_anchored(file_path, trusted_root=scan_root_path)
+                else:
+                    with SafeDir.open_root(file_path.parent) as safe_dir:
+                        content = read_file_via_safedir(safe_dir, file_path.name)
             except SymlinkRejected as exc:
                 logger.warning("Refused to read symlinked file {}: {}", file_path, exc)
                 return ProcessedFile(

--- a/src/services/text_processor.py
+++ b/src/services/text_processor.py
@@ -13,6 +13,8 @@ from models import TextModel
 from models.base import BaseModel, ModelConfig, ModelType
 from models.provider_factory import get_text_model
 from utils.file_readers import FileReadError, read_file
+from utils.readers import read_file_via_safedir
+from utils.safedir import SafeDir, SymlinkRejected
 from utils.text_processing import (
     clean_text,
     truncate_text,
@@ -138,9 +140,47 @@ class TextProcessor:
         start_time = time.time()
 
         try:
-            # Read file content
+            # Read file content via SafeDir for the migrated extensions
+            # (txt/md/docx/pdf/rtf/csv/xlsx/pptx — the LLM ingestion path).
+            # ``read_file_via_safedir`` opens with ``O_NOFOLLOW`` so a
+            # symlink swapped in between the directory walk and this read
+            # is refused rather than dereferenced — closes the LLM-
+            # exfiltration vector documented in #264. Other extensions
+            # fall back to the legacy path-based ``read_file`` until their
+            # readers are migrated in PR3b–PR3e.
             logger.debug("Reading file: {}", file_path.name)
-            content = read_file(file_path)
+            content: str | None = None
+            try:
+                with SafeDir.open_root(file_path.parent) as safe_dir:
+                    content = read_file_via_safedir(safe_dir, file_path.name)
+            except SymlinkRejected as exc:
+                logger.warning("Refused to read symlinked file {}: {}", file_path, exc)
+                return ProcessedFile(
+                    file_path=file_path,
+                    description="",
+                    folder_name="errors",
+                    filename=file_path.stem,
+                    error=f"Refused to read symlink: {file_path.name}",
+                )
+            except NotImplementedError:
+                # SafeDir requires POSIX dir_fd / O_NOFOLLOW; on Windows
+                # the Windows port is deferred (#264). Fall back to the
+                # legacy path-based reader so Windows users can still
+                # process .txt/.md/.pdf/.docx through TextProcessor.
+                # Tracked for follow-up in PR3b–PR3e.
+                logger.debug(
+                    "SafeDir unavailable on this platform; using legacy reader for {}",
+                    file_path.name,
+                )
+            if content is None:
+                # Either the SafeDir dispatcher returned ``None`` (extension
+                # not yet migrated — archives, ebooks, scientific, CAD,
+                # handled in PR3b–PR3e) OR SafeDir is unavailable (Windows).
+                # Real FS errors from the SafeDir branch propagate to the
+                # outer ``except FileReadError`` / ``except OSError``
+                # handlers — never silently masked by a path-based retry
+                # that could follow a symlink swapped in mid-flight.
+                content = read_file(file_path)
 
             if content is None:
                 return ProcessedFile(

--- a/src/utils/epub_enhanced.py
+++ b/src/utils/epub_enhanced.py
@@ -45,7 +45,61 @@ try:
 except ImportError:
     XMLParsedAsHTMLWarning = None  # type: ignore[assignment,misc]
 
+import os
+import sys
+
 from loguru import logger
+
+from utils.safedir import SafeDir, SymlinkRejected
+
+
+def _read_epub_safedir(file_path: Path) -> Any:
+    """Open *file_path* via SafeDir and pass the fileobj to ``epub.read_epub``.
+
+    On POSIX, opens the file with ``SafeDir.open_for_reader`` so a
+    symlink swapped into the directory between the walk and this read
+    is refused with ``SymlinkRejected`` (an ``OSError`` subclass)
+    rather than dereferenced — closes the symlink-following surface
+    in the enhanced-EPUB ingestion path (#264).
+
+    On Windows (where SafeDir's POSIX primitives raise
+    ``NotImplementedError``) falls back to direct
+    ``epub.read_epub(file_path)`` — preserves the legacy API.
+
+    Requires ``ebooklib>=0.20`` (verified in PR3c via #275) so the
+    fileobj branch of ``epub.read_epub`` works correctly; older
+    versions called ``os.path.isdir`` unconditionally on the input
+    and raised ``TypeError`` for file-likes.
+    """
+    if sys.platform == "win32":
+        return epub.read_epub(file_path)
+
+    # Narrowly catch NotImplementedError only around the SafeDir
+    # construction step. If ``epub.read_epub(fileobj)`` (or any
+    # downstream library code) raised NotImplementedError, an
+    # outer except would silently retry the same file through the
+    # path-based reader — reopening the symlink-following surface
+    # that this helper exists to close.
+    try:
+        safe_dir_cm = SafeDir.open_root(file_path.parent)
+    except NotImplementedError:
+        logger.debug("SafeDir unavailable; using legacy epub.read_epub for {}", file_path.name)
+        return epub.read_epub(file_path)
+
+    with safe_dir_cm as safe_dir:
+        fd = safe_dir.open_for_reader(file_path.name)
+        # fdopen takes ownership only once it returns; explicitly
+        # close the raw fd if fdopen itself raises.
+        try:
+            fileobj = os.fdopen(fd, "rb", closefd=True)
+        except OSError:
+            os.close(fd)
+            raise
+        with fileobj:
+            # ebooklib reads the ZIP synchronously; the returned EpubBook
+            # holds all content in memory before this returns, so closing
+            # fileobj on context exit is safe.
+            return epub.read_epub(fileobj)
 
 
 class EPUBProcessingError(Exception):
@@ -199,8 +253,13 @@ class EnhancedEPUBReader:
             raise FileNotFoundError(f"EPUB file not found: {file_path}")
 
         try:
-            book = epub.read_epub(file_path)
+            book = _read_epub_safedir(file_path)
             logger.debug(f"Successfully opened EPUB: {file_path.name}")
+        except SymlinkRejected:
+            # SafeDir refused a symlinked EPUB. Surface the security-
+            # specific OSError unchanged so callers can distinguish a
+            # refused symlink from an ordinary malformed EPUB.
+            raise
         except Exception as e:  # Intentional catch-all: ebooklib raises library-specific errors
             raise EPUBProcessingError(f"Failed to read EPUB file {file_path}: {e}") from e
 
@@ -610,8 +669,12 @@ class EnhancedEPUBReader:
                 output_dir = Path(output_dir)
                 output_dir.mkdir(parents=True, exist_ok=True)
 
-            # Determine file extension from content
-            img = Image.open(io.BytesIO(cover_data))
+            # Determine file extension from content.
+            # cover_data was already extracted from the EPUB via
+            # ebooklib (which read it via the SafeDir-routed
+            # _read_epub_safedir above), so the Image.open below
+            # consumes an in-memory BytesIO, not a path.
+            img = Image.open(io.BytesIO(cover_data))  # safedir: ok — in-memory bytes, not a path
             ext = img.format.lower() if img.format else "jpg"
 
             output_path = output_dir / f"{epub_path.stem}_cover.{ext}"
@@ -695,8 +758,13 @@ def get_epub_metadata(file_path: str | Path) -> EPUBMetadata:
     file_path = Path(file_path)
 
     try:
-        book = epub.read_epub(file_path)
+        book = _read_epub_safedir(file_path)
         reader = EnhancedEPUBReader()
         return reader._extract_metadata(book)
+    except SymlinkRejected:
+        # As in EnhancedEPUBReader.read_epub — let the SafeDir refusal
+        # propagate untouched so callers can distinguish symlink
+        # rejection from ordinary parsing failures.
+        raise
     except Exception as e:  # Intentional catch-all: ebooklib raises library-specific errors
         raise EPUBProcessingError(f"Failed to read EPUB metadata: {e}") from e

--- a/src/utils/readers/__init__.py
+++ b/src/utils/readers/__init__.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from loguru import logger
 
@@ -33,9 +32,6 @@ from utils.readers._base import (
     FileTooLargeError,
     _check_file_size,
 )
-
-if TYPE_CHECKING:
-    from utils.safedir import SafeDir
 from utils.readers.archives import (
     read_7z_file,
     read_rar_file,
@@ -63,6 +59,7 @@ from utils.readers.scientific import (
     read_mat_file,
     read_netcdf_file,
 )
+from utils.safedir import SafeDir
 
 __all__ = [
     # Exceptions / constants
@@ -72,6 +69,7 @@ __all__ = [
     # Dispatchers
     "read_file",
     "read_file_via_safedir",
+    "read_file_via_safedir_anchored",
     # Document readers
     "read_text_file",
     "read_docx_file",
@@ -270,5 +268,102 @@ def read_file_via_safedir(
 
     logger.debug(
         f"Extension {ext!r} not yet supported by read_file_via_safedir; caller may fall back"
+    )
+    return None
+
+
+def read_file_via_safedir_anchored(
+    file_path: Path,
+    *,
+    trusted_root: Path,
+    **kwargs: object,
+) -> str | None:
+    """Anchored-traversal variant of :func:`read_file_via_safedir`.
+
+    Walks ``file_path.relative_to(trusted_root)`` one component at a time
+    via :meth:`utils.safedir.SafeDir.open_anchored_reader`, so an ancestor
+    directory swapped to a symlink between enumeration and this read is
+    refused with :class:`utils.safedir.SymlinkRejected` rather than
+    silently dereferenced. Closes the nested-ancestor TOCTOU window
+    (#286) that the parent-rooted ``open_root(file_path.parent)`` pattern
+    leaves open.
+
+    Args:
+        file_path: Absolute path to the file to read. Must be inside
+            *trusted_root* (validated via :meth:`Path.relative_to`, which
+            raises ``ValueError`` otherwise).
+        trusted_root: The anchor directory whose contents are trusted —
+            typically the original scan / organize root the caller walked
+            to find *file_path*. Opened once via
+            :meth:`SafeDir.open_root`; subsequent components are
+            ``O_NOFOLLOW``-walked from there.
+        **kwargs: Forwarded to the dispatched reader.
+
+    Returns:
+        Extracted text content, or ``None`` if the extension isn't in the
+        SafeDir reader registry (mirrors
+        :func:`read_file_via_safedir`'s contract).
+
+    Raises:
+        ValueError: If *file_path* is not under *trusted_root*, or if any
+            component fails name validation.
+        utils.safedir.SymlinkRejected: If any path component (intermediate
+            or leaf) is a symlink at open time.
+        FileReadError: If the reader fails on the file content.
+        FileTooLargeError: If the file exceeds ``MAX_FILE_SIZE_BYTES``.
+
+    See Also:
+        :func:`read_file_via_safedir` — parent-rooted variant. Use this
+        anchored variant whenever the caller has a meaningful
+        ``trusted_root`` (the directory tree it walked); fall back to the
+        parent-rooted variant only for standalone reads without a walk
+        context.
+    """
+    # ``relative_to`` raises ValueError if file_path escapes trusted_root,
+    # which is itself a security violation worth surfacing — let it propagate.
+    relative = file_path.relative_to(trusted_root)
+
+    name_lower = file_path.name.lower()
+    if (
+        name_lower.endswith(".tar.gz")
+        or name_lower.endswith(".tar.bz2")
+        or name_lower.endswith(".tar.xz")
+    ):
+        compound_ext = "." + ".".join(file_path.name.split(".")[-2:]).lower()
+    else:
+        compound_ext = file_path.suffix.lower()
+    ext = file_path.suffix.lower()
+
+    for check_ext in [compound_ext, ext]:
+        for extensions, reader in _SAFEDIR_READERS.items():
+            if check_ext in extensions:
+                with SafeDir.open_root(trusted_root) as root:
+                    fd = root.open_anchored_reader(relative)
+                    # Split fdopen out so the raw fd is closed only when
+                    # ``fdopen`` itself fails to construct the file object
+                    # (e.g. EMFILE). Once ``fdopen`` returns, ``with fileobj``
+                    # owns the close — wrapping it in an outer try/except
+                    # that also calls ``os.close(fd)`` would double-close on
+                    # any exception inside the reader, masking the real error
+                    # with EBADF (Copilot review).
+                    try:
+                        fileobj = os.fdopen(fd, "rb", closefd=True)
+                    except OSError:
+                        os.close(fd)
+                        raise
+                    with fileobj:
+                        try:
+                            return reader(  # type: ignore[operator,no-any-return]
+                                file_path=Path(file_path.name),
+                                fileobj=fileobj,
+                                **kwargs,
+                            )
+                        except Exception as exc:
+                            logger.error(f"Error reading {file_path.name}: {exc}")
+                            raise
+
+    logger.debug(
+        f"Extension {ext!r} not yet supported by "
+        f"read_file_via_safedir_anchored; caller may fall back"
     )
     return None

--- a/src/utils/readers/__init__.py
+++ b/src/utils/readers/__init__.py
@@ -21,7 +21,9 @@ Example::
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from loguru import logger
 
@@ -31,6 +33,9 @@ from utils.readers._base import (
     FileTooLargeError,
     _check_file_size,
 )
+
+if TYPE_CHECKING:
+    from utils.safedir import SafeDir
 from utils.readers.archives import (
     read_7z_file,
     read_rar_file,
@@ -64,8 +69,9 @@ __all__ = [
     "FileReadError",
     "FileTooLargeError",
     "MAX_FILE_SIZE_BYTES",
-    # Dispatcher
+    # Dispatchers
     "read_file",
+    "read_file_via_safedir",
     # Document readers
     "read_text_file",
     "read_docx_file",
@@ -159,4 +165,86 @@ def read_file(file_path: str | Path, **kwargs: object) -> str | None:
                     raise
 
     logger.warning(f"Unsupported file type: {ext}")
+    return None
+
+
+# Readers that accept the SafeDir-friendly ``fileobj=`` kwarg. Migrated in
+# PR3a (#267): the LLM text-ingestion path — plain text, markdown, DOCX, PDF,
+# RTF, CSV/XLSX, and PowerPoint. Other readers (ebook, archives, scientific,
+# CAD) are still path-only and dispatch falls back to ``read_file`` (which
+# does not benefit from SafeDir's symlink rejection).
+_SAFEDIR_READERS: dict[tuple[str, ...], object] = {
+    (".txt", ".md"): read_text_file,
+    (".docx",): read_docx_file,
+    (".pdf",): read_pdf_file,
+    (".rtf",): read_rtf_file,
+    (".csv", ".xlsx", ".xls"): read_spreadsheet_file,
+    (".ppt", ".pptx"): read_presentation_file,
+}
+
+
+def read_file_via_safedir(
+    safe_dir: SafeDir,
+    name: str,
+    **kwargs: object,
+) -> str | None:
+    """Open *name* under *safe_dir* and dispatch to a reader.
+
+    The SafeDir-friendly entry point: ``safe_dir.open_for_reader(name)`` is
+    used to obtain a file descriptor with ``O_NOFOLLOW``, so a symlink
+    swapped in between directory enumeration and read is refused with
+    ``SymlinkRejected`` rather than dereferenced.
+
+    Args:
+        safe_dir: An open :class:`utils.safedir.SafeDir` for the parent
+            directory of *name*.
+        name: Single path component identifying the file inside *safe_dir*.
+        **kwargs: Additional arguments forwarded to the dispatched reader
+            (e.g. ``max_pages`` for PDF).
+
+    Returns:
+        Extracted text content, or ``None`` if the file extension isn't
+        currently supported via the SafeDir path (caller may choose to
+        fall back to legacy ``read_file`` or treat as unsupported). The
+        size-limit check uses ``os.fstat`` on the SafeDir-opened fd so
+        ``FileTooLargeError`` is raised before the reader receives the
+        stream.
+
+    Raises:
+        utils.safedir.SymlinkRejected: If *name* is a symlink.
+        ValueError: If *name* contains path separators or is reserved.
+        FileReadError: If the reader fails on the file content.
+        FileTooLargeError: If the file exceeds ``MAX_FILE_SIZE_BYTES``.
+    """
+    # Build a Path purely for extension parsing — never used for I/O.
+    name_path = Path(name)
+    name_lower = name.lower()
+    if (
+        name_lower.endswith(".tar.gz")
+        or name_lower.endswith(".tar.bz2")
+        or name_lower.endswith(".tar.xz")
+    ):
+        compound_ext = "." + ".".join(name_path.name.split(".")[-2:]).lower()
+    else:
+        compound_ext = name_path.suffix.lower()
+    ext = name_path.suffix.lower()
+
+    for check_ext in [compound_ext, ext]:
+        for extensions, reader in _SAFEDIR_READERS.items():
+            if check_ext in extensions:
+                fd = safe_dir.open_for_reader(name)
+                try:
+                    with os.fdopen(fd, "rb", closefd=True) as fileobj:
+                        return reader(  # type: ignore[operator,no-any-return]
+                            file_path=name_path,
+                            fileobj=fileobj,
+                            **kwargs,
+                        )
+                except Exception as exc:
+                    logger.error(f"Error reading {name}: {exc}")
+                    raise
+
+    logger.debug(
+        f"Extension {ext!r} not yet supported by read_file_via_safedir; caller may fall back"
+    )
     return None

--- a/src/utils/readers/__init__.py
+++ b/src/utils/readers/__init__.py
@@ -168,11 +168,16 @@ def read_file(file_path: str | Path, **kwargs: object) -> str | None:
     return None
 
 
-# Readers that accept the SafeDir-friendly ``fileobj=`` kwarg. Migrated in
-# PR3a (#267): the LLM text-ingestion path — plain text, markdown, DOCX, PDF,
-# RTF, CSV/XLSX, and PowerPoint. Other readers (ebook, archives, scientific,
-# CAD) are still path-only and dispatch falls back to ``read_file`` (which
-# does not benefit from SafeDir's symlink rejection).
+# Readers that accept the SafeDir-friendly ``fileobj=`` kwarg.
+#
+# Migrated in PR3a (#267): the LLM text-ingestion path — plain text, markdown,
+# DOCX, PDF, RTF, CSV/XLSX, and PowerPoint.
+#
+# Migrated in PR3b (#267): archive readers — ZIP, 7Z, TAR (incl. compound
+# extensions like ``.tar.gz``/``.tar.bz2``/``.tar.xz``), and RAR.
+#
+# Remaining path-only readers (ebook, scientific, CAD) dispatch falls back to
+# ``read_file`` and does not benefit from SafeDir's symlink rejection.
 _SAFEDIR_READERS: dict[tuple[str, ...], object] = {
     (".txt", ".md"): read_text_file,
     (".docx",): read_docx_file,
@@ -180,6 +185,10 @@ _SAFEDIR_READERS: dict[tuple[str, ...], object] = {
     (".rtf",): read_rtf_file,
     (".csv", ".xlsx", ".xls"): read_spreadsheet_file,
     (".ppt", ".pptx"): read_presentation_file,
+    (".zip",): read_zip_file,
+    (".7z",): read_7z_file,
+    (".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz"): read_tar_file,
+    (".rar",): read_rar_file,
 }
 
 

--- a/src/utils/readers/__init__.py
+++ b/src/utils/readers/__init__.py
@@ -176,8 +176,13 @@ def read_file(file_path: str | Path, **kwargs: object) -> str | None:
 # Migrated in PR3b (#267): archive readers — ZIP, 7Z, TAR (incl. compound
 # extensions like ``.tar.gz``/``.tar.bz2``/``.tar.xz``), and RAR.
 #
-# Remaining path-only readers (ebook, scientific, CAD) dispatch falls back to
-# ``read_file`` and does not benefit from SafeDir's symlink rejection.
+# Migrated in PR3c (#267): ebook (EPUB) and scientific (HDF5, NetCDF, MAT)
+# readers. NetCDF buffers the stream into memory via ``memory=`` because the
+# netCDF4 C extension doesn't accept file-likes directly; size is capped by
+# ``_check_fd_size`` before the buffer is materialised.
+#
+# Remaining path-only readers (CAD) dispatch falls back to ``read_file`` and
+# does not benefit from SafeDir's symlink rejection.
 _SAFEDIR_READERS: dict[tuple[str, ...], object] = {
     (".txt", ".md"): read_text_file,
     (".docx",): read_docx_file,
@@ -189,6 +194,10 @@ _SAFEDIR_READERS: dict[tuple[str, ...], object] = {
     (".7z",): read_7z_file,
     (".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2", ".tar.xz"): read_tar_file,
     (".rar",): read_rar_file,
+    (".epub",): read_ebook_file,
+    (".hdf5", ".h5", ".hdf"): read_hdf5_file,
+    (".nc", ".nc4", ".netcdf"): read_netcdf_file,
+    (".mat",): read_mat_file,
 }
 
 

--- a/src/utils/readers/__init__.py
+++ b/src/utils/readers/__init__.py
@@ -181,8 +181,10 @@ def read_file(file_path: str | Path, **kwargs: object) -> str | None:
 # netCDF4 C extension doesn't accept file-likes directly; size is capped by
 # ``_check_fd_size`` before the buffer is materialised.
 #
-# Remaining path-only readers (CAD) dispatch falls back to ``read_file`` and
-# does not benefit from SafeDir's symlink rejection.
+# Migrated in PR3d (#267): CAD readers — DXF, DWG, STEP, IGES. ezdxf takes a
+# text stream via ``ezdxf.read()`` (binary fileobj is wrapped in
+# ``io.TextIOWrapper``); STEP and IGES are ASCII text formats decoded the
+# same way.
 _SAFEDIR_READERS: dict[tuple[str, ...], object] = {
     (".txt", ".md"): read_text_file,
     (".docx",): read_docx_file,
@@ -198,6 +200,10 @@ _SAFEDIR_READERS: dict[tuple[str, ...], object] = {
     (".hdf5", ".h5", ".hdf"): read_hdf5_file,
     (".nc", ".nc4", ".netcdf"): read_netcdf_file,
     (".mat",): read_mat_file,
+    (".dxf",): read_dxf_file,
+    (".dwg",): read_dwg_file,
+    (".step", ".stp"): read_step_file,
+    (".iges", ".igs"): read_iges_file,
 }
 
 

--- a/src/utils/readers/__init__.py
+++ b/src/utils/readers/__init__.py
@@ -255,16 +255,26 @@ def read_file_via_safedir(
         for extensions, reader in _SAFEDIR_READERS.items():
             if check_ext in extensions:
                 fd = safe_dir.open_for_reader(name)
+                # Split fdopen out so the raw fd is closed only when
+                # ``fdopen`` itself fails (e.g. EMFILE under fd exhaustion).
+                # Mirrors the anchored variant below; collapsing this back
+                # into a single ``try/with`` would leak the fd if fdopen
+                # raises before the with-block takes ownership.
                 try:
-                    with os.fdopen(fd, "rb", closefd=True) as fileobj:
+                    fileobj = os.fdopen(fd, "rb", closefd=True)
+                except OSError:
+                    os.close(fd)
+                    raise
+                with fileobj:
+                    try:
                         return reader(  # type: ignore[operator,no-any-return]
                             file_path=name_path,
                             fileobj=fileobj,
                             **kwargs,
                         )
-                except Exception as exc:
-                    logger.error(f"Error reading {name}: {exc}")
-                    raise
+                    except Exception as exc:
+                        logger.error(f"Error reading {name}: {exc}")
+                        raise
 
     logger.debug(
         f"Extension {ext!r} not yet supported by read_file_via_safedir; caller may fall back"

--- a/src/utils/readers/_base.py
+++ b/src/utils/readers/_base.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from typing import BinaryIO
 
 
 class FileReadError(Exception):
@@ -39,4 +41,31 @@ def _check_file_size(file_path: Path, max_bytes: int = MAX_FILE_SIZE_BYTES) -> N
         limit_mb = max_bytes / (1024 * 1024)
         raise FileTooLargeError(
             f"File too large to process: {mb:.1f} MB (limit: {limit_mb:.0f} MB): {file_path}"
+        )
+
+
+def _check_fd_size(fileobj: BinaryIO, max_bytes: int = MAX_FILE_SIZE_BYTES) -> None:
+    """Raise FileTooLargeError if the file behind *fileobj* exceeds max_bytes.
+
+    Uses ``os.fstat`` on the underlying fd — avoids re-resolving the path
+    (which could be intercepted between a previous ``lstat`` and now).
+    Falls back silently if the fileobj doesn't expose ``fileno()`` (e.g.
+    in-memory ``BytesIO`` used in tests); the reader's downstream parse
+    will raise its own error if the content is truly oversized.
+    """
+    try:
+        fd = fileobj.fileno()
+    except (AttributeError, OSError, ValueError):
+        # In-memory wrappers (``BytesIO``) raise ``io.UnsupportedOperation``
+        # which subclasses both ``OSError`` and ``ValueError`` — be liberal.
+        return
+    try:
+        size = os.fstat(fd).st_size
+    except OSError:
+        return
+    if size > max_bytes:
+        mb = size / (1024 * 1024)
+        limit_mb = max_bytes / (1024 * 1024)
+        raise FileTooLargeError(
+            f"File too large to process: {mb:.1f} MB (limit: {limit_mb:.0f} MB)"
         )

--- a/src/utils/readers/archives.py
+++ b/src/utils/readers/archives.py
@@ -1,11 +1,22 @@
 # pyre-ignore-all-errors
-"""Readers for archive formats: ZIP, 7Z, TAR, RAR."""
+"""Readers for archive formats: ZIP, 7Z, TAR, RAR.
+
+Each public ``read_X_file`` function accepts either a path (legacy) or an
+open binary file-like via the ``fileobj`` keyword. The file-like path is the
+SafeDir-friendly entry point: callers open via ``SafeDir.open_for_reader``,
+wrap in ``os.fdopen(fd, "rb")``, and hand to the reader. Path-based callers
+continue to work unchanged.
+
+The underlying parse logic lives in private ``_parse_X`` helpers so the
+fileobj and path branches share a single implementation.
+"""
 
 from __future__ import annotations
 
 import tarfile
 import zipfile
 from pathlib import Path
+from typing import BinaryIO
 
 try:
     import py7zr
@@ -23,77 +34,145 @@ except ImportError:
 
 from loguru import logger
 
-from utils.readers._base import FileReadError
+from utils.readers._base import FileReadError, _check_fd_size
 
 
-def read_zip_file(file_path: str | Path, max_files: int = 50) -> str:
+def _parse_zip(fileobj: BinaryIO, max_files: int, label: str) -> str:
+    with zipfile.ZipFile(fileobj, "r") as zf:
+        # Cache infolist() so the archive is iterated only once
+        entries = zf.infolist()
+        info_list = entries[:max_files]
+
+        # Calculate statistics
+        total_files = len(entries)
+        total_compressed = sum(info.compress_size for info in entries)
+        total_uncompressed = sum(info.file_size for info in entries)
+        compression_ratio = (
+            (1 - total_compressed / total_uncompressed) * 100 if total_uncompressed > 0 else 0
+        )
+
+        # Check for encryption
+        encrypted = any(info.flag_bits & 0x1 for info in entries)
+
+        # Build metadata string
+        lines = [
+            f"ZIP Archive: {label}",
+            f"Total files: {total_files}",
+            f"Compressed size: {total_compressed / 1024:.2f} KB",
+            f"Uncompressed size: {total_uncompressed / 1024:.2f} KB",
+            f"Compression ratio: {compression_ratio:.1f}%",
+            f"Encrypted: {'Yes' if encrypted else 'No'}",
+            f"\nFiles (first {min(max_files, total_files)}):",
+        ]
+
+        # List files
+        for info in info_list:
+            size_kb = info.file_size / 1024
+            compressed_kb = info.compress_size / 1024
+            lines.append(f"  - {info.filename} ({size_kb:.2f} KB → {compressed_kb:.2f} KB)")
+
+        if total_files > max_files:
+            lines.append(f"  ... and {total_files - max_files} more files")
+
+        text = "\n".join(lines)
+        logger.debug(f"Extracted metadata from ZIP archive {label} ({total_files} files)")
+        return text
+
+
+def read_zip_file(
+    file_path: str | Path | None = None,
+    max_files: int = 50,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read contents and metadata from a ZIP archive.
 
     Args:
-        file_path: Path to ZIP file
+        file_path: Path to ZIP file (legacy entry point).
         max_files: Maximum number of files to list
+        fileobj: Open binary file-like (SafeDir-friendly entry point). When
+            given, ``file_path`` is used only for the log label.
 
     Returns:
         String with archive metadata and file listing
 
     Raises:
         FileReadError: If file cannot be read
+        FileTooLargeError: If the file behind ``fileobj`` exceeds the limit.
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
     max_files = max(0, int(max_files))
-    file_path = Path(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        # Size check outside the try so ``FileTooLargeError`` propagates.
+        _check_fd_size(fileobj)
+        try:
+            return _parse_zip(fileobj, max_files, label)
+        except Exception as e:  # Intentional catch-all: zipfile raises library-specific errors
+            raise FileReadError(f"Failed to read ZIP file {label}: {e}") from e
+    if file_path is None:
+        raise ValueError("read_zip_file requires file_path or fileobj")
+    path = Path(file_path)
     try:
-        with zipfile.ZipFile(file_path, "r") as zf:
-            # Cache infolist() so the archive is iterated only once
-            entries = zf.infolist()
-            info_list = entries[:max_files]
-
-            # Calculate statistics
-            total_files = len(entries)
-            total_compressed = sum(info.compress_size for info in entries)
-            total_uncompressed = sum(info.file_size for info in entries)
-            compression_ratio = (
-                (1 - total_compressed / total_uncompressed) * 100 if total_uncompressed > 0 else 0
-            )
-
-            # Check for encryption
-            encrypted = any(info.flag_bits & 0x1 for info in entries)
-
-            # Build metadata string
-            lines = [
-                f"ZIP Archive: {file_path.name}",
-                f"Total files: {total_files}",
-                f"Compressed size: {total_compressed / 1024:.2f} KB",
-                f"Uncompressed size: {total_uncompressed / 1024:.2f} KB",
-                f"Compression ratio: {compression_ratio:.1f}%",
-                f"Encrypted: {'Yes' if encrypted else 'No'}",
-                f"\nFiles (first {min(max_files, total_files)}):",
-            ]
-
-            # List files
-            for info in info_list:
-                size_kb = info.file_size / 1024
-                compressed_kb = info.compress_size / 1024
-                lines.append(f"  - {info.filename} ({size_kb:.2f} KB → {compressed_kb:.2f} KB)")
-
-            if total_files > max_files:
-                lines.append(f"  ... and {total_files - max_files} more files")
-
-            text = "\n".join(lines)
-            logger.debug(
-                f"Extracted metadata from ZIP archive {file_path.name} ({total_files} files)"
-            )
-            return text
-
+        with path.open("rb") as f:
+            return _parse_zip(f, max_files, path.name)
     except Exception as e:  # Intentional catch-all: zipfile raises library-specific errors
-        raise FileReadError(f"Failed to read ZIP file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read ZIP file {path}: {e}") from e
 
 
-def read_7z_file(file_path: str | Path, max_files: int = 50) -> str:
+def _parse_7z(fileobj: BinaryIO, max_files: int, label: str) -> str:
+    with py7zr.SevenZipFile(fileobj, "r") as archive:
+        all_files = archive.list()
+
+        # Calculate statistics
+        total_files = len(all_files)
+        total_compressed = sum(f.compressed or 0 for f in all_files)
+        total_uncompressed = sum(f.uncompressed or 0 for f in all_files)
+        compression_ratio = (
+            (1 - total_compressed / total_uncompressed) * 100 if total_uncompressed > 0 else 0
+        )
+
+        # Check for encryption
+        encrypted = archive.password_protected if hasattr(archive, "password_protected") else False
+
+        # Build metadata string
+        lines = [
+            f"7Z Archive: {label}",
+            f"Total files: {total_files}",
+            f"Compressed size: {total_compressed / 1024:.2f} KB",
+            f"Uncompressed size: {total_uncompressed / 1024:.2f} KB",
+            f"Compression ratio: {compression_ratio:.1f}%",
+            f"Encrypted: {'Yes' if encrypted else 'No'}",
+            f"\nFiles (first {min(max_files, total_files)}):",
+        ]
+
+        # List files
+        for file_info in all_files[:max_files]:
+            size_kb = (file_info.uncompressed or 0) / 1024
+            compressed_kb = (file_info.compressed or 0) / 1024
+            lines.append(f"  - {file_info.filename} ({size_kb:.2f} KB → {compressed_kb:.2f} KB)")
+
+        if total_files > max_files:
+            lines.append(f"  ... and {total_files - max_files} more files")
+
+        text = "\n".join(lines)
+        logger.debug(f"Extracted metadata from 7Z archive {label} ({total_files} files)")
+        return text
+
+
+def read_7z_file(
+    file_path: str | Path | None = None,
+    max_files: int = 50,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read contents and metadata from a 7Z archive.
 
     Args:
-        file_path: Path to 7Z file
+        file_path: Path to 7Z file (legacy entry point).
         max_files: Maximum number of files to list
+        fileobj: Open binary file-like (SafeDir-friendly entry point). When
+            given, ``file_path`` is used only for the log label.
 
     Returns:
         String with archive metadata and file listing
@@ -101,130 +180,187 @@ def read_7z_file(file_path: str | Path, max_files: int = 50) -> str:
     Raises:
         FileReadError: If file cannot be read
         ImportError: If py7zr is not installed
+        FileTooLargeError: If the file behind ``fileobj`` exceeds the limit.
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
     if not PY7ZR_AVAILABLE:
         raise ImportError("py7zr is not installed. Install with: pip install py7zr")
 
     max_files = max(0, int(max_files))
-    file_path = Path(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        _check_fd_size(fileobj)
+        try:
+            return _parse_7z(fileobj, max_files, label)
+        except Exception as e:  # Intentional catch-all: py7zr raises library-specific errors
+            raise FileReadError(f"Failed to read 7Z file {label}: {e}") from e
+    if file_path is None:
+        raise ValueError("read_7z_file requires file_path or fileobj")
+    path = Path(file_path)
     try:
-        with py7zr.SevenZipFile(file_path, "r") as archive:
-            all_files = archive.list()
-
-            # Calculate statistics
-            total_files = len(all_files)
-            total_compressed = sum(f.compressed or 0 for f in all_files)
-            total_uncompressed = sum(f.uncompressed or 0 for f in all_files)
-            compression_ratio = (
-                (1 - total_compressed / total_uncompressed) * 100 if total_uncompressed > 0 else 0
-            )
-
-            # Check for encryption
-            encrypted = (
-                archive.password_protected if hasattr(archive, "password_protected") else False
-            )
-
-            # Build metadata string
-            lines = [
-                f"7Z Archive: {file_path.name}",
-                f"Total files: {total_files}",
-                f"Compressed size: {total_compressed / 1024:.2f} KB",
-                f"Uncompressed size: {total_uncompressed / 1024:.2f} KB",
-                f"Compression ratio: {compression_ratio:.1f}%",
-                f"Encrypted: {'Yes' if encrypted else 'No'}",
-                f"\nFiles (first {min(max_files, total_files)}):",
-            ]
-
-            # List files
-            for file_info in all_files[:max_files]:
-                size_kb = (file_info.uncompressed or 0) / 1024
-                compressed_kb = (file_info.compressed or 0) / 1024
-                lines.append(
-                    f"  - {file_info.filename} ({size_kb:.2f} KB → {compressed_kb:.2f} KB)"
-                )
-
-            if total_files > max_files:
-                lines.append(f"  ... and {total_files - max_files} more files")
-
-            text = "\n".join(lines)
-            logger.debug(
-                f"Extracted metadata from 7Z archive {file_path.name} ({total_files} files)"
-            )
-            return text
-
+        with path.open("rb") as f:
+            return _parse_7z(f, max_files, path.name)
     except Exception as e:  # Intentional catch-all: py7zr raises library-specific errors
-        raise FileReadError(f"Failed to read 7Z file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read 7Z file {path}: {e}") from e
 
 
-def read_tar_file(file_path: str | Path, max_files: int = 50) -> str:
-    """Read contents and metadata from a TAR/GZ/BZ2 archive.
+def _detect_tar_compression(name_lower: str) -> str:
+    """Return the compression label shown in tar metadata.
+
+    Derived from the filename, not the magic bytes — matches legacy behavior.
+    ``<fileobj>`` (the default label when no path was supplied) reports
+    ``"Unknown"`` rather than the misleading ``"None"``.
+    """
+    if name_lower.endswith(".tar.gz") or name_lower.endswith(".tgz"):
+        return "GZ"
+    if name_lower.endswith(".tar.bz2") or name_lower.endswith(".tbz2"):
+        return "BZ2"
+    if name_lower.endswith(".tar.xz") or name_lower.endswith(".xz"):
+        return "XZ"
+    if name_lower.endswith(".tar"):
+        return "None"
+    # Caller did not supply a usable filename (e.g. direct fileobj= without
+    # file_path=). tarfile itself auto-detects the underlying stream below;
+    # we just can't display the type in the metadata header.
+    return "Unknown"
+
+
+def _parse_tar(fileobj: BinaryIO, max_files: int, label: str) -> str:
+    # ``mode="r:*"`` auto-detects compression from the stream's magic bytes
+    # (gz / bz2 / xz / plain); requires the fileobj to be seekable, which
+    # both ``path.open("rb")`` and ``os.fdopen(SafeDir fd, "rb")`` are.
+    with tarfile.open(fileobj=fileobj, mode="r:*") as tf:
+        members = tf.getmembers()
+
+        # Calculate statistics
+        total_files = len([m for m in members if m.isfile()])
+        total_dirs = len([m for m in members if m.isdir()])
+        total_size = sum(m.size for m in members if m.isfile())
+
+        compression_type = _detect_tar_compression(label.lower())
+
+        # Build metadata string
+        lines = [
+            f"TAR Archive: {label}",
+            f"Compression: {compression_type}",
+            f"Total files: {total_files}",
+            f"Total directories: {total_dirs}",
+            f"Total size: {total_size / 1024:.2f} KB",
+            f"\nFiles (first {min(max_files, total_files)}):",
+        ]
+
+        # List files (skip directories)
+        file_members = [m for m in members if m.isfile()][:max_files]
+        for member in file_members:
+            size_kb = member.size / 1024
+            lines.append(f"  - {member.name} ({size_kb:.2f} KB)")
+
+        if total_files > max_files:
+            lines.append(f"  ... and {total_files - max_files} more files")
+
+        text = "\n".join(lines)
+        logger.debug(f"Extracted metadata from TAR archive {label} ({total_files} files)")
+        return text
+
+
+def read_tar_file(
+    file_path: str | Path | None = None,
+    max_files: int = 50,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
+    """Read contents and metadata from a TAR/GZ/BZ2/XZ archive.
 
     Args:
-        file_path: Path to TAR file (.tar, .tar.gz, .tgz, .tar.bz2)
+        file_path: Path to TAR file (``.tar``, ``.tar.gz`` / ``.tgz``,
+            ``.tar.bz2`` / ``.tbz2``, ``.tar.xz`` / ``.xz``). Used as
+            the compression-type hint when ``fileobj`` is supplied.
         max_files: Maximum number of files to list
+        fileobj: Open binary file-like (SafeDir-friendly entry point). The
+            stream must be seekable (file fds and ``BytesIO`` both qualify);
+            compression is auto-detected from the magic bytes by ``tarfile``
+            itself, while the displayed compression type still derives from
+            the filename hint.
 
     Returns:
         String with archive metadata and file listing
 
     Raises:
         FileReadError: If file cannot be read
+        FileTooLargeError: If the file behind ``fileobj`` exceeds the limit.
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
     max_files = max(0, int(max_files))
-    file_path = Path(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        _check_fd_size(fileobj)
+        try:
+            return _parse_tar(fileobj, max_files, label)
+        except Exception as e:  # Intentional catch-all: tarfile raises library-specific errors
+            raise FileReadError(f"Failed to read TAR file {label}: {e}") from e
+    if file_path is None:
+        raise ValueError("read_tar_file requires file_path or fileobj")
+    path = Path(file_path)
     try:
-        with tarfile.open(file_path, "r:*") as tf:
-            members = tf.getmembers()
-
-            # Calculate statistics
-            total_files = len([m for m in members if m.isfile()])
-            total_dirs = len([m for m in members if m.isdir()])
-            total_size = sum(m.size for m in members if m.isfile())
-
-            # Determine compression type using name.endswith for compound extensions
-            _name = file_path.name.lower()
-            compression_type = "None"
-            if _name.endswith(".tar.gz") or _name.endswith(".tgz"):
-                compression_type = "GZ"
-            elif _name.endswith(".tar.bz2") or _name.endswith(".tbz2"):
-                compression_type = "BZ2"
-            elif _name.endswith(".tar.xz") or _name.endswith(".xz"):
-                compression_type = "XZ"
-
-            # Build metadata string
-            lines = [
-                f"TAR Archive: {file_path.name}",
-                f"Compression: {compression_type}",
-                f"Total files: {total_files}",
-                f"Total directories: {total_dirs}",
-                f"Total size: {total_size / 1024:.2f} KB",
-                f"\nFiles (first {min(max_files, total_files)}):",
-            ]
-
-            # List files (skip directories)
-            file_members = [m for m in members if m.isfile()][:max_files]
-            for member in file_members:
-                size_kb = member.size / 1024
-                lines.append(f"  - {member.name} ({size_kb:.2f} KB)")
-
-            if total_files > max_files:
-                lines.append(f"  ... and {total_files - max_files} more files")
-
-            text = "\n".join(lines)
-            logger.debug(
-                f"Extracted metadata from TAR archive {file_path.name} ({total_files} files)"
-            )
-            return text
-
+        with path.open("rb") as f:
+            return _parse_tar(f, max_files, path.name)
     except Exception as e:  # Intentional catch-all: tarfile raises library-specific errors
-        raise FileReadError(f"Failed to read TAR file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read TAR file {path}: {e}") from e
 
 
-def read_rar_file(file_path: str | Path, max_files: int = 50) -> str:
+def _parse_rar(fileobj: BinaryIO, max_files: int, label: str) -> str:
+    with rarfile.RarFile(fileobj, "r") as rf:
+        info_list = rf.infolist()
+
+        # Calculate statistics
+        total_files = len(info_list)
+        total_compressed = sum(info.compress_size for info in info_list)
+        total_uncompressed = sum(info.file_size for info in info_list)
+        compression_ratio = (
+            (1 - total_compressed / total_uncompressed) * 100 if total_uncompressed > 0 else 0
+        )
+
+        # Check for encryption
+        encrypted = rf.needs_password()
+
+        # Build metadata string
+        lines = [
+            f"RAR Archive: {label}",
+            f"Total files: {total_files}",
+            f"Compressed size: {total_compressed / 1024:.2f} KB",
+            f"Uncompressed size: {total_uncompressed / 1024:.2f} KB",
+            f"Compression ratio: {compression_ratio:.1f}%",
+            f"Encrypted: {'Yes' if encrypted else 'No'}",
+            f"\nFiles (first {min(max_files, total_files)}):",
+        ]
+
+        # List files
+        for info in info_list[:max_files]:
+            size_kb = info.file_size / 1024
+            compressed_kb = info.compress_size / 1024
+            lines.append(f"  - {info.filename} ({size_kb:.2f} KB → {compressed_kb:.2f} KB)")
+
+        if total_files > max_files:
+            lines.append(f"  ... and {total_files - max_files} more files")
+
+        text = "\n".join(lines)
+        logger.debug(f"Extracted metadata from RAR archive {label} ({total_files} files)")
+        return text
+
+
+def read_rar_file(
+    file_path: str | Path | None = None,
+    max_files: int = 50,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read contents and metadata from a RAR archive.
 
     Args:
-        file_path: Path to RAR file
+        file_path: Path to RAR file (legacy entry point).
         max_files: Maximum number of files to list
+        fileobj: Open binary file-like (SafeDir-friendly entry point). When
+            given, ``file_path`` is used only for the log label.
 
     Returns:
         String with archive metadata and file listing
@@ -232,6 +368,8 @@ def read_rar_file(file_path: str | Path, max_files: int = 50) -> str:
     Raises:
         FileReadError: If file cannot be read
         ImportError: If rarfile is not installed
+        FileTooLargeError: If the file behind ``fileobj`` exceeds the limit.
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
     if not RARFILE_AVAILABLE:
         raise ImportError(
@@ -240,52 +378,28 @@ def read_rar_file(file_path: str | Path, max_files: int = 50) -> str:
         )
 
     max_files = max(0, int(max_files))
-    file_path = Path(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        _check_fd_size(fileobj)
+        try:
+            return _parse_rar(fileobj, max_files, label)
+        except rarfile.RarCannotExec as e:
+            raise FileReadError(
+                f"Failed to read RAR file {label}: unrar tool not found. "
+                "Install the unrar command-line tool to extract RAR archives."
+            ) from e
+        except Exception as e:  # Intentional catch-all: rarfile raises library-specific errors
+            raise FileReadError(f"Failed to read RAR file {label}: {e}") from e
+    if file_path is None:
+        raise ValueError("read_rar_file requires file_path or fileobj")
+    path = Path(file_path)
     try:
-        with rarfile.RarFile(file_path, "r") as rf:
-            info_list = rf.infolist()
-
-            # Calculate statistics
-            total_files = len(info_list)
-            total_compressed = sum(info.compress_size for info in info_list)
-            total_uncompressed = sum(info.file_size for info in info_list)
-            compression_ratio = (
-                (1 - total_compressed / total_uncompressed) * 100 if total_uncompressed > 0 else 0
-            )
-
-            # Check for encryption
-            encrypted = rf.needs_password()
-
-            # Build metadata string
-            lines = [
-                f"RAR Archive: {file_path.name}",
-                f"Total files: {total_files}",
-                f"Compressed size: {total_compressed / 1024:.2f} KB",
-                f"Uncompressed size: {total_uncompressed / 1024:.2f} KB",
-                f"Compression ratio: {compression_ratio:.1f}%",
-                f"Encrypted: {'Yes' if encrypted else 'No'}",
-                f"\nFiles (first {min(max_files, total_files)}):",
-            ]
-
-            # List files
-            for info in info_list[:max_files]:
-                size_kb = info.file_size / 1024
-                compressed_kb = info.compress_size / 1024
-                lines.append(f"  - {info.filename} ({size_kb:.2f} KB → {compressed_kb:.2f} KB)")
-
-            if total_files > max_files:
-                lines.append(f"  ... and {total_files - max_files} more files")
-
-            text = "\n".join(lines)
-            logger.debug(
-                f"Extracted metadata from RAR archive {file_path.name} ({total_files} files)"
-            )
-            return text
-
+        with path.open("rb") as f:
+            return _parse_rar(f, max_files, path.name)
     except rarfile.RarCannotExec as e:
         raise FileReadError(
-            f"Failed to read RAR file {file_path}: unrar tool not found. "
+            f"Failed to read RAR file {path}: unrar tool not found. "
             "Install the unrar command-line tool to extract RAR archives."
         ) from e
     except Exception as e:  # Intentional catch-all: rarfile raises library-specific errors
-        raise FileReadError(f"Failed to read RAR file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read RAR file {path}: {e}") from e

--- a/src/utils/readers/archives.py
+++ b/src/utils/readers/archives.py
@@ -114,7 +114,9 @@ def read_zip_file(
         raise ValueError("read_zip_file requires file_path or fileobj")
     path = Path(file_path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _parse_zip(f, max_files, path.name)
     except Exception as e:  # Intentional catch-all: zipfile raises library-specific errors
         raise FileReadError(f"Failed to read ZIP file {path}: {e}") from e
@@ -198,7 +200,9 @@ def read_7z_file(
         raise ValueError("read_7z_file requires file_path or fileobj")
     path = Path(file_path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _parse_7z(f, max_files, path.name)
     except Exception as e:  # Intentional catch-all: py7zr raises library-specific errors
         raise FileReadError(f"Failed to read 7Z file {path}: {e}") from e
@@ -302,7 +306,9 @@ def read_tar_file(
         raise ValueError("read_tar_file requires file_path or fileobj")
     path = Path(file_path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _parse_tar(f, max_files, path.name)
     except Exception as e:  # Intentional catch-all: tarfile raises library-specific errors
         raise FileReadError(f"Failed to read TAR file {path}: {e}") from e
@@ -394,7 +400,9 @@ def read_rar_file(
         raise ValueError("read_rar_file requires file_path or fileobj")
     path = Path(file_path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _parse_rar(f, max_files, path.name)
     except rarfile.RarCannotExec as e:
         raise FileReadError(

--- a/src/utils/readers/cad.py
+++ b/src/utils/readers/cad.py
@@ -1,10 +1,27 @@
 # pyre-ignore-all-errors
-"""Readers for CAD formats: DXF, DWG, STEP, IGES."""
+"""Readers for CAD formats: DXF, DWG, STEP, IGES.
+
+Each public ``read_X_file`` function accepts either a path (legacy) or an
+open binary file-like via the ``fileobj`` keyword. The file-like path is
+the SafeDir-friendly entry point: callers open via
+``SafeDir.open_for_reader``, wrap in ``os.fdopen(fd, "rb")``, and hand to
+the reader.
+
+Library-specific notes:
+
+- ``ezdxf.readfile`` takes a path; ``ezdxf.read`` takes a **text** stream.
+  The fileobj branch wraps the binary fileobj in ``io.TextIOWrapper``
+  before handing it to ``ezdxf.read``.
+- STEP and IGES are plain ASCII text formats; the fileobj branch wraps
+  the binary fileobj in ``io.TextIOWrapper`` and reads as text.
+"""
 
 from __future__ import annotations
 
+import io
+import os
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO
 
 try:
     import ezdxf
@@ -15,18 +32,19 @@ except ImportError:
 
 from loguru import logger
 
-from utils.readers._base import FileReadError, _check_file_size
+from utils.readers._base import FileReadError, _check_fd_size, _check_file_size
 
 
-def _process_dxf_doc(doc: Any, file_path: Path, max_layers: int = 20) -> str:
+def _process_dxf_doc(doc: Any, label: str, max_layers: int = 20) -> str:
     """Extract metadata from an already-loaded ezdxf document.
 
     Shared by :func:`read_dxf_file` and :func:`read_dwg_file` so the file is
     opened only once even when a DWG read falls back to the DXF path.
 
     Args:
-        doc: An ezdxf document object returned by ``ezdxf.readfile()``.
-        file_path: Original file path (used only for the log message).
+        doc: An ezdxf document object returned by ``ezdxf.readfile()`` or
+            ``ezdxf.read()``.
+        label: Filename (or ``<fileobj>``) used in the log message.
         max_layers: Maximum number of layers to list.
 
     Returns:
@@ -43,9 +61,7 @@ def _process_dxf_doc(doc: Any, file_path: Path, max_layers: int = 20) -> str:
             if title:
                 metadata_parts.append(f"Title: {title}")
         except Exception:  # Intentional catch-all: ezdxf header raises library-specific errors
-            logger.opt(exception=True).debug(
-                "Failed to read DXF $TITLE header for {}", file_path.name
-            )
+            logger.opt(exception=True).debug("Failed to read DXF $TITLE header for {}", label)
 
         try:
             author = doc.header.get("$AUTHOR", "")
@@ -53,14 +69,10 @@ def _process_dxf_doc(doc: Any, file_path: Path, max_layers: int = 20) -> str:
                 author = doc.header.get("$LASTSAVEDBY", "Unknown")
             metadata_parts.append(f"Author: {author}")
         except Exception:  # Intentional catch-all: ezdxf header raises library-specific errors
-            logger.opt(exception=True).debug(
-                "Failed to read DXF author metadata for {}", file_path.name
-            )
+            logger.opt(exception=True).debug("Failed to read DXF author metadata for {}", label)
 
-    # DXF version
     metadata_parts.append(f"DXF Version: {doc.dxfversion}")
 
-    # Layer information
     if doc.layers:
         layer_count = len(doc.layers)
         metadata_parts.append(f"\n=== Layers ({layer_count} total) ===")
@@ -75,7 +87,6 @@ def _process_dxf_doc(doc: Any, file_path: Path, max_layers: int = 20) -> str:
                 layer_info += f" (Color: {layer.dxf.color})"
             metadata_parts.append(layer_info)
 
-    # Entity statistics
     modelspace = doc.modelspace()
     entity_types: dict[str, int] = {}
 
@@ -90,7 +101,6 @@ def _process_dxf_doc(doc: Any, file_path: Path, max_layers: int = 20) -> str:
         for entity_type, count in sorted(entity_types.items()):
             metadata_parts.append(f"  {entity_type}: {count}")
 
-    # Blocks
     if doc.blocks:
         block_count = len([b for b in doc.blocks if not b.name.startswith("*")])
         if block_count > 0:
@@ -98,75 +108,158 @@ def _process_dxf_doc(doc: Any, file_path: Path, max_layers: int = 20) -> str:
             metadata_parts.append(f"Block definitions: {block_count}")
 
     text = "\n".join(metadata_parts)
-    logger.debug(f"Extracted {len(text)} characters from DXF file {file_path.name}")
+    logger.debug(f"Extracted {len(text)} characters from DXF file {label}")
     return text
 
 
-def read_dxf_file(file_path: str | Path, max_layers: int = 20) -> str:
+def _read_dxf_from_fileobj(fileobj: BinaryIO) -> Any:
+    """Hand a binary fileobj to ``ezdxf.read`` via a text wrapper.
+
+    ``ezdxf.read`` takes a ``TextIO``; SafeDir hands us a binary fd. The
+    ``surrogateescape`` errors handler matches ``ezdxf.readfile``'s default
+    so non-UTF-8 byte sequences in headers round-trip cleanly.
+
+    The wrapper is ``detach()``'d on every exit path — including
+    exceptions — so the caller's underlying binary stream survives the
+    wrapper's garbage collection (``TextIOWrapper`` otherwise closes
+    its source on ``__del__``). This both preserves the caller-owned
+    ``fileobj=`` contract and lets the DWG fallback path below still
+    ``os.fstat`` the same fd after a parse failure.
+    """
+    text_stream = io.TextIOWrapper(fileobj, encoding="utf-8", errors="surrogateescape")
+    try:
+        return ezdxf.read(text_stream)  # type: ignore[attr-defined]  # ezdxf stubs incomplete
+    finally:
+        text_stream.detach()
+
+
+def read_dxf_file(
+    file_path: str | Path | None = None,
+    max_layers: int = 20,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read metadata and content from a DXF CAD file.
 
     Args:
-        file_path: Path to DXF file
+        file_path: Path to DXF file (legacy entry point).
         max_layers: Maximum number of layers to list
+        fileobj: Open binary file-like (SafeDir-friendly entry point). When
+            given, ``file_path`` is used only for the log label.
 
     Returns:
         Extracted metadata and layer information
 
     Raises:
         FileReadError: If file cannot be read
+        FileTooLargeError: If the file behind ``fileobj`` exceeds the limit.
         ImportError: If ezdxf is not installed
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
+    if fileobj is None and file_path is None:
+        raise ValueError("read_dxf_file requires file_path or fileobj")
     if not EZDXF_AVAILABLE:
         raise ImportError("ezdxf is not installed. Install with: pip install ezdxf")
 
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        _check_fd_size(fileobj)
+        try:
+            doc = _read_dxf_from_fileobj(fileobj)
+            return _process_dxf_doc(doc, label, max_layers)
+        except Exception as e:  # Intentional catch-all: ezdxf raises library-specific errors
+            raise FileReadError(f"Failed to read DXF file {label}: {e}") from e
+    assert file_path is not None  # narrowed above
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        doc = ezdxf.readfile(file_path)  # type: ignore[attr-defined]  # ezdxf stubs incomplete
-        return _process_dxf_doc(doc, file_path, max_layers)
+        doc = ezdxf.readfile(path)  # type: ignore[attr-defined]  # ezdxf stubs incomplete
+        return _process_dxf_doc(doc, path.name, max_layers)
     except Exception as e:  # Intentional catch-all: ezdxf raises library-specific errors
-        raise FileReadError(f"Failed to read DXF file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read DXF file {path}: {e}") from e
 
 
-def read_dwg_file(file_path: str | Path) -> str:
+def read_dwg_file(
+    file_path: str | Path | None = None,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read metadata from a DWG CAD file.
 
-    Note: DWG is a proprietary format. This function attempts to read it using ezdxf,
-    which has limited DWG support. For full DWG support, consider using ODA File Converter
-    to convert DWG to DXF first.
+    Note: DWG is a proprietary format. This function attempts to read it
+    using ezdxf, which has limited DWG support. For full DWG support,
+    consider using ODA File Converter to convert DWG to DXF first.
 
     Args:
-        file_path: Path to DWG file
+        file_path: Path to DWG file (legacy entry point).
+        fileobj: Open binary file-like (SafeDir-friendly entry point). When
+            given, ``file_path`` is used only for the log label and the
+            file-info fallback message; the fallback that displays
+            ``Size: ... KB`` uses ``os.fstat`` on the fd.
 
     Returns:
         Extracted metadata or basic file information
 
     Raises:
         FileReadError: If file cannot be read
+        FileTooLargeError: If the file behind ``fileobj`` exceeds the limit.
         ImportError: If ezdxf is not installed
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
+    if fileobj is None and file_path is None:
+        raise ValueError("read_dwg_file requires file_path or fileobj")
     if not EZDXF_AVAILABLE:
         raise ImportError("ezdxf is not installed. Install with: pip install ezdxf")
 
-    file_path = Path(file_path)
-    _check_file_size(file_path)
-    try:
-        # Try to read with ezdxf (limited support).
-        # Capture the returned document and pass it through to avoid re-opening the file.
-        doc = ezdxf.readfile(file_path)  # type: ignore[attr-defined]  # ezdxf stubs incomplete
-        return _process_dxf_doc(doc, file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        _check_fd_size(fileobj)
+        try:
+            doc = _read_dxf_from_fileobj(fileobj)
+            return _process_dxf_doc(doc, label)
+        except Exception as e:  # Intentional catch-all: ezdxf raises library-specific errors
+            logger.warning(f"Could not parse DWG file with ezdxf: {e}")
+            # Path-based fallback inspected the file with ``file_path.stat()``;
+            # for the fileobj branch we use the fd size, which avoids a
+            # second filesystem call that could race against SafeDir's
+            # symlink rejection.
+            try:
+                size_bytes = os.fstat(fileobj.fileno()).st_size
+                size_kb = size_bytes / 1024
+            except (OSError, AttributeError, ValueError):
+                size_kb = -1.0
 
+            metadata_parts = [
+                "=== DWG File Information ===",
+                f"File: {label}",
+            ]
+            if size_kb >= 0:
+                metadata_parts.append(f"Size: {size_kb:.2f} KB")
+            metadata_parts.extend(
+                [
+                    "",
+                    "Note: Full DWG parsing requires additional tools.",
+                    "Consider using ODA File Converter to convert DWG to DXF for better support.",
+                ]
+            )
+            return "\n".join(metadata_parts)
+
+    assert file_path is not None  # narrowed above
+    path = Path(file_path)
+    _check_file_size(path)
+    try:
+        doc = ezdxf.readfile(path)  # type: ignore[attr-defined]  # ezdxf stubs incomplete
+        return _process_dxf_doc(doc, path.name)
     except Exception as e:  # Intentional catch-all: ezdxf raises library-specific errors
-        # If ezdxf can't read it, provide basic file info
         logger.warning(f"Could not parse DWG file with ezdxf: {e}")
 
-        if not file_path.exists():
-            raise FileReadError(f"File not found: {file_path}") from e
+        if not path.exists():
+            raise FileReadError(f"File not found: {path}") from e
 
         metadata_parts = [
             "=== DWG File Information ===",
-            f"File: {file_path.name}",
-            f"Size: {file_path.stat().st_size / 1024:.2f} KB",
+            f"File: {path.name}",
+            f"Size: {path.stat().st_size / 1024:.2f} KB",
             "",
             "Note: Full DWG parsing requires additional tools.",
             "Consider using ODA File Converter to convert DWG to DXF for better support.",
@@ -175,162 +268,225 @@ def read_dwg_file(file_path: str | Path) -> str:
         return "\n".join(metadata_parts)
 
 
-def read_step_file(file_path: str | Path, max_lines: int = 100) -> str:
+def _parse_step_text(content: str, label: str, size_kb: float) -> str:
+    """Extract STEP metadata from the first 10 KB of the file content."""
+    metadata_parts = ["=== STEP File Information ===", f"File: {label}"]
+    if size_kb >= 0:
+        metadata_parts.append(f"Size: {size_kb:.2f} KB")
+
+    # Extract header section (between HEADER; and ENDSEC;)
+    if "HEADER;" in content and "ENDSEC;" in content:
+        header_start = content.find("HEADER;")
+        header_end = content.find("ENDSEC;", header_start)
+        header = content[header_start:header_end]
+
+        metadata_parts.append("\n=== Header Information ===")
+
+        if "FILE_DESCRIPTION" in header:
+            desc_start = header.find("FILE_DESCRIPTION")
+            desc_end = header.find(");", desc_start)
+            if desc_end > desc_start:
+                desc = header[desc_start : desc_end + 2]
+                metadata_parts.append(desc.strip())
+
+        if "FILE_NAME" in header:
+            name_start = header.find("FILE_NAME")
+            name_end = header.find(");", name_start)
+            if name_end > name_start:
+                name_info = header[name_start : name_end + 2]
+                metadata_parts.append(name_info.strip())
+
+        if "FILE_SCHEMA" in header:
+            schema_start = header.find("FILE_SCHEMA")
+            schema_end = header.find(");", schema_start)
+            if schema_end > schema_start:
+                schema = header[schema_start : schema_end + 2]
+                metadata_parts.append(schema.strip())
+
+    if "DATA;" in content:
+        entity_count = content.count("\n#")
+        metadata_parts.append(f"\nApproximate entity count: {entity_count}")
+
+    text = "\n".join(metadata_parts)
+    logger.debug(f"Extracted {len(text)} characters from STEP file {label}")
+    return text
+
+
+def read_step_file(
+    file_path: str | Path | None = None,
+    max_lines: int = 100,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read metadata from a STEP (.step, .stp) CAD file.
 
     STEP files are ISO 10303 standard format for 3D CAD data exchange.
-    This function extracts basic header information.
+    This function extracts basic header information from the first 10 KB.
 
     Args:
-        file_path: Path to STEP file
-        max_lines: Maximum lines to read from header
+        file_path: Path to STEP file (legacy entry point).
+        max_lines: Unused (kept for backward compat).
+        fileobj: Open binary file-like (SafeDir-friendly entry point).
+            STEP is plain ASCII; the binary stream is decoded UTF-8 with
+            errors ignored, matching the legacy path-branch behavior.
 
     Returns:
         Extracted header information
 
     Raises:
         FileReadError: If file cannot be read
+        FileTooLargeError: If the file behind ``fileobj`` exceeds the limit.
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if fileobj is None and file_path is None:
+        raise ValueError("read_step_file requires file_path or fileobj")
+
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        _check_fd_size(fileobj)
+        try:
+            content = fileobj.read(10000).decode("utf-8", errors="ignore")
+            try:
+                size_kb = os.fstat(fileobj.fileno()).st_size / 1024
+            except (OSError, AttributeError, ValueError):
+                size_kb = -1.0
+            return _parse_step_text(content, label, size_kb)
+        except (OSError, UnicodeDecodeError, ValueError) as e:
+            raise FileReadError(f"Failed to read STEP file {label}: {e}") from e
+
+    assert file_path is not None  # narrowed above
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        with open(file_path, encoding="utf-8", errors="ignore") as f:
-            content = f.read(10000)  # Read first 10KB
-
-        metadata_parts = ["=== STEP File Information ==="]
-        metadata_parts.append(f"File: {file_path.name}")
-        metadata_parts.append(f"Size: {file_path.stat().st_size / 1024:.2f} KB")
-
-        # Extract header section (between HEADER; and ENDSEC;)
-        if "HEADER;" in content and "ENDSEC;" in content:
-            header_start = content.find("HEADER;")
-            header_end = content.find("ENDSEC;", header_start)
-            header = content[header_start:header_end]
-
-            metadata_parts.append("\n=== Header Information ===")
-
-            # Extract file description
-            if "FILE_DESCRIPTION" in header:
-                desc_start = header.find("FILE_DESCRIPTION")
-                desc_end = header.find(");", desc_start)
-                if desc_end > desc_start:
-                    desc = header[desc_start : desc_end + 2]
-                    metadata_parts.append(desc.strip())
-
-            # Extract file name
-            if "FILE_NAME" in header:
-                name_start = header.find("FILE_NAME")
-                name_end = header.find(");", name_start)
-                if name_end > name_start:
-                    name_info = header[name_start : name_end + 2]
-                    metadata_parts.append(name_info.strip())
-
-            # Extract schema
-            if "FILE_SCHEMA" in header:
-                schema_start = header.find("FILE_SCHEMA")
-                schema_end = header.find(");", schema_start)
-                if schema_end > schema_start:
-                    schema = header[schema_start : schema_end + 2]
-                    metadata_parts.append(schema.strip())
-
-        # Count entities in DATA section
-        if "DATA;" in content:
-            # Count lines starting with # (entities)
-            entity_count = content.count("\n#")
-            metadata_parts.append(f"\nApproximate entity count: {entity_count}")
-
-        text = "\n".join(metadata_parts)
-        logger.debug(f"Extracted {len(text)} characters from STEP file {file_path.name}")
-        return text
-
+        with path.open(encoding="utf-8", errors="ignore") as f:
+            content = f.read(10000)
+        size_kb = path.stat().st_size / 1024
+        return _parse_step_text(content, path.name, size_kb)
     except (OSError, UnicodeDecodeError, ValueError) as e:
-        raise FileReadError(f"Failed to read STEP file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read STEP file {path}: {e}") from e
 
 
-def read_iges_file(file_path: str | Path, max_lines: int = 50) -> str:
+def _parse_iges_lines(lines: list[str], label: str, size_kb: float) -> str:
+    """Extract IGES metadata from the first N lines of the file."""
+    metadata_parts = ["=== IGES File Information ===", f"File: {label}"]
+    if size_kb >= 0:
+        metadata_parts.append(f"Size: {size_kb:.2f} KB")
+
+    # IGES files have structured sections marked in column 73
+    # S = Start, G = Global, D = Directory Entry, P = Parameter Data, T = Terminate
+
+    start_section = []
+    global_section = []
+
+    for line in lines:
+        if len(line) >= 73:
+            section_type = line[72]
+            content = line[:72].strip()
+
+            if section_type == "S" and content:
+                start_section.append(content)
+            elif section_type == "G" and content:
+                global_section.append(content)
+
+    if start_section:
+        metadata_parts.append("\n=== Start Section ===")
+        metadata_parts.extend(start_section[:10])
+
+    if global_section:
+        metadata_parts.append("\n=== Global Parameters ===")
+        global_params = "".join(global_section)
+        params = global_params.split(",")[:5]
+
+        param_names = [
+            "Parameter delimiter",
+            "Record delimiter",
+            "Product ID from sender",
+            "File name",
+            "Native system ID",
+        ]
+
+        for name, value in zip(param_names, params, strict=False):
+            if value.strip():
+                metadata_parts.append(f"{name}: {value.strip()}")
+
+    entity_count = sum(1 for line in lines if len(line) >= 73 and line[72] == "D")
+    if entity_count > 0:
+        metadata_parts.append(f"\nDirectory entries found: {entity_count}")
+
+    text = "\n".join(metadata_parts)
+    logger.debug(f"Extracted {len(text)} characters from IGES file {label}")
+    return text
+
+
+def read_iges_file(
+    file_path: str | Path | None = None,
+    max_lines: int = 50,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read metadata from an IGES (.iges, .igs) CAD file.
 
-    IGES (Initial Graphics Exchange Specification) is a vendor-neutral file format
-    for 3D CAD data exchange.
+    IGES (Initial Graphics Exchange Specification) is a vendor-neutral file
+    format for 3D CAD data exchange.
 
     Args:
-        file_path: Path to IGES file
+        file_path: Path to IGES file (legacy entry point).
         max_lines: Maximum lines to read from header
+        fileobj: Open binary file-like (SafeDir-friendly entry point). The
+            binary stream is decoded UTF-8 line-by-line with errors ignored,
+            matching the legacy path-branch behavior.
 
     Returns:
         Extracted header information
 
     Raises:
         FileReadError: If file cannot be read
+        FileTooLargeError: If the file behind ``fileobj`` exceeds the limit.
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if fileobj is None and file_path is None:
+        raise ValueError("read_iges_file requires file_path or fileobj")
+
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        _check_fd_size(fileobj)
+        try:
+            # ``TextIOWrapper`` closes its source stream on GC; detach the
+            # underlying binary fd before the wrapper goes out of scope so
+            # the caller-owned ``fileobj`` survives this call.
+            text_stream = io.TextIOWrapper(fileobj, encoding="utf-8", errors="ignore")
+            try:
+                lines = [text_stream.readline() for _ in range(max_lines)]
+            finally:
+                text_stream.detach()
+            try:
+                size_kb = os.fstat(fileobj.fileno()).st_size / 1024
+            except (OSError, AttributeError, ValueError):
+                size_kb = -1.0
+            return _parse_iges_lines(lines, label, size_kb)
+        except (OSError, UnicodeDecodeError, ValueError) as e:
+            raise FileReadError(f"Failed to read IGES file {label}: {e}") from e
+
+    assert file_path is not None  # narrowed above
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        with open(file_path, encoding="utf-8", errors="ignore") as f:
+        with path.open(encoding="utf-8", errors="ignore") as f:
             lines = [f.readline() for _ in range(max_lines)]
-
-        metadata_parts = ["=== IGES File Information ==="]
-        metadata_parts.append(f"File: {file_path.name}")
-        metadata_parts.append(f"Size: {file_path.stat().st_size / 1024:.2f} KB")
-
-        # IGES files have structured sections marked in column 73
-        # S = Start, G = Global, D = Directory Entry, P = Parameter Data, T = Terminate
-
-        start_section = []
-        global_section = []
-
-        for line in lines:
-            if len(line) >= 73:
-                section_type = line[72]
-                content = line[:72].strip()
-
-                if section_type == "S" and content:
-                    start_section.append(content)
-                elif section_type == "G" and content:
-                    global_section.append(content)
-
-        # Display start section (usually contains file description)
-        if start_section:
-            metadata_parts.append("\n=== Start Section ===")
-            metadata_parts.extend(start_section[:10])  # First 10 lines
-
-        # Display global section (contains parameters)
-        if global_section:
-            metadata_parts.append("\n=== Global Parameters ===")
-            # Join and split by commas to get parameters
-            global_params = "".join(global_section)
-            params = global_params.split(",")[:5]  # First 5 parameters
-
-            # Parameter meanings (typical order)
-            param_names = [
-                "Parameter delimiter",
-                "Record delimiter",
-                "Product ID from sender",
-                "File name",
-                "Native system ID",
-            ]
-
-            for name, value in zip(param_names, params, strict=False):
-                if value.strip():
-                    metadata_parts.append(f"{name}: {value.strip()}")
-
-        # Count entities
-        entity_count = sum(1 for line in lines if len(line) >= 73 and line[72] == "D")
-        if entity_count > 0:
-            metadata_parts.append(f"\nDirectory entries found: {entity_count}")
-
-        text = "\n".join(metadata_parts)
-        logger.debug(f"Extracted {len(text)} characters from IGES file {file_path.name}")
-        return text
-
+        size_kb = path.stat().st_size / 1024
+        return _parse_iges_lines(lines, path.name, size_kb)
     except (OSError, UnicodeDecodeError, ValueError) as e:
-        raise FileReadError(f"Failed to read IGES file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read IGES file {path}: {e}") from e
 
 
 def read_cad_file(file_path: str | Path, **kwargs: object) -> str:
-    """Read content from any CAD file format.
+    """Read content from any CAD file format (path-only convenience dispatcher).
 
-    Auto-detects CAD file type and uses appropriate reader.
+    Auto-detects CAD file type and uses appropriate reader. This is the
+    legacy path-based entry point; the SafeDir dispatcher in
+    ``utils.readers.read_file_via_safedir`` registers each extension
+    directly against the per-format readers so the fileobj branch is
+    reached without going through this function.
 
     Args:
         file_path: Path to CAD file
@@ -356,6 +512,6 @@ def read_cad_file(file_path: str | Path, **kwargs: object) -> str:
 
     reader = cad_readers.get(ext)
     if reader:
-        return reader(file_path, **kwargs)  # type: ignore[operator,no-any-return]  # Union dict value; see pyproject.toml [[tool.mypy.overrides]]
+        return reader(file_path, **kwargs)  # type: ignore[operator,no-any-return,arg-type]  # Union dict value; see pyproject.toml [[tool.mypy.overrides]]
     else:
         raise FileReadError(f"Unsupported CAD file format: {ext}")

--- a/src/utils/readers/cad.py
+++ b/src/utils/readers/cad.py
@@ -358,7 +358,9 @@ def read_step_file(
     path = Path(file_path)
     _check_file_size(path)
     try:
-        with path.open(encoding="utf-8", errors="ignore") as f:
+        with path.open(
+            encoding="utf-8", errors="ignore"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             content = f.read(10000)
         size_kb = path.stat().st_size / 1024
         return _parse_step_text(content, path.name, size_kb)
@@ -471,7 +473,9 @@ def read_iges_file(
     path = Path(file_path)
     _check_file_size(path)
     try:
-        with path.open(encoding="utf-8", errors="ignore") as f:
+        with path.open(
+            encoding="utf-8", errors="ignore"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             lines = [f.readline() for _ in range(max_lines)]
         size_kb = path.stat().st_size / 1024
         return _parse_iges_lines(lines, path.name, size_kb)

--- a/src/utils/readers/documents.py
+++ b/src/utils/readers/documents.py
@@ -1,9 +1,22 @@
 # pyre-ignore-all-errors
-"""Readers for document formats: plain text, DOCX, PDF, spreadsheets, presentations."""
+"""Readers for document formats: plain text, DOCX, PDF, spreadsheets, presentations.
+
+Each public ``read_X_file`` function accepts either a path (legacy) or an
+open binary file-like via the ``fileobj`` keyword. The file-like path is the
+SafeDir-friendly entry point: callers open via ``SafeDir.open_for_reader``,
+wrap in ``os.fdopen(fd, "rb")``, and hand to the reader. Path-based callers
+continue to work unchanged.
+
+The underlying parse logic lives in private ``_parse_X`` helpers so the
+fileobj and path branches share a single implementation.
+"""
 
 from __future__ import annotations
 
+import csv
+import io
 from pathlib import Path
+from typing import BinaryIO
 
 try:
     import fitz  # PyMuPDF
@@ -27,6 +40,8 @@ except ImportError:
     STRIPRTF_AVAILABLE = False
 
 try:
+    import openpyxl
+
     OPENPYXL_AVAILABLE = True
 except ImportError:
     OPENPYXL_AVAILABLE = False
@@ -40,209 +55,350 @@ except ImportError:
 
 from loguru import logger
 
-from utils.readers._base import FileReadError, _check_file_size
+from utils.readers._base import FileReadError, _check_fd_size, _check_file_size
 
 
-def read_text_file(file_path: str | Path, max_chars: int = 5000) -> str:
+def _parse_text(fileobj: BinaryIO, max_chars: int, label: str) -> str:
+    """Decode bytes from *fileobj* as UTF-8 (errors='ignore') and truncate."""
+    data = fileobj.read(max_chars * 4)  # *4 to allow worst-case multi-byte chars
+    text = data.decode("utf-8", errors="ignore")[:max_chars]
+    logger.debug(f"Read {len(text)} characters from {label}")
+    return text
+
+
+def read_text_file(
+    file_path: str | Path | None = None,
+    max_chars: int = 5000,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read text content from a plain text file.
 
     Args:
-        file_path: Path to text file
-        max_chars: Maximum characters to read
+        file_path: Path to text file (legacy entry point).
+        max_chars: Maximum characters to read.
+        fileobj: Open binary file-like (SafeDir-friendly entry point). When
+            given, ``file_path`` is used only for the log label.
 
     Returns:
-        Text content
+        Text content (UTF-8 decoded, errors ignored, truncated).
 
     Raises:
-        FileReadError: If file cannot be read
+        FileReadError: If file cannot be read.
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        # Size check outside the try so ``FileTooLargeError`` propagates
+        # to callers as the dispatcher docstring promises (it would
+        # otherwise be wrapped as ``FileReadError`` by the broad catch).
+        _check_fd_size(fileobj)
+        try:
+            return _parse_text(fileobj, max_chars, label)
+        except OSError as e:
+            raise FileReadError(f"Failed to read text file {label}: {e}") from e
+    if file_path is None:
+        raise ValueError("read_text_file requires file_path or fileobj")
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        with open(file_path, encoding="utf-8", errors="ignore") as f:
-            text = f.read(max_chars)
-        logger.debug(f"Read {len(text)} characters from {file_path.name}")
-        return text
-    except (OSError, UnicodeDecodeError) as e:
-        raise FileReadError(f"Failed to read text file {file_path}: {e}") from e
+        with path.open("rb") as f:
+            return _parse_text(f, max_chars, path.name)
+    except OSError as e:
+        raise FileReadError(f"Failed to read text file {path}: {e}") from e
 
 
-def read_docx_file(file_path: str | Path) -> str:
+def _parse_docx(fileobj: BinaryIO, label: str) -> str:
+    doc = docx.Document(fileobj)
+    paragraphs = [para.text for para in doc.paragraphs if para.text.strip()]
+    text = "\n".join(paragraphs)
+    logger.debug(f"Extracted {len(text)} characters from {label}")
+    return text
+
+
+def read_docx_file(
+    file_path: str | Path | None = None,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read text content from a .docx file.
 
     Args:
-        file_path: Path to DOCX file
+        file_path: Path to DOCX file (legacy entry point).
+        fileobj: Open binary file-like (SafeDir-friendly entry point).
 
     Returns:
-        Extracted text content
+        Extracted text content.
 
     Raises:
-        FileReadError: If file cannot be read
-        ImportError: If python-docx is not installed
+        FileReadError: If file cannot be read.
+        ImportError: If python-docx is not installed.
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
     if not DOCX_AVAILABLE:
         raise ImportError("python-docx is not installed. Install with: pip install python-docx")
-
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        # Size check outside the try so ``FileTooLargeError`` propagates.
+        _check_fd_size(fileobj)
+        try:
+            return _parse_docx(fileobj, label)
+        except Exception as e:  # Intentional catch-all: python-docx raises library-specific errors
+            raise FileReadError(f"Failed to read DOCX file {label}: {e}") from e
+    if file_path is None:
+        raise ValueError("read_docx_file requires file_path or fileobj")
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        doc = docx.Document(str(file_path))
-        paragraphs = [para.text for para in doc.paragraphs if para.text.strip()]
-        text = "\n".join(paragraphs)
-        logger.debug(f"Extracted {len(text)} characters from {file_path.name}")
-        return text
+        with path.open("rb") as f:
+            return _parse_docx(f, path.name)
     except Exception as e:  # Intentional catch-all: python-docx raises library-specific errors
-        raise FileReadError(f"Failed to read DOCX file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read DOCX file {path}: {e}") from e
 
 
-def read_pdf_file(file_path: str | Path, max_pages: int = 5) -> str:
+def _extract_pdf_pages(doc: object, max_pages: int, label: str) -> str:
+    """Extract text from the first ``max_pages`` of an open PyMuPDF document."""
+    num_pages = min(max_pages, len(doc))  # type: ignore[arg-type]
+    pages_text = [
+        doc.load_page(i).get_text()  # type: ignore[attr-defined]
+        for i in range(num_pages)
+    ]
+    text = "\n".join(pages_text)
+    logger.debug(f"Extracted {len(text)} characters from {num_pages} pages of {label}")
+    return text
+
+
+def _parse_pdf_stream(fileobj: BinaryIO, max_pages: int, label: str) -> str:
+    """Parse PDF from a file-like by reading bytes and using fitz.open(stream=).
+
+    Used only when the caller already has a fileobj (the SafeDir-friendly
+    entry point); the path branch streams from disk via ``fitz.open(path)``
+    to avoid loading the whole PDF into memory before ``max_pages`` is
+    applied.
+    """
+    data = fileobj.read()
+    with fitz.open(stream=data, filetype="pdf") as doc:
+        return _extract_pdf_pages(doc, max_pages, label)
+
+
+def read_pdf_file(
+    file_path: str | Path | None = None,
+    max_pages: int = 5,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read text content from a PDF file.
 
     Args:
-        file_path: Path to PDF file
-        max_pages: Maximum pages to read
+        file_path: Path to PDF file (legacy entry point).
+        max_pages: Maximum pages to read.
+        fileobj: Open binary file-like (SafeDir-friendly entry point).
 
     Returns:
-        Extracted text content
+        Extracted text content.
 
     Raises:
-        FileReadError: If file cannot be read
-        ImportError: If PyMuPDF is not installed
+        FileReadError: If file cannot be read.
+        ImportError: If PyMuPDF is not installed.
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
     if not PYMUPDF_AVAILABLE:
         raise ImportError("PyMuPDF is not installed. Install with: pip install PyMuPDF")
-
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        # Size check outside the try so ``FileTooLargeError`` propagates.
+        _check_fd_size(fileobj)
+        try:
+            return _parse_pdf_stream(fileobj, max_pages, label)
+        except Exception as e:  # Intentional catch-all: PyMuPDF raises library-specific errors
+            raise FileReadError(f"Failed to read PDF file {label}: {e}") from e
+    if file_path is None:
+        raise ValueError("read_pdf_file requires file_path or fileobj")
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        with fitz.open(file_path) as doc:
-            num_pages = min(max_pages, len(doc))
-
-            pages_text = []
-            for page_num in range(num_pages):
-                page = doc.load_page(page_num)
-                pages_text.append(page.get_text())
-
-            text = "\n".join(pages_text)
-
-        logger.debug(f"Extracted {len(text)} characters from {num_pages} pages of {file_path.name}")
-        return text
+        with fitz.open(str(path)) as doc:
+            return _extract_pdf_pages(doc, max_pages, path.name)
     except Exception as e:  # Intentional catch-all: PyMuPDF raises library-specific errors
-        raise FileReadError(f"Failed to read PDF file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read PDF file {path}: {e}") from e
 
 
-def read_rtf_file(file_path: str | Path, max_chars: int = 50_000) -> str:
+def _parse_rtf(fileobj: BinaryIO, max_chars: int, label: str) -> str:
+    raw = fileobj.read().decode("latin-1", errors="ignore")
+    text: str = str(_rtf_to_text(raw))
+    out = text[:max_chars] if len(text) > max_chars else text
+    logger.debug(f"Read {len(out)} characters from RTF {label}")
+    return out
+
+
+def read_rtf_file(
+    file_path: str | Path | None = None,
+    max_chars: int = 50_000,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Extract plain text from an RTF file using striprtf."""
     if not STRIPRTF_AVAILABLE:
         raise ImportError("striprtf is required for RTF support: pip install striprtf")
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        # Size check outside the try so ``FileTooLargeError`` propagates.
+        _check_fd_size(fileobj)
+        try:
+            return _parse_rtf(fileobj, max_chars, label)
+        except Exception as exc:
+            raise FileReadError(f"Failed to read RTF {label}: {exc}") from exc
+    if file_path is None:
+        raise ValueError("read_rtf_file requires file_path or fileobj")
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        raw = file_path.read_text(encoding="latin-1")
-        text: str = str(_rtf_to_text(raw))
-        return text[:max_chars] if len(text) > max_chars else text
+        with path.open("rb") as f:
+            return _parse_rtf(f, max_chars, path.name)
     except Exception as exc:
-        raise FileReadError(f"Failed to read RTF {file_path.name}: {exc}") from exc
+        raise FileReadError(f"Failed to read RTF {path.name}: {exc}") from exc
 
 
-def read_spreadsheet_file(file_path: str | Path, max_rows: int = 100) -> str:
+def _parse_csv(fileobj: BinaryIO, max_rows: int, label: str) -> str:
+    # csv.reader needs text mode; wrap the binary fileobj.
+    text_stream = io.TextIOWrapper(fileobj, encoding="utf-8", errors="ignore", newline="")
+    rows = []
+    reader = csv.reader(text_stream)
+    for i, row in enumerate(reader):
+        if i >= max_rows:
+            break
+        rows.append(",".join(row))
+    text = "\n".join(rows)
+    logger.debug(f"Extracted {len(text)} characters from {len(rows)} rows of {label}")
+    return text
+
+
+def _parse_xlsx(fileobj: BinaryIO, max_rows: int, label: str) -> str:
+    wb = openpyxl.load_workbook(fileobj, data_only=True, read_only=True)
+    ws = wb.active
+    rows = []
+    for i, row in enumerate(ws.iter_rows(values_only=True)):
+        if i >= max_rows:
+            break
+        row_str = ",".join(str(cell) if cell is not None else "" for cell in row)
+        if row_str.strip(","):
+            rows.append(row_str)
+    text = "\n".join(rows)
+    logger.debug(f"Extracted {len(text)} characters from {len(rows)} rows of {label}")
+    return text
+
+
+def _dispatch_spreadsheet(fileobj: BinaryIO, ext: str, max_rows: int, label: str) -> str:
+    """Route to ``_parse_csv`` or ``_parse_xlsx`` by extension."""
+    if ext == ".csv":
+        return _parse_csv(fileobj, max_rows, label)
+    if ext in (".xlsx", ".xls"):
+        if not OPENPYXL_AVAILABLE:
+            raise ImportError("openpyxl is not installed. Install with: pip install openpyxl")
+        return _parse_xlsx(fileobj, max_rows, label)
+    raise FileReadError(f"Unsupported spreadsheet format: {ext}")
+
+
+def read_spreadsheet_file(
+    file_path: str | Path | None = None,
+    max_rows: int = 100,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read content from Excel or CSV file.
 
     Args:
-        file_path: Path to spreadsheet file
-        max_rows: Maximum rows to read
+        file_path: Path to spreadsheet file (legacy entry point, also used to
+            detect extension when ``fileobj`` is provided).
+        max_rows: Maximum rows to read.
+        fileobj: Open binary file-like (SafeDir-friendly entry point). The
+            extension is taken from ``file_path`` so the caller must still
+            pass the original name; only the I/O is routed through ``fileobj``.
 
     Returns:
-        String representation of data
+        String representation of data.
 
     Raises:
-        FileReadError: If file cannot be read
-        ImportError: If openpyxl is not installed (for Excel files)
+        FileReadError: If file cannot be read or extension is unsupported.
+        ImportError: If openpyxl is not installed (for Excel files).
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if file_path is None:
+        raise ValueError(
+            "read_spreadsheet_file requires file_path (also needed for extension detection "
+            "when fileobj is provided)"
+        )
+    path = Path(file_path)
+    ext = path.suffix.lower()
+    if fileobj is not None:
+        # Size check outside the try so ``FileTooLargeError`` propagates.
+        _check_fd_size(fileobj)
+        try:
+            return _dispatch_spreadsheet(fileobj, ext, max_rows, path.name)
+        except (ImportError, FileReadError):
+            raise
+        except Exception as e:  # Intentional catch-all: openpyxl/csv raise library-specific errors
+            raise FileReadError(f"Failed to read spreadsheet file {path.name}: {e}") from e
+    _check_file_size(path)
     try:
-        if file_path.suffix.lower() == ".csv":
-            import csv
-
-            rows = []
-            with open(file_path, newline="", encoding="utf-8", errors="ignore") as f:
-                reader = csv.reader(f)
-                for i, row in enumerate(reader):
-                    if i >= max_rows:
-                        break
-                    rows.append(",".join(row))
-            text = "\n".join(rows)
-            logger.debug(
-                f"Extracted {len(text)} characters from {len(rows)} rows of {file_path.name}"
-            )
-            return text
-
-        elif file_path.suffix.lower() in (".xlsx", ".xls"):
-            if not OPENPYXL_AVAILABLE:
-                raise ImportError("openpyxl is not installed. Install with: pip install openpyxl")
-            import openpyxl
-
-            wb = openpyxl.load_workbook(file_path, data_only=True, read_only=True)
-            ws = wb.active
-            rows = []
-            for i, row in enumerate(ws.iter_rows(values_only=True)):
-                if i >= max_rows:
-                    break
-                # Only keep non-empty values
-                row_str = ",".join(str(cell) if cell is not None else "" for cell in row)
-                if row_str.strip(","):
-                    rows.append(row_str)
-            text = "\n".join(rows)
-            logger.debug(
-                f"Extracted {len(text)} characters from {len(rows)} rows of {file_path.name}"
-            )
-            return text
-
-        else:
-            raise FileReadError(f"Unsupported spreadsheet format: {file_path.suffix}")
-
-    except ImportError:
+        with path.open("rb") as f:
+            return _dispatch_spreadsheet(f, ext, max_rows, path.name)
+    except (ImportError, FileReadError):
         raise
     except Exception as e:  # Intentional catch-all: openpyxl/csv raise library-specific errors
-        raise FileReadError(f"Failed to read spreadsheet file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read spreadsheet file {path}: {e}") from e
 
 
-def read_presentation_file(file_path: str | Path) -> str:
+def _parse_presentation(fileobj: BinaryIO, label: str) -> str:
+    prs = Presentation(fileobj)
+    slides_text = []
+    for slide_num, slide in enumerate(prs.slides, 1):
+        slide_content = []
+        for shape in slide.shapes:
+            if hasattr(shape, "text") and shape.text.strip():
+                slide_content.append(shape.text)
+        if slide_content:
+            slides_text.append(f"Slide {slide_num}: " + " | ".join(slide_content))
+    text = "\n".join(slides_text)
+    logger.debug(f"Extracted {len(text)} characters from {len(slides_text)} slides of {label}")
+    return text
+
+
+def read_presentation_file(
+    file_path: str | Path | None = None,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read text content from PowerPoint file.
 
     Args:
-        file_path: Path to PPT/PPTX file
+        file_path: Path to PPT/PPTX file (legacy entry point).
+        fileobj: Open binary file-like (SafeDir-friendly entry point).
 
     Returns:
-        Extracted text from all slides
+        Extracted text from all slides.
 
     Raises:
-        FileReadError: If file cannot be read
-        ImportError: If python-pptx is not installed
+        FileReadError: If file cannot be read.
+        ImportError: If python-pptx is not installed.
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
     if not PPTX_AVAILABLE:
         raise ImportError("python-pptx is not installed. Install with: pip install python-pptx")
-
-    file_path = Path(file_path)
-    _check_file_size(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        # Size check outside the try so ``FileTooLargeError`` propagates.
+        _check_fd_size(fileobj)
+        try:
+            return _parse_presentation(fileobj, label)
+        except Exception as e:  # Intentional catch-all: python-pptx raises library-specific errors
+            raise FileReadError(f"Failed to read presentation file {label}: {e}") from e
+    if file_path is None:
+        raise ValueError("read_presentation_file requires file_path or fileobj")
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        prs = Presentation(str(file_path))
-
-        slides_text = []
-        for slide_num, slide in enumerate(prs.slides, 1):
-            slide_content = []
-            for shape in slide.shapes:
-                if hasattr(shape, "text") and shape.text.strip():
-                    slide_content.append(shape.text)
-
-            if slide_content:
-                slides_text.append(f"Slide {slide_num}: " + " | ".join(slide_content))
-
-        text = "\n".join(slides_text)
-        logger.debug(
-            f"Extracted {len(text)} characters from {len(slides_text)} slides of {file_path.name}"
-        )
-        return text
+        with path.open("rb") as f:
+            return _parse_presentation(f, path.name)
     except Exception as e:  # Intentional catch-all: python-pptx raises library-specific errors
-        raise FileReadError(f"Failed to read presentation file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read presentation file {path}: {e}") from e

--- a/src/utils/readers/documents.py
+++ b/src/utils/readers/documents.py
@@ -266,17 +266,23 @@ def read_rtf_file(
 
 
 def _parse_csv(fileobj: BinaryIO, max_rows: int, label: str) -> str:
-    # csv.reader needs text mode; wrap the binary fileobj.
+    # csv.reader needs text mode; wrap the binary fileobj. ``detach()`` in
+    # the finally so TextIOWrapper.__del__ doesn't close the caller-owned
+    # underlying binary stream — same pattern as the CAD readers
+    # (_read_dxf_from_fileobj, read_iges_file).
     text_stream = io.TextIOWrapper(fileobj, encoding="utf-8", errors="ignore", newline="")
-    rows = []
-    reader = csv.reader(text_stream)
-    for i, row in enumerate(reader):
-        if i >= max_rows:
-            break
-        rows.append(",".join(row))
-    text = "\n".join(rows)
-    logger.debug(f"Extracted {len(text)} characters from {len(rows)} rows of {label}")
-    return text
+    try:
+        rows = []
+        reader = csv.reader(text_stream)
+        for i, row in enumerate(reader):
+            if i >= max_rows:
+                break
+            rows.append(",".join(row))
+        text = "\n".join(rows)
+        logger.debug(f"Extracted {len(text)} characters from {len(rows)} rows of {label}")
+        return text
+    finally:
+        text_stream.detach()
 
 
 def _parse_xlsx(fileobj: BinaryIO, max_rows: int, label: str) -> str:

--- a/src/utils/readers/documents.py
+++ b/src/utils/readers/documents.py
@@ -102,7 +102,9 @@ def read_text_file(
     path = Path(file_path)
     _check_file_size(path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _parse_text(f, max_chars, path.name)
     except OSError as e:
         raise FileReadError(f"Failed to read text file {path}: {e}") from e
@@ -150,7 +152,9 @@ def read_docx_file(
     path = Path(file_path)
     _check_file_size(path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _parse_docx(f, path.name)
     except Exception as e:  # Intentional catch-all: python-docx raises library-specific errors
         raise FileReadError(f"Failed to read DOCX file {path}: {e}") from e
@@ -253,7 +257,9 @@ def read_rtf_file(
     path = Path(file_path)
     _check_file_size(path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _parse_rtf(f, max_chars, path.name)
     except Exception as exc:
         raise FileReadError(f"Failed to read RTF {path.name}: {exc}") from exc
@@ -341,7 +347,9 @@ def read_spreadsheet_file(
             raise FileReadError(f"Failed to read spreadsheet file {path.name}: {e}") from e
     _check_file_size(path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _dispatch_spreadsheet(f, ext, max_rows, path.name)
     except (ImportError, FileReadError):
         raise
@@ -398,7 +406,9 @@ def read_presentation_file(
     path = Path(file_path)
     _check_file_size(path)
     try:
-        with path.open("rb") as f:
+        with path.open(
+            "rb"
+        ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
             return _parse_presentation(f, path.name)
     except Exception as e:  # Intentional catch-all: python-pptx raises library-specific errors
         raise FileReadError(f"Failed to read presentation file {path}: {e}") from e

--- a/src/utils/readers/ebook.py
+++ b/src/utils/readers/ebook.py
@@ -1,10 +1,19 @@
 # pyre-ignore-all-errors
-"""Reader for eBook formats (EPUB)."""
+"""Reader for eBook formats (EPUB).
+
+Accepts either a path (legacy) or an open binary file-like via the
+``fileobj`` keyword. The file-like path is the SafeDir-friendly entry
+point: callers open via ``SafeDir.open_for_reader``, wrap in
+``os.fdopen(fd, "rb")``, and hand to the reader. ``ebooklib`` itself
+delegates to ``zipfile`` for the underlying read, which accepts both
+paths and file-like objects.
+"""
 
 from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import BinaryIO
 
 try:
     import ebooklib
@@ -16,57 +25,95 @@ except ImportError:
 
 from loguru import logger
 
-from utils.readers._base import FileReadError, _check_file_size
+from utils.readers._base import FileReadError, _check_fd_size, _check_file_size
 
 
-def read_ebook_file(file_path: str | Path, max_chars: int = 10000) -> str:
+def _parse_epub(source: object, max_chars: int, label: str) -> str:
+    """Parse an EPUB from either a path string or an open file-like.
+
+    ``epub.read_epub`` delegates to ``zipfile.ZipFile`` for the archive
+    container; both accept a path string or a file-like, so the helper
+    forwards either kind without further branching.
+    """
+    book = epub.read_epub(source)
+
+    text_parts = []
+    total_chars = 0
+
+    for item in book.get_items():
+        if item.get_type() == ebooklib.ITEM_DOCUMENT:
+            content = item.get_content().decode("utf-8", errors="ignore")
+            # Basic HTML stripping (simple approach)
+            content = re.sub(r"<[^>]+>", " ", content)
+            content = re.sub(r"\s+", " ", content).strip()
+
+            if content:
+                text_parts.append(content)
+                total_chars += len(content)
+
+                if total_chars >= max_chars:
+                    break
+
+    text = " ".join(text_parts)[:max_chars]
+    logger.debug(f"Extracted {len(text)} characters from ebook {label}")
+    return text
+
+
+def read_ebook_file(
+    file_path: str | Path | None = None,
+    max_chars: int = 10000,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read text content from ebook file (EPUB only for now).
 
     Args:
-        file_path: Path to ebook file
+        file_path: Path to ebook file (legacy entry point).
         max_chars: Maximum characters to extract
+        fileobj: Open binary file-like (SafeDir-friendly entry point). When
+            given, ``file_path`` is used for extension validation and the
+            log label; only ``.epub`` is supported.
 
     Returns:
         Extracted text content
 
     Raises:
-        FileReadError: If file cannot be read
+        FileReadError: If file cannot be read or extension is unsupported.
+        FileTooLargeError: If the file behind ``fileobj`` exceeds the limit.
         ImportError: If ebooklib is not installed
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
+    # Argument-validation contract is independent of the optional dep —
+    # raise ValueError on missing args BEFORE checking EBOOKLIB_AVAILABLE.
+    if fileobj is None and file_path is None:
+        raise ValueError("read_ebook_file requires file_path or fileobj")
     if not EBOOKLIB_AVAILABLE:
         raise ImportError("ebooklib is not installed. Install with: pip install ebooklib")
 
-    file_path = Path(file_path)
-    _check_file_size(file_path)
-
-    try:
-        # Only support EPUB for now
-        if file_path.suffix.lower() != ".epub":
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        # Extension validation — preserves the legacy "only .epub" contract
+        # for the fileobj branch too. ``file_path`` is required when the
+        # extension isn't a literal ``.epub`` because we can't sniff it
+        # from the stream without consuming bytes.
+        if file_path is not None and Path(file_path).suffix.lower() != ".epub":
             raise FileReadError(
-                f"Unsupported ebook format: {file_path.suffix}. Only .epub supported."
+                f"Unsupported ebook format: {Path(file_path).suffix}. Only .epub supported."
             )
-        book = epub.read_epub(file_path)
-
-        text_parts = []
-        total_chars = 0
-
-        for item in book.get_items():
-            if item.get_type() == ebooklib.ITEM_DOCUMENT:
-                content = item.get_content().decode("utf-8", errors="ignore")
-                # Basic HTML stripping (simple approach)
-                content = re.sub(r"<[^>]+>", " ", content)
-                content = re.sub(r"\s+", " ", content).strip()
-
-                if content:
-                    text_parts.append(content)
-                    total_chars += len(content)
-
-                    if total_chars >= max_chars:
-                        break
-
-        text = " ".join(text_parts)[:max_chars]
-
-        logger.debug(f"Extracted {len(text)} characters from ebook {file_path.name}")
-        return text
+        # Size check outside the try so ``FileTooLargeError`` propagates.
+        _check_fd_size(fileobj)
+        try:
+            return _parse_epub(fileobj, max_chars, label)
+        except Exception as e:  # Intentional catch-all: ebooklib raises library-specific errors
+            raise FileReadError(f"Failed to read ebook file {label}: {e}") from e
+    assert file_path is not None  # narrowed by the early ValueError above
+    path = Path(file_path)
+    _check_file_size(path)
+    try:
+        if path.suffix.lower() != ".epub":
+            raise FileReadError(f"Unsupported ebook format: {path.suffix}. Only .epub supported.")
+        return _parse_epub(str(path), max_chars, path.name)
+    except FileReadError:
+        raise
     except Exception as e:  # Intentional catch-all: ebooklib raises library-specific errors
-        raise FileReadError(f"Failed to read ebook file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read ebook file {path}: {e}") from e

--- a/src/utils/readers/scientific.py
+++ b/src/utils/readers/scientific.py
@@ -232,6 +232,10 @@ def read_netcdf_file(
             raise FileReadError(f"Failed to read NetCDF file {label}: {e}") from e
     assert file_path is not None  # narrowed by the early ValueError above
     path = Path(file_path)
+    # Cap path-branch reads at MAX_FILE_SIZE_BYTES — mirrors the fileobj
+    # branch's _check_fd_size and the read_hdf5_file path-branch guard,
+    # so oversized files don't get buffered into memory by netCDF4.
+    _check_file_size(path)
     try:
         with netCDF4.Dataset(path, "r") as nc:
             return _parse_netcdf(nc, path.name)
@@ -308,6 +312,9 @@ def read_mat_file(
             raise FileReadError(f"Failed to read MAT file {label}: {e}") from e
     assert file_path is not None  # narrowed by the early ValueError above
     path = Path(file_path)
+    # Cap path-branch reads at MAX_FILE_SIZE_BYTES — mirrors the fileobj
+    # branch's _check_fd_size and the read_hdf5_file path-branch guard.
+    _check_file_size(path)
     try:
         return _parse_mat(path, path.name)
     except Exception as e:  # Intentional catch-all: scipy.io raises library-specific errors

--- a/src/utils/readers/scientific.py
+++ b/src/utils/readers/scientific.py
@@ -1,9 +1,27 @@
 # pyre-ignore-all-errors
-"""Readers for scientific data formats: HDF5, NetCDF, MATLAB."""
+"""Readers for scientific data formats: HDF5, NetCDF, MATLAB.
+
+Each public ``read_X_file`` function accepts either a path (legacy) or an
+open binary file-like via the ``fileobj`` keyword. The file-like path is
+the SafeDir-friendly entry point: callers open via
+``SafeDir.open_for_reader``, wrap in ``os.fdopen(fd, "rb")``, and hand to
+the reader.
+
+Library-specific notes:
+
+- ``h5py.File`` accepts a file-like directly.
+- ``scipy.io.loadmat`` accepts a file-like directly.
+- ``netCDF4.Dataset`` is a C extension that needs either a path string or
+  ``memory=<bytes>`` (an in-memory buffer). The fileobj branch reads the
+  entire stream into bytes and passes ``memory=`` — fine for the kind of
+  metadata-only extraction we do, but means very large NetCDF files would
+  be buffered. ``_check_fd_size`` caps this defensively.
+"""
 
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, BinaryIO
 
 try:
     import h5py
@@ -28,182 +46,269 @@ except ImportError:
 
 from loguru import logger
 
-from utils.readers._base import FileReadError
+from utils.readers._base import FileReadError, _check_fd_size, _check_file_size
 
 
-def read_hdf5_file(file_path: str | Path, max_datasets: int = 20) -> str:
+def _parse_hdf5(source: object, max_datasets: int, label: str) -> str:
+    """Parse HDF5 metadata from either a path or a fileobj.
+
+    ``h5py.File`` accepts both forms, so this helper is shared between
+    the path and fileobj branches.
+    """
+    with h5py.File(source, "r") as hf:
+        lines = [
+            f"HDF5 File: {label}",
+            f"Total groups: {len(list(hf.keys()))}",
+            "\nStructure:",
+        ]
+
+        dataset_count = 0
+
+        def visit_item(name: str, obj: h5py.Dataset | h5py.Group) -> None:
+            nonlocal dataset_count
+            if dataset_count >= max_datasets:
+                return
+
+            if isinstance(obj, h5py.Dataset):
+                shape_str = "x".join(map(str, obj.shape))
+                size_kb = obj.nbytes / 1024
+                lines.append(f"  Dataset: {name} [{obj.dtype}] {shape_str} ({size_kb:.2f} KB)")
+
+                if obj.attrs:
+                    for attr_name, attr_value in list(obj.attrs.items())[:3]:
+                        lines.append(f"    - {attr_name}: {attr_value}")
+
+                dataset_count += 1
+            elif isinstance(obj, h5py.Group):
+                lines.append(f"  Group: {name}/")
+
+        hf.visititems(visit_item)
+
+        if dataset_count >= max_datasets:
+            lines.append(f"  ... (showing first {max_datasets} datasets)")
+
+        text = "\n".join(lines)
+        logger.debug(f"Extracted metadata from HDF5 file {label}")
+        return text
+
+
+def read_hdf5_file(
+    file_path: str | Path | None = None,
+    max_datasets: int = 20,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read metadata and structure from an HDF5 file.
 
     Args:
-        file_path: Path to HDF5 file
+        file_path: Path to HDF5 file (legacy entry point).
         max_datasets: Maximum number of datasets to list
+        fileobj: Open binary file-like (SafeDir-friendly entry point). When
+            given, ``file_path`` is used only for the log label.
 
     Returns:
         String with HDF5 structure and metadata
 
     Raises:
         FileReadError: If file cannot be read
+        FileTooLargeError: If the file behind ``fileobj`` exceeds the limit.
         ImportError: If h5py is not installed
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
+    # Argument-validation contract is independent of the optional dep —
+    # raise ValueError on missing args BEFORE checking H5PY_AVAILABLE so a
+    # caller that supplies neither arg gets a clear API error regardless of
+    # whether h5py is installed.
+    if fileobj is None and file_path is None:
+        raise ValueError("read_hdf5_file requires file_path or fileobj")
     if not H5PY_AVAILABLE:
         raise ImportError("h5py is not installed. Install with: pip install h5py")
 
-    file_path = Path(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        # Size check outside the try so ``FileTooLargeError`` propagates.
+        _check_fd_size(fileobj)
+        try:
+            return _parse_hdf5(fileobj, max_datasets, label)
+        except Exception as e:  # Intentional catch-all: h5py raises library-specific errors
+            raise FileReadError(f"Failed to read HDF5 file {label}: {e}") from e
+    assert file_path is not None  # narrowed by the early ValueError above
+    path = Path(file_path)
+    _check_file_size(path)
     try:
-        with h5py.File(file_path, "r") as hf:
-            lines = [
-                f"HDF5 File: {file_path.name}",
-                f"Total groups: {len(list(hf.keys()))}",
-                "\nStructure:",
-            ]
-
-            dataset_count = 0
-
-            def visit_item(name: str, obj: h5py.Dataset | h5py.Group) -> None:
-                """Visit and document HDF5 datasets and groups.
-
-                Args:
-                    name: The name of the dataset or group.
-                    obj: The HDF5 dataset or group object.
-                """
-                nonlocal dataset_count
-                if dataset_count >= max_datasets:
-                    return
-
-                if isinstance(obj, h5py.Dataset):
-                    shape_str = "x".join(map(str, obj.shape))
-                    size_kb = obj.nbytes / 1024
-                    lines.append(f"  Dataset: {name} [{obj.dtype}] {shape_str} ({size_kb:.2f} KB)")
-
-                    # List attributes
-                    if obj.attrs:
-                        for attr_name, attr_value in list(obj.attrs.items())[:3]:
-                            lines.append(f"    - {attr_name}: {attr_value}")
-
-                    dataset_count += 1
-                elif isinstance(obj, h5py.Group):
-                    lines.append(f"  Group: {name}/")
-
-            hf.visititems(visit_item)
-
-            if dataset_count >= max_datasets:
-                lines.append(f"  ... (showing first {max_datasets} datasets)")
-
-            text = "\n".join(lines)
-            logger.debug(f"Extracted metadata from HDF5 file {file_path.name}")
-            return text
-
+        return _parse_hdf5(path, max_datasets, path.name)
     except Exception as e:  # Intentional catch-all: h5py raises library-specific errors
-        raise FileReadError(f"Failed to read HDF5 file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read HDF5 file {path}: {e}") from e
 
 
-def read_netcdf_file(file_path: str | Path) -> str:
+def _parse_netcdf(nc: Any, label: str) -> str:
+    """Build the metadata string from an open netCDF4 ``Dataset``.
+
+    The Dataset is opened by the caller — either from a path or from the
+    ``memory=`` bytes buffer — and passed in already-open. We never call
+    ``netCDF4.Dataset(<path>)`` from within this helper, so the surface
+    flagged by the SafeDir rail stays in the public entry point.
+
+    ``nc`` is typed as ``Any`` because netCDF4 lacks type stubs; the
+    library exposes ``data_model``, ``dimensions``, ``variables``,
+    ``ncattrs()``, and ``getncattr()`` on the Dataset.
+    """
+    lines = [
+        f"NetCDF File: {label}",
+        f"Format: {nc.data_model}",
+        "\nDimensions:",
+    ]
+
+    for dim_name, dim in nc.dimensions.items():
+        size = len(dim) if not dim.isunlimited() else "unlimited"
+        lines.append(f"  - {dim_name}: {size}")
+
+    lines.append("\nVariables:")
+
+    for _idx, (var_name, var) in enumerate(list(nc.variables.items())[:20]):
+        shape_str = "x".join(str(var.shape[i]) for i in range(len(var.shape)))
+        lines.append(f"  - {var_name} ({var.dtype}): {shape_str}")
+
+        if hasattr(var, "units"):
+            lines.append(f"      units: {var.units}")
+        if hasattr(var, "long_name"):
+            lines.append(f"      long_name: {var.long_name}")
+
+    if len(nc.variables) > 20:
+        lines.append(f"  ... and {len(nc.variables) - 20} more variables")
+
+    if nc.ncattrs():
+        lines.append("\nGlobal Attributes:")
+        for attr_name in list(nc.ncattrs())[:10]:
+            attr_value = nc.getncattr(attr_name)
+            lines.append(f"  - {attr_name}: {attr_value}")
+
+    text = "\n".join(lines)
+    logger.debug(f"Extracted metadata from NetCDF file {label}")
+    return text
+
+
+def read_netcdf_file(
+    file_path: str | Path | None = None,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read metadata and structure from a NetCDF file.
 
     Args:
-        file_path: Path to NetCDF file
+        file_path: Path to NetCDF file (legacy entry point).
+        fileobj: Open binary file-like (SafeDir-friendly entry point). The
+            netCDF4 C library does not accept file-likes directly, so the
+            fileobj branch reads the stream into bytes and uses the
+            ``memory=`` parameter. ``_check_fd_size`` enforces the 500 MB
+            cap before the buffer is materialised.
 
     Returns:
         String with NetCDF structure and metadata
 
     Raises:
         FileReadError: If file cannot be read
+        FileTooLargeError: If the file behind ``fileobj`` exceeds the limit.
         ImportError: If netCDF4 is not installed
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
+    # Argument-validation contract precedes the optional-dep check.
+    if fileobj is None and file_path is None:
+        raise ValueError("read_netcdf_file requires file_path or fileobj")
     if not NETCDF4_AVAILABLE:
         raise ImportError("netCDF4 is not installed. Install with: pip install netCDF4")
 
-    file_path = Path(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        _check_fd_size(fileobj)
+        try:
+            data = fileobj.read()
+            # ``memory=`` requires a non-empty placeholder name; the actual
+            # path on disk is never opened. Library docs: pass anything
+            # non-empty as ``filename`` when ``memory`` is given.
+            with netCDF4.Dataset("inmemory", mode="r", memory=data) as nc:
+                return _parse_netcdf(nc, label)
+        except Exception as e:  # Intentional catch-all: netCDF4 raises library-specific errors
+            raise FileReadError(f"Failed to read NetCDF file {label}: {e}") from e
+    assert file_path is not None  # narrowed by the early ValueError above
+    path = Path(file_path)
     try:
-        with netCDF4.Dataset(file_path, "r") as nc:
-            lines = [
-                f"NetCDF File: {file_path.name}",
-                f"Format: {nc.data_model}",
-                "\nDimensions:",
-            ]
-
-            # List dimensions
-            for dim_name, dim in nc.dimensions.items():
-                size = len(dim) if not dim.isunlimited() else "unlimited"
-                lines.append(f"  - {dim_name}: {size}")
-
-            lines.append("\nVariables:")
-
-            # List variables (first 20)
-            for _idx, (var_name, var) in enumerate(list(nc.variables.items())[:20]):
-                shape_str = "x".join(str(var.shape[i]) for i in range(len(var.shape)))
-                lines.append(f"  - {var_name} ({var.dtype}): {shape_str}")
-
-                # Show some attributes
-                if hasattr(var, "units"):
-                    lines.append(f"      units: {var.units}")
-                if hasattr(var, "long_name"):
-                    lines.append(f"      long_name: {var.long_name}")
-
-            if len(nc.variables) > 20:
-                lines.append(f"  ... and {len(nc.variables) - 20} more variables")
-
-            # Global attributes
-            if nc.ncattrs():
-                lines.append("\nGlobal Attributes:")
-                for attr_name in list(nc.ncattrs())[:10]:
-                    attr_value = nc.getncattr(attr_name)
-                    lines.append(f"  - {attr_name}: {attr_value}")
-
-            text = "\n".join(lines)
-            logger.debug(f"Extracted metadata from NetCDF file {file_path.name}")
-            return text
-
+        with netCDF4.Dataset(path, "r") as nc:
+            return _parse_netcdf(nc, path.name)
     except Exception as e:  # Intentional catch-all: netCDF4 raises library-specific errors
-        raise FileReadError(f"Failed to read NetCDF file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read NetCDF file {path}: {e}") from e
 
 
-def read_mat_file(file_path: str | Path) -> str:
+def _parse_mat(source: object, label: str) -> str:
+    """Build MAT-file metadata from a path or fileobj.
+
+    ``scipy.io.loadmat`` accepts both forms, so this helper is shared
+    between the path and fileobj branches.
+    """
+    mat_contents = loadmat(source, struct_as_record=False, squeeze_me=True)
+
+    lines = [
+        f"MATLAB File: {label}",
+        "\nVariables:",
+    ]
+
+    var_names = [k for k in mat_contents.keys() if not k.startswith("__")]
+
+    for var_name in var_names[:30]:
+        var = mat_contents[var_name]
+
+        var_type = type(var).__name__
+        if hasattr(var, "shape"):
+            shape_str = "x".join(map(str, var.shape))
+            lines.append(f"  - {var_name} ({var_type}): {shape_str}")
+        else:
+            lines.append(f"  - {var_name} ({var_type})")
+
+    if len(var_names) > 30:
+        lines.append(f"  ... and {len(var_names) - 30} more variables")
+
+    text = "\n".join(lines)
+    logger.debug(f"Extracted metadata from MAT file {label}")
+    return text
+
+
+def read_mat_file(
+    file_path: str | Path | None = None,
+    *,
+    fileobj: BinaryIO | None = None,
+) -> str:
     """Read metadata and structure from a MATLAB .mat file.
 
     Args:
-        file_path: Path to MAT file
+        file_path: Path to MAT file (legacy entry point).
+        fileobj: Open binary file-like (SafeDir-friendly entry point). When
+            given, ``file_path`` is used only for the log label.
 
     Returns:
         String with MAT file structure and metadata
 
     Raises:
         FileReadError: If file cannot be read
+        FileTooLargeError: If the file behind ``fileobj`` exceeds the limit.
         ImportError: If scipy is not installed
+        ValueError: If neither ``file_path`` nor ``fileobj`` is provided.
     """
+    # Argument-validation contract precedes the optional-dep check.
+    if fileobj is None and file_path is None:
+        raise ValueError("read_mat_file requires file_path or fileobj")
     if not SCIPY_AVAILABLE:
         raise ImportError("scipy is not installed. Install with: pip install scipy")
 
-    file_path = Path(file_path)
+    if fileobj is not None:
+        label = Path(file_path).name if file_path is not None else "<fileobj>"
+        _check_fd_size(fileobj)
+        try:
+            return _parse_mat(fileobj, label)
+        except Exception as e:  # Intentional catch-all: scipy.io raises library-specific errors
+            raise FileReadError(f"Failed to read MAT file {label}: {e}") from e
+    assert file_path is not None  # narrowed by the early ValueError above
+    path = Path(file_path)
     try:
-        # Load mat file
-        mat_contents = loadmat(file_path, struct_as_record=False, squeeze_me=True)
-
-        lines = [
-            f"MATLAB File: {file_path.name}",
-            "\nVariables:",
-        ]
-
-        # Filter out metadata variables
-        var_names = [k for k in mat_contents.keys() if not k.startswith("__")]
-
-        for var_name in var_names[:30]:  # Limit to first 30 variables
-            var = mat_contents[var_name]
-
-            # Get type and shape info
-            var_type = type(var).__name__
-            if hasattr(var, "shape"):
-                shape_str = "x".join(map(str, var.shape))
-                lines.append(f"  - {var_name} ({var_type}): {shape_str}")
-            else:
-                lines.append(f"  - {var_name} ({var_type})")
-
-        if len(var_names) > 30:
-            lines.append(f"  ... and {len(var_names) - 30} more variables")
-
-        text = "\n".join(lines)
-        logger.debug(f"Extracted metadata from MAT file {file_path.name}")
-        return text
-
+        return _parse_mat(path, path.name)
     except Exception as e:  # Intentional catch-all: scipy.io raises library-specific errors
-        raise FileReadError(f"Failed to read MAT file {file_path}: {e}") from e
+        raise FileReadError(f"Failed to read MAT file {path}: {e}") from e

--- a/src/utils/safedir.py
+++ b/src/utils/safedir.py
@@ -32,11 +32,12 @@ CI is Linux; nightly Windows runs skip the dependent test modules. See
 
 from __future__ import annotations
 
+import contextlib
 import errno
 import os
 import sys
 from collections.abc import Iterator
-from pathlib import Path
+from pathlib import Path, PurePath
 from types import TracebackType
 from typing import Self
 
@@ -391,6 +392,55 @@ class SafeDir:
                 _raise_symlink_rejected(name, exc)
             raise _wrap_open_errno(exc, name) from exc
         return SafeDir(fd)
+
+    def open_anchored_reader(self, relative_path: str | os.PathLike[str]) -> int:
+        """Walk *relative_path* from this SafeDir and open the leaf as a reader fd.
+
+        Each intermediate component is opened via :meth:`open_subdir` (which
+        uses ``O_NOFOLLOW``), and the leaf is opened via
+        :meth:`open_for_reader`. An attacker-controlled ancestor swapped to
+        a symlink between directory enumeration and this read is refused with
+        :class:`SymlinkRejected`, not dereferenced — closes the nested-
+        ancestor TOCTOU window (#286) that the parent-rooted pattern leaves
+        open.
+
+        Args:
+            relative_path: A relative path under this SafeDir. Must not be
+                absolute and must not contain ``..`` components. May be a
+                ``str`` or any ``os.PathLike`` (typically ``PurePath`` /
+                ``Path``).
+
+        Returns:
+            The reader file descriptor for the leaf. Caller owns lifetime —
+            wrap with ``os.fdopen(fd, "rb", closefd=True)`` and close on
+            ``fdopen`` failure (``os.close(fd)``). The intermediate subdir
+            fds opened during traversal are released before this returns.
+
+        Raises:
+            ValueError: If *relative_path* is absolute, contains ``..``, is
+                empty, or any component fails :func:`_validate_name`.
+            SymlinkRejected: If any component (intermediate or leaf) is a
+                symlink at open time.
+            OSError: For other open failures (permission denied, missing
+                component, etc.).
+        """
+        self._check_open()
+        rel = PurePath(relative_path) if not isinstance(relative_path, PurePath) else relative_path
+        if rel.is_absolute():
+            raise ValueError(f"open_anchored_reader requires a relative path, got absolute {rel!r}")
+        parts = rel.parts
+        if not parts:
+            raise ValueError("open_anchored_reader requires a non-empty relative path")
+        if any(part == ".." for part in parts):
+            raise ValueError(f"open_anchored_reader refuses '..' components in {rel!r}")
+        # Walk intermediates inside an ExitStack so any subdir fd is closed
+        # exactly once even if a later component raises. The leaf fd is
+        # handed back open — caller owns its lifetime (see Returns above).
+        with contextlib.ExitStack() as stack:
+            current = self
+            for component in parts[:-1]:
+                current = stack.enter_context(current.open_subdir(component))
+            return current.open_for_reader(parts[-1])
 
     # ------------------------------------------------------------------
     # Inspect / list / stat

--- a/tests/ci/test_symlink_safety_lints.py
+++ b/tests/ci/test_symlink_safety_lints.py
@@ -16,6 +16,7 @@ The CI test verifies three things:
 
 from __future__ import annotations
 
+import ast
 import subprocess
 import sys
 from pathlib import Path
@@ -282,3 +283,170 @@ class TestFlaggedCallsContract:
         }
         missing = required - _FLAGGED_CALLS
         assert not missing, f"watch list dropped flagged calls: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Bare-open detection — added in PR3g (deferred from #271)
+# ---------------------------------------------------------------------------
+
+
+class TestBareOpenDetectionDirScoped:
+    """Bare ``open(path, "r"...)`` / ``Path.open("r"...)`` / ``io.open(path, "r"...)``
+    calls are only flagged inside directories listed in
+    ``_READ_OPEN_ENFORCED_DIRS``. PR3g adds the detection with an
+    empty enforced-dirs set as a placeholder; PR3i populates it for
+    migrated reader / dedup directories.
+    """
+
+    def test_bare_open_not_flagged_when_dir_set_empty(self, tmp_path: Path) -> None:
+        """With no directories enforced, bare-open reads aren't flagged
+        even in synthetic files — the detection class is opt-in.
+        """
+        source = "with open('/x/y.txt', 'rb') as f: pass\n"
+        # Synthetic path under tmp/src/x — not in _READ_OPEN_ENFORCED_DIRS.
+        # Empty set means no file is enforced.
+        violations = find_violations(_synth(tmp_path, source))
+        assert violations == []
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "with open('/x/y.txt', 'rb') as f: pass\n",
+            'with open("/x", mode="r") as f: pass\n',
+            "with open('/x') as f: pass\n",  # default mode = "r"
+            "import io\nwith io.open('/x', 'rb') as f: pass\n",
+            "from pathlib import Path\nPath('/x').open('rb')\n",
+            "from pathlib import Path\nPath('/x').open()\n",  # default mode
+            "from pathlib import Path\nPath('/x').open(mode='r')\n",
+        ],
+    )
+    def test_bare_open_detected_via_helper(self, tmp_path: Path, source: str) -> None:
+        """Direct unit-test of the AST helper — bypasses the dir-scope
+        gate so we can verify the detection logic itself.
+        """
+        from check_safedir_required import _bare_open_violation
+
+        tree = ast.parse(source)
+        calls = [n for n in ast.walk(tree) if isinstance(n, ast.Call)]
+        flagged = [_bare_open_violation(c) for c in calls if _bare_open_violation(c) is not None]
+        assert len(flagged) == 1, f"expected exactly one read-mode call, got {flagged}"
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            # Write modes are not reads.
+            "with open('/x', 'wb') as f: pass\n",
+            'with open("/x", mode="w") as f: pass\n',
+            "with open('/x', 'a') as f: pass\n",
+            "from pathlib import Path\nPath('/x').open('wb')\n",
+            "from pathlib import Path\nPath('/x').open(mode='a')\n",
+            "import io\nio.open('/x', 'wb')\n",
+        ],
+    )
+    def test_write_modes_not_flagged(self, tmp_path: Path, source: str) -> None:
+        """Write-only modes (``"w"``/``"a"``/``"x"`` without ``"+"``) are
+        legitimate writes, not reads — handled by the atomic-write rail
+        instead. The bare-open read detector must not flag them.
+        """
+        from check_safedir_required import _bare_open_violation
+
+        tree = ast.parse(source)
+        calls = [n for n in ast.walk(tree) if isinstance(n, ast.Call)]
+        flagged = [_bare_open_violation(c) for c in calls if _bare_open_violation(c) is not None]
+        assert flagged == [], f"write-mode call wrongly flagged: {flagged}"
+
+    def test_read_plus_modes_flagged(self) -> None:
+        """``"r+"`` / ``"w+"`` / ``"a+"`` reads-and-writes still open
+        the underlying file and could dereference a symlink."""
+        from check_safedir_required import _bare_open_violation
+
+        for source in [
+            "open('/x', 'r+')\n",
+            "open('/x', 'w+')\n",
+            "open('/x', 'a+')\n",
+        ]:
+            tree = ast.parse(source)
+            call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call))
+            assert _bare_open_violation(call) is not None, f"missed read-write mode: {source!r}"
+
+
+class TestBareOpenDetectionDirScopedIntegration:
+    """Integration test: when ``_READ_OPEN_ENFORCED_DIRS`` is non-empty,
+    ``find_violations`` reports bare reads on files inside the enforced
+    directory. Verifies the pass-2 wiring + ``_file_under_enforced_dir``
+    end-to-end, not just the helper in isolation.
+
+    Patches the module-level ``_READ_OPEN_ENFORCED_DIRS`` set so the
+    test owns the membership for its duration; the patch is reverted
+    after the test runs.
+    """
+
+    def test_find_violations_flags_bare_open_when_dir_enforced(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import check_safedir_required as _csr
+
+        # Create the same ``src/x/<file>`` layout ``_synth`` uses so the
+        # ``_file_under_enforced_dir`` resolution succeeds: it computes
+        # the path relative to ``_SRC_DIR``'s parent. We must point
+        # ``_SRC_DIR`` at our synthetic root so its parent is tmp_path.
+        src_root = tmp_path / "src"
+        src_root.mkdir()
+        target_dir = src_root / "myreaders"
+        target_dir.mkdir()
+        target = target_dir / "mod.py"
+        target.write_text("with open('/x/y.txt', 'rb') as f: pass\n")
+
+        monkeypatch.setattr(_csr, "_SRC_DIR", src_root)
+        monkeypatch.setattr(_csr, "_READ_OPEN_ENFORCED_DIRS", frozenset({"src/myreaders"}))
+        violations = _csr.find_violations(target)
+
+        # The bare ``open(path, "rb")`` is now flagged because the
+        # directory is enforced.
+        assert len(violations) == 1
+        line_no, name, _excerpt = violations[0]
+        assert name == "open"
+        assert line_no == 1
+
+    def test_find_violations_skips_bare_open_outside_enforced_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """File NOT under an enforced dir → bare open ignored even when
+        the set is populated."""
+        import check_safedir_required as _csr
+
+        src_root = tmp_path / "src"
+        src_root.mkdir()
+        target_dir = src_root / "elsewhere"
+        target_dir.mkdir()
+        target = target_dir / "mod.py"
+        target.write_text("with open('/x/y.txt', 'rb') as f: pass\n")
+
+        monkeypatch.setattr(_csr, "_SRC_DIR", src_root)
+        # Different directory enforced.
+        monkeypatch.setattr(_csr, "_READ_OPEN_ENFORCED_DIRS", frozenset({"src/myreaders"}))
+        violations = _csr.find_violations(target)
+
+        assert violations == []
+
+    def test_find_violations_respects_opt_out_marker_for_bare_open(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Trailing ``# safedir: ok — <reason>`` marker exempts a bare
+        open just like it does for library-call violations."""
+        import check_safedir_required as _csr
+
+        src_root = tmp_path / "src"
+        src_root.mkdir()
+        target_dir = src_root / "myreaders"
+        target_dir.mkdir()
+        target = target_dir / "mod.py"
+        target.write_text(
+            "with open('/x/y.txt', 'rb') as f: pass  # safedir: ok — legacy callsite\n"
+        )
+
+        monkeypatch.setattr(_csr, "_SRC_DIR", src_root)
+        monkeypatch.setattr(_csr, "_READ_OPEN_ENFORCED_DIRS", frozenset({"src/myreaders"}))
+        violations = _csr.find_violations(target)
+
+        assert violations == []

--- a/tests/ci/test_symlink_safety_lints.py
+++ b/tests/ci/test_symlink_safety_lints.py
@@ -32,6 +32,7 @@ sys.path.insert(0, str(_FO_ROOT / "scripts"))
 from check_safedir_required import (  # noqa: E402  — sys.path manipulation above
     _ALLOWLISTED_FILES,
     _FLAGGED_CALLS,
+    _READ_OPEN_ENFORCED_DIRS,
     _call_name,
     _collect_marker_comment_lines,
     _has_opt_out_in_window,
@@ -250,6 +251,46 @@ class TestLiveTreeAdvisory:
         assert "call site(s)" in result.stderr
         assert "Breakdown by callee:" in result.stderr
         assert "ADVISORY mode" in result.stderr
+
+    def test_no_bare_open_violations_in_enforced_dirs(self) -> None:
+        """PR3i populates ``_READ_OPEN_ENFORCED_DIRS`` with every PR3a–PR3h
+        migration target. Every bare ``open(...)`` / ``Path.open(...)`` /
+        ``io.open(...)`` site in those files must either be migrated to
+        SafeDir OR carry a ``# safedir: ok — <reason>`` opt-out marker
+        (legacy / Windows / NotImplementedError fallback branches).
+
+        This test reads the live tree and asserts Pass 2 (bare-open
+        detection) finds zero unmarked violations in the enforced dirs.
+        If this fails, either a new bare-open read was added to a
+        migrated file (route it through SafeDir or add a marker) or
+        an existing marker has drifted out of the matching window.
+
+        Implicit contract: ``find_violations`` (the function that
+        backs ``scan_tree``) only emits Pass 2 detections when the
+        file is in ``_READ_OPEN_ENFORCED_DIRS`` — see
+        ``_file_under_enforced_dir`` in the checker script. So
+        filtering by call name alone is sufficient here; the
+        path-scope guard is inherited from the detector. If
+        ``find_violations`` is ever refactored to decouple path-scope
+        from emission, add an explicit ``_file_under_enforced_dir(path)``
+        guard below.
+        """
+        # Sanity: enforcement is actually on (PR3i populated the set).
+        assert _READ_OPEN_ENFORCED_DIRS, (
+            "expected _READ_OPEN_ENFORCED_DIRS to be populated by PR3i; "
+            "if you cleared it intentionally, update this test"
+        )
+
+        violations = scan_tree()
+        bare_call_names = {"open", "io.open", "Path.open"}
+        bare = [
+            (path, lineno, name)
+            for path, lineno, name, _excerpt in violations
+            if name in bare_call_names
+        ]
+        assert not bare, "unmarked bare-open reads found in enforced dirs:\n" + "\n".join(
+            f"  {path.relative_to(_FO_ROOT)}:{lineno}  {name}" for path, lineno, name in bare
+        )
 
     def test_allowlist_files_not_scanned(self) -> None:
         """Allowlisted implementation files don't generate self-flags."""

--- a/tests/cli/test_cli_rules.py
+++ b/tests/cli/test_cli_rules.py
@@ -359,7 +359,7 @@ class TestRulesExport:
         with patch(_RULE_MGR_PATH, return_value=mock_rule_manager):
             result = runner.invoke(rules_app, ["export", "-o", str(existing_dir)])
         assert result.exit_code == 2
-        assert "not a regular file" in result.output.lower()
+        assert "not a regular file" in " ".join(result.output.lower().split())
 
     @pytest.mark.integration
     @pytest.mark.ci
@@ -440,7 +440,7 @@ class TestRulesImport:
         d.mkdir()
         result = runner.invoke(rules_app, ["import", str(d)])
         assert result.exit_code == 2
-        assert "not a regular file" in result.output.lower()
+        assert "not a regular file" in " ".join(result.output.lower().split())
 
     def test_import_invalid_yaml(self, runner, tmp_path):
         bad_yaml = tmp_path / "bad.yaml"

--- a/tests/cli/test_path_validation_wiring.py
+++ b/tests/cli/test_path_validation_wiring.py
@@ -91,7 +91,7 @@ def test_benchmark_compare_directory_rejected(tmp_path: Path) -> None:
     compare_dir.mkdir()
     result = runner.invoke(app, ["benchmark", "run", str(input_dir), "--compare", str(compare_dir)])
     assert result.exit_code == 2
-    assert "not a regular file" in result.output.lower()
+    assert "not a regular file" in " ".join(result.output.lower().split())
 
 
 def test_analyze_directory_rejected_with_regular_file_message(tmp_path: Path) -> None:
@@ -103,4 +103,4 @@ def test_analyze_directory_rejected_with_regular_file_message(tmp_path: Path) ->
     d.mkdir()
     result = runner.invoke(app, ["analyze", str(d)])
     assert result.exit_code == 1
-    assert "not a regular file" in result.output.lower()
+    assert "not a regular file" in " ".join(result.output.lower().split())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,6 +238,19 @@ def provider_env(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
 # `@pytest.mark.uses_setup_gate`.
 # Those tests configure the on-disk `setup_completed` flag via a
 # tmp_path config dir and need the gate to actually run.
+# Pre-import ``cli.organize`` so the ``_bypass_setup_gate`` patch below
+# can resolve ``cli.organize._check_setup_completed``. ``cli/__init__.py``
+# uses ``__getattr__`` for lazy attribute imports but does NOT pre-register
+# submodules — ``getattr(cli, "organize")`` therefore raises AttributeError
+# the first time ``mock.patch`` resolves the dotted name, unless some
+# earlier test in the session already imported the submodule explicitly.
+# Hook-driven single-test invocations (e.g. ``pre-commit run search-corpus-
+# safety``) have no such earlier import, so the autouse fixture errors at
+# setup and the hook fails. Pre-importing here makes the submodule a real
+# attribute on ``cli`` before any test runs.
+import cli.organize  # noqa: F401,E402
+
+
 @pytest.fixture(autouse=True)
 def _bypass_setup_gate(request: pytest.FixtureRequest) -> object:
     """Default-bypass the global setup gate; opt-out via `uses_setup_gate` marker."""

--- a/tests/core/test_organizer_sha256_safedir.py
+++ b/tests/core/test_organizer_sha256_safedir.py
@@ -1,0 +1,131 @@
+"""Regression tests for ``FileOrganizer._sha256_via_safedir`` (PR3h).
+
+The dedup hasher routes file reads through ``SafeDir.open_root`` +
+``open_for_reader`` so a symlink swapped between organize-time
+enumeration and the hash read is refused. This file covers every
+branch the SafeDir migration introduced:
+
+- happy path on a real on-disk file (no mocks) — verifies the SHA-256
+  matches a stdlib reference
+- ``SymlinkRejected`` returns ``None`` (caller treats as "unknown
+  hash" and keeps the file rather than dropping it)
+- ``NotImplementedError`` falls back to the legacy ``path.open(...)``
+- ``os.fdopen`` failure after ``open_for_reader`` returned a raw fd:
+  the fd MUST be explicitly closed
+- generic ``OSError`` from SafeDir returns ``None``
+- legacy fallback ``OSError`` returns ``None``
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.organizer import FileOrganizer
+from utils.safedir import SymlinkRejected
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+    pytest.mark.integration,
+]
+
+
+class TestSha256ViaSafedirHappyPath:
+    def test_real_file_hash_matches_stdlib(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.bin"
+        payload = b"the quick brown fox jumps over the lazy dog"
+        target.write_bytes(payload)
+        expected = hashlib.sha256(payload).hexdigest()
+        assert FileOrganizer._sha256_via_safedir(target) == expected
+
+    def test_large_file_chunked_hash(self, tmp_path: Path) -> None:
+        """Hash boundary: input larger than the 64 KiB chunk size must
+        still match the stdlib digest."""
+        target = tmp_path / "big.bin"
+        payload = b"a" * (128 * 1024 + 17)  # spans two chunks + tail
+        target.write_bytes(payload)
+        assert FileOrganizer._sha256_via_safedir(target) == hashlib.sha256(payload).hexdigest()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
+class TestSha256ViaSafedirBranches:
+    def test_symlink_rejected_returns_none(self, tmp_path: Path) -> None:
+        target = tmp_path / "real.bin"
+        target.write_bytes(b"never read")
+        with patch(
+            "core.organizer.SafeDir.open_root",
+            side_effect=SymlinkRejected("real.bin"),
+        ):
+            assert FileOrganizer._sha256_via_safedir(target) is None
+
+    def test_not_implemented_falls_back_to_legacy_open(self, tmp_path: Path) -> None:
+        target = tmp_path / "fallback.bin"
+        payload = b"fallback bytes"
+        target.write_bytes(payload)
+        with patch(
+            "core.organizer.SafeDir.open_root",
+            side_effect=NotImplementedError("no dir_fd"),
+        ):
+            assert FileOrganizer._sha256_via_safedir(target) == hashlib.sha256(payload).hexdigest()
+
+    def test_fdopen_failure_closes_bare_fd(self, tmp_path: Path) -> None:
+        target = tmp_path / "real.bin"
+        target.write_bytes(b"never read")
+        sentinel_fd = 4242
+
+        fake_safe_dir = MagicMock()
+        fake_safe_dir.open_for_reader.return_value = sentinel_fd
+        fake_cm = MagicMock()
+        fake_cm.__enter__.return_value = fake_safe_dir
+        fake_cm.__exit__.return_value = False
+
+        with (
+            patch("core.organizer.SafeDir.open_root", return_value=fake_cm),
+            patch("core.organizer.os.fdopen", side_effect=OSError("fdopen failed")),
+            patch("core.organizer.os.close") as mock_close,
+        ):
+            assert FileOrganizer._sha256_via_safedir(target) is None
+            mock_close.assert_called_once_with(sentinel_fd)
+
+    def test_safedir_oserror_returns_none(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.bin"
+        with patch(
+            "core.organizer.SafeDir.open_root",
+            side_effect=OSError("no such file"),
+        ):
+            assert FileOrganizer._sha256_via_safedir(target) is None
+
+    def test_safedir_valueerror_returns_none(self, tmp_path: Path) -> None:
+        """SafeDir's name validation rejects filenames containing
+        backslash / NUL / path separators with ``ValueError``. On
+        POSIX such filenames are legal in the filesystem, so a
+        ``safe_walk`` enumerator can yield them. The helper must treat
+        them like any other unreadable file and return ``None`` rather
+        than letting the ``ValueError`` abort the entire organize run.
+        """
+        target = tmp_path / "ok.bin"
+        target.write_bytes(b"data")
+        with patch(
+            "core.organizer.SafeDir.open_root",
+            side_effect=ValueError("name 'a\\b' contains path separator"),
+        ):
+            assert FileOrganizer._sha256_via_safedir(target) is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
+class TestSha256ViaSafedirLegacyFallback:
+    def test_legacy_open_oserror_returns_none(self, tmp_path: Path) -> None:
+        """When SafeDir is unavailable AND the legacy path-open also
+        fails (e.g. file doesn't exist), the function returns None."""
+        target = tmp_path / "ghost.bin"
+        # File never created.
+        with patch(
+            "core.organizer.SafeDir.open_root",
+            side_effect=NotImplementedError(),
+        ):
+            assert FileOrganizer._sha256_via_safedir(target) is None

--- a/tests/integration/test_audio_video_services_batch4.py
+++ b/tests/integration/test_audio_video_services_batch4.py
@@ -540,7 +540,7 @@ class TestAudioMetadataExtractor:
 
         with patch(
             "services.audio.metadata_extractor.AudioMetadataExtractor._extract_with_mutagen",
-            side_effect=lambda p: (_ for _ in ()).throw(Exception("decode error")),
+            side_effect=Exception("decode error"),
         ):
             with patch(
                 "services.audio.metadata_extractor.AudioMetadataExtractor._extract_with_tinytag",
@@ -1656,7 +1656,10 @@ class TestTextProcessor:
         mock_model.generate = MagicMock(return_value="programming")
 
         with (
-            patch("services.text_processor.read_file", return_value="Python programming content"),
+            patch(
+                "services.text_processor.read_file_via_safedir",
+                return_value="Python programming content",
+            ),
             patch(
                 "services.text_processor.truncate_text", return_value="Python programming content"
             ),
@@ -1693,9 +1696,19 @@ class TestTextProcessor:
 
         mock_model = self._make_mock_text_model()
 
-        with patch(
-            "services.text_processor.read_file",
-            side_effect=FileReadError("cannot read file"),
+        # PR3a (#267): TextProcessor reads via SafeDir first, falling back
+        # to legacy ``read_file`` only for non-existent files / unsupported
+        # extensions. Patch both entry points so the error contract is
+        # exercised regardless of which path is taken.
+        with (
+            patch(
+                "services.text_processor.read_file_via_safedir",
+                side_effect=FileReadError("cannot read file"),
+            ),
+            patch(
+                "services.text_processor.read_file",
+                side_effect=FileReadError("cannot read file"),
+            ),
         ):
             processor = TextProcessor(text_model=mock_model)
             result = processor.process_file(fp)
@@ -1721,7 +1734,7 @@ class TestTextProcessor:
         mock_model.generate = MagicMock(side_effect=gen_side_effect)
 
         with (
-            patch("services.text_processor.read_file", return_value="python content"),
+            patch("services.text_processor.read_file_via_safedir", return_value="python content"),
             patch("services.text_processor.truncate_text", return_value="python content"),
             patch("services.text_processor.clean_text", return_value="programming"),
         ):
@@ -1740,7 +1753,7 @@ class TestTextProcessor:
         mock_model.generate = MagicMock(return_value="programming")
 
         with (
-            patch("services.text_processor.read_file", return_value="hello world"),
+            patch("services.text_processor.read_file_via_safedir", return_value="hello world"),
             patch("services.text_processor.truncate_text", return_value="hello world"),
             patch("services.text_processor.clean_text", return_value="programming"),
         ):
@@ -1759,7 +1772,7 @@ class TestTextProcessor:
         mock_model.generate = MagicMock(return_value="notes")
 
         with (
-            patch("services.text_processor.read_file", return_value="some text"),
+            patch("services.text_processor.read_file_via_safedir", return_value="some text"),
             patch("services.text_processor.truncate_text", return_value="some text"),
             patch("services.text_processor.clean_text", return_value="notes"),
         ):
@@ -1837,13 +1850,22 @@ class TestTextProcessor:
 
         mock_model = self._make_mock_text_model()
 
-        def raise_unexpected(_path: Any) -> None:
+        def raise_unexpected(*_args: Any, **_kwargs: Any) -> None:
             # text_processor catches RuntimeError/ValueError/OSError/AttributeError
             raise OSError("unexpected error")
 
-        with patch(
-            "services.text_processor.read_file",
-            side_effect=raise_unexpected,
+        # PR3a (#267): patch both SafeDir-aware and legacy entry points so
+        # the unexpected-OSError contract holds regardless of which path
+        # is taken.
+        with (
+            patch(
+                "services.text_processor.read_file_via_safedir",
+                side_effect=raise_unexpected,
+            ),
+            patch(
+                "services.text_processor.read_file",
+                side_effect=raise_unexpected,
+            ),
         ):
             processor = TextProcessor(text_model=mock_model)
             result = processor.process_file(fp)
@@ -1861,7 +1883,7 @@ class TestTextProcessor:
         mock_model.generate = MagicMock(return_value="sample")
 
         with (
-            patch("services.text_processor.read_file", return_value="sample text"),
+            patch("services.text_processor.read_file_via_safedir", return_value="sample text"),
             patch("services.text_processor.truncate_text", return_value="sample text"),
             patch("services.text_processor.clean_text", return_value="sample"),
         ):
@@ -1881,7 +1903,7 @@ class TestTextProcessor:
         mock_model.generate = MagicMock(return_value="words")
 
         with (
-            patch("services.text_processor.read_file", return_value=long_content),
+            patch("services.text_processor.read_file_via_safedir", return_value=long_content),
             patch("services.text_processor.truncate_text", return_value=long_content[:5000]),
             patch("services.text_processor.clean_text", return_value="words"),
         ):

--- a/tests/integration/test_coverage_gap_supplements.py
+++ b/tests/integration/test_coverage_gap_supplements.py
@@ -448,6 +448,8 @@ class TestCopilotExecutorHandlers:
         assert "search" in result.message.lower()
 
     def test_handle_find_with_results(self, executor, tmp_path: Path) -> None:
+        # Routes through BM25Index which requires rank-bm25 (``search`` extra).
+        pytest.importorskip("rank_bm25")
         from services.copilot.executor import Intent, IntentType
 
         f = tmp_path / "important_report.txt"

--- a/tests/integration/test_deduplication_core.py
+++ b/tests/integration/test_deduplication_core.py
@@ -221,6 +221,17 @@ class TestDocumentExtractor:
 # ---------------------------------------------------------------------------
 
 
+def _make_jpeg(path: Path, size: tuple[int, int] = (8, 8)) -> None:
+    """Write a tiny real JPEG to ``path``.
+
+    PR3f's ``get_image_hash`` opens via ``safedir_image_open`` and feeds
+    a numpy array to the hasher — fake JPEG-prefix bytes don't decode.
+    """
+    from PIL import Image as _PILImage
+
+    _PILImage.new("RGB", size, color=(100, 150, 200)).save(path, format="JPEG")
+
+
 class TestImageDeduplicator:
     """Tests for ImageDeduplicator (image_dedup.py)."""
 
@@ -316,16 +327,18 @@ class TestImageDeduplicator:
     def test_get_image_hash_supported_format_calls_hasher(self, tmp_path: Path) -> None:
         dedup = self._make_deduplicator()
         f = tmp_path / "img.jpg"
-        f.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(f)
         dedup.hasher.encode_image.return_value = "abcd1234"
         result = dedup.get_image_hash(f)
         assert result == "abcd1234"
-        dedup.hasher.encode_image.assert_called_once_with(str(f))
+        # PR3f: encode_image now receives image_array kwarg, not path
+
+        dedup.hasher.encode_image.assert_called_once()
 
     def test_get_image_hash_hasher_returns_none(self, tmp_path: Path) -> None:
         dedup = self._make_deduplicator()
         f = tmp_path / "img.jpg"
-        f.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(f)
         dedup.hasher.encode_image.return_value = None
         result = dedup.get_image_hash(f)
         assert result is None
@@ -342,8 +355,8 @@ class TestImageDeduplicator:
         dedup = self._make_deduplicator()
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8\xff")
-        img2.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
         dedup.hasher.encode_image.return_value = "ff00ff00ff00ff00"
         result = dedup.compute_similarity(img1, img2)
         assert result is not None
@@ -354,7 +367,7 @@ class TestImageDeduplicator:
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
         # only img1 exists
-        img1.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(img1)
         dedup.hasher.encode_image.side_effect = [OSError(), OSError()]
         result = dedup.compute_similarity(img1, img2)
         assert result is None
@@ -381,8 +394,8 @@ class TestImageDeduplicator:
         dedup = self._make_deduplicator()
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8\xff")
-        img2.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
         hash_val = "ff00ff00ff00ff00"
         dedup.hasher.encode_image.return_value = hash_val
         dedup.hasher.find_duplicates.return_value = {
@@ -401,7 +414,7 @@ class TestImageDeduplicator:
     def test_batch_compute_hashes_with_images(self, tmp_path: Path) -> None:
         dedup = self._make_deduplicator()
         img = tmp_path / "img.jpg"
-        img.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(img)
         dedup.hasher.encode_image.return_value = "aabbccdd"
         result = dedup.batch_compute_hashes([img])
         assert img in result
@@ -416,8 +429,8 @@ class TestImageDeduplicator:
         dedup = self._make_deduplicator(threshold=0)
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8\xff")
-        img2.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
         # Return very different hashes
         dedup.hasher.encode_image.side_effect = ["ff00000000000000", "00ff000000000000"]
         result = dedup.cluster_by_similarity([img1, img2])
@@ -453,7 +466,7 @@ class TestImageDeduplicator:
     def test_progress_callback_called(self, tmp_path: Path) -> None:
         dedup = self._make_deduplicator()
         img = tmp_path / "img.jpg"
-        img.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(img)
         dedup.hasher.encode_image.return_value = "aabb"
         calls: list[tuple[int, int]] = []
         dedup.batch_compute_hashes([img], progress_callback=lambda c, t: calls.append((c, t)))
@@ -466,8 +479,8 @@ class TestImageDeduplicator:
         sub.mkdir()
         top_img = tmp_path / "top.jpg"
         sub_img = sub / "nested.jpg"
-        top_img.write_bytes(b"\xff\xd8\xff")
-        sub_img.write_bytes(b"\xff\xd8\xff")
+        _make_jpeg(top_img)
+        _make_jpeg(sub_img)
         files = dedup._find_image_files(tmp_path, recursive=False)
         paths = [str(f) for f in files]
         assert str(top_img) in paths

--- a/tests/integration/test_pipeline_orchestrator_and_services.py
+++ b/tests/integration/test_pipeline_orchestrator_and_services.py
@@ -841,6 +841,11 @@ class TestCommandExecutorFind:
         assert result.success is False
 
     def test_find_by_filename_match(self, tmp_path: Path) -> None:
+        # CommandExecutor.find_files routes through BM25Index which
+        # requires rank-bm25 (``search`` extra). Skip when absent so
+        # the test doesn't fail in dev envs without ``[search]``; CI
+        # installs ``.[dev,search]`` and exercises this path normally.
+        pytest.importorskip("rank_bm25")
         from services.copilot.executor import CommandExecutor
         from services.copilot.models import Intent, IntentType
 

--- a/tests/integration/test_services_auto_tagging_copilot_feedback.py
+++ b/tests/integration/test_services_auto_tagging_copilot_feedback.py
@@ -781,6 +781,9 @@ class TestCommandExecutorAdditional:
         assert "search for" in result.message.lower()
 
     def test_execute_find_with_matches(self, tmp_path: Path) -> None:
+        # CommandExecutor.find_files routes through BM25Index which
+        # requires rank-bm25 (``search`` extra). Skip when absent.
+        pytest.importorskip("rank_bm25")
         from services.copilot.executor import CommandExecutor
 
         (tmp_path / "report.txt").write_text("content")

--- a/tests/integration/utils/readers/test_archives_reader.py
+++ b/tests/integration/utils/readers/test_archives_reader.py
@@ -245,7 +245,13 @@ class TestRead7zMockedPaths:
             else:
                 archives.py7zr = original_py7zr
 
-        seven_zip_ctor.assert_called_once_with(path, "r")
+        # After PR3b: the path branch opens the path itself and hands a file
+        # object to ``py7zr.SevenZipFile`` (matches the unified _parse_7z
+        # helper shared with the ``fileobj=`` branch).
+        seven_zip_ctor.assert_called_once()
+        call_args, _ = seven_zip_ctor.call_args
+        assert hasattr(call_args[0], "read"), "first arg should be a file-like"
+        assert call_args[1] == "r"
         assert "7Z Archive: mocked.7z" in result
         assert "Encrypted: Yes" in result
         assert "a.txt" in result
@@ -278,7 +284,12 @@ class TestRead7zMockedPaths:
             else:
                 archives.py7zr = original_py7zr
 
-        seven_zip_ctor.assert_called_once_with(path, "r")
+        # After PR3b: the path branch hands a file-like (not the path) to
+        # ``py7zr.SevenZipFile`` — see the success-case assertion above.
+        seven_zip_ctor.assert_called_once()
+        call_args, _ = seven_zip_ctor.call_args
+        assert hasattr(call_args[0], "read")
+        assert call_args[1] == "r"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/methodologies/para/test_heuristics_read_content_safedir.py
+++ b/tests/methodologies/para/test_heuristics_read_content_safedir.py
@@ -1,0 +1,140 @@
+"""Regression tests for ``AIHeuristic._read_content_bytes`` (PR3h).
+
+The PARA content extractor routes file reads through ``SafeDir`` so a
+symlink swapped between detection and the content sample is refused.
+
+This file exercises every branch the SafeDir migration introduced:
+
+- happy path on a real on-disk file (no mocks)
+- ``SymlinkRejected`` returns ``None``
+- ``NotImplementedError`` falls back to legacy ``path.open(...)``
+- ``os.fdopen`` failure closes the bare fd
+- generic ``OSError`` from SafeDir returns ``None``
+- legacy fallback ``OSError`` returns ``None``
+- defensive limit clamp: non-positive ``limit`` returns ``None``
+  without reading
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from methodologies.para.detection.heuristics import AIHeuristic
+from utils.safedir import SymlinkRejected
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+    pytest.mark.integration,
+]
+
+
+class TestReadContentBytesHappyPath:
+    def test_reads_up_to_limit(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.txt"
+        target.write_bytes(b"abcdefghij")
+        assert AIHeuristic._read_content_bytes(target, limit=5) == b"abcde"
+
+    def test_reads_whole_file_when_smaller_than_limit(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.txt"
+        target.write_bytes(b"abc")
+        assert AIHeuristic._read_content_bytes(target, limit=100) == b"abc"
+
+
+class TestReadContentBytesLimitGuard:
+    """Non-positive limits (from a misconfigured ``max_content_chars``)
+    must not let ``read(limit)`` read the whole file."""
+
+    def test_zero_limit_returns_none(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.txt"
+        target.write_bytes(b"content")
+        assert AIHeuristic._read_content_bytes(target, limit=0) is None
+
+    def test_negative_limit_returns_none(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.txt"
+        target.write_bytes(b"content")
+        assert AIHeuristic._read_content_bytes(target, limit=-1) is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
+class TestReadContentBytesSafedirBranches:
+    def test_symlink_rejected_returns_none(self, tmp_path: Path) -> None:
+        target = tmp_path / "real.txt"
+        target.write_bytes(b"secret")
+        with patch(
+            "methodologies.para.detection.heuristics.SafeDir.open_root",
+            side_effect=SymlinkRejected("real.txt"),
+        ):
+            assert AIHeuristic._read_content_bytes(target, limit=64) is None
+
+    def test_not_implemented_falls_back_to_legacy_open(self, tmp_path: Path) -> None:
+        target = tmp_path / "fb.txt"
+        payload = b"fallback content"
+        target.write_bytes(payload)
+        with patch(
+            "methodologies.para.detection.heuristics.SafeDir.open_root",
+            side_effect=NotImplementedError(),
+        ):
+            assert AIHeuristic._read_content_bytes(target, limit=100) == payload
+
+    def test_fdopen_failure_closes_bare_fd(self, tmp_path: Path) -> None:
+        target = tmp_path / "real.txt"
+        target.write_bytes(b"never read")
+        sentinel_fd = 4242
+
+        fake_safe_dir = MagicMock()
+        fake_safe_dir.open_for_reader.return_value = sentinel_fd
+        fake_cm = MagicMock()
+        fake_cm.__enter__.return_value = fake_safe_dir
+        fake_cm.__exit__.return_value = False
+
+        with (
+            patch(
+                "methodologies.para.detection.heuristics.SafeDir.open_root",
+                return_value=fake_cm,
+            ),
+            patch(
+                "methodologies.para.detection.heuristics.os.fdopen",
+                side_effect=OSError("fdopen failed"),
+            ),
+            patch("methodologies.para.detection.heuristics.os.close") as mock_close,
+        ):
+            assert AIHeuristic._read_content_bytes(target, limit=64) is None
+            mock_close.assert_called_once_with(sentinel_fd)
+
+    def test_safedir_oserror_returns_none(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.txt"
+        with patch(
+            "methodologies.para.detection.heuristics.SafeDir.open_root",
+            side_effect=OSError("no such file"),
+        ):
+            assert AIHeuristic._read_content_bytes(target, limit=64) is None
+
+    def test_safedir_valueerror_returns_none(self, tmp_path: Path) -> None:
+        """SafeDir's name validation raises ``ValueError`` for
+        filenames containing backslash / NUL / path separators. On
+        POSIX such filenames are legal in the filesystem, so a
+        directory walk can yield them. The helper must return ``None``
+        rather than letting the ``ValueError`` abort PARA detection."""
+        target = tmp_path / "ok.txt"
+        target.write_bytes(b"data")
+        with patch(
+            "methodologies.para.detection.heuristics.SafeDir.open_root",
+            side_effect=ValueError("name 'a\\b' contains path separator"),
+        ):
+            assert AIHeuristic._read_content_bytes(target, limit=64) is None
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
+class TestReadContentBytesLegacyFallback:
+    def test_legacy_open_oserror_returns_none(self, tmp_path: Path) -> None:
+        target = tmp_path / "ghost.txt"
+        with patch(
+            "methodologies.para.detection.heuristics.SafeDir.open_root",
+            side_effect=NotImplementedError(),
+        ):
+            assert AIHeuristic._read_content_bytes(target, limit=64) is None

--- a/tests/security/test_symlink_safety.py
+++ b/tests/security/test_symlink_safety.py
@@ -40,6 +40,7 @@ from core.path_guard import safe_walk
 pytestmark = [
     pytest.mark.ci,
     pytest.mark.unit,
+    pytest.mark.integration,
     pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlink semantics"),
 ]
 
@@ -162,36 +163,103 @@ class TestSafeWalkSymlinkFiltering:
 
 
 class TestReadSideSymlinkSafety:
-    """Tests for the LLM-exfiltration vector (blocked on PR3, #267)."""
+    """Tests for the LLM-exfiltration vector — un-skipped in PR3a (#267)."""
+
+    @staticmethod
+    def _mock_text_processor():
+        """Return a ``TextProcessor`` with a mocked TEXT model.
+
+        Imports happen inside the function so the module imports during
+        test collection don't require LLM extras.
+        """
+        from unittest.mock import MagicMock
+
+        from models.base import ModelType
+        from services.text_processor import TextProcessor
+
+        model = MagicMock()
+        model.config.model_type = ModelType.TEXT
+        model.is_initialized = True
+        # A recorder for content the LLM would have seen. If the symlink
+        # were dereferenced, honey bytes would land here.
+        model.generate = MagicMock(return_value="MOCK_SUMMARY")
+        return TextProcessor(text_model=model), model
 
     def test_reader_does_not_open_symlink_target(self, tmp_path: Path) -> None:
-        """A swapped symlink between enumeration and read is rejected.
+        """A symlinked file in the organize root is refused before the reader runs.
 
-        Sequence the test will exercise once SafeDir is wired in:
+        Setup:
+        1. Honey file outside the organize root with sensitive content.
+        2. ``organize/report.txt`` is a symlink pointing at the honey file.
+        3. Caller invokes ``text_processor.process_file(organize/report.txt)``.
 
-        1. ``safe_walk`` yields ``organize/report.pdf`` as a regular file.
-        2. Between yield and read, the file is replaced by a symlink to the
-           honey file (simulated via patched ``open`` callback or a sleep +
-           subprocess swap).
-        3. ``SafeDir.open_for_reader`` uses ``O_NOFOLLOW`` and raises
-           ``SymlinkRejected``. The content reader is never called.
-
-        Acceptance: a recorder mock attached to the LLM processor never
-        receives ``_HONEY_CONTENT``.
+        Expected:
+        - ``SafeDir.open_for_reader`` raises ``SymlinkRejected``.
+        - ``ProcessedFile.folder_name == "errors"``.
+        - ``ProcessedFile.error`` mentions the symlink refusal.
+        - The mocked LLM is NOT called (no ``generate`` invocation), so
+          honey content cannot have leaked into the inference path.
         """
-        pytest.skip("blocked on PR3 (#267) — SafeDir read-side migration")
+        honey = _make_honey(tmp_path)  # tmp_path/honey/SECRET
+        organize = _make_organize_root(tmp_path)
+        # The symlink uses a .txt extension so it would be routed through
+        # the SafeDir text reader if SafeDir didn't refuse it.
+        link = organize / "report.txt"
+        try:
+            link.symlink_to(honey)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        processor, model = self._mock_text_processor()
+        result = processor.process_file(link)
+
+        assert result.folder_name == "errors"
+        assert result.error is not None
+        assert "symlink" in result.error.lower(), (
+            f"expected refusal message to mention symlink: {result.error!r}"
+        )
+        assert model.generate.call_count == 0, (
+            "LLM was invoked despite symlink rejection — honey content may have leaked"
+        )
 
     def test_organize_large_symlink_target_not_opened(self, tmp_path: Path) -> None:
-        """A 200MB out-of-tree symlink target is not read.
+        """A symlink to a large out-of-tree file is refused without reading the target.
 
-        Today ``collect_files`` (legacy ``os.walk``) yields the symlink and
-        the content reader opens it. After PR3+PR6 this path goes through
-        SafeDir and the read is refused. The test measures wall-clock + I/O
-        — if the reader actually opens 200MB the test will trip a timeout
-        guard. Once green, it becomes the canary for "fo organize doesn't
-        accidentally pull arbitrary files into memory via a planted link".
+        Today (PR3a) the SafeDir reader refuses the symlink at open time —
+        no bytes from the target are ever read. The canary: time the
+        operation and confirm it's fast even when the target is large.
+        500 KB of zeros is enough to detect a regression where the
+        reader would have opened the target.
         """
-        pytest.skip("blocked on PR3 (#267) and PR6 (#270) — legacy collect_files")
+        honey_dir = tmp_path / "honey"
+        honey_dir.mkdir()
+        # 500KB sentinel — big enough that reading it would be measurable,
+        # small enough to keep test runtime negligible.
+        big_target = honey_dir / "huge.txt"
+        big_target.write_bytes(b"\x00" * (500 * 1024))
+
+        organize = _make_organize_root(tmp_path)
+        link = organize / "report.txt"
+        try:
+            link.symlink_to(big_target)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        processor, model = self._mock_text_processor()
+
+        import time
+
+        start = time.perf_counter()
+        result = processor.process_file(link)
+        elapsed = time.perf_counter() - start
+
+        assert result.folder_name == "errors"
+        assert result.error is not None
+        # The refusal path does a few syscalls + log calls. Even on a slow
+        # CI runner it should finish in well under 0.5 seconds. Reading
+        # 500 KB through the LLM pipeline would take much longer.
+        assert elapsed < 0.5, f"refusal took {elapsed:.2f}s — symlink target may have been read"
+        assert model.generate.call_count == 0
 
 
 class TestDedupeSymlinkSafety:

--- a/tests/security/test_symlink_safety.py
+++ b/tests/security/test_symlink_safety.py
@@ -247,18 +247,16 @@ class TestReadSideSymlinkSafety:
 
         processor, model = self._mock_text_processor()
 
-        import time
-
-        start = time.perf_counter()
         result = processor.process_file(link)
-        elapsed = time.perf_counter() - start
 
+        # Deterministic behaviour checks — the refusal must surface as a
+        # "errors" routing with an error message, and the model must NOT
+        # have been called (which would have meant the symlink target was
+        # dereferenced and its content fed to the LLM). The previous
+        # wall-clock guard was removed per C1 FLAKY_GATE — timing-based
+        # assertions are environment-dependent on CI runners.
         assert result.folder_name == "errors"
         assert result.error is not None
-        # The refusal path does a few syscalls + log calls. Even on a slow
-        # CI runner it should finish in well under 0.5 seconds. Reading
-        # 500 KB through the LLM pipeline would take much longer.
-        assert elapsed < 0.5, f"refusal took {elapsed:.2f}s — symlink target may have been read"
         assert model.generate.call_count == 0
 
 

--- a/tests/services/deduplication/test_dedup_viewer.py
+++ b/tests/services/deduplication/test_dedup_viewer.py
@@ -220,7 +220,8 @@ class TestShowComparison:
         """If some images fail to load, the rest still show up."""
         call_count = 0
 
-        def _meta_side_effect(path):
+        def _meta_side_effect(path, **_kwargs):
+            # PR3f: _get_image_metadata accepts ``trusted_root=`` kwarg now
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -473,11 +474,11 @@ class TestGenerateAsciiPreview:
         type(fake_img.resize.return_value).width = 40
 
         mock_open_cm = MagicMock()
-        mock_open_cm.__enter__ = MagicMock(return_value=fake_img)
+        mock_open_cm.__enter__ = MagicMock(return_value=(fake_img, None))
         mock_open_cm.__exit__ = MagicMock(return_value=False)
 
         with patch(
-            "services.deduplication.viewer.Image.open",
+            "services.deduplication.viewer.safedir_image_open",
             return_value=mock_open_cm,
         ):
             result = viewer._generate_ascii_preview(
@@ -522,10 +523,10 @@ class TestGenerateAsciiPreview:
         # Landscape: 400x100, aspect_ratio=4 > 1
         landscape_img = _make_fake_img(400, 100, 20, 10)
         mock_cm = MagicMock()
-        mock_cm.__enter__ = MagicMock(return_value=landscape_img)
+        mock_cm.__enter__ = MagicMock(return_value=(landscape_img, None))
         mock_cm.__exit__ = MagicMock(return_value=False)
         with patch(
-            "services.deduplication.viewer.Image.open",
+            "services.deduplication.viewer.safedir_image_open",
             return_value=mock_cm,
         ):
             result = viewer._generate_ascii_preview(
@@ -536,10 +537,10 @@ class TestGenerateAsciiPreview:
         # Portrait: 100x400, aspect_ratio=0.25 < 1
         portrait_img = _make_fake_img(100, 400, 20, 10)
         mock_cm2 = MagicMock()
-        mock_cm2.__enter__ = MagicMock(return_value=portrait_img)
+        mock_cm2.__enter__ = MagicMock(return_value=(portrait_img, None))
         mock_cm2.__exit__ = MagicMock(return_value=False)
         with patch(
-            "services.deduplication.viewer.Image.open",
+            "services.deduplication.viewer.safedir_image_open",
             return_value=mock_cm2,
         ):
             result = viewer._generate_ascii_preview(

--- a/tests/services/deduplication/test_extractor_safedir.py
+++ b/tests/services/deduplication/test_extractor_safedir.py
@@ -1,0 +1,290 @@
+"""Tests for the SafeDir-aware branch of ``DocumentExtractor.extract_text``.
+
+PR3e of #267 wires ``utils.safedir.SafeDir`` into the dedup ingestion
+``extract_text`` entry point so a symlink swapped into the organize root
+between the directory walk and the read is refused with
+``SymlinkRejected`` rather than dereferenced.
+
+Verifies:
+
+- Plain ``.txt`` / ``.md`` extraction round-trips through SafeDir
+- Symlinks under the SafeDir root are refused (extractor returns ``""``)
+- DOCX / PDF / RTF / ODT exercise the ``fileobj=`` branch of the private
+  ``_extract_X`` helpers (mocked underlying libs so the tests don't need
+  the full optional-dep matrix)
+- On Windows the ``NotImplementedError`` fallback uses the legacy
+  path-based extraction
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services.deduplication.extractor import DocumentExtractor
+from utils.safedir import SafeDir
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+    pytest.mark.integration,
+    pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only"),
+]
+
+
+@pytest.fixture
+def extractor() -> DocumentExtractor:
+    return DocumentExtractor()
+
+
+class TestSafeDirBranchPlainText:
+    """The simplest path: ``.txt`` / ``.md`` round-trip via SafeDir."""
+
+    def test_extracts_txt_via_safedir(self, extractor: DocumentExtractor, tmp_path: Path) -> None:
+        target = tmp_path / "notes.txt"
+        target.write_text("first line\nsecond line\n")
+        out = extractor.extract_text(target)
+        assert "first line" in out
+        assert "second line" in out
+
+    def test_extracts_md_via_safedir(self, extractor: DocumentExtractor, tmp_path: Path) -> None:
+        target = tmp_path / "doc.md"
+        target.write_text("# Heading\n\nbody text\n")
+        out = extractor.extract_text(target)
+        assert "Heading" in out
+        assert "body text" in out
+
+    def test_refuses_symlinked_file_and_returns_empty(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        """A symlink in the organize root is refused via SafeDir.open_for_reader;
+        the extractor returns ``""`` instead of dereferencing to the real
+        target. Matches the legacy contract of returning ``""`` for any
+        unrecoverable extraction error.
+        """
+        real = tmp_path / "secret.txt"
+        real.write_text("DO_NOT_EXFILTRATE_THIS_CONTENT")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "decoy.txt").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        out = extractor.extract_text(organize / "decoy.txt")
+        assert out == ""
+
+    def test_file_not_found_still_raises(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        """File-not-found is a caller-level error, not a SafeDir issue —
+        the public contract still raises OSError. (Matches legacy behavior.)
+        """
+        with pytest.raises(OSError, match="File not found"):
+            extractor.extract_text(tmp_path / "missing.txt")
+
+
+class TestSafeDirBranchPdf:
+    """PDF extraction via the ``fileobj=`` branch of ``_extract_pdf``."""
+
+    def test_pdf_extraction_uses_pypdf_with_fileobj(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        p = tmp_path / "report.pdf"
+        p.write_bytes(b"%PDF-fake content\n")
+
+        mock_page = MagicMock()
+        mock_page.extract_text.return_value = "page text"
+        mock_reader = MagicMock()
+        mock_reader.pages = [mock_page]
+
+        with patch("pypdf.PdfReader", return_value=mock_reader) as mock_ctor:
+            out = extractor.extract_text(p)
+
+        assert out == "page text"
+        # The SafeDir branch passes a fileobj, not a path.
+        call_args, _ = mock_ctor.call_args
+        assert hasattr(call_args[0], "read"), "PdfReader should receive a file-like"
+
+
+class TestSafeDirBranchDocx:
+    """DOCX extraction via the ``fileobj=`` branch of ``_extract_docx``."""
+
+    def test_docx_extraction_uses_docx_with_fileobj(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        p = tmp_path / "report.docx"
+        p.write_bytes(b"fake docx bytes")
+
+        mock_para = MagicMock()
+        mock_para.text = "Hello docx"
+        mock_doc = MagicMock()
+        mock_doc.paragraphs = [mock_para]
+        mock_doc.tables = []
+
+        with patch("docx.Document", return_value=mock_doc) as mock_ctor:
+            out = extractor.extract_text(p)
+
+        assert out == "Hello docx"
+        # The SafeDir branch passes a fileobj, not a path string.
+        call_args, _ = mock_ctor.call_args
+        assert hasattr(call_args[0], "read")
+
+
+class TestSafeDirBranchRtf:
+    """RTF extraction via the ``fileobj=`` branch of ``_extract_rtf``."""
+
+    def test_rtf_extraction_uses_striprtf_on_fileobj_bytes(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        p = tmp_path / "letter.rtf"
+        p.write_bytes(b"{\\rtf1\\ansi this is rtf}")
+
+        with patch("striprtf.striprtf.rtf_to_text", return_value="this is rtf") as mock_strip:
+            out = extractor.extract_text(p)
+
+        assert "this is rtf" in out
+        mock_strip.assert_called_once()
+
+
+class TestSafeDirBranchOdt:
+    """ODT extraction via the ``fileobj=`` branch of ``_extract_odt``."""
+
+    def test_odt_extraction_reads_zip_from_fileobj(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        p = tmp_path / "doc.odt"
+        # Build a minimal ODT (zip with content.xml)
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr(
+                "content.xml",
+                (
+                    '<?xml version="1.0"?>'
+                    '<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" '
+                    'xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0">'
+                    "<office:body><office:text>"
+                    "<text:p>ODT paragraph one</text:p>"
+                    "<text:p>ODT paragraph two</text:p>"
+                    "</office:text></office:body></office:document-content>"
+                ),
+            )
+
+        out = extractor.extract_text(p)
+        assert "ODT paragraph one" in out
+        assert "ODT paragraph two" in out
+
+
+class TestSafeDirFallbackOnNotImplemented:
+    """When SafeDir raises ``NotImplementedError`` (Windows-style port not
+    available), the extractor falls back to the legacy path-based read so
+    the public contract still produces a result.
+    """
+
+    def test_falls_back_to_path_extraction(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "via_path.txt"
+        target.write_text("path-branch content")
+
+        with patch(
+            "services.deduplication.extractor.SafeDir.open_root",
+            side_effect=NotImplementedError("simulated platform without SafeDir"),
+        ):
+            out = extractor.extract_text(target)
+        assert "path-branch content" in out
+
+    def test_real_oserror_does_not_silently_fall_back(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        """A real OS error from SafeDir (e.g. permission denied) is logged
+        and ``""`` is returned — not silently routed to the path branch
+        that would defeat the SafeDir hardening.
+        """
+        target = tmp_path / "x.txt"
+        target.write_text("data")
+
+        with patch(
+            "services.deduplication.extractor.SafeDir.open_root",
+            side_effect=OSError("simulated permission denied"),
+        ):
+            out = extractor.extract_text(target)
+        assert out == ""
+
+
+class TestExtractorFileobjUnitMethods:
+    """Direct unit tests on the new ``fileobj=`` branches of each helper."""
+
+    def test_extract_pdf_fileobj(self, extractor: DocumentExtractor) -> None:
+        mock_page = MagicMock()
+        mock_page.extract_text.return_value = "p1 text"
+        mock_reader = MagicMock()
+        mock_reader.pages = [mock_page]
+        with patch("pypdf.PdfReader", return_value=mock_reader):
+            out = extractor._extract_pdf(fileobj=io.BytesIO(b"%PDF-fake"), label="t.pdf")
+        assert out == "p1 text"
+
+    def test_extract_docx_fileobj(self, extractor: DocumentExtractor) -> None:
+        mock_para = MagicMock()
+        mock_para.text = "hello"
+        mock_doc = MagicMock()
+        mock_doc.paragraphs = [mock_para]
+        mock_doc.tables = []
+        with patch("docx.Document", return_value=mock_doc):
+            out = extractor._extract_docx(fileobj=io.BytesIO(b"data"), label="t.docx")
+        assert out == "hello"
+
+    def test_extract_text_fileobj_utf8(self, extractor: DocumentExtractor) -> None:
+        out = extractor._extract_text(fileobj=io.BytesIO(b"hello world"), label="t.txt")
+        assert out == "hello world"
+
+    def test_extract_text_fileobj_falls_back_to_latin1(self, extractor: DocumentExtractor) -> None:
+        # Byte 0xff is invalid UTF-8 but valid latin-1
+        out = extractor._extract_text(fileobj=io.BytesIO(b"hello \xff world"), label="t.txt")
+        # Either latin-1 (preferred fallback) or utf-8 with errors=ignore
+        assert "hello" in out
+        assert "world" in out
+
+    def test_extract_rtf_fileobj(self, extractor: DocumentExtractor) -> None:
+        with patch("striprtf.striprtf.rtf_to_text", return_value="plain text"):
+            out = extractor._extract_rtf(fileobj=io.BytesIO(b"{\\rtf1}"), label="t.rtf")
+        assert "plain text" in out
+
+    def test_extract_odt_fileobj(self, extractor: DocumentExtractor, tmp_path: Path) -> None:
+        # Build the ODT bytes in memory.
+        zip_bytes = io.BytesIO()
+        with zipfile.ZipFile(zip_bytes, "w") as zf:
+            zf.writestr(
+                "content.xml",
+                '<?xml version="1.0"?><office:document-content '
+                'xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" '
+                'xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0">'
+                "<office:body><office:text><text:p>odt content</text:p>"
+                "</office:text></office:body></office:document-content>",
+            )
+        zip_bytes.seek(0)
+        out = extractor._extract_odt(fileobj=zip_bytes, label="t.odt")
+        assert "odt content" in out
+
+
+class TestSafeDirRouteSelected:
+    """Locks in the routing: the SafeDir branch is the default on POSIX."""
+
+    def test_safedir_open_root_is_called(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        """The non-Windows code path always tries SafeDir.open_root before
+        any fallback. Regression-locks the wire-up.
+        """
+        target = tmp_path / "x.txt"
+        target.write_text("data")
+        with patch(
+            "services.deduplication.extractor.SafeDir.open_root",
+            wraps=SafeDir.open_root,
+        ) as mock_open_root:
+            extractor.extract_text(target)
+        mock_open_root.assert_called_once_with(tmp_path)

--- a/tests/services/deduplication/test_image_dedup.py
+++ b/tests/services/deduplication/test_image_dedup.py
@@ -81,6 +81,20 @@ def _make_dedup(hash_method: str = "phash", threshold: int = 10) -> ImageDedupli
     return dedup
 
 
+def _make_jpeg(path: Path, size: tuple[int, int] = (8, 8)) -> None:
+    """Write a tiny real JPEG to ``path``.
+
+    PR3f's ``get_image_hash`` opens the file via ``safedir_image_open``
+    and hands a numpy array to the hasher — fake bytes won't decode.
+    Tests that previously used ``write_bytes(b"\\xff\\xd8...")`` to fake
+    a JPEG should call this helper instead so the actual SafeDir +
+    Pillow code path runs end-to-end.
+    """
+    from PIL import Image as _PILImage
+
+    _PILImage.new("RGB", size, color=(100, 150, 200)).save(path, format="JPEG")
+
+
 # ---------------------------------------------------------------------------
 # Initialization
 # ---------------------------------------------------------------------------
@@ -148,14 +162,20 @@ class TestGetImageHash:
     def test_hash_valid_image(self, tmp_path: Path):
         """Test successful hash of a valid image file."""
         img = tmp_path / "photo.jpg"
-        img.write_bytes(b"\xff\xd8\xff\xe0fake-jpeg-data")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = "abcdef1234567890"
 
         result = dedup.get_image_hash(img)
         assert result == "abcdef1234567890"
-        dedup.hasher.encode_image.assert_called_once_with(str(img))
+        # PR3f: hasher is now called with an image_array kwarg (numpy
+        # array from SafeDir-opened PIL Image), not the string path.
+        # That bypasses imagededup's internal Image.open(path) which
+        # would re-introduce the symlink-dereference we closed.
+        dedup.hasher.encode_image.assert_called_once()
+        kwargs = dedup.hasher.encode_image.call_args.kwargs
+        assert "image_array" in kwargs
 
     def test_hash_nonexistent_file(self, tmp_path: Path):
         """Test that missing file returns None."""
@@ -190,7 +210,7 @@ class TestGetImageHash:
     def test_hash_unexpected_exception(self, tmp_path: Path):
         """Test that unexpected exception during encoding returns None."""
         img = tmp_path / "weird.jpg"
-        img.write_bytes(b"\xff\xd8\xff\xe0junk")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.side_effect = RuntimeError("kaboom")
@@ -204,7 +224,11 @@ class TestGetImageHash:
 
         for ext in (".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".tif", ".webp"):
             img = tmp_path / f"image{ext}"
-            img.write_bytes(b"\x00" * 10)
+            # PR3f: get_image_hash now decodes via PIL before hashing;
+            # the test exercises the extension-suffix check, not format
+            # detection, so writing JPEG bytes to every suffix works
+            # (Pillow reads the magic bytes, not the extension).
+            _make_jpeg(img)
             result = dedup.get_image_hash(img)
             assert result == "aabbccdd", f"Failed for extension {ext}"
 
@@ -269,8 +293,8 @@ class TestComputeSimilarity:
         """Test perfect similarity for images with identical hashes."""
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8data1")
-        img2.write_bytes(b"\xff\xd8data2")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = "abcdef1234567890"
@@ -282,8 +306,8 @@ class TestComputeSimilarity:
         """Test zero similarity for maximally different hashes."""
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8data1")
-        img2.write_bytes(b"\xff\xd8data2")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.side_effect = [
@@ -298,8 +322,8 @@ class TestComputeSimilarity:
         """Test partial similarity with known distance."""
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8data1")
-        img2.write_bytes(b"\xff\xd8data2")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
 
         dedup = _make_dedup()
         # 0x000000000000000f vs 0x0000000000000000 -> 4 bits differ
@@ -315,7 +339,7 @@ class TestComputeSimilarity:
         """Test None returned when first image can't be hashed."""
         img1 = tmp_path / "missing.jpg"  # does not exist
         img2 = tmp_path / "b.jpg"
-        img2.write_bytes(b"\xff\xd8data2")
+        _make_jpeg(img2)
 
         dedup = _make_dedup()
         result = dedup.compute_similarity(img1, img2)
@@ -324,7 +348,7 @@ class TestComputeSimilarity:
     def test_second_image_fails(self, tmp_path: Path):
         """Test None returned when second image can't be hashed."""
         img1 = tmp_path / "a.jpg"
-        img1.write_bytes(b"\xff\xd8data1")
+        _make_jpeg(img1)
         img2 = tmp_path / "missing.jpg"
 
         dedup = _make_dedup()
@@ -363,8 +387,8 @@ class TestFindDuplicates:
         """Test empty result when all images are unique."""
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.png"
-        img1.write_bytes(b"\xff\xd8data1")
-        img2.write_bytes(b"\x89PNGdata2")
+        _make_jpeg(img1)
+        _make_jpeg(img2)  # JPEG bytes in .png — Pillow opens by magic, not suffix
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.side_effect = ["hash1", "hash2"]
@@ -382,7 +406,7 @@ class TestFindDuplicates:
         img2 = tmp_path / "b.jpg"
         img3 = tmp_path / "c.png"
         for img in (img1, img2, img3):
-            img.write_bytes(b"\xff\xd8fakeimage")
+            _make_jpeg(img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.side_effect = ["hash_a", "hash_b", "hash_c"]
@@ -401,7 +425,7 @@ class TestFindDuplicates:
     def test_progress_callback(self, tmp_path: Path):
         """Test that progress callback is invoked for each image."""
         img = tmp_path / "photo.jpg"
-        img.write_bytes(b"\xff\xd8data")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = "somehash"
@@ -416,7 +440,7 @@ class TestFindDuplicates:
         subdir = tmp_path / "sub"
         subdir.mkdir()
         img = subdir / "nested.jpg"
-        img.write_bytes(b"\xff\xd8data")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = "nested_hash"
@@ -429,38 +453,42 @@ class TestFindDuplicates:
         """Test recursive=False does NOT find images in subdirectories."""
         subdir = tmp_path / "sub"
         subdir.mkdir()
-        (subdir / "nested.jpg").write_bytes(b"\xff\xd8data")
+        _make_jpeg(subdir / "nested.jpg")
         root_img = tmp_path / "root.jpg"
-        root_img.write_bytes(b"\xff\xd8data")
+        _make_jpeg(root_img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = "root_hash"
         dedup.hasher.find_duplicates.return_value = {str(root_img): []}
 
         dedup.find_duplicates(tmp_path, recursive=False)
-        dedup.hasher.encode_image.assert_called_once_with(str(root_img))
+        # PR3f: hasher receives image_array=, not path
+        dedup.hasher.encode_image.assert_called_once()
+        kwargs = dedup.hasher.encode_image.call_args.kwargs
+        assert "image_array" in kwargs
 
     def test_skips_unhashable_images(self, tmp_path: Path):
         """Test that images failing to hash are excluded."""
         good = tmp_path / "good.jpg"
         bad = tmp_path / "bad.jpg"
-        good.write_bytes(b"\xff\xd8good")
-        bad.write_bytes(b"\xff\xd8bad")
+        _make_jpeg(good)
+        _make_jpeg(bad)
 
         dedup = _make_dedup()
 
-        # encode_image should return hash for good, None for bad (order-independent)
-        def encode_image_side_effect(path: str) -> str | None:
-            if path == str(good):
+        # PR3f: encode_image is now called with image_array=<numpy array>,
+        # not str(path) — we can't dispatch by path. Patch get_image_hash
+        # directly so we can decide good vs bad by path without relying on
+        # _find_image_files' ordering.
+        def hash_side_effect(image_path: Path, *, trusted_root: Path | None = None) -> str | None:
+            if image_path == good:
                 return "good_hash"
-            elif path == str(bad):
-                return None
             return None
 
-        dedup.hasher.encode_image.side_effect = encode_image_side_effect
-        dedup.hasher.find_duplicates.return_value = {str(good): []}
+        with patch.object(dedup, "get_image_hash", side_effect=hash_side_effect):
+            dedup.hasher.find_duplicates.return_value = {str(good): []}
+            dedup.find_duplicates(tmp_path)
 
-        dedup.find_duplicates(tmp_path)
         call_kwargs = dedup.hasher.find_duplicates.call_args
         encoding_map = call_kwargs.kwargs.get("encoding_map", call_kwargs[1].get("encoding_map"))
         assert str(good) in encoding_map
@@ -482,7 +510,7 @@ class TestClusterBySimilarity:
     def test_all_hashes_fail(self, tmp_path: Path):
         """Test empty clusters when no image can be hashed."""
         img = tmp_path / "bad.jpg"
-        img.write_bytes(b"\xff\xd8corrupt")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = None
@@ -493,7 +521,7 @@ class TestClusterBySimilarity:
     def test_single_image_no_cluster(self, tmp_path: Path):
         """Test that a single image does not form a cluster."""
         img = tmp_path / "solo.jpg"
-        img.write_bytes(b"\xff\xd8solo")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = "0000000000000000"
@@ -505,8 +533,8 @@ class TestClusterBySimilarity:
         """Test cluster of two identical images."""
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8data")
-        img2.write_bytes(b"\xff\xd8data")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
 
         dedup = _make_dedup(threshold=10)
         dedup.hasher.encode_image.return_value = "abcdef1234567890"
@@ -520,8 +548,8 @@ class TestClusterBySimilarity:
         """Test no clusters for very different images."""
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8data1")
-        img2.write_bytes(b"\xff\xd8data2")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
 
         dedup = _make_dedup(threshold=0)
         dedup.hasher.encode_image.side_effect = [
@@ -536,8 +564,8 @@ class TestClusterBySimilarity:
         """Test progress callback is called during clustering."""
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.jpg"
-        img1.write_bytes(b"\xff\xd8d1")
-        img2.write_bytes(b"\xff\xd8d2")
+        _make_jpeg(img1)
+        _make_jpeg(img2)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = "aabb"
@@ -553,7 +581,7 @@ class TestClusterBySimilarity:
         imgs = []
         for name in ("a.jpg", "b.jpg", "c.jpg", "d.jpg"):
             p = tmp_path / name
-            p.write_bytes(b"\xff\xd8data")
+            _make_jpeg(p)
             imgs.append(p)
 
         dedup = _make_dedup(threshold=5)
@@ -585,8 +613,8 @@ class TestBatchComputeHashes:
         """Test all images hashed successfully."""
         img1 = tmp_path / "a.jpg"
         img2 = tmp_path / "b.png"
-        img1.write_bytes(b"\xff\xd8d1")
-        img2.write_bytes(b"\x89PNGd2")
+        _make_jpeg(img1)
+        _make_jpeg(img2)  # JPEG bytes in .png — Pillow detects by magic bytes
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.side_effect = ["hash_a", "hash_b"]
@@ -598,8 +626,8 @@ class TestBatchComputeHashes:
         """Test that failed images are excluded from results."""
         good = tmp_path / "good.jpg"
         bad = tmp_path / "bad.jpg"
-        good.write_bytes(b"\xff\xd8good")
-        bad.write_bytes(b"\xff\xd8bad")
+        _make_jpeg(good)
+        _make_jpeg(bad)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.side_effect = ["good_hash", None]
@@ -612,7 +640,7 @@ class TestBatchComputeHashes:
         imgs = []
         for i in range(3):
             p = tmp_path / f"img{i}.jpg"
-            p.write_bytes(b"\xff\xd8data")
+            _make_jpeg(p)
             imgs.append(p)
 
         dedup = _make_dedup()
@@ -628,7 +656,7 @@ class TestBatchComputeHashes:
     def test_no_callback(self, tmp_path: Path):
         """Test batch works without progress callback."""
         img = tmp_path / "only.jpg"
-        img.write_bytes(b"\xff\xd8ok")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
         dedup.hasher.encode_image.return_value = "ok_hash"
@@ -719,13 +747,16 @@ class TestValidateImage:
     def test_valid_image(self, tmp_path: Path):
         """Test validation passes for a readable image."""
         img = tmp_path / "valid.jpg"
-        img.write_bytes(b"\xff\xd8\xff\xe0data")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
-        with patch("services.deduplication.image_dedup.Image") as mock_image:
+        # PR3f: validate_image now opens via ``safedir_image_open`` which
+        # yields a (img, fd) tuple. Patch the helper directly so the test
+        # doesn't need a real JPEG payload or a live SafeDir.
+        with patch("services.deduplication.image_dedup.safedir_image_open") as mock_open:
             mock_ctx = MagicMock()
-            mock_image.open.return_value.__enter__ = MagicMock(return_value=mock_ctx)
-            mock_image.open.return_value.__exit__ = MagicMock(return_value=False)
+            mock_open.return_value.__enter__ = MagicMock(return_value=(mock_ctx, None))
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
 
             is_valid, error = dedup.validate_image(img)
             assert is_valid is True
@@ -758,12 +789,12 @@ class TestValidateImage:
     def test_corrupt_image_os_error(self, tmp_path: Path):
         """Test validation fails for corrupt image (PIL raises OSError)."""
         img = tmp_path / "corrupt.jpg"
-        img.write_bytes(b"\xff\xd8\xff\xe0corrupt")
+        _make_jpeg(img)
 
         dedup = _make_dedup()
-        with patch("services.deduplication.image_dedup.Image") as mock_image:
-            mock_image.open.return_value.__enter__ = MagicMock(side_effect=OSError("truncated"))
-            mock_image.open.return_value.__exit__ = MagicMock(return_value=False)
+        with patch("services.deduplication.image_dedup.safedir_image_open") as mock_open:
+            mock_open.return_value.__enter__ = MagicMock(side_effect=OSError("truncated"))
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
 
             is_valid, error = dedup.validate_image(img)
             assert is_valid is False
@@ -775,11 +806,9 @@ class TestValidateImage:
         img.write_bytes(b"\x89PNGbaddata")
 
         dedup = _make_dedup()
-        with patch("services.deduplication.image_dedup.Image") as mock_image:
-            mock_image.open.return_value.__enter__ = MagicMock(
-                side_effect=RuntimeError("weird error")
-            )
-            mock_image.open.return_value.__exit__ = MagicMock(return_value=False)
+        with patch("services.deduplication.image_dedup.safedir_image_open") as mock_open:
+            mock_open.return_value.__enter__ = MagicMock(side_effect=RuntimeError("weird error"))
+            mock_open.return_value.__exit__ = MagicMock(return_value=False)
 
             is_valid, error = dedup.validate_image(img)
             assert is_valid is False

--- a/tests/services/deduplication/test_image_safedir.py
+++ b/tests/services/deduplication/test_image_safedir.py
@@ -1,0 +1,446 @@
+"""Tests for the SafeDir-aware ``safedir_image_open`` helper and its
+integration with the image-dedup utilities.
+
+PR3f of #267 wires ``utils.safedir.SafeDir`` into the image dedup
+ingestion path. Every ``PIL.Image.open(...)`` call in
+``services/deduplication/{image_utils,image_dedup,viewer}.py`` now goes
+through ``safedir_image_open`` so a symlink swapped into the organize
+root between the directory walk and the read is refused with
+``SymlinkRejected`` rather than dereferenced.
+
+Verifies:
+
+- ``safedir_image_open`` opens a real image and yields a PIL.Image
+- Symlinks under the SafeDir root are refused
+- On Windows (``NotImplementedError``) the helper falls back to direct
+  ``Image.open(path)``
+- The downstream utility functions
+  (``get_image_metadata`` / ``get_image_dimensions`` / etc.) route
+  symlinks to the same safe-default returns as other I/O errors
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from PIL import Image as _PILImage
+
+from services.deduplication.image_utils import (
+    get_image_dimensions,
+    get_image_format,
+    get_image_metadata,
+    safedir_image_open,
+    validate_image_file,
+)
+from utils.safedir import SymlinkRejected
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+    pytest.mark.integration,
+    pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only"),
+]
+
+
+def _make_jpeg(path: Path, size: tuple[int, int] = (8, 8)) -> None:
+    """Write a tiny JPEG to ``path`` for round-trip tests."""
+    img = _PILImage.new("RGB", size, color=(100, 150, 200))
+    img.save(path, format="JPEG")
+
+
+class TestSafedirImageOpenHelper:
+    def test_opens_real_image(self, tmp_path: Path) -> None:
+        target = tmp_path / "photo.jpg"
+        _make_jpeg(target, size=(16, 8))
+        with safedir_image_open(target) as (img, _fd):
+            assert img.size == (16, 8)
+            assert img.format == "JPEG"
+
+    def test_refuses_symlinked_image(self, tmp_path: Path) -> None:
+        """A symlinked image in the organize root must be refused —
+        ``SafeDir.open_for_reader`` raises ``SymlinkRejected``, which
+        is an ``OSError`` subclass.
+        """
+        real = tmp_path / "secret.jpg"
+        _make_jpeg(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "decoy.jpg").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        with pytest.raises(SymlinkRejected):
+            with safedir_image_open(organize / "decoy.jpg"):
+                pass
+
+    def test_falls_back_to_path_open_when_safedir_not_implemented(self, tmp_path: Path) -> None:
+        """When SafeDir.open_root raises NotImplementedError (Windows-style
+        port not available), the helper falls back to direct
+        ``Image.open(path)`` — preserves the legacy API surface.
+        """
+        target = tmp_path / "fallback.jpg"
+        _make_jpeg(target)
+        with patch(
+            "services.deduplication.image_utils.SafeDir.open_root",
+            side_effect=NotImplementedError("simulated unavailable SafeDir"),
+        ):
+            with safedir_image_open(target) as (img, _fd):
+                assert img.size == (8, 8)
+
+    def test_closes_fd_when_fdopen_raises(self, tmp_path: Path) -> None:
+        """If ``os.fdopen`` raises (e.g. transient OSError on a closed
+        dir_fd race), the helper must close the raw fd returned by
+        ``open_for_reader`` before the exception propagates — otherwise
+        we leak a descriptor. Verified via patch on ``os.fdopen``.
+
+        ``os.close`` is patched with ``side_effect=os.close`` (i.e. the
+        real ``os.close``) so the leak guard's call AND SafeDir's own
+        dir_fd cleanup actually close their fds — patching with a bare
+        ``MagicMock`` would just record the calls and leak the fds
+        during the test run (Copilot #281 review).
+        """
+        target = tmp_path / "fd_leak_test.jpg"
+        _make_jpeg(target)
+        real_os_close = os.close  # capture before patching
+        with patch(
+            "services.deduplication.image_utils.os.fdopen",
+            side_effect=OSError("synthetic fdopen failure"),
+        ) as mock_fdopen:
+            with patch(
+                "services.deduplication.image_utils.os.close",
+                side_effect=real_os_close,
+            ) as mock_close:
+                with pytest.raises(OSError, match="synthetic fdopen failure"):
+                    with safedir_image_open(target):
+                        pass
+                # The raw fd from SafeDir.open_for_reader was reclaimed —
+                # SafeDir.__exit__ also closes its own dir_fd, so we get
+                # ≥1 close call. The fd that ``os.fdopen`` tried to wrap
+                # must be among the closed fds.
+                assert mock_close.call_count >= 1
+                fdopen_fd = mock_fdopen.call_args[0][0]
+                assert isinstance(fdopen_fd, int) and fdopen_fd >= 0
+                closed_fds = {call.args[0] for call in mock_close.call_args_list}
+                assert fdopen_fd in closed_fds
+
+
+class TestImageUtilsRoutesThroughHelper:
+    """The migrated image_utils functions return the legacy safe-default
+    ``None`` when the underlying image is unreadable. Symlink rejection is
+    just another OSError and routes the same way."""
+
+    def test_get_image_metadata_returns_none_on_symlink(self, tmp_path: Path) -> None:
+        real = tmp_path / "real.jpg"
+        _make_jpeg(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "link.jpg").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        out = get_image_metadata(organize / "link.jpg")
+        assert out is None
+
+    def test_get_image_dimensions_returns_none_on_symlink(self, tmp_path: Path) -> None:
+        real = tmp_path / "real.jpg"
+        _make_jpeg(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "link.jpg").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        assert get_image_dimensions(organize / "link.jpg") is None
+
+    def test_get_image_format_returns_none_on_symlink(self, tmp_path: Path) -> None:
+        real = tmp_path / "real.jpg"
+        _make_jpeg(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "link.jpg").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        assert get_image_format(organize / "link.jpg") is None
+
+    def test_validate_image_file_rejects_symlink(self, tmp_path: Path) -> None:
+        """``validate_image_file`` exists-checks first (the symlink itself
+        exists), then tries to open via SafeDir — which refuses. The
+        function returns ``(False, "...")``.
+        """
+        real = tmp_path / "real.jpg"
+        _make_jpeg(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "link.jpg").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        is_valid, err = validate_image_file(organize / "link.jpg")
+        assert is_valid is False
+        assert err is not None
+
+    def test_get_image_metadata_happy_path(self, tmp_path: Path) -> None:
+        target = tmp_path / "p.jpg"
+        _make_jpeg(target, size=(20, 10))
+        meta = get_image_metadata(target)
+        assert meta is not None
+        assert meta.width == 20
+        assert meta.height == 10
+        assert meta.format == "JPEG"
+        assert meta.size_bytes > 0
+
+
+class TestImageDedupValidateRefusesSymlinks:
+    """The ``ImageDeduplicator.validate_image`` flow now goes through
+    ``safedir_image_open`` — symlinks return ``(False, "Cannot read
+    image: ...")``."""
+
+    def test_validate_refuses_symlinked_image(self, tmp_path: Path) -> None:
+        pytest.importorskip("imagededup")  # dedup-image extra not in [dev,search]
+        from services.deduplication.image_dedup import ImageDeduplicator
+
+        real = tmp_path / "real.jpg"
+        _make_jpeg(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "decoy.jpg").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        dedup = ImageDeduplicator()
+        is_valid, err = dedup.validate_image(organize / "decoy.jpg")
+        assert is_valid is False
+        assert err is not None
+        assert "Cannot read image" in err or "symlink" in err.lower()
+
+
+class TestGetImageHashErrorBranches:
+    """Cover the new error-handling branches in ``ImageDeduplicator.
+    get_image_hash`` introduced by PR3f's SafeDir-routed hashing
+    (#281 reviews). These run with mocked imagededup so they don't
+    need the ``dedup-image`` extra installed.
+    """
+
+    def _make_dedup(self):
+        """Build an ImageDeduplicator with a controllable hasher mock.
+
+        Patches the imagededup availability flag so the constructor
+        succeeds even when the optional extra is absent (CI matrix).
+        """
+        from unittest.mock import MagicMock
+        from unittest.mock import patch as _patch
+
+        from services.deduplication import image_dedup as _id
+
+        with (
+            _patch.object(_id, "_IMAGEDEDUP_AVAILABLE", True),
+            _patch.object(_id, "PHash", MagicMock(return_value=MagicMock())),
+            _patch.object(_id, "DHash", MagicMock(return_value=MagicMock())),
+            _patch.object(_id, "AHash", MagicMock(return_value=MagicMock())),
+        ):
+            d = _id.ImageDeduplicator()
+        d.hasher = MagicMock()
+        return d
+
+    def test_decompression_bomb_returns_none(self, tmp_path: Path) -> None:
+        """DecompressionBombError on Image.open is caught and returns
+        None — must not abort a find_duplicates / batch_compute_hashes
+        scan."""
+        from PIL.Image import DecompressionBombError
+
+        img = tmp_path / "bomb.jpg"
+        img.write_bytes(b"\x00")  # bytes irrelevant; we patch safedir_image_open
+
+        dedup = self._make_dedup()
+        with patch(
+            "services.deduplication.image_dedup.safedir_image_open",
+            side_effect=DecompressionBombError("synthetic bomb"),
+        ):
+            result = dedup.get_image_hash(img)
+        assert result is None
+
+    def test_non_rgb_image_is_converted(self, tmp_path: Path) -> None:
+        """Non-RGB images (e.g. RGBA, L) are converted before being
+        handed to imagededup as a numpy array. Exercises the
+        ``img.mode != "RGB": img = img.convert("RGB")`` branch.
+        """
+        from unittest.mock import MagicMock
+
+        img = tmp_path / "rgba.png"
+        _make_jpeg(img)
+
+        # Mock the helper to return a non-RGB image.
+        mock_rgba_img = MagicMock()
+        mock_rgba_img.mode = "RGBA"
+        mock_rgb_img = MagicMock()
+        mock_rgb_img.mode = "RGB"
+        mock_rgba_img.convert.return_value = mock_rgb_img
+
+        mock_cm = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=(mock_rgba_img, None))
+        mock_cm.__exit__ = MagicMock(return_value=False)
+
+        dedup = self._make_dedup()
+        dedup.hasher.encode_image.return_value = "deadbeef"
+
+        import numpy as np
+
+        # Provide a real 3-channel uint8 array so the new BGR-reverse
+        # slicing (``[:, :, ::-1]``) and ``np.ascontiguousarray`` work.
+        fake_rgb = np.zeros((4, 4, 3), dtype=np.uint8)
+        with (
+            patch(
+                "services.deduplication.image_dedup.safedir_image_open",
+                return_value=mock_cm,
+            ),
+            patch("numpy.asarray", return_value=fake_rgb),
+        ):
+            result = dedup.get_image_hash(img)
+
+        assert result == "deadbeef"
+        # The non-RGB branch was taken: convert("RGB") called once.
+        mock_rgba_img.convert.assert_called_once_with("RGB")
+        # imagededup received a contiguous RGB 3-channel array.
+        # ``ascontiguousarray`` is preserved for future-proofing even
+        # though plain ``np.asarray(img)`` is already C-contiguous —
+        # the assertion locks the contract.
+        passed_array = dedup.hasher.encode_image.call_args.kwargs["image_array"]
+        assert passed_array.shape == (4, 4, 3)
+        assert passed_array.flags["C_CONTIGUOUS"]
+
+
+class TestViewerMetadataFdNoneFallback:
+    """``viewer._get_image_metadata`` falls back to ``image_path.stat()``
+    when ``safedir_image_open`` yields ``fd is None`` (Windows / SafeDir
+    unavailable). Exercised by simulating the NotImplementedError
+    fallback path."""
+
+    def test_viewer_metadata_uses_path_stat_when_fd_none(self, tmp_path: Path) -> None:
+        from services.deduplication.viewer import ComparisonViewer
+
+        target = tmp_path / "img.jpg"
+        _make_jpeg(target, size=(12, 10))
+
+        viewer = ComparisonViewer()
+        # Force the Windows-style fallback so the helper yields fd=None.
+        with patch(
+            "services.deduplication.image_utils.SafeDir.open_root",
+            side_effect=NotImplementedError("simulated fallback"),
+        ):
+            meta = viewer._get_image_metadata(target)
+
+        assert meta.width == 12
+        assert meta.height == 10
+        # File size came from path.stat (not os.fstat).
+        assert meta.file_size > 0
+
+
+class TestHashEquivalenceWithPathCodepath:
+    """The SafeDir-routed ``get_image_hash`` must produce the same
+    perceptual hash as imagededup's path-based ``encode_image(path)``
+    flow — otherwise the migration silently breaks dedup matches on
+    existing corpora. This test runs with REAL imagededup installed
+    and asserts byte-for-byte hash equality between the two paths.
+
+    Skipped when ``imagededup`` is absent (CI matrix without the
+    dedup-image extra). Locally with the extra installed this is the
+    regression test that catches channel-order / preprocessing
+    mismatches like the one Codex flagged on PR3f.
+    """
+
+    def test_safedir_hash_matches_path_hash(self, tmp_path: Path) -> None:
+        # ``test_image_dedup.py`` injects a fake ``imagededup`` into
+        # ``sys.modules`` via ``setdefault`` when the real extra is
+        # absent, which means a plain ``importorskip("imagededup")``
+        # succeeds against the mock and the test would then fail
+        # calling real hash methods. Probe a submodule the fake doesn't
+        # provide instead — it only exists when the actual library is
+        # installed.
+        pytest.importorskip("imagededup.utils.image_utils")
+        # A color photo where R/B differ noticeably, so any R/B swap
+        # would produce a clearly different perceptual hash.
+        from PIL import Image as _PILImage
+
+        from services.deduplication.image_dedup import ImageDeduplicator
+
+        target = tmp_path / "color.jpg"
+        # Diagonal gradient with strong red dominance so the grayscale
+        # luminance differs from a B-dominant version.
+        img = _PILImage.new("RGB", (32, 32))
+        pixels = img.load()
+        for y in range(32):
+            for x in range(32):
+                pixels[x, y] = (200 + (x % 16), 50, 30 + (y % 32))
+        img.save(target, format="JPEG", quality=95)
+
+        dedup = ImageDeduplicator(hash_method="phash")
+        # Path-based reference hash (what imagededup would compute on
+        # its own, no SafeDir involved).
+        reference = dedup.hasher.encode_image(image_file=str(target))
+
+        # SafeDir-routed hash via our refactored get_image_hash.
+        safedir_hash = dedup.get_image_hash(target)
+
+        assert safedir_hash == reference, (
+            f"SafeDir hash {safedir_hash!r} != path-based reference "
+            f"{reference!r} — channel ordering or preprocessing drift"
+        )
+
+
+class TestQualityFdStatBranch:
+    """Cover the new ``os.fstat(fd)`` branch in
+    ``quality.ImageQualityAnalyzer._extract_metrics_with_pil``
+    introduced by 552228c. The existing test_quality.py tests mock
+    safedir_image_open to yield ``(mock_img, None)`` — only the
+    ``fd is None`` path is exercised. Add a test that yields a real
+    integer fd so the ``os.fstat(fd)`` branch is hit.
+    """
+
+    def test_quality_uses_fstat_when_fd_is_supplied(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        from services.deduplication.quality import ImageQualityAnalyzer
+
+        analyzer = ImageQualityAnalyzer()
+        target = tmp_path / "img.jpg"
+        _make_jpeg(target, size=(40, 30))
+
+        # Open a real fd so os.fstat() can be called on it. Provide
+        # a fake PIL Image with the expected attributes; the helper
+        # mock yields (img, fd). The fd must be valid for fstat to
+        # report a sensible size.
+        real_fd = os.open(str(target), os.O_RDONLY)
+        try:
+            mock_img = MagicMock()
+            mock_img.size = (40, 30)
+            mock_img.format = "JPEG"
+            mock_img.mode = "RGB"
+            mock_img.info = {}
+
+            cm = MagicMock()
+            cm.__enter__ = MagicMock(return_value=(mock_img, real_fd))
+            cm.__exit__ = MagicMock(return_value=False)
+            with patch(
+                "services.deduplication.image_utils.safedir_image_open",
+                return_value=cm,
+            ):
+                metrics = analyzer._extract_metrics_with_pil(target)
+        finally:
+            os.close(real_fd)
+
+        assert metrics is not None
+        assert metrics.width == 40
+        assert metrics.height == 30
+        # os.fstat path was taken: file_size came from the fd, not path.stat().
+        assert metrics.file_size > 0

--- a/tests/services/deduplication/test_quality.py
+++ b/tests/services/deduplication/test_quality.py
@@ -5,7 +5,7 @@ fallback behavior when PIL is unavailable.
 """
 
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -297,10 +297,18 @@ class TestExtractMetricsWithPil:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
+        # PR3f: quality.py now opens via safedir_image_open (tuple yield).
 
-        m = analyzer._extract_metrics_with_pil(p)
+        # Patch the helper to yield (mock_img, None).
+
+        _cm = MagicMock()
+
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+
+        _cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer._extract_metrics_with_pil(p)
         assert m is not None
         assert m.width == 1920
         assert m.height == 1080
@@ -324,10 +332,18 @@ class TestExtractMetricsWithPil:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
+        # PR3f: quality.py now opens via safedir_image_open (tuple yield).
 
-        m = analyzer._extract_metrics_with_pil(p)
+        # Patch the helper to yield (mock_img, None).
+
+        _cm = MagicMock()
+
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+
+        _cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer._extract_metrics_with_pil(p)
         assert m.has_transparency is True
         assert m.color_depth == 32
 
@@ -344,10 +360,18 @@ class TestExtractMetricsWithPil:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
+        # PR3f: quality.py now opens via safedir_image_open (tuple yield).
 
-        m = analyzer._extract_metrics_with_pil(p)
+        # Patch the helper to yield (mock_img, None).
+
+        _cm = MagicMock()
+
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+
+        _cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer._extract_metrics_with_pil(p)
         assert m.has_transparency is True
         assert m.color_depth == 8  # P mode
 
@@ -364,10 +388,18 @@ class TestExtractMetricsWithPil:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
+        # PR3f: quality.py now opens via safedir_image_open (tuple yield).
 
-        m = analyzer._extract_metrics_with_pil(p)
+        # Patch the helper to yield (mock_img, None).
+
+        _cm = MagicMock()
+
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+
+        _cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer._extract_metrics_with_pil(p)
         assert m.has_transparency is True
 
     def test_unknown_mode_defaults_to_24_bit(self, analyzer, tmp_path):
@@ -383,10 +415,18 @@ class TestExtractMetricsWithPil:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
+        # PR3f: quality.py now opens via safedir_image_open (tuple yield).
 
-        m = analyzer._extract_metrics_with_pil(p)
+        # Patch the helper to yield (mock_img, None).
+
+        _cm = MagicMock()
+
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+
+        _cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer._extract_metrics_with_pil(p)
         assert m.color_depth == 24
 
     def test_height_zero_aspect_ratio(self, analyzer, tmp_path):
@@ -402,10 +442,18 @@ class TestExtractMetricsWithPil:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
+        # PR3f: quality.py now opens via safedir_image_open (tuple yield).
 
-        m = analyzer._extract_metrics_with_pil(p)
+        # Patch the helper to yield (mock_img, None).
+
+        _cm = MagicMock()
+
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+
+        _cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer._extract_metrics_with_pil(p)
         assert m.aspect_ratio == 0
 
     def test_exception_returns_none(self, analyzer, tmp_path):
@@ -413,11 +461,13 @@ class TestExtractMetricsWithPil:
         p = tmp_path / "corrupt.jpg"
         p.write_bytes(b"\x00" * 100)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.side_effect = OSError("Corrupt image")
-
-        m = analyzer._extract_metrics_with_pil(p)
-        assert m is None
+        # PR3f: quality.py now opens via safedir_image_open.
+        with patch(
+            "services.deduplication.image_utils.safedir_image_open",
+            side_effect=OSError("Corrupt image"),
+        ):
+            m = analyzer._extract_metrics_with_pil(p)
+            assert m is None
 
     def test_webp_format_is_compressed(self, analyzer, tmp_path):
         """WEBP format is correctly flagged as compressed."""
@@ -432,10 +482,18 @@ class TestExtractMetricsWithPil:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
+        # PR3f: quality.py now opens via safedir_image_open (tuple yield).
 
-        m = analyzer._extract_metrics_with_pil(p)
+        # Patch the helper to yield (mock_img, None).
+
+        _cm = MagicMock()
+
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+
+        _cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer._extract_metrics_with_pil(p)
         assert m.is_compressed is True
 
     def test_png_format_not_compressed(self, analyzer, tmp_path):
@@ -451,10 +509,18 @@ class TestExtractMetricsWithPil:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
+        # PR3f: quality.py now opens via safedir_image_open (tuple yield).
 
-        m = analyzer._extract_metrics_with_pil(p)
+        # Patch the helper to yield (mock_img, None).
+
+        _cm = MagicMock()
+
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+
+        _cm.__exit__ = MagicMock(return_value=False)
+
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer._extract_metrics_with_pil(p)
         assert m.is_compressed is False
 
 
@@ -499,10 +565,12 @@ class TestGetQualityMetrics:
         mock_img.__enter__ = MagicMock(return_value=mock_img)
         mock_img.__exit__ = MagicMock(return_value=False)
 
-        analyzer.Image = MagicMock()
-        analyzer.Image.open.return_value = mock_img
-
-        m = analyzer.get_quality_metrics(p)
+        # PR3f: quality.py now opens via safedir_image_open.
+        _cm = MagicMock()
+        _cm.__enter__ = MagicMock(return_value=(mock_img, None))
+        _cm.__exit__ = MagicMock(return_value=False)
+        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+            m = analyzer.get_quality_metrics(p)
         assert m is not None
         assert m.width == 800
         assert m.height == 600

--- a/tests/services/search/test_read_text_safe_safedir.py
+++ b/tests/services/search/test_read_text_safe_safedir.py
@@ -1,0 +1,193 @@
+"""Regression tests for the SafeDir-routed read in
+``services.search.hybrid_retriever.read_text_safe`` (PR3h).
+
+The corpus text extractor reads up to ``CORPUS_TEXT_LIMIT`` bytes via
+``SafeDir.open_root`` + ``open_for_reader`` so a symlink swapped between
+corpus enumeration and the content read is refused rather than
+dereferenced (closes the LLM-exfiltration vector documented in #264).
+
+This file exercises every branch the SafeDir migration introduced:
+- happy path on a real on-disk file (no mocks)
+- ``SymlinkRejected`` returning ``""`` and logging a warning
+- ``NotImplementedError`` falling back to the legacy path-based open
+- ``os.fdopen`` raising ``OSError`` after the bare fd has been
+  obtained (cleanup must not leak the fd)
+- legacy path-based ``open`` raising ``OSError`` (returns ``""``)
+- defensive limit clamp: ``limit <= 0`` returns ``""`` without reading
+- defensive limit clamp: ``limit > CORPUS_TEXT_LIMIT`` is capped
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ``hybrid_retriever`` transitively imports BM25 / sklearn / numpy via
+# its ``VectorIndex`` and ``BM25Index`` siblings. The ``read_text_safe``
+# helper itself doesn't depend on them, but module import still pulls
+# them in, so we skip the file cleanly when the optional ``search`` /
+# ``dedup-text`` extras aren't installed (e.g. CI's lint env).
+pytest.importorskip("rank_bm25")
+pytest.importorskip("sklearn")
+
+from services.search.hybrid_retriever import (
+    CORPUS_TEXT_LIMIT,
+    read_text_safe,
+)
+from utils.safedir import SymlinkRejected
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+    pytest.mark.integration,
+]
+
+
+class TestReadTextSafeHappyPath:
+    """Sanity checks: real on-disk files must still work end-to-end."""
+
+    def test_reads_text_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "hello.txt"
+        target.write_text("hello world")
+        assert read_text_safe(target) == "hello world"
+
+    def test_returns_empty_for_binary_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "bin"
+        target.write_bytes(b"\x00\x01\x02\x03prefix")
+        assert read_text_safe(target) == ""
+
+    def test_caps_at_limit(self, tmp_path: Path) -> None:
+        target = tmp_path / "big.txt"
+        target.write_text("a" * (CORPUS_TEXT_LIMIT + 1000))
+        assert len(read_text_safe(target, limit=128)) == 128
+
+
+class TestReadTextSafeLimitClamp:
+    """Defensive limit handling: non-positive or oversized values must
+    not let the underlying ``read(n)`` call read the entire file (S3
+    corpus-cap rule)."""
+
+    def test_zero_limit_returns_empty(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.txt"
+        target.write_text("content")
+        assert read_text_safe(target, limit=0) == ""
+
+    def test_negative_limit_returns_empty(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.txt"
+        target.write_text("content")
+        assert read_text_safe(target, limit=-1) == ""
+
+    def test_oversized_limit_clamped_to_corpus_text_limit(self, tmp_path: Path) -> None:
+        target = tmp_path / "big.txt"
+        target.write_text("a" * (CORPUS_TEXT_LIMIT * 2))
+        # An oversized limit must NOT let us read more than CORPUS_TEXT_LIMIT.
+        out = read_text_safe(target, limit=CORPUS_TEXT_LIMIT * 2)
+        assert len(out) <= CORPUS_TEXT_LIMIT
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
+class TestReadTextSafeSafedirBranches:
+    """Each SafeDir error branch is mocked so we can prove the function
+    handles it the way the security contract demands (return ``""``,
+    log, no fd leak)."""
+
+    def test_symlink_rejected_returns_empty_string(self, tmp_path: Path) -> None:
+        target = tmp_path / "real.txt"
+        target.write_text("secret")
+        with patch(
+            "services.search.hybrid_retriever.SafeDir.open_root",
+            side_effect=SymlinkRejected("name"),
+        ):
+            assert read_text_safe(target) == ""
+
+    def test_not_implemented_falls_back_to_legacy_open(self, tmp_path: Path) -> None:
+        """When SafeDir is unavailable (e.g. macOS without dir_fd), the
+        function must read the file via the legacy ``path.open(...)``
+        fallback rather than returning empty.
+        """
+        target = tmp_path / "fallback.txt"
+        target.write_text("fallback content")
+        with patch(
+            "services.search.hybrid_retriever.SafeDir.open_root",
+            side_effect=NotImplementedError("no dir_fd"),
+        ):
+            assert read_text_safe(target) == "fallback content"
+
+    def test_fdopen_failure_closes_bare_fd(self, tmp_path: Path) -> None:
+        """If ``os.fdopen`` raises after ``open_for_reader`` already
+        returned a raw fd, the function must close that fd explicitly
+        (otherwise we leak file descriptors). We verify the cleanup by
+        spying on ``os.close``.
+        """
+        target = tmp_path / "real.txt"
+        target.write_text("never read")
+        sentinel_fd = 4242
+
+        # Build a fake SafeDir context whose open_for_reader returns
+        # our sentinel fd. We don't actually have an OS fd at that
+        # number, so we patch os.close to swallow it.
+        fake_safe_dir = MagicMock()
+        fake_safe_dir.open_for_reader.return_value = sentinel_fd
+        fake_cm = MagicMock()
+        fake_cm.__enter__.return_value = fake_safe_dir
+        fake_cm.__exit__.return_value = False
+
+        with (
+            patch(
+                "services.search.hybrid_retriever.SafeDir.open_root",
+                return_value=fake_cm,
+            ),
+            patch(
+                "services.search.hybrid_retriever.os.fdopen",
+                side_effect=OSError("fdopen blew up"),
+            ),
+            patch("services.search.hybrid_retriever.os.close") as mock_close,
+        ):
+            assert read_text_safe(target) == ""
+            mock_close.assert_called_once_with(sentinel_fd)
+
+    def test_safedir_oserror_returns_empty(self, tmp_path: Path) -> None:
+        """Any non-symlink OSError from the SafeDir branch (e.g. file
+        not found at open_for_reader) returns ``""`` — same shape as
+        the legacy path's ``except OSError: return ""``."""
+        target = tmp_path / "x.txt"
+        target.write_text("data")
+        with patch(
+            "services.search.hybrid_retriever.SafeDir.open_root",
+            side_effect=OSError("no such file"),
+        ):
+            assert read_text_safe(target) == ""
+
+    def test_safedir_valueerror_returns_empty(self, tmp_path: Path) -> None:
+        """SafeDir's name validation raises ``ValueError`` for
+        filenames containing backslash / NUL / path separators. On
+        POSIX such filenames are legal in the filesystem, so a corpus
+        enumerator can yield them. The helper must return ``""``
+        rather than letting the ``ValueError`` abort the caller."""
+        target = tmp_path / "ok.txt"
+        target.write_text("data")
+        with patch(
+            "services.search.hybrid_retriever.SafeDir.open_root",
+            side_effect=ValueError("name 'a\\b' contains path separator"),
+        ):
+            assert read_text_safe(target) == ""
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
+class TestReadTextSafeLegacyFallback:
+    """When the function falls through to the legacy ``path.open(...)``
+    branch (e.g. via ``NotImplementedError``), it must still return
+    ``""`` on OSError, matching the original PR1 behavior."""
+
+    def test_legacy_open_oserror_returns_empty(self, tmp_path: Path) -> None:
+        target = tmp_path / "x.txt"
+        # File never created — Path.open will OSError. We also disable
+        # the SafeDir path so we reach the legacy fallback.
+        with patch(
+            "services.search.hybrid_retriever.SafeDir.open_root",
+            side_effect=NotImplementedError(),
+        ):
+            assert read_text_safe(target) == ""

--- a/tests/services/test_text_processor.py
+++ b/tests/services/test_text_processor.py
@@ -176,6 +176,31 @@ class TestTextProcessorFileProcessing:
     """Tests for file processing logic."""
 
     @patch("services.text_processor.read_file")
+    @patch(
+        "services.text_processor.SafeDir.open_root",
+        side_effect=NotImplementedError("SafeDir requires POSIX dir_fd / O_NOFOLLOW support"),
+    )
+    def test_process_file_falls_back_when_safedir_unavailable(
+        self,
+        _mock_safedir: MagicMock,
+        mock_legacy_read: MagicMock,
+        text_processor: TextProcessor,
+        mock_text_model: MagicMock,
+    ) -> None:
+        """On Windows (or anywhere SafeDir is unavailable), ``process_file``
+        must fall back to the legacy path-based ``read_file`` so users can
+        still process common documents. Regression test for the Windows
+        ``NotImplementedError`` path."""
+        mock_legacy_read.return_value = "fallback content"
+        mock_text_model.generate.side_effect = ["desc", "folder_cat", "file_name"]
+
+        result = text_processor.process_file("test.txt")
+
+        assert result.error is None
+        assert "fallback" in (result.original_content or "")
+        mock_legacy_read.assert_called_once()
+
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_success(
         self, mock_read: MagicMock, text_processor: TextProcessor, mock_text_model: MagicMock
     ) -> None:
@@ -197,7 +222,7 @@ class TestTextProcessorFileProcessing:
         assert result.filename == "python_script_test"
         assert "test file about python" in result.original_content
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_path_conversion(
         self, mock_read: MagicMock, text_processor: TextProcessor, mock_text_model: MagicMock
     ) -> None:
@@ -209,7 +234,7 @@ class TestTextProcessorFileProcessing:
 
         assert result.file_path == Path("/some/path/test.md")
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_unsupported(
         self, mock_read: MagicMock, text_processor: TextProcessor
     ) -> None:
@@ -222,7 +247,7 @@ class TestTextProcessorFileProcessing:
         assert result.folder_name == "unsupported"
         assert result.filename == "test"
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_read_error(
         self, mock_read: MagicMock, text_processor: TextProcessor
     ) -> None:
@@ -234,7 +259,7 @@ class TestTextProcessorFileProcessing:
         assert result.error == "Permission denied"
         assert result.folder_name == "errors"
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_general_exception(
         self, mock_read: MagicMock, text_processor: TextProcessor
     ) -> None:
@@ -246,7 +271,7 @@ class TestTextProcessorFileProcessing:
         assert result.error == "Unexpected failure"
         assert result.folder_name == "errors"
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_toggle_flags(
         self, mock_read: MagicMock, text_processor: TextProcessor, mock_text_model: MagicMock
     ) -> None:
@@ -265,7 +290,7 @@ class TestTextProcessorFileProcessing:
         assert result.filename == ""
         mock_text_model.generate.assert_not_called()
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_original_content_truncated(
         self, mock_read: MagicMock, text_processor: TextProcessor, mock_text_model: MagicMock
     ) -> None:
@@ -279,7 +304,7 @@ class TestTextProcessorFileProcessing:
         assert result.original_content is not None
         assert len(result.original_content) == 500
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_has_processing_time(
         self, mock_read: MagicMock, text_processor: TextProcessor, mock_text_model: MagicMock
     ) -> None:
@@ -291,7 +316,7 @@ class TestTextProcessorFileProcessing:
 
         assert result.processing_time >= 0.0
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_description_only(
         self, mock_read: MagicMock, text_processor: TextProcessor, mock_text_model: MagicMock
     ) -> None:
@@ -311,7 +336,7 @@ class TestTextProcessorFileProcessing:
         assert result.filename == ""
         mock_text_model.generate.assert_called_once()
 
-    @patch("services.text_processor.read_file")
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_folder_uses_content_when_no_description(
         self, mock_read: MagicMock, text_processor: TextProcessor, mock_text_model: MagicMock
     ) -> None:

--- a/tests/services/test_text_processor_logging.py
+++ b/tests/services/test_text_processor_logging.py
@@ -68,7 +68,7 @@ class TestInfoLevelDoesNotLeakContent:
         with (
             patch("services.text_processor.logger") as mock_logger,
             patch(
-                "services.text_processor.read_file",
+                "services.text_processor.read_file_via_safedir",
                 return_value="healthcare content",
             ),
         ):
@@ -86,7 +86,7 @@ class TestInfoLevelDoesNotLeakContent:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="medical records"),
+            patch("services.text_processor.read_file_via_safedir", return_value="medical records"),
         ):
             processor.process_file(str(tmp_path / "records.txt"))
 
@@ -105,7 +105,7 @@ class TestInfoLevelDoesNotLeakContent:
         with (
             patch("services.text_processor.logger") as mock_logger,
             patch(
-                "services.text_processor.read_file",
+                "services.text_processor.read_file_via_safedir",
                 return_value="financial planning",
             ),
         ):
@@ -141,7 +141,7 @@ class TestWarningLevelDoesNotLeakContent:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="some text"),
+            patch("services.text_processor.read_file_via_safedir", return_value="some text"),
             patch("services.text_processor.clean_text", return_value="fallback_folder"),
         ):
             processor.process_file(str(tmp_path / "short_folder.txt"))
@@ -167,7 +167,7 @@ class TestWarningLevelDoesNotLeakContent:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="some code"),
+            patch("services.text_processor.read_file_via_safedir", return_value="some code"),
             patch("services.text_processor.clean_text", return_value="code_snippet"),
         ):
             processor.process_file(str(tmp_path / "short_fn.txt"))
@@ -186,7 +186,7 @@ class TestWarningLevelDoesNotLeakContent:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="content"),
+            patch("services.text_processor.read_file_via_safedir", return_value="content"),
             patch("services.text_processor.clean_text", return_value="fallback"),
         ):
             processor.process_file(str(tmp_path / "warn_test.txt"))
@@ -223,7 +223,7 @@ class TestDebugLevelDoesNotLeakAiResponses:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="text"),
+            patch("services.text_processor.read_file_via_safedir", return_value="text"),
         ):
             processor.process_file(str(tmp_path / "debug_test.txt"))
 
@@ -244,7 +244,7 @@ class TestDebugLevelDoesNotLeakAiResponses:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="text"),
+            patch("services.text_processor.read_file_via_safedir", return_value="text"),
         ):
             processor.process_file(str(tmp_path / "debug_fn_test.txt"))
 
@@ -267,7 +267,7 @@ class TestDebugLevelDoesNotLeakAiResponses:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="python code"),
+            patch("services.text_processor.read_file_via_safedir", return_value="python code"),
         ):
             processor.process_file(str(tmp_path / "code_guide.txt"))
 
@@ -300,7 +300,7 @@ class TestLogMessageFormats:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="recipe content"),
+            patch("services.text_processor.read_file_via_safedir", return_value="recipe content"),
         ):
             processor.process_file(str(tmp_path / "recipe.txt"))
 
@@ -321,7 +321,7 @@ class TestLogMessageFormats:
 
         with (
             patch("services.text_processor.logger") as mock_logger,
-            patch("services.text_processor.read_file", return_value="cooking content"),
+            patch("services.text_processor.read_file_via_safedir", return_value="cooking content"),
         ):
             processor.process_file(str(tmp_path / "cooking.txt"))
 

--- a/tests/services/test_text_processor_scan_root.py
+++ b/tests/services/test_text_processor_scan_root.py
@@ -114,3 +114,8 @@ class TestTextProcessorScanRoot:
         )
         # No error; the parent-rooted SafeDir open succeeded.
         assert result.error is None
+        # Verify the file content was actually read — guards against a
+        # regression where the parent-rooted branch silently returns
+        # empty/None content without surfacing an error.
+        assert result.original_content is not None
+        assert "legitimate content" in result.original_content

--- a/tests/services/test_text_processor_scan_root.py
+++ b/tests/services/test_text_processor_scan_root.py
@@ -1,0 +1,116 @@
+"""Tests for ``TextProcessor.process_file(..., scan_root=...)`` (#286).
+
+Separate from ``tests/utils/test_safedir_anchored.py`` because the tests
+here import ``services.text_processor.TextProcessor``, which transitively
+pulls in the ``models`` package singletons. Under ``-m ci`` (Test PR
+suite, xdist ``--dist=loadgroup``), those imports interact with the
+audio-model singleton state in a way that surfaces the pre-existing
+flake tracked in #291. By keeping these tests out of the ``ci`` mark
+set, the Test PR suite stays green; integration coverage is preserved
+via the ``integration`` mark, which is what the PR per-module coverage
+floor uses.
+
+If/when #291 is fixed (audio model singleton gets a proper teardown
+fixture), add the ``ci`` mark here too.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# NOTE on marks: ``ci`` is deliberately omitted — see module docstring.
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.integration,
+    pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only"),
+]
+
+
+def _mock_text_model() -> object:
+    """Build a MagicMock text model that satisfies TextProcessor's contract."""
+    from unittest.mock import MagicMock
+
+    from models.base import ModelType
+
+    model = MagicMock()
+    model.config.model_type = ModelType.TEXT
+    model.is_initialized = True
+    model.generate.return_value = "Mocked AI Response"
+    return model
+
+
+class TestTextProcessorScanRoot:
+    """``TextProcessor.process_file`` accepts an optional scan_root.
+
+    - Without scan_root: behavior is unchanged (parent-rooted SafeDir open).
+    - With scan_root: anchored traversal kicks in for the LLM-ingestion path.
+    """
+
+    def test_signature_accepts_scan_root(self, tmp_path: Path) -> None:
+        """Smoke test: kwarg appears in the function signature."""
+        from services.text_processor import TextProcessor
+
+        processor = TextProcessor(text_model=_mock_text_model())
+        sig_params = processor.process_file.__code__.co_varnames
+        assert "scan_root" in sig_params
+
+    def test_scan_root_exercises_anchored_path(self, tmp_path: Path) -> None:
+        """Calling process_file with scan_root walks intermediates anchored.
+
+        Verifies an ancestor symlink under scan_root causes the read to
+        be refused — which the parent-rooted path would silently
+        dereference. Covers the new branch in process_file end-to-end.
+        """
+        from services.text_processor import TextProcessor
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("attacker content")
+
+        inside = tmp_path / "inside"
+        inside.mkdir()
+        (inside / "evil").symlink_to(outside)
+
+        # Caller "discovered" inside/evil/secret.txt during a walk and now
+        # asks TextProcessor to read it under the anchored root `inside`.
+        victim = inside / "evil" / "secret.txt"
+
+        processor = TextProcessor(text_model=_mock_text_model())
+        result = processor.process_file(
+            victim,
+            generate_description=False,
+            generate_folder=False,
+            generate_filename=False,
+            scan_root=inside,
+        )
+        # The anchored path refuses the read (via SymlinkRejected on the
+        # 'evil' intermediate). The wrapper catches it and returns a
+        # ProcessedFile with the "Refused to read symlink" error.
+        assert result.error is not None
+        assert "symlink" in result.error.lower()
+        # Crucially, no attacker content reached the model.
+        assert result.original_content is None or "attacker" not in (result.original_content or "")
+
+    def test_scan_root_none_uses_parent_rooted_path(self, tmp_path: Path) -> None:
+        """When scan_root is None (default), legacy parent-rooted SafeDir open.
+
+        Same behaviour as PR3a–PR3i — covers the else branch.
+        """
+        from services.text_processor import TextProcessor
+
+        leaf = tmp_path / "doc.txt"
+        leaf.write_text("legitimate content")
+
+        processor = TextProcessor(text_model=_mock_text_model())
+        result = processor.process_file(
+            leaf,
+            generate_description=False,
+            generate_folder=False,
+            generate_filename=False,
+            # scan_root omitted — default None
+        )
+        # No error; the parent-rooted SafeDir open succeeded.
+        assert result.error is None

--- a/tests/utils/test_epub_enhanced_safedir.py
+++ b/tests/utils/test_epub_enhanced_safedir.py
@@ -1,0 +1,149 @@
+"""Regression tests for SafeDir-routed reads in
+``utils/epub_enhanced.py`` (PR3g #282).
+
+Verifies that ``EnhancedEPUBReader.read_epub`` and ``get_epub_metadata``
+refuse a symlinked EPUB rather than dereferencing it. The hardening
+landed alongside the rail bare-open detection in PR3g; without this
+regression, a future refactor that silently reverts to
+``epub.read_epub(file_path)`` would only show up in a security audit.
+"""
+
+from __future__ import annotations
+
+import sys
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from utils.safedir import SymlinkRejected
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.integration,
+    pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only"),
+]
+
+
+def _make_minimal_epub(path: Path) -> None:
+    """Build a smallest-possible EPUB so ebooklib can parse it.
+
+    Matches the structure used in PR3a's reader tests — just enough to
+    pass ebooklib's container/manifest checks.
+    """
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("mimetype", "application/epub+zip")
+        zf.writestr(
+            "META-INF/container.xml",
+            (
+                '<?xml version="1.0"?>'
+                '<container version="1.0" '
+                'xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
+                "<rootfiles>"
+                '<rootfile full-path="content.opf" '
+                'media-type="application/oebps-package+xml"/>'
+                "</rootfiles></container>"
+            ),
+        )
+        zf.writestr(
+            "content.opf",
+            (
+                '<?xml version="1.0"?>'
+                '<package version="2.0" xmlns="http://www.idpf.org/2007/opf" '
+                'unique-identifier="bookid">'
+                '<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">'
+                "<dc:title>Reg Test Book</dc:title>"
+                '<dc:identifier id="bookid">test</dc:identifier>'
+                "<dc:language>en</dc:language></metadata>"
+                '<manifest><item id="ch1" href="ch1.xhtml" '
+                'media-type="application/xhtml+xml"/></manifest>'
+                '<spine><itemref idref="ch1"/></spine></package>'
+            ),
+        )
+        zf.writestr(
+            "ch1.xhtml",
+            "<html><body><p>regression test chapter</p></body></html>",
+        )
+
+
+class TestEnhancedReaderRefusesSymlink:
+    """``EnhancedEPUBReader.read_epub`` must refuse a symlinked EPUB."""
+
+    def test_read_epub_refuses_symlinked_file(self, tmp_path: Path) -> None:
+        pytest.importorskip("ebooklib")
+        pytest.importorskip("bs4")
+        from utils.epub_enhanced import EnhancedEPUBReader
+
+        real = tmp_path / "secret.epub"
+        _make_minimal_epub(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "decoy.epub").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        reader = EnhancedEPUBReader()
+        # The security-specific OSError subclass propagates — callers
+        # can distinguish symlink rejection from a malformed EPUB.
+        with pytest.raises(SymlinkRejected):
+            reader.read_epub(organize / "decoy.epub")
+
+    def test_get_epub_metadata_refuses_symlinked_file(self, tmp_path: Path) -> None:
+        pytest.importorskip("ebooklib")
+        pytest.importorskip("bs4")
+        from utils.epub_enhanced import get_epub_metadata
+
+        real = tmp_path / "real.epub"
+        _make_minimal_epub(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "link.epub").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        with pytest.raises(SymlinkRejected):
+            get_epub_metadata(organize / "link.epub")
+
+    def test_read_epub_does_not_invoke_path_based_read_on_symlink(self, tmp_path: Path) -> None:
+        """Belt-and-suspenders: even if the read fails some other way,
+        verify ``epub.read_epub`` is never called with the symlink
+        path. Patches the underlying library binding to detect the
+        unsafe call.
+        """
+        pytest.importorskip("ebooklib")
+        pytest.importorskip("bs4")
+        from utils.epub_enhanced import EnhancedEPUBReader
+
+        real = tmp_path / "real.epub"
+        _make_minimal_epub(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "decoy.epub").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        reader = EnhancedEPUBReader()
+        with patch("utils.epub_enhanced.epub.read_epub") as spy:
+            # SymlinkRejected fires before epub.read_epub gets called.
+            with pytest.raises(SymlinkRejected):
+                reader.read_epub(organize / "decoy.epub")
+            # Lock in: epub.read_epub was never invoked with the
+            # symlinked path (or anything else).
+            assert spy.call_count == 0
+
+    def test_read_epub_still_works_for_real_file(self, tmp_path: Path) -> None:
+        """Sanity check: the hardening doesn't break the happy path."""
+        pytest.importorskip("ebooklib")
+        pytest.importorskip("bs4")
+        from utils.epub_enhanced import EnhancedEPUBReader
+
+        target = tmp_path / "book.epub"
+        _make_minimal_epub(target)
+
+        reader = EnhancedEPUBReader()
+        content = reader.read_epub(target)
+        assert content.metadata.title == "Reg Test Book"

--- a/tests/utils/test_file_readers.py
+++ b/tests/utils/test_file_readers.py
@@ -33,7 +33,7 @@ from utils.file_readers import (
 from utils.readers._base import _check_file_size
 from utils.readers.ebook import EBOOKLIB_AVAILABLE
 
-pytestmark = [pytest.mark.unit]
+pytestmark = [pytest.mark.unit, pytest.mark.integration]
 
 
 @pytest.mark.unit

--- a/tests/utils/test_readers_safedir.py
+++ b/tests/utils/test_readers_safedir.py
@@ -1,0 +1,347 @@
+"""Tests for the SafeDir-aware reader API.
+
+Covers the additions made in PR3a (#267):
+
+- ``fileobj=`` kwarg on the public reader functions in
+  ``utils.readers.documents`` (text, docx, pdf, rtf, spreadsheet,
+  presentation). When given, the reader uses the library's file-like
+  API instead of opening the path. Path-based callers are unchanged
+  (covered by the existing ``tests/utils/test_file_readers.py``).
+- ``utils.readers.read_file_via_safedir(safe_dir, name)`` — the
+  SafeDir-friendly dispatcher: opens via ``SafeDir.open_for_reader``
+  (which refuses symlinks with ``O_NOFOLLOW``) and routes to the
+  matching reader via ``fileobj=``.
+- ``utils.readers._base._check_fd_size`` — fd-based size check used by
+  the fileobj branch.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from utils.readers import (
+    MAX_FILE_SIZE_BYTES,
+    FileTooLargeError,
+    read_docx_file,
+    read_file_via_safedir,
+    read_pdf_file,
+    read_presentation_file,
+    read_rtf_file,
+    read_spreadsheet_file,
+    read_text_file,
+)
+from utils.readers._base import _check_fd_size
+from utils.safedir import SafeDir, SymlinkRejected
+
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+    pytest.mark.integration,
+    pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only"),
+]
+
+
+# ---------------------------------------------------------------------------
+# fileobj= on individual readers
+# ---------------------------------------------------------------------------
+
+
+class TestReadTextFileFileobj:
+    def test_reads_from_fileobj(self) -> None:
+        data = b"hello\nworld\n"
+        assert read_text_file(fileobj=io.BytesIO(data)) == "hello\nworld\n"
+
+    def test_respects_max_chars(self) -> None:
+        data = b"x" * 50_000
+        out = read_text_file(fileobj=io.BytesIO(data), max_chars=100)
+        assert out == "x" * 100
+
+    def test_ignores_invalid_utf8(self) -> None:
+        # An invalid UTF-8 byte gets dropped; the surrounding ASCII remains.
+        data = b"valid \xfe more"
+        out = read_text_file(fileobj=io.BytesIO(data))
+        assert "valid" in out
+        assert "more" in out
+
+    def test_label_falls_back_when_no_file_path(self) -> None:
+        # Doesn't raise; label is just used in logs.
+        assert read_text_file(fileobj=io.BytesIO(b"x")) == "x"
+
+
+class TestReadDocxFileFileobj:
+    @patch("utils.readers.documents.docx")
+    def test_reads_from_fileobj(self, mock_docx: MagicMock, tmp_path: Path) -> None:
+        para = MagicMock()
+        para.text = "Hello docx"
+        mock_doc = MagicMock()
+        mock_doc.paragraphs = [para]
+        mock_docx.Document.return_value = mock_doc
+
+        out = read_docx_file(fileobj=io.BytesIO(b"fake docx bytes"))
+        assert out == "Hello docx"
+        mock_docx.Document.assert_called_once()
+
+
+class TestReadPdfFileFileobj:
+    @patch("utils.readers.documents.fitz")
+    def test_reads_from_fileobj_via_stream(self, mock_fitz: MagicMock) -> None:
+        mock_page = MagicMock()
+        mock_page.get_text.return_value = "page text"
+        mock_doc = MagicMock()
+        mock_doc.__enter__.return_value = mock_doc
+        mock_doc.__exit__.return_value = None
+        mock_doc.__len__.return_value = 1
+        mock_doc.load_page.return_value = mock_page
+        mock_fitz.open.return_value = mock_doc
+
+        out = read_pdf_file(fileobj=io.BytesIO(b"%PDF-fake"))
+        assert out == "page text"
+        # The fileobj path must use ``stream=`` so fitz never receives a path.
+        kwargs = mock_fitz.open.call_args.kwargs
+        assert "stream" in kwargs
+        assert kwargs.get("filetype") == "pdf"
+
+
+class TestReadRtfFileFileobj:
+    @patch("utils.readers.documents._rtf_to_text", return_value="rtf content")
+    def test_reads_from_fileobj(self, _mock_rtf: MagicMock) -> None:
+        out = read_rtf_file(fileobj=io.BytesIO(b"{\\rtf1...}"))
+        assert "rtf content" in out
+
+
+class TestReadSpreadsheetFileFileobj:
+    def test_csv_from_fileobj(self, tmp_path: Path) -> None:
+        data = b"a,b,c\n1,2,3\n4,5,6\n"
+        out = read_spreadsheet_file(
+            file_path=tmp_path / "data.csv",
+            fileobj=io.BytesIO(data),
+        )
+        assert out == "a,b,c\n1,2,3\n4,5,6"
+
+    @patch("utils.readers.documents.openpyxl")
+    def test_xlsx_from_fileobj(self, mock_openpyxl: MagicMock, tmp_path: Path) -> None:
+        mock_ws = MagicMock()
+        mock_ws.iter_rows.return_value = iter([("h1", "h2"), (1, 2)])
+        mock_wb = MagicMock()
+        mock_wb.active = mock_ws
+        mock_openpyxl.load_workbook.return_value = mock_wb
+
+        out = read_spreadsheet_file(
+            file_path=tmp_path / "data.xlsx",
+            fileobj=io.BytesIO(b"fake xlsx"),
+        )
+        assert "h1,h2" in out
+        assert "1,2" in out
+
+    def test_requires_file_path_for_extension_detection(self) -> None:
+        with pytest.raises(ValueError, match="file_path"):
+            read_spreadsheet_file(fileobj=io.BytesIO(b"data"))
+
+
+class TestReadPresentationFileFileobj:
+    @patch("utils.readers.documents.Presentation")
+    def test_reads_from_fileobj(self, mock_prs_cls: MagicMock) -> None:
+        shape = MagicMock()
+        shape.text = "Slide text"
+        slide = MagicMock()
+        slide.shapes = [shape]
+        mock_prs = MagicMock()
+        mock_prs.slides = [slide]
+        mock_prs_cls.return_value = mock_prs
+
+        out = read_presentation_file(fileobj=io.BytesIO(b"fake pptx"))
+        assert "Slide text" in out
+
+
+# ---------------------------------------------------------------------------
+# Either-or argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestFileTooLargeErrorPropagation:
+    """`FileTooLargeError` from ``_check_fd_size`` must propagate to callers
+    of the ``fileobj=`` branch. The dispatcher docstring promises this type;
+    if the broad ``except Exception`` parser-error handler wrapped it as
+    ``FileReadError``, callers could no longer distinguish oversized files
+    from genuine reader failures.
+
+    Patches ``_check_fd_size`` to raise directly — the goal here is to
+    verify the reader's exception handling preserves the type, not to
+    re-test ``_check_fd_size`` itself (covered above).
+    """
+
+    @staticmethod
+    def _raise_too_large(*_args: object, **_kwargs: object) -> None:
+        raise FileTooLargeError("test: file too large")
+
+    def test_text_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.documents._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_text_file(fileobj=io.BytesIO(b"any"))
+
+    def test_docx_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.documents._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_docx_file(fileobj=io.BytesIO(b"any"))
+
+    def test_pdf_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.documents._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_pdf_file(fileobj=io.BytesIO(b"any"))
+
+    def test_rtf_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.documents._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_rtf_file(fileobj=io.BytesIO(b"any"))
+
+    def test_spreadsheet_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.documents._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_spreadsheet_file(file_path=tmp_path / "x.csv", fileobj=io.BytesIO(b"any"))
+
+    def test_presentation_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.documents._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_presentation_file(fileobj=io.BytesIO(b"any"))
+
+
+class TestRequiresFilePathOrFileobj:
+    """Every reader must reject calls with neither arg supplied."""
+
+    @pytest.mark.parametrize(
+        "reader",
+        [read_text_file, read_docx_file, read_pdf_file, read_rtf_file, read_presentation_file],
+    )
+    def test_rejects_both_args_missing(self, reader) -> None:  # type: ignore[no-untyped-def]
+        with pytest.raises(ValueError):
+            reader()
+
+
+# ---------------------------------------------------------------------------
+# read_file_via_safedir: dispatcher + symlink rejection
+# ---------------------------------------------------------------------------
+
+
+class TestReadFileViaSafedir:
+    def test_reads_real_text_file(self, tmp_path: Path) -> None:
+        (tmp_path / "notes.txt").write_text("integration test content")
+        with SafeDir.open_root(tmp_path) as sd:
+            out = read_file_via_safedir(sd, "notes.txt")
+        assert out == "integration test content"
+
+    def test_reads_md_file(self, tmp_path: Path) -> None:
+        (tmp_path / "doc.md").write_text("# heading\n\nbody")
+        with SafeDir.open_root(tmp_path) as sd:
+            out = read_file_via_safedir(sd, "doc.md")
+        assert "heading" in out
+
+    def test_refuses_symlink(self, tmp_path: Path) -> None:
+        """The dispatcher uses ``open_for_reader`` which refuses symlinks."""
+        honey = tmp_path / "honey.txt"
+        honey.write_text("do_not_exfiltrate")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "link.txt").symlink_to(honey)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+
+        with SafeDir.open_root(organize) as sd:
+            with pytest.raises(SymlinkRejected):
+                read_file_via_safedir(sd, "link.txt")
+
+    def test_unsupported_extension_returns_none(self, tmp_path: Path) -> None:
+        """Extensions not yet in ``_SAFEDIR_READERS`` (archives, ebooks, etc.)
+        return None — caller can fall back to legacy path-based ``read_file``.
+        """
+        (tmp_path / "archive.zip").write_bytes(b"PK\x03\x04")
+        with SafeDir.open_root(tmp_path) as sd:
+            assert read_file_via_safedir(sd, "archive.zip") is None
+
+    def test_rejects_bad_name(self, tmp_path: Path) -> None:
+        """Component-name validation rides on SafeDir.open_for_reader."""
+        with SafeDir.open_root(tmp_path) as sd:
+            with pytest.raises(ValueError):
+                read_file_via_safedir(sd, "../escape.txt")
+
+
+# ---------------------------------------------------------------------------
+# _check_fd_size
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFdSize:
+    def test_raises_for_large_fd(self, tmp_path: Path) -> None:
+        big = tmp_path / "big.bin"
+        big.write_bytes(b"\x00" * 1024)
+        with big.open("rb") as f:
+            with pytest.raises(FileTooLargeError):
+                _check_fd_size(f, max_bytes=512)
+
+    def test_allows_small_fd(self, tmp_path: Path) -> None:
+        small = tmp_path / "small.bin"
+        small.write_bytes(b"\x00" * 100)
+        with small.open("rb") as f:
+            _check_fd_size(f, max_bytes=MAX_FILE_SIZE_BYTES)  # no raise
+
+    def test_silently_skips_in_memory_buffers(self) -> None:
+        """``BytesIO`` raises ``io.UnsupportedOperation`` on ``fileno()``;
+        the check should fall through silently rather than erroring out.
+        """
+        _check_fd_size(io.BytesIO(b"x" * 100), max_bytes=10)  # no raise
+
+    def test_silently_skips_when_fstat_fails(self, tmp_path: Path) -> None:
+        """If ``os.fstat`` itself errors (e.g. closed fd), the check
+        falls through. The reader's subsequent read will raise its own
+        error; the size check shouldn't mask the real problem.
+        """
+        import os as _os
+
+        target = tmp_path / "x.bin"
+        target.write_bytes(b"data")
+        f = target.open("rb")
+        _os.close(f.fileno())
+        # f.fileno() still returns the int, but fstat now raises EBADF
+        _check_fd_size(f, max_bytes=10)  # no raise
+
+
+class TestReadFileViaSafedirCompoundExtension:
+    """Cover the ``.tar.gz`` / ``.tar.bz2`` / ``.tar.xz`` branch and the
+    dispatcher's exception-rewrap path."""
+
+    def test_tar_gz_returns_none(self, tmp_path: Path) -> None:
+        """Archives aren't in ``_SAFEDIR_READERS`` yet (migrated in PR3b),
+        but the compound-extension parsing path still executes — covers
+        the ``.tar.gz`` branch in ``read_file_via_safedir``.
+        """
+        (tmp_path / "data.tar.gz").write_bytes(b"PK\x03\x04")
+        with SafeDir.open_root(tmp_path) as sd:
+            assert read_file_via_safedir(sd, "data.tar.gz") is None
+
+    def test_dispatcher_reraises_unexpected_reader_exception(self, tmp_path: Path) -> None:
+        """``read_file_via_safedir`` wraps the reader call in a try/except
+        that logs then re-raises any exception. Covers the
+        ``except Exception as exc: logger.error(...); raise`` block.
+
+        Patching ``utils.readers.documents.fitz.open`` (the underlying
+        library) reliably triggers the path because ``read_pdf_file``
+        is reached via the dispatcher's ``_SAFEDIR_READERS`` dict —
+        patching the module-level binding wouldn't intercept that.
+        """
+        (tmp_path / "report.pdf").write_bytes(b"%PDF-fake")
+        with SafeDir.open_root(tmp_path) as sd:
+            with patch(
+                "utils.readers.documents.fitz.open",
+                side_effect=RuntimeError("synthetic fitz failure"),
+            ):
+                # The reader wraps the fitz error as FileReadError;
+                # the dispatcher logs and re-raises that.
+                from utils.readers import FileReadError as _FRE
+
+                with pytest.raises(_FRE):
+                    read_file_via_safedir(sd, "report.pdf")

--- a/tests/utils/test_readers_safedir.py
+++ b/tests/utils/test_readers_safedir.py
@@ -29,7 +29,11 @@ from utils.readers import (
     FileTooLargeError,
     read_7z_file,
     read_docx_file,
+    read_ebook_file,
     read_file_via_safedir,
+    read_hdf5_file,
+    read_mat_file,
+    read_netcdf_file,
     read_pdf_file,
     read_presentation_file,
     read_rar_file,
@@ -344,6 +348,253 @@ class TestReadRarFileFileobj:
 
 
 # ---------------------------------------------------------------------------
+# Ebook + scientific readers — fileobj= branch (PR3c)
+# ---------------------------------------------------------------------------
+
+
+def _make_epub(path: Path) -> None:
+    """Minimal valid EPUB so ebooklib.read_epub round-trips through fileobj.
+
+    The structure mirrors the ebooklib happy-path: mimetype + container.xml
+    + a content.opf manifest + one XHTML chapter. Smaller than fixturing a
+    real ebook on disk and avoids a binary blob in the repo.
+    """
+    import zipfile as _zf
+
+    with _zf.ZipFile(path, "w") as zf:
+        zf.writestr("mimetype", "application/epub+zip")
+        zf.writestr(
+            "META-INF/container.xml",
+            (
+                '<?xml version="1.0"?>'
+                '<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
+                "<rootfiles>"
+                '<rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>'
+                "</rootfiles></container>"
+            ),
+        )
+        zf.writestr(
+            "content.opf",
+            (
+                '<?xml version="1.0"?>'
+                '<package version="2.0" xmlns="http://www.idpf.org/2007/opf" '
+                'unique-identifier="bookid">'
+                '<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">'
+                "<dc:title>Test Book</dc:title>"
+                '<dc:identifier id="bookid">test</dc:identifier>'
+                "<dc:language>en</dc:language></metadata>"
+                '<manifest><item id="ch1" href="ch1.xhtml" '
+                'media-type="application/xhtml+xml"/></manifest>'
+                '<spine><itemref idref="ch1"/></spine></package>'
+            ),
+        )
+        zf.writestr(
+            "ch1.xhtml",
+            "<html><body><p>Chapter one with searchable content text</p></body></html>",
+        )
+
+
+class TestReadEbookFileFileobj:
+    def test_reads_from_fileobj(self, tmp_path: Path) -> None:
+        epub_path = tmp_path / "book.epub"
+        _make_epub(epub_path)
+        with epub_path.open("rb") as f:
+            out = read_ebook_file(file_path=epub_path, fileobj=f)
+        assert "Chapter one with searchable content" in out
+
+    def test_label_falls_back_when_no_file_path(self, tmp_path: Path) -> None:
+        epub_path = tmp_path / "book.epub"
+        _make_epub(epub_path)
+        with epub_path.open("rb") as f:
+            # No file_path supplied: extension check is skipped, label is <fileobj>
+            out = read_ebook_file(fileobj=f)
+        assert "Chapter one" in out
+
+    def test_rejects_non_epub_extension(self, tmp_path: Path) -> None:
+        from utils.readers import FileReadError as _FRE
+
+        with pytest.raises(_FRE, match="Only .epub supported"):
+            read_ebook_file(file_path=tmp_path / "book.azw3", fileobj=io.BytesIO(b"x"))
+
+    def test_fileobj_error_wraps_as_file_read_error(self, tmp_path: Path) -> None:
+        """A parse error from ebooklib is wrapped as FileReadError on the
+        fileobj branch, mirroring the path branch's contract.
+        """
+        from utils.readers import FileReadError as _FRE
+
+        with pytest.raises(_FRE, match="ebook file"):
+            read_ebook_file(file_path=tmp_path / "x.epub", fileobj=io.BytesIO(b"not a zip"))
+
+    def test_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="file_path or fileobj"):
+            read_ebook_file()
+
+
+class TestReadHdf5FileFileobj:
+    """``h5py`` is in the ``scientific`` optional extra and not installed by
+    the default CI matrix (``.[dev,search]``). Tests mock the library so
+    they exercise the reader's Python code paths regardless — matches the
+    existing pattern in ``test_file_readers_extended.py``.
+    """
+
+    def _build_mocked_h5py(self) -> tuple[MagicMock, MagicMock]:
+        mock_ds = MagicMock()
+        mock_ds.shape = (4,)
+        mock_ds.dtype = "int32"
+        mock_ds.nbytes = 16
+        mock_ds.attrs = {}
+
+        def fake_visititems(callback):  # type: ignore[no-untyped-def]
+            callback("alpha", mock_ds)
+
+        mock_hf = MagicMock()
+        mock_hf.keys.return_value = ["alpha"]
+        mock_hf.visititems.side_effect = fake_visititems
+        mock_hf.__enter__.return_value = mock_hf
+        mock_hf.__exit__.return_value = None
+        mock_h5py = MagicMock()
+        mock_h5py.File.return_value = mock_hf
+        mock_h5py.Dataset = type(mock_ds)  # so isinstance(ds, Dataset) holds
+        mock_h5py.Group = type(None)  # Won't match group branch
+        return mock_h5py, mock_hf
+
+    def test_reads_from_fileobj(self, tmp_path: Path) -> None:
+        mock_h5py, _ = self._build_mocked_h5py()
+        with (
+            patch("utils.readers.scientific.H5PY_AVAILABLE", True),
+            patch("utils.readers.scientific.h5py", mock_h5py, create=True),
+        ):
+            out = read_hdf5_file(
+                file_path=tmp_path / "data.h5", fileobj=io.BytesIO(b"fake h5 bytes")
+            )
+        assert "HDF5 File: data.h5" in out
+        assert "alpha" in out
+        # Library reached with the fileobj, not the path.
+        call_args, _kwargs = mock_h5py.File.call_args
+        assert hasattr(call_args[0], "read")
+
+    def test_fileobj_error_wraps_as_file_read_error(self, tmp_path: Path) -> None:
+        from utils.readers import FileReadError as _FRE
+
+        mock_h5py = MagicMock()
+        mock_h5py.File.side_effect = RuntimeError("synthetic h5 failure")
+        with (
+            patch("utils.readers.scientific.H5PY_AVAILABLE", True),
+            patch("utils.readers.scientific.h5py", mock_h5py, create=True),
+        ):
+            with pytest.raises(_FRE, match="HDF5"):
+                read_hdf5_file(file_path=tmp_path / "x.h5", fileobj=io.BytesIO(b"not h5"))
+
+    def test_requires_arg(self) -> None:
+        # No deps needed — ValueError fires before the AVAILABLE check.
+        with pytest.raises(ValueError, match="file_path or fileobj"):
+            read_hdf5_file()
+
+
+class TestReadNetcdfFileFileobj:
+    """``netCDF4`` is in the ``scientific`` optional extra. Mocked here so
+    CI without the C library still exercises the buffer-into-``memory=``
+    flow on the fileobj branch.
+    """
+
+    def _build_mocked_netcdf(self) -> tuple[MagicMock, MagicMock]:
+        mock_dim = MagicMock()
+        mock_dim.isunlimited.return_value = False
+        mock_dim.__len__ = MagicMock(return_value=5)
+
+        mock_var = MagicMock()
+        mock_var.dtype = "float32"
+        mock_var.shape = (5,)
+        mock_var.units = "K"
+        # ``hasattr(var, "long_name")`` returns True on MagicMock unless we
+        # restrict the spec — accept either branch by leaving it on.
+
+        mock_nc = MagicMock()
+        mock_nc.data_model = "NETCDF4"
+        mock_nc.dimensions = {"time": mock_dim}
+        mock_nc.variables = {"temperature": mock_var}
+        mock_nc.ncattrs.return_value = []
+        mock_nc.__enter__.return_value = mock_nc
+        mock_nc.__exit__.return_value = None
+
+        mock_netcdf4 = MagicMock()
+        mock_netcdf4.Dataset.return_value = mock_nc
+        return mock_netcdf4, mock_nc
+
+    def test_reads_from_fileobj_via_memory_param(self, tmp_path: Path) -> None:
+        """``netCDF4.Dataset`` doesn't accept fileobj; the reader buffers
+        the stream into bytes and passes ``memory=`` (the public C API).
+        """
+        mock_netcdf4, _ = self._build_mocked_netcdf()
+        with (
+            patch("utils.readers.scientific.NETCDF4_AVAILABLE", True),
+            patch("utils.readers.scientific.netCDF4", mock_netcdf4, create=True),
+        ):
+            out = read_netcdf_file(
+                file_path=tmp_path / "data.nc", fileobj=io.BytesIO(b"\x89HDF\r\n\x1a\n" * 4)
+            )
+        assert "NetCDF File: data.nc" in out
+        assert "NETCDF4" in out
+        assert "temperature" in out
+        # The fileobj branch passes ``memory=<bytes>`` (not a path).
+        _args, kwargs = mock_netcdf4.Dataset.call_args
+        assert kwargs.get("memory") is not None
+        assert isinstance(kwargs["memory"], bytes)
+
+    def test_fileobj_error_wraps_as_file_read_error(self, tmp_path: Path) -> None:
+        from utils.readers import FileReadError as _FRE
+
+        mock_netcdf4 = MagicMock()
+        mock_netcdf4.Dataset.side_effect = RuntimeError("synthetic netcdf failure")
+        with (
+            patch("utils.readers.scientific.NETCDF4_AVAILABLE", True),
+            patch("utils.readers.scientific.netCDF4", mock_netcdf4, create=True),
+        ):
+            with pytest.raises(_FRE, match="NetCDF"):
+                read_netcdf_file(file_path=tmp_path / "x.nc", fileobj=io.BytesIO(b"not netcdf"))
+
+    def test_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="file_path or fileobj"):
+            read_netcdf_file()
+
+
+class TestReadMatFileFileobj:
+    """``scipy`` is in the ``scientific`` optional extra. Mocked so the
+    fileobj branch of ``read_mat_file`` is exercised on CI without scipy.
+    """
+
+    def test_reads_from_fileobj(self, tmp_path: Path) -> None:
+        mock_loadmat = MagicMock(
+            return_value={"__header__": b"MAT", "alpha": MagicMock(shape=(3,))}
+        )
+        with (
+            patch("utils.readers.scientific.SCIPY_AVAILABLE", True),
+            patch("utils.readers.scientific.loadmat", mock_loadmat, create=True),
+        ):
+            out = read_mat_file(file_path=tmp_path / "data.mat", fileobj=io.BytesIO(b"fake"))
+        assert "MATLAB File: data.mat" in out
+        assert "alpha" in out
+        # Library reached with the fileobj, not the path.
+        call_args, _kwargs = mock_loadmat.call_args
+        assert hasattr(call_args[0], "read")
+
+    def test_fileobj_error_wraps_as_file_read_error(self, tmp_path: Path) -> None:
+        from utils.readers import FileReadError as _FRE
+
+        mock_loadmat = MagicMock(side_effect=RuntimeError("synthetic mat failure"))
+        with (
+            patch("utils.readers.scientific.SCIPY_AVAILABLE", True),
+            patch("utils.readers.scientific.loadmat", mock_loadmat, create=True),
+        ):
+            with pytest.raises(_FRE, match="MAT"):
+                read_mat_file(file_path=tmp_path / "x.mat", fileobj=io.BytesIO(b"not a mat"))
+
+    def test_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="file_path or fileobj"):
+            read_mat_file()
+
+
+# ---------------------------------------------------------------------------
 # Either-or argument validation
 # ---------------------------------------------------------------------------
 
@@ -414,6 +665,37 @@ class TestFileTooLargeErrorPropagation:
             with pytest.raises(FileTooLargeError):
                 read_rar_file(fileobj=io.BytesIO(b"any"))
 
+    def test_ebook_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.ebook._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_ebook_file(fileobj=io.BytesIO(b"any"))
+
+    def test_hdf5_reader_propagates(self, tmp_path: Path) -> None:
+        # Patch H5PY_AVAILABLE so the optional-dep ImportError doesn't fire
+        # ahead of the size-check on CI without h5py installed.
+        with (
+            patch("utils.readers.scientific.H5PY_AVAILABLE", True),
+            patch("utils.readers.scientific._check_fd_size", side_effect=self._raise_too_large),
+        ):
+            with pytest.raises(FileTooLargeError):
+                read_hdf5_file(fileobj=io.BytesIO(b"any"))
+
+    def test_netcdf_reader_propagates(self, tmp_path: Path) -> None:
+        with (
+            patch("utils.readers.scientific.NETCDF4_AVAILABLE", True),
+            patch("utils.readers.scientific._check_fd_size", side_effect=self._raise_too_large),
+        ):
+            with pytest.raises(FileTooLargeError):
+                read_netcdf_file(fileobj=io.BytesIO(b"any"))
+
+    def test_mat_reader_propagates(self, tmp_path: Path) -> None:
+        with (
+            patch("utils.readers.scientific.SCIPY_AVAILABLE", True),
+            patch("utils.readers.scientific._check_fd_size", side_effect=self._raise_too_large),
+        ):
+            with pytest.raises(FileTooLargeError):
+                read_mat_file(fileobj=io.BytesIO(b"any"))
+
 
 class TestRequiresFilePathOrFileobj:
     """Every reader must reject calls with neither arg supplied."""
@@ -430,6 +712,10 @@ class TestRequiresFilePathOrFileobj:
             read_7z_file,
             read_tar_file,
             read_rar_file,
+            read_ebook_file,
+            read_hdf5_file,
+            read_netcdf_file,
+            read_mat_file,
         ],
     )
     def test_rejects_both_args_missing(self, reader) -> None:  # type: ignore[no-untyped-def]
@@ -471,13 +757,12 @@ class TestReadFileViaSafedir:
                 read_file_via_safedir(sd, "link.txt")
 
     def test_unsupported_extension_returns_none(self, tmp_path: Path) -> None:
-        """Extensions not yet in ``_SAFEDIR_READERS`` (ebooks, scientific,
-        CAD) return None — caller can fall back to legacy path-based
-        ``read_file``.
+        """Extensions not yet in ``_SAFEDIR_READERS`` (CAD) return None —
+        caller can fall back to legacy path-based ``read_file``.
         """
-        (tmp_path / "book.epub").write_bytes(b"PK\x03\x04")
+        (tmp_path / "model.dxf").write_text("dummy dxf")
         with SafeDir.open_root(tmp_path) as sd:
-            assert read_file_via_safedir(sd, "book.epub") is None
+            assert read_file_via_safedir(sd, "model.dxf") is None
 
     def test_rejects_bad_name(self, tmp_path: Path) -> None:
         """Component-name validation rides on SafeDir.open_for_reader."""
@@ -579,6 +864,135 @@ class TestReadFileViaSafedir:
         mock_rarfile_mod.RarFile.assert_called_once()
         call_args, _ = mock_rarfile_mod.RarFile.call_args
         assert hasattr(call_args[0], "read")
+
+    def test_dispatches_epub_extension(self, tmp_path: Path) -> None:
+        """End-to-end: dispatcher resolves ``.epub`` via the new SafeDir
+        ebook entry and returns ebooklib's parsed text.
+        """
+        _make_epub(tmp_path / "book.epub")
+        with SafeDir.open_root(tmp_path) as sd:
+            out = read_file_via_safedir(sd, "book.epub")
+        assert out is not None
+        assert "Chapter one with searchable content" in out
+
+    @pytest.mark.parametrize("name", ["data.h5", "data.hdf5", "data.hdf"])
+    def test_dispatches_hdf5_extensions(self, tmp_path: Path, name: str) -> None:
+        """Each HDF5 alias must reach ``read_hdf5_file`` via the dispatcher.
+
+        Mocked rather than using a real HDF5 file so the test runs on the
+        default CI matrix (``.[dev,search]`` — no ``scientific`` extra).
+        Asserts the SafeDir-opened fileobj reached the library binding.
+        """
+        # _SAFEDIR_READERS still requires the file to exist for SafeDir's
+        # open_for_reader, so a placeholder is enough.
+        (tmp_path / name).write_bytes(b"\x89HDF\r\n\x1a\n" + b"\x00" * 32)
+
+        mock_ds = MagicMock()
+        mock_ds.shape = (3,)
+        mock_ds.dtype = "int32"
+        mock_ds.nbytes = 12
+        mock_ds.attrs = {}
+
+        def fake_visititems(callback):  # type: ignore[no-untyped-def]
+            callback("alpha", mock_ds)
+
+        mock_hf = MagicMock()
+        mock_hf.keys.return_value = ["alpha"]
+        mock_hf.visititems.side_effect = fake_visititems
+        mock_hf.__enter__.return_value = mock_hf
+        mock_hf.__exit__.return_value = None
+
+        with SafeDir.open_root(tmp_path) as sd:
+            with (
+                patch("utils.readers.scientific.H5PY_AVAILABLE", True),
+                patch("utils.readers.scientific.h5py", create=True) as mock_h5py,
+            ):
+                mock_h5py.File.return_value = mock_hf
+                mock_h5py.Dataset = type(mock_ds)
+                mock_h5py.Group = type(None)
+                out = read_file_via_safedir(sd, name)
+        assert out is not None
+        assert f"HDF5 File: {name}" in out
+        assert "alpha" in out
+        # SafeDir-opened fileobj reached the underlying library.
+        call_args, _kwargs = mock_h5py.File.call_args
+        assert hasattr(call_args[0], "read")
+
+    @pytest.mark.parametrize("name", ["data.nc", "data.nc4", "data.netcdf"])
+    def test_dispatches_netcdf_extensions(self, tmp_path: Path, name: str) -> None:
+        """Each NetCDF alias must reach ``read_netcdf_file`` via the
+        dispatcher and route through the ``memory=`` parameter (the
+        netCDF4 C API doesn't accept fileobjs).
+        """
+        (tmp_path / name).write_bytes(b"CDF\x01" + b"\x00" * 32)
+
+        mock_dim = MagicMock()
+        mock_dim.isunlimited.return_value = False
+        mock_dim.__len__ = MagicMock(return_value=2)
+        mock_var = MagicMock()
+        mock_var.dtype = "float32"
+        mock_var.shape = (2,)
+
+        mock_nc = MagicMock()
+        mock_nc.data_model = "NETCDF4"
+        mock_nc.dimensions = {"time": mock_dim}
+        mock_nc.variables = {"x": mock_var}
+        mock_nc.ncattrs.return_value = []
+        mock_nc.__enter__.return_value = mock_nc
+        mock_nc.__exit__.return_value = None
+
+        with SafeDir.open_root(tmp_path) as sd:
+            with (
+                patch("utils.readers.scientific.NETCDF4_AVAILABLE", True),
+                patch("utils.readers.scientific.netCDF4", create=True) as mock_netcdf4,
+            ):
+                mock_netcdf4.Dataset.return_value = mock_nc
+                out = read_file_via_safedir(sd, name)
+        assert out is not None
+        assert f"NetCDF File: {name}" in out
+        assert "time: 2" in out
+        # The fileobj was buffered into bytes and passed as ``memory=``.
+        _args, kwargs = mock_netcdf4.Dataset.call_args
+        assert isinstance(kwargs.get("memory"), bytes)
+
+    def test_dispatches_mat_extension(self, tmp_path: Path) -> None:
+        """End-to-end: ``.mat`` reaches ``read_mat_file`` and scipy parses
+        the in-memory stream.
+        """
+        (tmp_path / "data.mat").write_bytes(b"MATLAB 5.0 MAT-file\x00" + b"\x00" * 32)
+
+        mock_loadmat = MagicMock(
+            return_value={"__header__": b"MAT", "alpha": MagicMock(shape=(2,))}
+        )
+        with SafeDir.open_root(tmp_path) as sd:
+            with (
+                patch("utils.readers.scientific.SCIPY_AVAILABLE", True),
+                patch("utils.readers.scientific.loadmat", mock_loadmat, create=True),
+            ):
+                out = read_file_via_safedir(sd, "data.mat")
+        assert out is not None
+        assert "MATLAB File: data.mat" in out
+        assert "alpha" in out
+        # SafeDir-opened fileobj reached the underlying library.
+        call_args, _kwargs = mock_loadmat.call_args
+        assert hasattr(call_args[0], "read")
+
+    def test_refuses_symlinked_epub(self, tmp_path: Path) -> None:
+        """The dispatcher refuses a symlinked EPUB in the organize root —
+        the SafeDir fd would dereference the link otherwise.
+        """
+        real = tmp_path / "real.epub"
+        _make_epub(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "decoy.epub").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+
+        with SafeDir.open_root(organize) as sd:
+            with pytest.raises(SymlinkRejected):
+                read_file_via_safedir(sd, "decoy.epub")
 
     def test_refuses_symlinked_zip(self, tmp_path: Path) -> None:
         """A symlinked archive in the organize root must be refused, not

--- a/tests/utils/test_readers_safedir.py
+++ b/tests/utils/test_readers_safedir.py
@@ -27,13 +27,17 @@ import pytest
 from utils.readers import (
     MAX_FILE_SIZE_BYTES,
     FileTooLargeError,
+    read_7z_file,
     read_docx_file,
     read_file_via_safedir,
     read_pdf_file,
     read_presentation_file,
+    read_rar_file,
     read_rtf_file,
     read_spreadsheet_file,
+    read_tar_file,
     read_text_file,
+    read_zip_file,
 )
 from utils.readers._base import _check_fd_size
 from utils.safedir import SafeDir, SymlinkRejected
@@ -159,6 +163,187 @@ class TestReadPresentationFileFileobj:
 
 
 # ---------------------------------------------------------------------------
+# Archive readers — fileobj= branch (PR3b)
+# ---------------------------------------------------------------------------
+
+
+def _make_zip(path: Path) -> None:
+    import zipfile as _zf
+
+    with _zf.ZipFile(path, "w", _zf.ZIP_DEFLATED) as zf:
+        zf.writestr("hello.txt", "hello\n")
+        zf.writestr("data.csv", "a,b,c\n1,2,3\n")
+
+
+def _make_tar(path: Path, *, mode: str = "w:gz") -> None:
+    import tarfile as _tf
+
+    payload = path.parent / f".__tar_payload_{path.name}.txt"
+    payload.write_text("tar payload")
+    with _tf.open(path, mode) as tf:
+        tf.add(payload, arcname="readme.txt")
+    payload.unlink()
+
+
+class TestReadZipFileFileobj:
+    def test_reads_from_fileobj(self, tmp_path: Path) -> None:
+        zip_path = tmp_path / "archive.zip"
+        _make_zip(zip_path)
+
+        with zip_path.open("rb") as f:
+            out = read_zip_file(file_path=zip_path, fileobj=f)
+        assert "ZIP Archive: archive.zip" in out
+        assert "Total files: 2" in out
+        assert "hello.txt" in out
+        assert "data.csv" in out
+
+    def test_label_falls_back_when_no_file_path(self, tmp_path: Path) -> None:
+        zip_path = tmp_path / "archive.zip"
+        _make_zip(zip_path)
+        with zip_path.open("rb") as f:
+            out = read_zip_file(fileobj=f)
+        assert "ZIP Archive: <fileobj>" in out
+
+    def test_fileobj_error_wraps_as_file_read_error(self, tmp_path: Path) -> None:
+        """A zipfile parse error from the fileobj branch wraps as FileReadError."""
+        from utils.readers import FileReadError as _FRE
+
+        with patch(
+            "utils.readers.archives.zipfile.ZipFile",
+            side_effect=RuntimeError("synthetic zip failure"),
+        ):
+            with pytest.raises(_FRE, match="ZIP file"):
+                read_zip_file(fileobj=io.BytesIO(b"not a zip"))
+
+    def test_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="file_path or fileobj"):
+            read_zip_file()
+
+
+class TestReadTarFileFileobj:
+    def test_reads_tar_gz_from_fileobj(self, tmp_path: Path) -> None:
+        tar_path = tmp_path / "archive.tar.gz"
+        _make_tar(tar_path, mode="w:gz")
+        with tar_path.open("rb") as f:
+            out = read_tar_file(file_path=tar_path, fileobj=f)
+        assert "TAR Archive: archive.tar.gz" in out
+        assert "Compression: GZ" in out
+        assert "Total files: 1" in out
+        assert "readme.txt" in out
+
+    def test_reads_plain_tar_from_fileobj(self, tmp_path: Path) -> None:
+        tar_path = tmp_path / "archive.tar"
+        _make_tar(tar_path, mode="w")
+        with tar_path.open("rb") as f:
+            out = read_tar_file(file_path=tar_path, fileobj=f)
+        assert "Compression: None" in out
+
+    def test_compression_unknown_when_no_file_path(self, tmp_path: Path) -> None:
+        """Without a filename hint we can't display the compression type;
+        tarfile still auto-detects from the magic bytes so the read succeeds.
+        """
+        tar_path = tmp_path / "archive.tar.gz"
+        _make_tar(tar_path, mode="w:gz")
+        with tar_path.open("rb") as f:
+            out = read_tar_file(fileobj=f)
+        assert "Compression: Unknown" in out
+        assert "readme.txt" in out
+
+    def test_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="file_path or fileobj"):
+            read_tar_file()
+
+
+class TestRead7zFileFileobj:
+    @patch("utils.readers.archives.py7zr")
+    def test_reads_from_fileobj(self, mock_py7zr: MagicMock, tmp_path: Path) -> None:
+        mock_file_info = MagicMock()
+        mock_file_info.filename = "hello.txt"
+        mock_file_info.uncompressed = 12
+        mock_file_info.compressed = 6
+        mock_archive = MagicMock()
+        mock_archive.__enter__.return_value = mock_archive
+        mock_archive.__exit__.return_value = None
+        mock_archive.list.return_value = [mock_file_info]
+        mock_archive.password_protected = False
+        mock_py7zr.SevenZipFile.return_value = mock_archive
+
+        out = read_7z_file(file_path=tmp_path / "archive.7z", fileobj=io.BytesIO(b"7z fake"))
+        assert "7Z Archive: archive.7z" in out
+        assert "Total files: 1" in out
+        assert "hello.txt" in out
+
+    @patch("utils.readers.archives.py7zr")
+    def test_fileobj_error_wraps_as_file_read_error(
+        self, mock_py7zr: MagicMock, tmp_path: Path
+    ) -> None:
+        from utils.readers import FileReadError as _FRE
+
+        mock_py7zr.SevenZipFile.side_effect = RuntimeError("synthetic 7z failure")
+        with pytest.raises(_FRE, match="7Z file"):
+            read_7z_file(file_path=tmp_path / "x.7z", fileobj=io.BytesIO(b"not 7z"))
+
+    def test_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="file_path or fileobj"):
+            read_7z_file()
+
+
+class TestReadRarFileFileobj:
+    @patch("utils.readers.archives.rarfile")
+    def test_reads_from_fileobj(self, mock_rarfile_mod: MagicMock, tmp_path: Path) -> None:
+        mock_info = MagicMock()
+        mock_info.filename = "hello.txt"
+        mock_info.file_size = 100
+        mock_info.compress_size = 50
+        mock_rf = MagicMock()
+        mock_rf.__enter__.return_value = mock_rf
+        mock_rf.__exit__.return_value = None
+        mock_rf.infolist.return_value = [mock_info]
+        mock_rf.needs_password.return_value = False
+        # The reader references the module's RarCannotExec class for the
+        # narrower except branch — patch.dict-style replacement on the
+        # module-level binding loses that attribute, so re-attach a real
+        # class object that's never raised by the mock.
+        mock_rarfile_mod.RarFile.return_value = mock_rf
+        mock_rarfile_mod.RarCannotExec = type("RarCannotExec", (Exception,), {})
+
+        out = read_rar_file(file_path=tmp_path / "archive.rar", fileobj=io.BytesIO(b"rar fake"))
+        assert "RAR Archive: archive.rar" in out
+        assert "Total files: 1" in out
+        assert "hello.txt" in out
+
+    @patch("utils.readers.archives.rarfile")
+    def test_fileobj_error_wraps_as_file_read_error(
+        self, mock_rarfile_mod: MagicMock, tmp_path: Path
+    ) -> None:
+        from utils.readers import FileReadError as _FRE
+
+        mock_rarfile_mod.RarFile.side_effect = RuntimeError("synthetic rar failure")
+        mock_rarfile_mod.RarCannotExec = type("RarCannotExec", (Exception,), {})
+        with pytest.raises(_FRE, match="RAR file"):
+            read_rar_file(file_path=tmp_path / "x.rar", fileobj=io.BytesIO(b"not rar"))
+
+    @patch("utils.readers.archives.rarfile")
+    def test_fileobj_rar_cannot_exec_wraps_with_unrar_hint(
+        self, mock_rarfile_mod: MagicMock, tmp_path: Path
+    ) -> None:
+        """Missing ``unrar`` tool surfaces as ``FileReadError`` with the
+        install-hint message — the narrower ``RarCannotExec`` branch.
+        """
+        from utils.readers import FileReadError as _FRE
+
+        rar_cannot_exec_cls = type("RarCannotExec", (Exception,), {})
+        mock_rarfile_mod.RarCannotExec = rar_cannot_exec_cls
+        mock_rarfile_mod.RarFile.side_effect = rar_cannot_exec_cls("unrar missing")
+        with pytest.raises(_FRE, match="unrar tool not found"):
+            read_rar_file(file_path=tmp_path / "x.rar", fileobj=io.BytesIO(b"not rar"))
+
+    def test_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="file_path or fileobj"):
+            read_rar_file()
+
+
+# ---------------------------------------------------------------------------
 # Either-or argument validation
 # ---------------------------------------------------------------------------
 
@@ -209,13 +394,43 @@ class TestFileTooLargeErrorPropagation:
             with pytest.raises(FileTooLargeError):
                 read_presentation_file(fileobj=io.BytesIO(b"any"))
 
+    def test_zip_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.archives._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_zip_file(fileobj=io.BytesIO(b"any"))
+
+    def test_7z_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.archives._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_7z_file(fileobj=io.BytesIO(b"any"))
+
+    def test_tar_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.archives._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_tar_file(fileobj=io.BytesIO(b"any"))
+
+    def test_rar_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.archives._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_rar_file(fileobj=io.BytesIO(b"any"))
+
 
 class TestRequiresFilePathOrFileobj:
     """Every reader must reject calls with neither arg supplied."""
 
     @pytest.mark.parametrize(
         "reader",
-        [read_text_file, read_docx_file, read_pdf_file, read_rtf_file, read_presentation_file],
+        [
+            read_text_file,
+            read_docx_file,
+            read_pdf_file,
+            read_rtf_file,
+            read_presentation_file,
+            read_zip_file,
+            read_7z_file,
+            read_tar_file,
+            read_rar_file,
+        ],
     )
     def test_rejects_both_args_missing(self, reader) -> None:  # type: ignore[no-untyped-def]
         with pytest.raises(ValueError):
@@ -256,18 +471,131 @@ class TestReadFileViaSafedir:
                 read_file_via_safedir(sd, "link.txt")
 
     def test_unsupported_extension_returns_none(self, tmp_path: Path) -> None:
-        """Extensions not yet in ``_SAFEDIR_READERS`` (archives, ebooks, etc.)
-        return None — caller can fall back to legacy path-based ``read_file``.
+        """Extensions not yet in ``_SAFEDIR_READERS`` (ebooks, scientific,
+        CAD) return None — caller can fall back to legacy path-based
+        ``read_file``.
         """
-        (tmp_path / "archive.zip").write_bytes(b"PK\x03\x04")
+        (tmp_path / "book.epub").write_bytes(b"PK\x03\x04")
         with SafeDir.open_root(tmp_path) as sd:
-            assert read_file_via_safedir(sd, "archive.zip") is None
+            assert read_file_via_safedir(sd, "book.epub") is None
 
     def test_rejects_bad_name(self, tmp_path: Path) -> None:
         """Component-name validation rides on SafeDir.open_for_reader."""
         with SafeDir.open_root(tmp_path) as sd:
             with pytest.raises(ValueError):
                 read_file_via_safedir(sd, "../escape.txt")
+
+    def test_reads_real_zip_archive(self, tmp_path: Path) -> None:
+        """End-to-end: dispatcher resolves ``.zip`` via the new SafeDir
+        archive entry and returns the metadata-list output of
+        ``read_zip_file``.
+        """
+        _make_zip(tmp_path / "real.zip")
+        with SafeDir.open_root(tmp_path) as sd:
+            out = read_file_via_safedir(sd, "real.zip")
+        assert out is not None
+        assert "ZIP Archive: real.zip" in out
+        assert "hello.txt" in out
+
+    @pytest.mark.parametrize(
+        ("name", "tar_mode", "expected_compression"),
+        [
+            ("real.tar", "w", "None"),
+            ("real.tar.gz", "w:gz", "GZ"),
+            ("real.tgz", "w:gz", "GZ"),
+            ("real.tar.bz2", "w:bz2", "BZ2"),
+            ("real.tbz2", "w:bz2", "BZ2"),
+            ("real.tar.xz", "w:xz", "XZ"),
+        ],
+    )
+    def test_reads_real_tar_archive_for_each_extension(
+        self, tmp_path: Path, name: str, tar_mode: str, expected_compression: str
+    ) -> None:
+        """End-to-end via the dispatcher for every TAR extension in
+        ``_SAFEDIR_READERS``. A dropped mapping (incl. the compound-extension
+        branch in ``read_file_via_safedir``) would silently return ``None`` —
+        we assert real content makes it through for each alias so the
+        mapping has positive coverage.
+        """
+        _make_tar(tmp_path / name, mode=tar_mode)
+        with SafeDir.open_root(tmp_path) as sd:
+            out = read_file_via_safedir(sd, name)
+        assert out is not None, f"dispatcher returned None for {name!r}"
+        assert f"TAR Archive: {name}" in out
+        assert f"Compression: {expected_compression}" in out
+        assert "readme.txt" in out
+
+    def test_dispatches_7z_extension(self, tmp_path: Path) -> None:
+        """``.7z`` routes to ``read_7z_file`` via the SafeDir dispatcher.
+
+        ``_SAFEDIR_READERS`` holds direct function references — patching
+        ``read_7z_file`` at the module level won't intercept. Instead we
+        patch the underlying py7zr binding and assert the reader reached
+        it with the SafeDir-opened fileobj (same approach as
+        ``test_dispatcher_reraises_unexpected_reader_exception``).
+        """
+        (tmp_path / "data.7z").write_bytes(b"7z placeholder")
+        mock_file_info = MagicMock()
+        mock_file_info.filename = "inside.txt"
+        mock_file_info.uncompressed = 5
+        mock_file_info.compressed = 5
+        mock_archive = MagicMock()
+        mock_archive.__enter__.return_value = mock_archive
+        mock_archive.__exit__.return_value = None
+        mock_archive.list.return_value = [mock_file_info]
+        mock_archive.password_protected = False
+
+        with SafeDir.open_root(tmp_path) as sd:
+            with patch("utils.readers.archives.py7zr") as mock_py7zr:
+                mock_py7zr.SevenZipFile.return_value = mock_archive
+                out = read_file_via_safedir(sd, "data.7z")
+        assert out is not None
+        assert "7Z Archive: data.7z" in out
+        # SafeDir-opened fileobj reached the underlying library.
+        mock_py7zr.SevenZipFile.assert_called_once()
+        call_args, _ = mock_py7zr.SevenZipFile.call_args
+        assert hasattr(call_args[0], "read")
+
+    def test_dispatches_rar_extension(self, tmp_path: Path) -> None:
+        """``.rar`` routes to ``read_rar_file`` via the SafeDir dispatcher."""
+        (tmp_path / "data.rar").write_bytes(b"rar placeholder")
+        mock_info = MagicMock()
+        mock_info.filename = "inside.txt"
+        mock_info.file_size = 10
+        mock_info.compress_size = 8
+        mock_rf = MagicMock()
+        mock_rf.__enter__.return_value = mock_rf
+        mock_rf.__exit__.return_value = None
+        mock_rf.infolist.return_value = [mock_info]
+        mock_rf.needs_password.return_value = False
+
+        with SafeDir.open_root(tmp_path) as sd:
+            with patch("utils.readers.archives.rarfile") as mock_rarfile_mod:
+                mock_rarfile_mod.RarFile.return_value = mock_rf
+                mock_rarfile_mod.RarCannotExec = type("RarCannotExec", (Exception,), {})
+                out = read_file_via_safedir(sd, "data.rar")
+        assert out is not None
+        assert "RAR Archive: data.rar" in out
+        mock_rarfile_mod.RarFile.assert_called_once()
+        call_args, _ = mock_rarfile_mod.RarFile.call_args
+        assert hasattr(call_args[0], "read")
+
+    def test_refuses_symlinked_zip(self, tmp_path: Path) -> None:
+        """A symlinked archive in the organize root must be refused, not
+        followed and indexed.
+        """
+        real = tmp_path / "real.zip"
+        _make_zip(real)
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "decoy.zip").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+
+        with SafeDir.open_root(organize) as sd:
+            with pytest.raises(SymlinkRejected):
+                read_file_via_safedir(sd, "decoy.zip")
 
 
 # ---------------------------------------------------------------------------
@@ -314,14 +642,23 @@ class TestReadFileViaSafedirCompoundExtension:
     """Cover the ``.tar.gz`` / ``.tar.bz2`` / ``.tar.xz`` branch and the
     dispatcher's exception-rewrap path."""
 
-    def test_tar_gz_returns_none(self, tmp_path: Path) -> None:
-        """Archives aren't in ``_SAFEDIR_READERS`` yet (migrated in PR3b),
-        but the compound-extension parsing path still executes — covers
-        the ``.tar.gz`` branch in ``read_file_via_safedir``.
+    def test_tar_gz_dispatches_to_tar_reader(self, tmp_path: Path) -> None:
+        """Once archives migrated in PR3b, ``.tar.gz`` resolves via the
+        compound-extension branch and reaches ``read_tar_file`` with the
+        SafeDir-opened fd. We assert the route taken via patching, since
+        crafting a real tar.gz here would duplicate the round-trip test
+        below.
         """
-        (tmp_path / "data.tar.gz").write_bytes(b"PK\x03\x04")
+        (tmp_path / "data.tar.gz").write_bytes(b"\x1f\x8b\x08\x00")  # gz header
         with SafeDir.open_root(tmp_path) as sd:
-            assert read_file_via_safedir(sd, "data.tar.gz") is None
+            with patch(
+                "utils.readers.archives.tarfile.open",
+                side_effect=RuntimeError("synthetic tarfile failure"),
+            ):
+                from utils.readers import FileReadError as _FRE
+
+                with pytest.raises(_FRE):
+                    read_file_via_safedir(sd, "data.tar.gz")
 
     def test_dispatcher_reraises_unexpected_reader_exception(self, tmp_path: Path) -> None:
         """``read_file_via_safedir`` wraps the reader call in a try/except

--- a/tests/utils/test_readers_safedir.py
+++ b/tests/utils/test_readers_safedir.py
@@ -29,9 +29,12 @@ from utils.readers import (
     FileTooLargeError,
     read_7z_file,
     read_docx_file,
+    read_dwg_file,
+    read_dxf_file,
     read_ebook_file,
     read_file_via_safedir,
     read_hdf5_file,
+    read_iges_file,
     read_mat_file,
     read_netcdf_file,
     read_pdf_file,
@@ -39,6 +42,7 @@ from utils.readers import (
     read_rar_file,
     read_rtf_file,
     read_spreadsheet_file,
+    read_step_file,
     read_tar_file,
     read_text_file,
     read_zip_file,
@@ -595,6 +599,238 @@ class TestReadMatFileFileobj:
 
 
 # ---------------------------------------------------------------------------
+# CAD readers — fileobj= branch (PR3d)
+# ---------------------------------------------------------------------------
+
+
+def _build_mocked_ezdxf_doc() -> MagicMock:
+    """Return a MagicMock that quacks like an ezdxf Drawing.
+
+    Shared by the DXF / DWG fileobj tests so the mock surface stays
+    consistent — ``_process_dxf_doc`` iterates layers, modelspace
+    entities, and blocks; the mock provides one of each.
+    """
+    mock_header = MagicMock()
+    mock_header.get.return_value = "Test Drawing"
+
+    mock_layer = MagicMock()
+    mock_layer.dxf.name = "Layer0"
+    mock_layer.dxf.color = 7
+
+    mock_entity = MagicMock()
+    mock_entity.dxftype.return_value = "LINE"
+
+    mock_modelspace = MagicMock()
+    mock_modelspace.__iter__ = MagicMock(return_value=iter([mock_entity]))
+
+    mock_block = MagicMock()
+    mock_block.name = "MyBlock"
+
+    mock_doc = MagicMock()
+    mock_doc.header = mock_header
+    mock_doc.dxfversion = "AC1032"
+    mock_doc.layers = [mock_layer]
+    mock_doc.modelspace.return_value = mock_modelspace
+    mock_doc.blocks = [mock_block]
+    return mock_doc
+
+
+class TestReadDxfFileFileobj:
+    """``ezdxf`` is in the ``cad`` optional extra (not in ``.[dev,search]``).
+    Mocked so the reader's Python code paths are exercised on CI without
+    the library installed.
+    """
+
+    def test_reads_from_fileobj(self, tmp_path: Path) -> None:
+        mock_doc = _build_mocked_ezdxf_doc()
+        with (
+            patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+            patch("utils.readers.cad.ezdxf", create=True) as mock_ezdxf,
+        ):
+            mock_ezdxf.read.return_value = mock_doc
+            out = read_dxf_file(
+                file_path=tmp_path / "model.dxf", fileobj=io.BytesIO(b"0\nSECTION\n")
+            )
+        assert "DXF Document Metadata" in out
+        assert "AC1032" in out
+        assert "Layer0" in out
+        # The fileobj branch must use ``ezdxf.read`` (text-stream API),
+        # not ``ezdxf.readfile`` (path API).
+        mock_ezdxf.read.assert_called_once()
+        mock_ezdxf.readfile.assert_not_called()
+
+    def test_fileobj_error_wraps_as_file_read_error(self, tmp_path: Path) -> None:
+        from utils.readers import FileReadError as _FRE
+
+        with (
+            patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+            patch("utils.readers.cad.ezdxf", create=True) as mock_ezdxf,
+        ):
+            mock_ezdxf.read.side_effect = RuntimeError("synthetic ezdxf failure")
+            with pytest.raises(_FRE, match="DXF"):
+                read_dxf_file(file_path=tmp_path / "bad.dxf", fileobj=io.BytesIO(b"not dxf"))
+
+    def test_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="file_path or fileobj"):
+            read_dxf_file()
+
+    def test_fileobj_not_closed_after_return(self, tmp_path: Path) -> None:
+        """The fileobj= contract preserves caller ownership. ``ezdxf.read``
+        is fed via ``io.TextIOWrapper``, which closes its source stream
+        on GC unless ``detach()`` is called — verify the underlying
+        binary stream survives the call.
+        """
+        mock_doc = _build_mocked_ezdxf_doc()
+        fileobj = io.BytesIO(b"0\nSECTION\n")
+        with (
+            patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+            patch("utils.readers.cad.ezdxf", create=True) as mock_ezdxf,
+        ):
+            mock_ezdxf.read.return_value = mock_doc
+            read_dxf_file(file_path=tmp_path / "x.dxf", fileobj=fileobj)
+        import gc
+
+        gc.collect()  # force TextIOWrapper finalisation
+        assert not fileobj.closed
+
+
+class TestReadDwgFileFileobj:
+    """DWG falls back to a basic file-info message when ezdxf can't parse —
+    the fileobj branch uses ``os.fstat`` for size instead of ``Path.stat()``.
+    """
+
+    def test_reads_from_fileobj_when_ezdxf_parses(self, tmp_path: Path) -> None:
+        mock_doc = _build_mocked_ezdxf_doc()
+        with (
+            patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+            patch("utils.readers.cad.ezdxf", create=True) as mock_ezdxf,
+        ):
+            mock_ezdxf.read.return_value = mock_doc
+            out = read_dwg_file(file_path=tmp_path / "model.dwg", fileobj=io.BytesIO(b"00000"))
+        assert "AC1032" in out
+        mock_ezdxf.read.assert_called_once()
+
+    def test_fileobj_fallback_when_ezdxf_fails(self, tmp_path: Path) -> None:
+        """``ezdxf`` can't always parse DWG; the reader catches and emits
+        a basic file-info message. The fileobj branch derives size from
+        ``os.fstat`` rather than touching the path.
+        """
+        p = tmp_path / "blob.dwg"
+        p.write_bytes(b"binary dwg content here")
+        with (
+            patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+            patch("utils.readers.cad.ezdxf", create=True) as mock_ezdxf,
+        ):
+            mock_ezdxf.read.side_effect = RuntimeError("cannot parse DWG")
+            with p.open("rb") as f:
+                out = read_dwg_file(file_path=p, fileobj=f)
+        assert "DWG File Information" in out
+        assert "blob.dwg" in out
+        assert "ODA File Converter" in out
+        # Size came from os.fstat on the fileobj, not Path.stat.
+        assert "Size:" in out
+
+    def test_fileobj_fallback_handles_unstatable_stream(self, tmp_path: Path) -> None:
+        """``BytesIO`` raises on ``fileno()``; the size line is omitted."""
+        with (
+            patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+            patch("utils.readers.cad.ezdxf", create=True) as mock_ezdxf,
+        ):
+            mock_ezdxf.read.side_effect = RuntimeError("cannot parse")
+            out = read_dwg_file(file_path=tmp_path / "x.dwg", fileobj=io.BytesIO(b"binary"))
+        assert "DWG File Information" in out
+        # Size line is suppressed when fstat fails (BytesIO).
+        assert "Size:" not in out
+
+    def test_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="file_path or fileobj"):
+            read_dwg_file()
+
+
+class TestReadStepFileFileobj:
+    """STEP is plain ASCII; the fileobj branch decodes the first 10 KB."""
+
+    def test_reads_from_fileobj(self, tmp_path: Path) -> None:
+        step_content = (
+            "ISO-10303-21;\n"
+            "HEADER;\n"
+            "FILE_DESCRIPTION(('test description'),'2;1');\n"
+            "FILE_NAME('test.step','2026-01-01',('me'),('co'),'tool','sys','auth');\n"
+            "FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\n"
+            "ENDSEC;\n"
+            "DATA;\n"
+            "#1=POINT('',(0.,0.,0.));\n"
+            "#2=POINT('',(1.,1.,1.));\n"
+            "ENDSEC;\n"
+            "END-ISO-10303-21;\n"
+        )
+        p = tmp_path / "model.step"
+        p.write_text(step_content)
+        with p.open("rb") as f:
+            out = read_step_file(file_path=p, fileobj=f)
+        assert "STEP File Information" in out
+        assert "model.step" in out
+        assert "FILE_DESCRIPTION" in out
+        assert "Approximate entity count: 2" in out
+        assert "Size:" in out
+
+    def test_fileobj_size_omitted_for_unstatable_stream(self, tmp_path: Path) -> None:
+        """``BytesIO`` can't be ``fstat``ed; the Size line is omitted."""
+        out = read_step_file(
+            file_path=tmp_path / "x.step",
+            fileobj=io.BytesIO(b"ISO-10303-21;\nHEADER;\n"),
+        )
+        assert "STEP File Information" in out
+        assert "Size:" not in out
+
+    def test_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="file_path or fileobj"):
+            read_step_file()
+
+
+class TestReadIgesFileFileobj:
+    """IGES is column-structured ASCII; the fileobj branch reads N lines."""
+
+    def test_reads_from_fileobj(self, tmp_path: Path) -> None:
+        # Column 73 is the section marker (S=Start, G=Global, D=DirectoryEntry,
+        # P=ParameterData, T=Terminate). Pad each line to 72 chars + marker.
+        def line(content: str, marker: str) -> str:
+            return content.ljust(72) + marker + "      1\n"
+
+        iges_content = (
+            line("This is the start section", "S")
+            + line(",,3HMy ,4HFILE,1,,,,", "G")
+            + line("0", "D")
+            + line("0", "D")
+            + line("Terminate", "T")
+        )
+        p = tmp_path / "model.iges"
+        p.write_text(iges_content)
+        with p.open("rb") as f:
+            out = read_iges_file(file_path=p, fileobj=f)
+        assert "IGES File Information" in out
+        assert "model.iges" in out
+        assert "Start Section" in out
+        assert "Directory entries found: 2" in out
+
+    def test_requires_arg(self) -> None:
+        with pytest.raises(ValueError, match="file_path or fileobj"):
+            read_iges_file()
+
+    def test_fileobj_not_closed_after_return(self, tmp_path: Path) -> None:
+        """IGES wraps the binary fileobj in ``TextIOWrapper`` to read text
+        lines; verify ``detach()`` releases ownership so the caller's
+        stream isn't closed when the wrapper goes out of scope.
+        """
+        fileobj = io.BytesIO(b" " * 80 + b"S\n" + b" " * 80 + b"G\n")
+        read_iges_file(file_path=tmp_path / "x.iges", fileobj=fileobj)
+        import gc
+
+        gc.collect()
+        assert not fileobj.closed
+
+
+# ---------------------------------------------------------------------------
 # Either-or argument validation
 # ---------------------------------------------------------------------------
 
@@ -696,6 +932,32 @@ class TestFileTooLargeErrorPropagation:
             with pytest.raises(FileTooLargeError):
                 read_mat_file(fileobj=io.BytesIO(b"any"))
 
+    def test_dxf_reader_propagates(self, tmp_path: Path) -> None:
+        with (
+            patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+            patch("utils.readers.cad._check_fd_size", side_effect=self._raise_too_large),
+        ):
+            with pytest.raises(FileTooLargeError):
+                read_dxf_file(fileobj=io.BytesIO(b"any"))
+
+    def test_dwg_reader_propagates(self, tmp_path: Path) -> None:
+        with (
+            patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+            patch("utils.readers.cad._check_fd_size", side_effect=self._raise_too_large),
+        ):
+            with pytest.raises(FileTooLargeError):
+                read_dwg_file(fileobj=io.BytesIO(b"any"))
+
+    def test_step_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.cad._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_step_file(fileobj=io.BytesIO(b"any"))
+
+    def test_iges_reader_propagates(self, tmp_path: Path) -> None:
+        with patch("utils.readers.cad._check_fd_size", side_effect=self._raise_too_large):
+            with pytest.raises(FileTooLargeError):
+                read_iges_file(fileobj=io.BytesIO(b"any"))
+
 
 class TestRequiresFilePathOrFileobj:
     """Every reader must reject calls with neither arg supplied."""
@@ -716,6 +978,10 @@ class TestRequiresFilePathOrFileobj:
             read_hdf5_file,
             read_netcdf_file,
             read_mat_file,
+            read_dxf_file,
+            read_dwg_file,
+            read_step_file,
+            read_iges_file,
         ],
     )
     def test_rejects_both_args_missing(self, reader) -> None:  # type: ignore[no-untyped-def]
@@ -757,12 +1023,15 @@ class TestReadFileViaSafedir:
                 read_file_via_safedir(sd, "link.txt")
 
     def test_unsupported_extension_returns_none(self, tmp_path: Path) -> None:
-        """Extensions not yet in ``_SAFEDIR_READERS`` (CAD) return None —
-        caller can fall back to legacy path-based ``read_file``.
+        """Extensions outside ``_SAFEDIR_READERS`` return None — caller can
+        fall back to legacy path-based ``read_file`` (which itself returns
+        None for genuinely unknown formats). After PR3d, every reader the
+        codebase supports has a SafeDir mapping, so this exercises the
+        truly-unsupported branch with a synthetic extension.
         """
-        (tmp_path / "model.dxf").write_text("dummy dxf")
+        (tmp_path / "data.unknownext").write_text("dummy")
         with SafeDir.open_root(tmp_path) as sd:
-            assert read_file_via_safedir(sd, "model.dxf") is None
+            assert read_file_via_safedir(sd, "data.unknownext") is None
 
     def test_rejects_bad_name(self, tmp_path: Path) -> None:
         """Component-name validation rides on SafeDir.open_for_reader."""
@@ -976,6 +1245,82 @@ class TestReadFileViaSafedir:
         # SafeDir-opened fileobj reached the underlying library.
         call_args, _kwargs = mock_loadmat.call_args
         assert hasattr(call_args[0], "read")
+
+    @pytest.mark.parametrize(
+        ("name", "reader_module_attr"),
+        [
+            ("model.dxf", "read"),
+            ("model.dwg", "read"),
+        ],
+    )
+    def test_dispatches_dxf_dwg_extensions(
+        self, tmp_path: Path, name: str, reader_module_attr: str
+    ) -> None:
+        """``.dxf`` and ``.dwg`` reach the ezdxf-based readers via the
+        dispatcher. Mocked because ``ezdxf`` is in the ``cad`` optional
+        extra (not in the default CI ``.[dev,search]`` install).
+        """
+        (tmp_path / name).write_text("0\nSECTION\nfake dxf content\n")
+
+        mock_doc = _build_mocked_ezdxf_doc()
+        with SafeDir.open_root(tmp_path) as sd:
+            with (
+                patch("utils.readers.cad.EZDXF_AVAILABLE", True),
+                patch("utils.readers.cad.ezdxf", create=True) as mock_ezdxf,
+            ):
+                mock_ezdxf.read.return_value = mock_doc
+                out = read_file_via_safedir(sd, name)
+        assert out is not None
+        assert "AC1032" in out
+        # ezdxf.read (text-stream API) called, not readfile (path API).
+        getattr(mock_ezdxf, reader_module_attr).assert_called_once()
+
+    @pytest.mark.parametrize("name", ["model.step", "model.stp"])
+    def test_dispatches_step_extensions(self, tmp_path: Path, name: str) -> None:
+        """Both ``.step`` and ``.stp`` reach ``read_step_file`` via the
+        dispatcher.
+        """
+        (tmp_path / name).write_text(
+            "ISO-10303-21;\nHEADER;\nFILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\nENDSEC;\nDATA;\n"
+            "#1=POINT('',(0.,0.,0.));\nENDSEC;\nEND-ISO-10303-21;\n"
+        )
+        with SafeDir.open_root(tmp_path) as sd:
+            out = read_file_via_safedir(sd, name)
+        assert out is not None
+        assert "STEP File Information" in out
+        assert name in out
+
+    @pytest.mark.parametrize("name", ["model.iges", "model.igs"])
+    def test_dispatches_iges_extensions(self, tmp_path: Path, name: str) -> None:
+        """Both ``.iges`` and ``.igs`` reach ``read_iges_file`` via the
+        dispatcher.
+        """
+        line = lambda content, marker: content.ljust(72) + marker + "      1\n"  # noqa: E731
+        (tmp_path / name).write_text(
+            line("Start info", "S") + line(",,3HMy,4HFILE,", "G") + line("0", "D")
+        )
+        with SafeDir.open_root(tmp_path) as sd:
+            out = read_file_via_safedir(sd, name)
+        assert out is not None
+        assert "IGES File Information" in out
+        assert name in out
+
+    def test_refuses_symlinked_step(self, tmp_path: Path) -> None:
+        """Symlinked CAD files are refused by the dispatcher — exercises
+        the SafeDir O_NOFOLLOW path for one of the new extensions.
+        """
+        real = tmp_path / "real.step"
+        real.write_text("ISO-10303-21;\nHEADER;\nENDSEC;\n")
+        organize = tmp_path / "organize"
+        organize.mkdir()
+        try:
+            (organize / "decoy.step").symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported")
+
+        with SafeDir.open_root(organize) as sd:
+            with pytest.raises(SymlinkRejected):
+                read_file_via_safedir(sd, "decoy.step")
 
     def test_refuses_symlinked_epub(self, tmp_path: Path) -> None:
         """The dispatcher refuses a symlinked EPUB in the organize root —

--- a/tests/utils/test_readers_safedir.py
+++ b/tests/utils/test_readers_safedir.py
@@ -985,7 +985,7 @@ class TestRequiresFilePathOrFileobj:
         ],
     )
     def test_rejects_both_args_missing(self, reader) -> None:  # type: ignore[no-untyped-def]
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="file_path or fileobj"):
             reader()
 
 
@@ -1036,7 +1036,9 @@ class TestReadFileViaSafedir:
     def test_rejects_bad_name(self, tmp_path: Path) -> None:
         """Component-name validation rides on SafeDir.open_for_reader."""
         with SafeDir.open_root(tmp_path) as sd:
-            with pytest.raises(ValueError):
+            # ``../escape.txt`` contains ``/`` → SafeDir's _validate_name
+            # rejects with "name contains forbidden character".
+            with pytest.raises(ValueError, match="forbidden character"):
                 read_file_via_safedir(sd, "../escape.txt")
 
     def test_reads_real_zip_archive(self, tmp_path: Path) -> None:

--- a/tests/utils/test_safedir_anchored.py
+++ b/tests/utils/test_safedir_anchored.py
@@ -1,0 +1,203 @@
+"""Tests for anchored-traversal SafeDir helpers (#286).
+
+Exercises ``SafeDir.open_anchored_reader(relative_path)`` and the
+module-level ``read_file_via_safedir_anchored`` wrapper. Both walk a
+relative path one component at a time via ``open_subdir`` so an
+intermediate-component symlink is refused with ``SymlinkRejected``
+rather than dereferenced — closes the nested-ancestor TOCTOU window
+documented in #286, separate from the final-component protection that
+``SafeDir.open_for_reader`` already provides.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from utils.readers import read_file_via_safedir_anchored
+from utils.safedir import SafeDir, SymlinkRejected
+
+# The suite exercises the anchored-traversal primitive end-to-end through
+# real filesystem syscalls. Module-level marks apply to every class in
+# this file:
+#
+# - ``ci``: included so the new SafeDir primitive + reader wrapper get
+#   diff-coverage credit in the Test PR suite (``-m "ci and not benchmark"``).
+#   The TextProcessorScanRoot class below explicitly overrides this with a
+#   per-class ``ci=False`` skipif to avoid #291 (audio-model singleton
+#   ordering flake) — see the class-level pytestmark for the rationale.
+# - ``unit``: local development sweep.
+# - ``integration``: PR integration job. The per-module floor check in
+#   pr-integration.yml drops below the baseline whenever this file's
+#   source coverage isn't seen in the integration run.
+pytestmark = [
+    pytest.mark.ci,
+    pytest.mark.unit,
+    pytest.mark.integration,
+    pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only"),
+]
+
+posix_only = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="SafeDir requires POSIX dir_fd / O_NOFOLLOW",
+)
+
+
+# ---------------------------------------------------------------------------
+# SafeDir.open_anchored_reader
+# ---------------------------------------------------------------------------
+
+
+@posix_only
+class TestOpenAnchoredReader:
+    """Direct tests for the SafeDir.open_anchored_reader primitive."""
+
+    def test_walks_simple_relative_path(self, tmp_path: Path) -> None:
+        """Single-component relative_path opens the leaf via open_for_reader."""
+        (tmp_path / "doc.txt").write_text("hello")
+        with SafeDir.open_root(tmp_path) as root:
+            fd = root.open_anchored_reader(Path("doc.txt"))
+            try:
+                fileobj = os.fdopen(fd, "rb", closefd=True)
+            except OSError:
+                os.close(fd)
+                raise
+            with fileobj:
+                assert fileobj.read() == b"hello"
+
+    def test_walks_nested_relative_path(self, tmp_path: Path) -> None:
+        """Multi-component relative_path walks each intermediate via open_subdir."""
+        (tmp_path / "a" / "b" / "c").mkdir(parents=True)
+        (tmp_path / "a" / "b" / "c" / "doc.txt").write_text("nested")
+        with SafeDir.open_root(tmp_path) as root:
+            fd = root.open_anchored_reader(Path("a/b/c/doc.txt"))
+            try:
+                fileobj = os.fdopen(fd, "rb", closefd=True)
+            except OSError:
+                os.close(fd)
+                raise
+            with fileobj:
+                assert fileobj.read() == b"nested"
+
+    def test_intermediate_symlink_refused(self, tmp_path: Path) -> None:
+        """Ancestor swapped to symlink between enumeration and read is refused.
+
+        This is the core anchored-traversal protection. The walk opens
+        ``a`` first, sees it's a symlink, and raises SymlinkRejected
+        before any subsequent component is opened.
+        """
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("attacker content")
+
+        inside = tmp_path / "inside"
+        inside.mkdir()
+        # Originally a directory; gets swapped to a symlink to `outside`
+        (inside / "a").symlink_to(outside)
+        # The "victim" leaf the caller intended to read
+        (inside / "doc.txt").write_text("legitimate")
+
+        with SafeDir.open_root(inside) as root:
+            # Walking 'a/secret.txt' should refuse at 'a' (the symlink),
+            # not dereference and open 'outside/secret.txt'.
+            with pytest.raises(SymlinkRejected):
+                root.open_anchored_reader(Path("a/secret.txt"))
+
+    def test_final_component_symlink_refused(self, tmp_path: Path) -> None:
+        """Leaf symlink is refused too (the existing final-component guard)."""
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("attacker content")
+        inside = tmp_path / "inside"
+        inside.mkdir()
+        (inside / "doc.txt").symlink_to(outside / "secret.txt")
+
+        with SafeDir.open_root(inside) as root:
+            with pytest.raises(SymlinkRejected):
+                root.open_anchored_reader(Path("doc.txt"))
+
+    def test_absolute_path_rejected(self, tmp_path: Path) -> None:
+        """Absolute relative_path is a programmer error — reject early."""
+        with SafeDir.open_root(tmp_path) as root:
+            with pytest.raises(ValueError, match="relative"):
+                root.open_anchored_reader(Path("/etc/passwd"))
+
+    def test_parent_traversal_rejected(self, tmp_path: Path) -> None:
+        """``..`` components would escape — must be refused before any open."""
+        (tmp_path / "child").mkdir()
+        (tmp_path / "doc.txt").write_text("data")
+        with SafeDir.open_root(tmp_path / "child") as root:
+            with pytest.raises(ValueError, match=r"\.\."):
+                root.open_anchored_reader(Path("../doc.txt"))
+
+    def test_empty_path_rejected(self, tmp_path: Path) -> None:
+        """Empty relative_path doesn't identify any file."""
+        with SafeDir.open_root(tmp_path) as root:
+            with pytest.raises(ValueError):
+                root.open_anchored_reader(Path(""))
+
+
+# ---------------------------------------------------------------------------
+# read_file_via_safedir_anchored
+# ---------------------------------------------------------------------------
+
+
+@posix_only
+class TestReadFileViaSafedirAnchored:
+    """Tests for the top-level anchored reader wrapper."""
+
+    def test_reads_text_in_nested_dir(self, tmp_path: Path) -> None:
+        (tmp_path / "docs" / "sub").mkdir(parents=True)
+        leaf = tmp_path / "docs" / "sub" / "note.txt"
+        leaf.write_text("hello anchored")
+
+        out = read_file_via_safedir_anchored(leaf, trusted_root=tmp_path)
+        assert out == "hello anchored"
+
+    def test_intermediate_symlink_refused_via_helper(self, tmp_path: Path) -> None:
+        """Same protection as the primitive, exercised through the wrapper.
+
+        Ensures the wrapper actually uses the anchored walk (not a
+        parent-rooted open of file_path.parent that would happily
+        dereference the ancestor symlink).
+        """
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("attacker content")
+
+        inside = tmp_path / "inside"
+        inside.mkdir()
+        (inside / "evil").symlink_to(outside)
+
+        # The leaf path the caller thinks they're reading
+        victim = inside / "evil" / "secret.txt"
+        with pytest.raises(SymlinkRejected):
+            read_file_via_safedir_anchored(victim, trusted_root=inside)
+
+    def test_file_outside_trusted_root_rejected(self, tmp_path: Path) -> None:
+        """file_path outside trusted_root is a security violation — raise."""
+        trusted = tmp_path / "trusted"
+        trusted.mkdir()
+        (trusted / "ok.txt").write_text("inside")
+        elsewhere = tmp_path / "elsewhere.txt"
+        elsewhere.write_text("outside")
+
+        with pytest.raises(ValueError):
+            read_file_via_safedir_anchored(elsewhere, trusted_root=trusted)
+
+    def test_unsupported_extension_returns_none(self, tmp_path: Path) -> None:
+        """Same contract as read_file_via_safedir: None when no reader matches."""
+        leaf = tmp_path / "data.unknownext"
+        leaf.write_text("payload")
+
+        out = read_file_via_safedir_anchored(leaf, trusted_root=tmp_path)
+        assert out is None
+
+
+# NOTE: ``TestTextProcessorScanRoot`` lives in
+# ``tests/services/test_text_processor_scan_root.py`` (kept off the
+# ``ci`` mark to avoid #291's audio-model singleton ordering flake —
+# see that file's module docstring for the full rationale).

--- a/tests/utils/test_safedir_anchored.py
+++ b/tests/utils/test_safedir_anchored.py
@@ -136,7 +136,7 @@ class TestOpenAnchoredReader:
     def test_empty_path_rejected(self, tmp_path: Path) -> None:
         """Empty relative_path doesn't identify any file."""
         with SafeDir.open_root(tmp_path) as root:
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="non-empty"):
                 root.open_anchored_reader(Path(""))
 
 
@@ -185,7 +185,10 @@ class TestReadFileViaSafedirAnchored:
         elsewhere = tmp_path / "elsewhere.txt"
         elsewhere.write_text("outside")
 
-        with pytest.raises(ValueError):
+        # ``Path.relative_to`` raises ValueError with a message containing
+        # "is not in the subpath of" (3.11) or "is not in the descendants of"
+        # (3.12+) — match the stable substring across Python versions.
+        with pytest.raises(ValueError, match=r"not in (the subpath|the descendants)"):
             read_file_via_safedir_anchored(elsewhere, trusted_root=trusted)
 
     def test_unsupported_extension_returns_none(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

PR3 rollup. Migrates **18 content-reading sites** across `src/` from path-based opens to the `SafeDir` primitive (#266), which holds an open directory fd and refuses symlinks at open time via `O_NOFOLLOW`. Closes the symlink-swap exfiltration vector documented in #264.

**Scope**: read-side only. PR4 (#268) covers dedup hasher/backup, PR5 (#269) covers `undo/`, PR6 (#270) covers `watcher/` + `daemon/`.

### Stats

- 11 commits (1 CI matrix enable + PR3a..PR3j)
- 49 files changed, +6,154 / -1,016 lines
- 1 new internal audit doc (read-side closeout + streaming-vs-stat decision)
- ~10 new SafeDir-specific test modules

## Migrations by sub-PR

| Sub-PR | Issue | Scope |
|---|---|---|
| **PR3a** | #273 | `services/text_processor.py` + document readers |
| **PR3b** | #274 | archive readers (zip/7z/tar/rar) |
| **PR3c** | #275 | ebook + scientific readers |
| **PR3d** | #276 | CAD readers (dxf/dwg/step/iges) |
| **PR3e** | #279 | dedup `DocumentExtractor` |
| **PR3f** | #281 | dedup image readers + anchoring + hash flow |
| **PR3g** | #282 | `utils/epub_enhanced.py` + rail bare-open detection |
| **PR3h** | #284 | 3 remaining bare `path.open("rb")` sites (`hybrid_retriever`, `organizer`, `heuristics`) |
| **PR3i** | #287 | promote bare-open detection from advisory → enforcing for PR3a–PR3h files |
| **PR3j** | #288 | `shutil` audit + streaming-vs-stat decision (#267 closeout) |

Each sub-PR shipped through its own CodeRabbit + Codex + sub-PR CI cycle before merging here.

## What this rollup does *not* change

- `_FLAGGED_CALLS` rail remains **advisory** across the broader tree (44 sites — all in PR4/PR5/PR6 scope; tracked in #268/#269/#270).
- `undo/durable_move.py` `shutil.copyfile`/`copystat` allowlisting unchanged — analysed in detail in `docs/internal/safedir-shutil-audit-pr3j.md`; final-component + intermediate-component TOCTOU windows close in PR5 (#286 anchored-traversal).

## Verification done in /pr-prep

- ✅ All 550 SafeDir tests pass together single-threaded (18.4s) and under xdist (12.5s) on this branch.
- ✅ Rail check runs clean in advisory mode (44 outstanding sites all in subsequent-phase scope).
- ✅ Ruff clean across `src/`, `scripts/`, `tests/`.
- ✅ Docstring drift spot-checks on new helpers pass.
- ⚠️ Local `pytest -m ci` shows 1 known flake (#285) + 3 audio model tests that pass in isolation. Confirmed **not** a PR3 regression: same `-m ci` on a clean main worktree shows only the #285 flake. CI uses `-n=auto --dist=loadgroup`; the audio failure is a pre-existing singleton state leak surfaced only by sequential local ordering. Tracked in #291.

## Follow-ups filed

- **#289** — Contributor guide for SafeDir reader contract (+ orphan audit-doc cross-ref).
- **#290** — Cross-reference SafeDir epic from hardening roadmap.
- **#291** — Audio model singleton state leak in single-threaded `-m ci`.

## Test plan

- [ ] CI passes on the rollup (xdist masks #291; if the rollup CI fails for the audio tests, fix in this PR; otherwise leave to #291)
- [ ] Rail's bare-open detection enforces correctly on the 13 migrated files (`tests/ci/test_symlink_safety_lints.py::test_no_bare_open_violations_in_enforced_dirs`)
- [ ] All SafeDir migration tests pass under xdist (already verified locally)

Closes #267.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnPpeovvetPSR8Vwhxsn9j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced symlink safety across file operations to prevent unauthorized file access and path traversal attacks.
  * Improved file handling in deduplication, document extraction, and image processing with stronger security controls.

* **Improvements**
  * Better error handling and resource cleanup in file read operations.
  * Extended CI/CD workflows to support additional development branches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->