### PR TITLE
fix(deps): roll back mypy 2.1.0 — INTERNAL ERROR crash on CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dev = [
     "pytest-timeout~=2.4.0",  # 2.4.0 regression: timer thread not cancelled on Windows; crashes during teardown (AssertionError in read_global_capture)
     "pytest-xdist~=3.5",
     "pytest-randomly~=3.15",
-    "mypy~=2.1",  # 1.20.2 regression: INTERNAL ERROR analyzing optional-dep models (llama_cpp_text_model, mlx_text_model) even with ignore_errors override; 1.20.1 works
+    "mypy!=1.20.2,~=1.8",  # 1.20.2 regression: INTERNAL ERROR on optional-dep models; 2.1.0 crash: INTERNAL ERROR exit-code-2 on CI; 1.20.1 is last stable
 
     "types-PyYAML~=6.0",
     "ruff>=0.1.0",  # 0.x — unstable API, keep >=


### PR DESCRIPTION
## Problem

mypy 2.1.0 (merged via dependabot #261) exits with code 2 (`INTERNAL ERROR`) on every CI lint run. No type violations — mypy itself crashes. Both `main` and all open PRs are blocked.

```
mypy (all source packages)..............Failed
- exit code: 2
error: INTERNAL ERROR -- version: 2.1.0
```

Confirmed across two consecutive runs on PR #300 and two runs on `main` (runs 26138155295, 26138741055, 26138929609).

## Fix

Roll back the mypy constraint to `!=1.20.2,~=1.8`, which resolves to **1.20.1** — the last confirmed-stable version. The `!=1.20.2` exclusion is preserved (pre-existing regression on optional-dep models documented in the original comment).

No other changes.

## Test plan

- [ ] CI lint passes on this branch (mypy 1.20.1 installed)
- [ ] No type regressions (1.20.1 was the baseline before #261)

🤖 Generated with [Claude Code](https://claude.com/claude-code)