### PR TITLE
feat(undo): capture dst inode in durable_move + thread through transaction (PR5b)

### DIFF
--- a/src/history/transaction.py
+++ b/src/history/transaction.py
@@ -91,6 +91,8 @@ class OperationTransaction:
         metadata: dict[str, Any] | None = None,
         status: OperationStatus = OperationStatus.COMPLETED,
         error_message: str | None = None,
+        dest_dev: int | None = None,
+        dest_ino: int | None = None,
     ) -> int:
         """Log an operation within this transaction.
 
@@ -101,6 +103,8 @@ class OperationTransaction:
             metadata: Additional metadata
             status: Operation status
             error_message: Error message if operation failed
+            dest_dev: Device number of destination file (from fstat at move time).
+            dest_ino: Inode number of destination file (from fstat at move time).
 
         Returns:
             Operation ID
@@ -116,10 +120,17 @@ class OperationTransaction:
             transaction_id=self.transaction_id,
             status=status,
             error_message=error_message,
+            dest_dev=dest_dev,
+            dest_ino=dest_ino,
         )
 
     def log_move(
-        self, source_path: Path, destination_path: Path, metadata: dict[str, Any] | None = None
+        self,
+        source_path: Path,
+        destination_path: Path,
+        metadata: dict[str, Any] | None = None,
+        dest_dev: int | None = None,
+        dest_ino: int | None = None,
     ) -> int:
         """Log a move operation.
 
@@ -127,6 +138,8 @@ class OperationTransaction:
             source_path: Source file path
             destination_path: Destination file path
             metadata: Additional metadata
+            dest_dev: Device number of destination file captured after the move.
+            dest_ino: Inode number of destination file captured after the move.
 
         Returns:
             Operation ID
@@ -136,6 +149,8 @@ class OperationTransaction:
             source_path=source_path,
             destination_path=destination_path,
             metadata=metadata,
+            dest_dev=dest_dev,
+            dest_ino=dest_ino,
         )
 
     def log_rename(

--- a/src/undo/durable_move.py
+++ b/src/undo/durable_move.py
@@ -81,6 +81,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 import tempfile
 import time
 import uuid
@@ -105,6 +106,11 @@ except ImportError:  # pragma: no cover - Windows
     _HAS_FCNTL = False
 
 logger = logging.getLogger(__name__)
+
+# PR5b / #269: type alias for the inode-identity triple returned by
+# durable_move after a successful move on POSIX.  ``None`` on Windows
+# (no O_NOFOLLOW / lstat inode semantics) or on any stat failure.
+DstInode = tuple[int, int, int]  # (st_dev, st_ino, st_size)
 
 # Heterogeneous collapse-identity tuple. Three shapes per §3.1:
 # ``("v2", op, op_id)`` / ``("v1", op, src, dst)`` / ``("unknown", op, _hash16)``.
@@ -145,6 +151,28 @@ def _hash16(raw: str) -> str:
     the protocol expects (≤ dozens).
     """
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _capture_dst_inode(dst: Path) -> DstInode | None:
+    """Lstat *dst* and return its inode identity triple.
+
+    Called immediately after the atomic rename / ``os.replace`` so the
+    caller can store ``(st_dev, st_ino, st_size)`` in the history record.
+    Using ``lstat`` (not ``stat``) is deliberate: if ``dst`` is a symlink
+    (``durable_move`` supports symlink moves), we want the symlink inode,
+    not the target.
+
+    Returns ``None`` on Windows or if ``lstat`` fails (caller treats as
+    a legacy row — size+hash fallback at undo time).
+    """
+    if sys.platform == "win32":  # pragma: no cover - Windows
+        return None
+    try:
+        st = os.lstat(dst)
+        return st.st_dev, st.st_ino, st.st_size
+    except OSError:
+        logger.debug("durable_move: lstat failed on %s; cannot capture dst inode", dst)
+        return None
 
 
 @dataclass(frozen=True)
@@ -265,7 +293,7 @@ def _locked(journal: Path, mode: int) -> Iterator[object | None]:
         fh.close()
 
 
-def durable_move(src: Path, dst: Path, *, journal: Path) -> None:
+def durable_move(src: Path, dst: Path, *, journal: Path) -> DstInode | None:
     """Move *src* to *dst* atomically (same device) or durably (EXDEV).
 
     Args:
@@ -280,6 +308,14 @@ def durable_move(src: Path, dst: Path, *, journal: Path) -> None:
             For same-device moves (the fast path) the journal is
             untouched — no crash recovery is needed because the move
             is one syscall.
+
+    Returns:
+        ``(st_dev, st_ino, st_size)`` of *dst* captured via ``lstat``
+        immediately after the move on POSIX. ``None`` on Windows or if
+        the lstat fails. Callers that record history should pass the
+        non-None triple to ``log_operation(dest_dev=..., dest_ino=...)``
+        so ``fo undo`` can verify the file identity before replaying
+        the move (PR5b / PR5c, #269).
 
     Raises:
         FileNotFoundError: If *src* doesn't exist.
@@ -316,6 +352,7 @@ def durable_move(src: Path, dst: Path, *, journal: Path) -> None:
         if exc.errno != errno.EXDEV:
             raise
         _durable_cross_device_move(src, dst, journal=journal)
+    return _capture_dst_inode(dst)
 
 
 def _durable_cross_device_move(src: Path, dst: Path, *, journal: Path) -> None:

--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -3554,6 +3554,21 @@ class TestDurableMoveInodeCapture:
         assert ops[0].dest_dev == dev
         assert ops[0].dest_ino == ino
 
+    def test_capture_dst_inode_returns_none_on_lstat_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_capture_dst_inode returns None and logs debug when os.lstat raises OSError."""
+        from undo.durable_move import _capture_dst_inode
+
+        def _raise_oserror(_path: object) -> None:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr("undo.durable_move.os.lstat", _raise_oserror)
+
+        result = _capture_dst_inode(tmp_path / "anything.txt")
+
+        assert result is None
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/undo/test_durable_move.py
+++ b/tests/undo/test_durable_move.py
@@ -3441,6 +3441,121 @@ class TestSweepEndToEndV2Started:
 
 
 # ---------------------------------------------------------------------------
+# PR5b — inode capture from durable_move (issue #269)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(sys.platform == "win32", reason="lstat inode semantics are POSIX-only")
+class TestDurableMoveInodeCapture:
+    """durable_move returns (dev, ino, size) for callers that record history."""
+
+    def test_same_device_returns_dst_inode(self, tmp_path: Path) -> None:
+        """durable_move returns non-None (dev, ino, size) after same-device move."""
+        from undo.durable_move import durable_move
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_bytes(b"hello inode")
+        journal = tmp_path / "move.journal"
+
+        pin = durable_move(src, dst, journal=journal)
+
+        assert pin is not None, "POSIX same-device move must return inode triple"
+        dev, ino, size = pin
+        st = dst.stat()
+        assert dev == st.st_dev
+        assert ino == st.st_ino
+        assert size == st.st_size
+
+    def test_inode_triple_matches_lstat(self, tmp_path: Path) -> None:
+        """The captured (dev, ino, size) matches os.lstat on the destination."""
+        from undo.durable_move import durable_move
+
+        src = tmp_path / "file.txt"
+        dst = tmp_path / "sub" / "file.txt"
+        src.write_bytes(b"x" * 512)
+        journal = tmp_path / "j.journal"
+
+        pin = durable_move(src, dst, journal=journal)
+
+        assert pin is not None
+        st = os.lstat(dst)
+        assert pin == (st.st_dev, st.st_ino, st.st_size)
+
+    def test_inode_stored_in_history_via_log_operation(self, tmp_path: Path) -> None:
+        """Caller passes (dev, ino) to log_operation; round-trip confirms non-None values."""
+        from history.models import OperationType
+        from history.tracker import OperationHistory
+        from undo.durable_move import durable_move
+
+        src = tmp_path / "a.txt"
+        dst = tmp_path / "b.txt"
+        src.write_bytes(b"history inode test")
+        journal = tmp_path / "h.journal"
+        db = tmp_path / "history.db"
+
+        pin = durable_move(src, dst, journal=journal)
+        assert pin is not None
+        dev, ino, size = pin
+
+        with OperationHistory(db_path=db) as history:
+            history.log_operation(
+                OperationType.MOVE,
+                source_path=src,
+                destination_path=dst,
+                dest_dev=dev,
+                dest_ino=ino,
+            )
+            ops = history.get_operations()
+
+        assert len(ops) == 1
+        op = ops[0]
+        assert op.dest_dev == dev
+        assert op.dest_ino == ino
+
+    def test_legacy_row_has_none_inode(self, tmp_path: Path) -> None:
+        """Operations logged without inode args (pre-PR5 rows) return None."""
+        from history.models import OperationType
+        from history.tracker import OperationHistory
+
+        src = tmp_path / "old.txt"
+        src.write_bytes(b"legacy")
+        db = tmp_path / "history.db"
+
+        with OperationHistory(db_path=db) as history:
+            history.log_operation(OperationType.MOVE, source_path=src, destination_path=src)
+            ops = history.get_operations()
+
+        assert ops[0].dest_dev is None
+        assert ops[0].dest_ino is None
+
+    def test_transaction_log_move_passes_inode(self, tmp_path: Path) -> None:
+        """OperationTransaction.log_move propagates dest_dev/dest_ino to the DB."""
+        from history.tracker import OperationHistory
+        from history.transaction import OperationTransaction
+        from undo.durable_move import durable_move
+
+        src = tmp_path / "txn_src.txt"
+        dst = tmp_path / "txn_dst.txt"
+        src.write_bytes(b"transaction inode")
+        journal = tmp_path / "txn.journal"
+        db = tmp_path / "txn.db"
+
+        pin = durable_move(src, dst, journal=journal)
+        assert pin is not None
+        dev, ino, _ = pin
+
+        with OperationHistory(db_path=db) as history:
+            with OperationTransaction(history) as txn:
+                txn.log_move(src, dst, dest_dev=dev, dest_ino=ino)
+            ops = history.get_operations()
+
+        assert ops[0].dest_dev == dev
+        assert ops[0].dest_ino == ino
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Part of the PR5 epic (`epic/safedir-undo-pr5`) for issue #269 — undo TOCTOU hardening.

Depends on PR5a (#308, already merged into epic).

- `durable_move` now returns `DstInode | None` — a `(st_dev, st_ino, st_size)` triple captured via `os.lstat(dst)` immediately after the atomic rename on POSIX; `None` on Windows or if lstat fails
- `_capture_dst_inode(dst)` helper uses `lstat` (not `stat`) so symlink moves capture the symlink's own inode rather than the target
- `DstInode = tuple[int, int, int]` exported as a named type alias
- `OperationTransaction.log_operation` gains `dest_dev` / `dest_ino` kwargs and passes them through to `OperationHistory.log_operation` (PR5a)
- `OperationTransaction.log_move` gains `dest_dev` / `dest_ino` kwargs

Callers that record history after a `durable_move` can now pass the triple directly to `log_operation(dest_dev=pin[0], dest_ino=pin[1])` so PR5c (`rollback.py`) can verify the file identity before replaying an undo.

## Test plan

- [x] `TestDurableMoveInodeCapture` — 5 new unit tests:
  - `test_same_device_returns_dst_inode` — same-device move returns correct `(dev, ino, size)`
  - `test_inode_triple_matches_lstat` — captured triple matches `os.lstat` on destination
  - `test_inode_stored_in_history_via_log_operation` — end-to-end: move → log → read back confirms non-None values
  - `test_legacy_row_has_none_inode` — rows logged without inode args return `None` (pre-PR5 compat)
  - `test_transaction_log_move_passes_inode` — `OperationTransaction.log_move` propagates `dest_dev`/`dest_ino`
- [x] All 297 existing `tests/history/` and `tests/undo/test_durable_move.py` tests pass

## Merge order

```
epic/safedir-undo-pr5-5a  →  epic/safedir-undo-pr5  ✅ merged
epic/safedir-undo-pr5-5b  →  epic/safedir-undo-pr5  (this PR)
epic/safedir-undo-pr5-5c  →  epic/safedir-undo-pr5  (depends on 5b)
epic/safedir-undo-pr5-5d  →  epic/safedir-undo-pr5  (independent)
epic/safedir-undo-pr5     →  main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)