### PR TITLE
fix(ci): erase stale coverage data before PR test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,8 @@ jobs:
           print(f'pytest-asyncio {pytest_asyncio.__version__} registered as plugin')
           print(f'faker {importlib.metadata.version(\"faker\")} importable')
           "
+      - name: Erase stale coverage data
+        run: coverage erase
       - name: Run tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

`Test PR suite (py3.11)` exits with code 3 after all tests pass:

```
DataError: Can't combine statement coverage data with branch data
INTERNALERROR> self.cov.combine()
```

pytest-xdist writes per-worker `.coverage.N` files and combines them at teardown. When a stale `.coverage` file from a previous run (with a different branch/statement mode) exists in the workspace, `coverage.py` refuses to combine the incompatible data.

Tracked in #302.

## Fix

Add a `coverage erase` step immediately before `Run tests`. One line, no logic change to the test run itself.

## Test plan

- [ ] `Test PR suite (py3.11)` passes on this PR (the fix validates itself)
- [ ] No other CI jobs affected

Fixes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)