### PR TITLE
fix: PR3 follow-ups — max_lines, test rename, RTF encoding (#277 #278 #280)

### DIFF
--- a/src/services/deduplication/extractor.py
+++ b/src/services/deduplication/extractor.py
@@ -300,13 +300,17 @@ class DocumentExtractor:
 
     @staticmethod
     def _decode_bytes(raw: bytes) -> str:
-        """Decode bytes using a utf-8 → latin-1 → cp1252 → ascii fallback chain."""
-        for encoding in ("utf-8", "latin-1", "cp1252", "ascii"):
+        """Decode bytes using a utf-8 → cp1252 → latin-1 fallback chain.
+
+        latin-1 is tried last because it accepts all 256 byte values without
+        error; placing it earlier would make cp1252 unreachable.
+        """
+        for encoding in ("utf-8", "cp1252", "latin-1"):
             try:
                 return raw.decode(encoding)
             except UnicodeDecodeError:
                 continue
-        return raw.decode("utf-8", errors="ignore")
+        return raw.decode("utf-8", errors="ignore")  # unreachable; latin-1 always succeeds
 
     def _extract_text(
         self,

--- a/src/services/deduplication/extractor.py
+++ b/src/services/deduplication/extractor.py
@@ -298,6 +298,16 @@ class DocumentExtractor:
             logger.error(f"Error extracting DOCX {display}: {e}")
             return ""
 
+    @staticmethod
+    def _decode_bytes(raw: bytes) -> str:
+        """Decode bytes using a utf-8 → latin-1 → cp1252 → ascii fallback chain."""
+        for encoding in ("utf-8", "latin-1", "cp1252", "ascii"):
+            try:
+                return raw.decode(encoding)
+            except UnicodeDecodeError:
+                continue
+        return raw.decode("utf-8", errors="ignore")
+
     def _extract_text(
         self,
         file_path: Path | None = None,
@@ -306,30 +316,22 @@ class DocumentExtractor:
         label: str | None = None,
     ) -> str:
         """Extract text from plain text file."""
-        encodings = ["utf-8", "latin-1", "cp1252", "ascii"]
         display = label or (file_path.name if file_path is not None else "<fileobj>")
 
         if fileobj is not None:
-            # Read all bytes once; try each encoding in turn.
             try:
                 raw = fileobj.read()
             except OSError as e:
                 logger.error(f"Error reading text file {display}: {e}")
                 return ""
-            for encoding in encodings:
-                try:
-                    text = raw.decode(encoding)
-                    logger.debug(f"Read {len(text)} chars from text file: {display}")
-                    return text
-                except UnicodeDecodeError:
-                    continue
-            # All strict decodes failed — fall back to ignore errors.
-            return raw.decode("utf-8", errors="ignore")
+            text = self._decode_bytes(raw)
+            logger.debug(f"Read {len(text)} chars from text file: {display}")
+            return text
 
         if file_path is None:
             raise TypeError("path-branch requires file_path")
         try:
-            for encoding in encodings:
+            for encoding in ("utf-8", "latin-1", "cp1252", "ascii"):
                 try:
                     with open(
                         file_path, encoding=encoding
@@ -362,14 +364,14 @@ class DocumentExtractor:
 
         try:
             if fileobj is not None:
-                rtf_content = fileobj.read().decode("utf-8", errors="ignore")
+                rtf_content = self._decode_bytes(fileobj.read())
             else:
                 if file_path is None:
                     raise TypeError("path-branch requires file_path")
                 with open(
-                    file_path, encoding="utf-8", errors="ignore"
+                    file_path, "rb"
                 ) as f:  # safedir: ok — Windows / NotImplementedError fallback
-                    rtf_content = f.read()
+                    rtf_content = self._decode_bytes(f.read())
 
             # Try using striprtf if available
             try:

--- a/src/utils/readers/cad.py
+++ b/src/utils/readers/cad.py
@@ -321,11 +321,12 @@ def read_step_file(
     """Read metadata from a STEP (.step, .stp) CAD file.
 
     STEP files are ISO 10303 standard format for 3D CAD data exchange.
-    This function extracts basic header information from the first 10 KB.
+    This function extracts basic header information from the first ``max_lines``
+    lines, matching the line-based behaviour of ``read_iges_file``.
 
     Args:
         file_path: Path to STEP file (legacy entry point).
-        max_lines: Unused (kept for backward compat).
+        max_lines: Maximum lines to read from the header (default 100).
         fileobj: Open binary file-like (SafeDir-friendly entry point).
             STEP is plain ASCII; the binary stream is decoded UTF-8 with
             errors ignored, matching the legacy path-branch behavior.
@@ -345,7 +346,11 @@ def read_step_file(
         label = Path(file_path).name if file_path is not None else "<fileobj>"
         _check_fd_size(fileobj)
         try:
-            content = fileobj.read(10000).decode("utf-8", errors="ignore")
+            text_stream = io.TextIOWrapper(fileobj, encoding="utf-8", errors="ignore")
+            try:
+                content = "".join(text_stream.readline() for _ in range(max_lines))
+            finally:
+                text_stream.detach()
             try:
                 size_kb = os.fstat(fileobj.fileno()).st_size / 1024
             except (OSError, AttributeError, ValueError):
@@ -361,7 +366,7 @@ def read_step_file(
         with path.open(
             encoding="utf-8", errors="ignore"
         ) as f:  # safedir: ok — legacy path-branch; SafeDir-aware callers pass fileobj=
-            content = f.read(10000)
+            content = "".join(f.readline() for _ in range(max_lines))
         size_kb = path.stat().st_size / 1024
         return _parse_step_text(content, path.name, size_kb)
     except (OSError, UnicodeDecodeError, ValueError) as e:

--- a/tests/integration/test_services_dedup_embedder_extractor_hasher_detector.py
+++ b/tests/integration/test_services_dedup_embedder_extractor_hasher_detector.py
@@ -257,25 +257,32 @@ class TestDocumentExtractor:
         assert "Hello" in text
 
     def test_extract_rtf_cp1252_path_branch(self, tmp_path: Path) -> None:
-        """cp1252-encoded RTF (common on Windows) preserves non-ASCII chars."""
+        """cp1252-encoded RTF (common on Windows) decodes 0x80-0x9F correctly."""
         from services.deduplication.extractor import DocumentExtractor
 
-        # é is 0xe9 in cp1252; pure UTF-8 decode would raise UnicodeDecodeError.
-        rtf_bytes = r"{\rtf1\ansi caf\e9}".encode("ascii") + b"\xe9"
+        # 0x92 is right single quote (') in cp1252, but a C1 control char in
+        # latin-1.  If the decoder tried latin-1 first it would return a
+        # control character, not the quotation mark.
+        rtf_bytes = rb"{\rtf1\ansi don" + b"\x92" + rb"t}"
         f = tmp_path / "windows.rtf"
         f.write_bytes(rtf_bytes)
         extractor = DocumentExtractor()
         text = extractor.extract_text(f)
         assert isinstance(text, str)
         assert len(text) > 0
+        # cp1252 maps 0x92 → U+2019 RIGHT SINGLE QUOTATION MARK
+        assert "’" in text or "'" in text
 
     def test_decode_bytes_fallback_chain(self) -> None:
-        """_decode_bytes tries utf-8 → latin-1 → cp1252 → ascii(ignore)."""
+        """_decode_bytes tries utf-8 → cp1252 → latin-1 fallback chain."""
         from services.deduplication.extractor import DocumentExtractor
 
         # Pure ASCII — utf-8 succeeds first.
         assert DocumentExtractor._decode_bytes(b"hello") == "hello"
-        # latin-1 byte 0xe9 (é) — utf-8 fails, latin-1 succeeds.
+        # 0x80 is € in cp1252, but a C1 control char in latin-1.
+        # Verifies cp1252 is tried before latin-1.
+        assert DocumentExtractor._decode_bytes(b"\x80") == "€"  # €
+        # 0xe9 is é in both latin-1 and cp1252 — covers the latin-1 fallback path.
         assert DocumentExtractor._decode_bytes(b"caf\xe9") == "café"
         # All bytes in range — ensure no exception on arbitrary bytes.
         result = DocumentExtractor._decode_bytes(bytes(range(256)))

--- a/tests/integration/test_services_dedup_embedder_extractor_hasher_detector.py
+++ b/tests/integration/test_services_dedup_embedder_extractor_hasher_detector.py
@@ -256,6 +256,31 @@ class TestDocumentExtractor:
         # Both striprtf and basic-stripping fallback extract "Hello" from the test input
         assert "Hello" in text
 
+    def test_extract_rtf_cp1252_path_branch(self, tmp_path: Path) -> None:
+        """cp1252-encoded RTF (common on Windows) preserves non-ASCII chars."""
+        from services.deduplication.extractor import DocumentExtractor
+
+        # é is 0xe9 in cp1252; pure UTF-8 decode would raise UnicodeDecodeError.
+        rtf_bytes = r"{\rtf1\ansi caf\e9}".encode("ascii") + b"\xe9"
+        f = tmp_path / "windows.rtf"
+        f.write_bytes(rtf_bytes)
+        extractor = DocumentExtractor()
+        text = extractor.extract_text(f)
+        assert isinstance(text, str)
+        assert len(text) > 0
+
+    def test_decode_bytes_fallback_chain(self) -> None:
+        """_decode_bytes tries utf-8 → latin-1 → cp1252 → ascii(ignore)."""
+        from services.deduplication.extractor import DocumentExtractor
+
+        # Pure ASCII — utf-8 succeeds first.
+        assert DocumentExtractor._decode_bytes(b"hello") == "hello"
+        # latin-1 byte 0xe9 (é) — utf-8 fails, latin-1 succeeds.
+        assert DocumentExtractor._decode_bytes(b"caf\xe9") == "café"
+        # All bytes in range — ensure no exception on arbitrary bytes.
+        result = DocumentExtractor._decode_bytes(bytes(range(256)))
+        assert isinstance(result, str)
+
     def test_extract_odt_basic(self, tmp_path: Path) -> None:
         import io
         import zipfile

--- a/tests/utils/test_readers_safedir.py
+++ b/tests/utils/test_readers_safedir.py
@@ -783,6 +783,26 @@ class TestReadStepFileFileobj:
         assert "STEP File Information" in out
         assert "Size:" not in out
 
+    def test_max_lines_limits_content(self, tmp_path: Path) -> None:
+        """``max_lines`` caps how many lines are read; the reported entity
+        count is lower when fewer lines are consumed."""
+        # 4-line preamble + 200 entity lines + 2 footer lines.
+        lines = ["ISO-10303-21;\n", "HEADER;\n", "ENDSEC;\n", "DATA;\n"]
+        for i in range(1, 201):
+            lines.append(f"#{i}=POINT('',(0.,0.,{i}.));\n")
+        lines.append("ENDSEC;\n")
+        lines.append("END-ISO-10303-21;\n")
+        p = tmp_path / "big.step"
+        p.write_text("".join(lines))
+
+        # 10 lines: preamble (4) + 6 entity lines → entity count reported as 6.
+        out_limited = read_step_file(file_path=p, max_lines=10)
+        assert "Approximate entity count: 6" in out_limited
+
+        # 300 lines covers all 200 entities.
+        out_full = read_step_file(file_path=p, max_lines=300)
+        assert "Approximate entity count: 200" in out_full
+
     def test_requires_arg(self) -> None:
         with pytest.raises(ValueError, match="file_path or fileobj"):
             read_step_file()
@@ -1249,14 +1269,14 @@ class TestReadFileViaSafedir:
         assert hasattr(call_args[0], "read")
 
     @pytest.mark.parametrize(
-        ("name", "reader_module_attr"),
+        ("name", "expected_ezdxf_method"),
         [
             ("model.dxf", "read"),
             ("model.dwg", "read"),
         ],
     )
     def test_dispatches_dxf_dwg_extensions(
-        self, tmp_path: Path, name: str, reader_module_attr: str
+        self, tmp_path: Path, name: str, expected_ezdxf_method: str
     ) -> None:
         """``.dxf`` and ``.dwg`` reach the ezdxf-based readers via the
         dispatcher. Mocked because ``ezdxf`` is in the ``cad`` optional
@@ -1275,7 +1295,7 @@ class TestReadFileViaSafedir:
         assert out is not None
         assert "AC1032" in out
         # ezdxf.read (text-stream API) called, not readfile (path API).
-        getattr(mock_ezdxf, reader_module_attr).assert_called_once()
+        getattr(mock_ezdxf, expected_ezdxf_method).assert_called_once()
 
     @pytest.mark.parametrize("name", ["model.step", "model.stp"])
     def test_dispatches_step_extensions(self, tmp_path: Path, name: str) -> None:


### PR DESCRIPTION
## Summary

Batches three CodeRabbit/Copilot follow-up findings from the PR3 (SafeDir read-side) series into a single cleanup PR.

- **#277** — `read_step_file` had `max_lines: int = 100` documented as "unused (kept for backward compat)". Plumbed it through as a `readline` loop (matching `read_iges_file`'s existing contract). Added `test_max_lines_limits_content` asserting entity count differs between a 10-line and 300-line read on a 200-entity STEP file.

- **#278** — Renamed `reader_module_attr` → `expected_ezdxf_method` in `test_dispatches_dxf_dwg_extensions` parametrize; the old name was generic for what the test actually asserts (`ezdxf.read` called, not `ezdxf.readfile`).

- **#280** — Added `DocumentExtractor._decode_bytes` static helper (utf-8 → latin-1 → cp1252 → ascii/errors=ignore chain). Wired it into `_extract_rtf` for both the fileobj and path branches, replacing the previous hard-coded `decode("utf-8", errors="ignore")` that silently dropped bytes ≥ 0x80 in cp1252-encoded Windows RTF files. Simplifies `_extract_text` fileobj branch to use the same helper. Added `test_extract_rtf_cp1252_path_branch` and `test_decode_bytes_fallback_chain`.

## Test plan

- [ ] `TestReadStepFileFileobj` — all 4 tests pass (including new `test_max_lines_limits_content`)
- [ ] `test_dispatches_dxf_dwg_extensions` — 2 parametrized cases pass with renamed parameter
- [ ] `test_decode_bytes_fallback_chain` — verifies utf-8 / latin-1 / catch-all paths
- [ ] `test_extract_rtf_cp1252_path_branch` — verifies non-ASCII RTF round-trips via path branch
- [ ] `ruff check` clean on all 4 changed files
- [ ] `mypy --ignore-missing-imports` clean on both changed source files

Closes #277, #278, #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved extraction of text and rich-text documents with enhanced character encoding handling and fallback support.

* **Changes**
  * STEP file header extraction now uses line-based reading instead of fixed-size byte window.

* **Tests**
  * Added integration tests for document extraction encoding resilience and file reading with configurable limits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->