### PR TITLE
docs: cross-reference SafeDir hardening epic from hardening roadmap (#290)

### DIFF
--- a/docs/superpowers/specs/2026-04-22-hardening-roadmap-design.md
+++ b/docs/superpowers/specs/2026-04-22-hardening-roadmap-design.md
@@ -463,4 +463,13 @@ Source of truth: `src/cli/main.py` registers each sub-app with a plain name (`ap
 | `src/cli/doctor.py` | `fo doctor` (single top-level command, not a sub-app) | `path` | 357 |
 | `src/cli/profile.py` | `fo profile import` / `export` | path args (Click group, lazy-loaded) | deferred in main.py:245 |
 
+## Parallel epics
+
+The SafeDir read-side hardening epic (#264 / #267 PR3 / #268 PR4 / #269 PR5 / #270 PR6)
+addresses TOCTOU and symlink-swap vectors across content readers, dedup, undo, and watcher.
+Tracked separately; not part of the A–G roadmap above.
+
+See `docs/internal/safedir-shutil-audit-pr3j.md` for the PR3 closeout audit and
+`docs/developer/safedir-readers.md` for the contributor guide.
+
 Each of the above wires through `validate_within_roots()` as a commit inside `epic-a-cli`. Out of scope for A2: `fo copilot` (free-text `message`), `fo undo`/`redo`/`history` (operation IDs only), `fo version`/`hardware-info`/`config`/`model`/`setup`/`update`/`completion` (no path args).


### PR DESCRIPTION
## Summary

The hardening roadmap (`docs/superpowers/specs/2026-04-22-hardening-roadmap-design.md`) lists 15 PRs across epics A–G but had no mention of the parallel SafeDir TOCTOU/symlink-hardening work.

Adds a "Parallel epics" section at the end pointing to #264 (base issue), PR3–PR6 tracking issues (#267–#270), the PR3 closeout audit (`safedir-shutil-audit-pr3j.md`), and the contributor guide (`safedir-readers.md`).

One-file doc change, 9 lines added.

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated hardening roadmap specification with a new section documenting parallel epics and related work being tracked separately from the main roadmap.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->