### PR TITLE
fix(ci): also delete .coverage.* parallel files before PR test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,10 @@ jobs:
           print(f'faker {importlib.metadata.version(\"faker\")} importable')
           "
       - name: Erase stale coverage data
-        run: coverage erase
+        # coverage erase clears .coverage; find removes .coverage.* parallel
+        # worker files that xdist writes — stale ones from a previous run with
+        # a different branch/statement mode cause DataError on combine (#302).
+        run: coverage erase && find . -maxdepth 1 -name ".coverage.*" -delete
       - name: Run tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

`coverage erase` (added in #303) only removes the main `.coverage` database. pytest-xdist writes per-worker `.coverage.N` files during the run, but stale ones from a prior run with a different branch/statement mode survive and get included in the combine step:

```
DataError: Can't combine statement coverage data with branch data
```

Still hitting this on PRs #300 and #304 despite #303. Refs #302.

## Fix

Add `find . -maxdepth 1 -name ".coverage.*" -delete` alongside `coverage erase` to clear all parallel worker files too.

## Test plan

- [ ] `Test PR suite (py3.11)` passes on this PR (self-validating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)