### PR TITLE
test(cli): collapse whitespace in 'not a regular file' assertions (closes #285)

### DIFF
--- a/tests/cli/test_cli_rules.py
+++ b/tests/cli/test_cli_rules.py
@@ -359,7 +359,7 @@ class TestRulesExport:
         with patch(_RULE_MGR_PATH, return_value=mock_rule_manager):
             result = runner.invoke(rules_app, ["export", "-o", str(existing_dir)])
         assert result.exit_code == 2
-        assert "not a regular file" in result.output.lower()
+        assert "not a regular file" in " ".join(result.output.lower().split())
 
     @pytest.mark.integration
     @pytest.mark.ci
@@ -440,7 +440,7 @@ class TestRulesImport:
         d.mkdir()
         result = runner.invoke(rules_app, ["import", str(d)])
         assert result.exit_code == 2
-        assert "not a regular file" in result.output.lower()
+        assert "not a regular file" in " ".join(result.output.lower().split())
 
     def test_import_invalid_yaml(self, runner, tmp_path):
         bad_yaml = tmp_path / "bad.yaml"

--- a/tests/cli/test_path_validation_wiring.py
+++ b/tests/cli/test_path_validation_wiring.py
@@ -91,7 +91,7 @@ def test_benchmark_compare_directory_rejected(tmp_path: Path) -> None:
     compare_dir.mkdir()
     result = runner.invoke(app, ["benchmark", "run", str(input_dir), "--compare", str(compare_dir)])
     assert result.exit_code == 2
-    assert "not a regular file" in result.output.lower()
+    assert "not a regular file" in " ".join(result.output.lower().split())
 
 
 def test_analyze_directory_rejected_with_regular_file_message(tmp_path: Path) -> None:
@@ -103,4 +103,4 @@ def test_analyze_directory_rejected_with_regular_file_message(tmp_path: Path) ->
     d.mkdir()
     result = runner.invoke(app, ["analyze", str(d)])
     assert result.exit_code == 1
-    assert "not a regular file" in result.output.lower()
+    assert "not a regular file" in " ".join(result.output.lower().split())


### PR DESCRIPTION
## Summary

Closes #285.

Typer/Click wraps CLI error output across line boundaries based on detected terminal width. The wrap point varies per run depending on `tmp_path` length, breaking substring assertions like `"not a regular file" in result.output.lower()` when the output becomes `"is not a\nregular file"`.

Identical fix to the precedent already in place at `tests/cli/test_analyze.py:122` — collapse whitespace before the substring check:

```diff
-assert "not a regular file" in result.output.lower()
+assert "not a regular file" in " ".join(result.output.lower().split())
```

## Sites fixed

| File | Line | Test |
|---|---|---|
| `tests/cli/test_path_validation_wiring.py` | 94 | `test_benchmark_compare_directory_rejected` |
| `tests/cli/test_path_validation_wiring.py` | 106 | `test_analyze_directory_rejected_with_regular_file_message` (explicitly called out in #285) |
| `tests/cli/test_cli_rules.py` | 362 | rules export against directory |
| `tests/cli/test_cli_rules.py` | 443 | rules import against directory |

## Why this targets `epic/safedir-readside-pr3`, not `main`

The flake has been blocking PR3 rollup CI on PR #292. Landing the fix in the integration branch first lets the PR3 rollup CI rerun cleanly before merging the whole stack into main.

## Test plan

- [x] All 4 affected tests pass locally (50 passed in 15s across both files).
- [x] Ruff clean on touched files.
- [ ] CI on this PR passes (the very test that was flaky should now be deterministic).
- [ ] After merge: PR #292 (PR3 rollup) `Test PR suite (py3.11)` rerun goes green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnPpeovvetPSR8Vwhxsn9j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced CLI error message validation tests by adding whitespace normalization to ensure consistent test behavior across different output formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->