### PR TITLE
feat(undo): inode verification before undo replay; un-skip Test 6 (PR5c)

### DIFF
--- a/src/undo/rollback.py
+++ b/src/undo/rollback.py
@@ -7,7 +7,9 @@ handling all operation types and transaction management.
 from __future__ import annotations
 
 import logging
+import os
 import shutil
+import sys
 from pathlib import Path
 
 from history.models import Operation, OperationType
@@ -149,6 +151,16 @@ class RollbackExecutor:
     def rollback_move(self, operation: Operation) -> bool:
         """Rollback a move operation (move file back to source).
 
+        PR5c / #269: Before replaying the move, verify that the file
+        currently at ``destination`` is the same inode that was there
+        when the original move landed.  If the history row carries
+        ``dest_dev`` / ``dest_ino`` (recorded by PR5b's
+        ``durable_move`` return value) and the current lstat disagrees,
+        the file was swapped — refuse and log a security event.
+
+        Legacy rows (pre-PR5, ``dest_dev is None``) fall through to the
+        existing behaviour without inode verification.
+
         Args:
             operation: Move operation to rollback
 
@@ -164,6 +176,11 @@ class RollbackExecutor:
 
         logger.info(f"Rolling back move: {destination} -> {source}")
 
+        # PR5c inode verification — POSIX only.
+        if sys.platform != "win32" and operation.dest_dev is not None:
+            if not self._verify_dst_inode(operation, destination):
+                return False
+
         try:
             # F7: durable_move replaces ``shutil.move`` for files;
             # ``_move`` dispatches to ``shutil.move`` for directories
@@ -177,6 +194,57 @@ class RollbackExecutor:
         except Exception as e:
             logger.error(f"Failed to rollback move operation {operation.id}: {e}")
             return False
+
+    def _verify_dst_inode(self, operation: Operation, destination: Path) -> bool:
+        """Return True iff the file at *destination* matches the recorded inode.
+
+        Called by :meth:`rollback_move` for new-style rows (``dest_dev``
+        is not ``None``).  On mismatch — indicating a swap between the
+        original move and the undo attempt — logs a ``security_event``
+        and returns ``False`` so the caller refuses the replay.
+
+        ``FileNotFoundError`` (destination gone) is treated as a
+        mismatch: if the file is missing we cannot verify identity and
+        must refuse rather than silently skip (which would look like
+        success to the caller).
+        """
+        try:
+            st = os.lstat(destination)
+        except FileNotFoundError:
+            logger.error(
+                "security_event undo_dst_missing op_id=%s path=%s: "
+                "destination absent at undo time; refusing replay",
+                operation.id,
+                destination,
+                exc_info=True,
+            )
+            return False
+        except OSError:
+            logger.error(
+                "security_event undo_dst_lstat_error op_id=%s path=%s: "
+                "cannot stat destination; refusing replay",
+                operation.id,
+                destination,
+                exc_info=True,
+            )
+            return False
+
+        if st.st_dev != operation.dest_dev or st.st_ino != operation.dest_ino:
+            logger.error(
+                "security_event undo_inode_mismatch op_id=%s path=%s: "
+                "recorded (dev=%s ino=%s) != current (dev=%s ino=%s); "
+                "file was replaced — refusing undo replay",
+                operation.id,
+                destination,
+                operation.dest_dev,
+                operation.dest_ino,
+                st.st_dev,
+                st.st_ino,
+                exc_info=True,
+            )
+            return False
+
+        return True
 
     def rollback_rename(self, operation: Operation) -> bool:
         """Rollback a rename operation (rename back to original).

--- a/tests/security/test_symlink_safety.py
+++ b/tests/security/test_symlink_safety.py
@@ -30,6 +30,7 @@ the SafeDir primitive isn't implemented for it (see #264 → #266).
 
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 
@@ -466,23 +467,173 @@ class TestDaemonSymlinkSafety:
 
 
 class TestUndoSymlinkSafety:
-    """Replay TOCTOU (blocked on PR5, #269)."""
+    """Replay TOCTOU — PR5c (#269)."""
 
     def test_undo_refuses_replay_on_inode_change(self, tmp_path: Path) -> None:
         """Undo refuses to overwrite a destination whose (dev, ino) changed.
 
-        Sequence the test will exercise once history records (dev, ino):
+        Sequence:
 
-        1. ``fo organize`` moves ``input/A`` to ``output/cat/A``; history
-           records ``dest_dev`` / ``dest_ino`` from ``os.fstat`` on the open
-           fd.
-        2. ``output/cat/A`` is deleted and replaced by a different file with
-           the same name (different inode).
-        3. ``fo undo`` re-stats the destination; the recorded
-           ``(dest_dev, dest_ino)`` doesn't match.
-        4. Undo refuses, logs a ``security_event``.
+        1. Create ``output/cat/A`` and build a history record that pins its
+           ``(dev, ino)`` via PR5a accessors.
+        2. Delete ``output/cat/A`` and replace it with a new file (different
+           inode) at the same path.
+        3. Call ``RollbackExecutor.rollback_move`` — the inode check fires,
+           sees a mismatch, logs ``security_event undo_inode_mismatch``, and
+           returns ``False``.
 
-        Acceptance: the replacement file at ``output/cat/A`` is untouched
-        and ``input/A`` is not re-created.
+        Acceptance:
+        - ``rollback_move`` returns ``False``
+        - The replacement file at ``output/cat/A`` is untouched
+        - ``input/A`` is NOT re-created
+        - A log record containing ``security_event undo_inode_mismatch`` is emitted
         """
-        pytest.skip("blocked on PR5 (#269) — history (dev, ino) + verify on undo")
+        from datetime import UTC, datetime
+
+        from history.models import Operation, OperationStatus, OperationType
+        from undo.rollback import RollbackExecutor
+        from undo.validator import OperationValidator
+
+        # Set up paths
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output" / "cat"
+        input_dir.mkdir(parents=True)
+        output_dir.mkdir(parents=True)
+
+        source = input_dir / "A"
+        destination = output_dir / "A"
+
+        # Step 1: Simulate an original organize move — destination exists.
+        destination.write_bytes(b"original content")
+        st = destination.stat()
+
+        # Build a history record with the original inode pinned.
+        op = Operation(
+            operation_type=OperationType.MOVE,
+            timestamp=datetime.now(UTC),
+            source_path=source,
+            destination_path=destination,
+            status=OperationStatus.COMPLETED,
+            metadata={
+                "dest_dev": st.st_dev,
+                "dest_ino": st.st_ino,
+            },
+        )
+        assert op.dest_dev == st.st_dev
+        assert op.dest_ino == st.st_ino
+
+        # Step 2: Attacker replaces destination with a different file.
+        destination.unlink()
+        destination.write_bytes(b"attacker content")
+        new_st = destination.stat()
+        assert new_st.st_ino != st.st_ino, "sanity: new file must have a different inode"
+
+        # Step 3: Attempt undo — rollback_move should refuse.
+        journal = tmp_path / "test.journal"
+        validator = OperationValidator(journal_path=journal)
+        executor = RollbackExecutor(validator=validator, journal_path=journal)
+
+        with self._capture_security_log() as records:
+            result = executor.rollback_move(op)
+
+        # Acceptance checks
+        assert result is False, "rollback_move must refuse when inode changed"
+        assert destination.read_bytes() == b"attacker content", "replacement file must be untouched"
+        assert not source.exists(), "source must NOT be re-created"
+        assert any("security_event undo_inode_mismatch" in r.getMessage() for r in records), (
+            "a security_event undo_inode_mismatch log record must be emitted"
+        )
+
+    def test_undo_proceeds_when_inode_matches(self, tmp_path: Path) -> None:
+        """Undo succeeds when (dev, ino) still match — happy path."""
+        from datetime import UTC, datetime
+
+        from history.models import Operation, OperationStatus, OperationType
+        from undo.rollback import RollbackExecutor
+        from undo.validator import OperationValidator
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        dst.write_bytes(b"correct file")
+        st = dst.stat()
+
+        op = Operation(
+            operation_type=OperationType.MOVE,
+            timestamp=datetime.now(UTC),
+            source_path=src,
+            destination_path=dst,
+            status=OperationStatus.COMPLETED,
+            metadata={"dest_dev": st.st_dev, "dest_ino": st.st_ino},
+        )
+
+        journal = tmp_path / "test.journal"
+        validator = OperationValidator(journal_path=journal)
+        executor = RollbackExecutor(validator=validator, journal_path=journal)
+        result = executor.rollback_move(op)
+
+        assert result is True
+        assert src.read_bytes() == b"correct file"
+        assert not dst.exists()
+
+    def test_undo_legacy_row_skips_inode_check(self, tmp_path: Path) -> None:
+        """Legacy rows (dest_dev=None) proceed without inode verification."""
+        from datetime import UTC, datetime
+
+        from history.models import Operation, OperationStatus, OperationType
+        from undo.rollback import RollbackExecutor
+        from undo.validator import OperationValidator
+
+        src = tmp_path / "legacy_src.txt"
+        dst = tmp_path / "legacy_dst.txt"
+        dst.write_bytes(b"legacy content")
+
+        # No dest_dev / dest_ino in metadata — simulates a pre-PR5 row.
+        op = Operation(
+            operation_type=OperationType.MOVE,
+            timestamp=datetime.now(UTC),
+            source_path=src,
+            destination_path=dst,
+            status=OperationStatus.COMPLETED,
+            metadata={},
+        )
+        assert op.dest_dev is None  # pre-PR5 legacy row
+
+        journal = tmp_path / "test.journal"
+        validator = OperationValidator(journal_path=journal)
+        executor = RollbackExecutor(validator=validator, journal_path=journal)
+        result = executor.rollback_move(op)
+
+        assert result is True
+        assert src.read_bytes() == b"legacy content"
+
+    # ------------------------------------------------------------------
+    # Helper
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _capture_security_log():
+        """Context manager: capture log records from the rollback module."""
+        import contextlib
+
+        @contextlib.contextmanager
+        def _ctx():
+            handler = _ListHandler()
+            log = logging.getLogger("undo.rollback")
+            log.addHandler(handler)
+            try:
+                yield handler.records
+            finally:
+                log.removeHandler(handler)
+
+        return _ctx()
+
+
+class _ListHandler(logging.Handler):
+    """Accumulates LogRecord objects for test assertions."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)

--- a/tests/security/test_symlink_safety.py
+++ b/tests/security/test_symlink_safety.py
@@ -611,6 +611,81 @@ class TestUndoSymlinkSafety:
         assert result is True
         assert src.read_bytes() == b"legacy content"
 
+    def test_undo_refuses_when_destination_missing(self, tmp_path: Path) -> None:
+        """Undo refuses when the destination file no longer exists."""
+        from datetime import UTC, datetime
+
+        from history.models import Operation, OperationStatus, OperationType
+        from undo.rollback import RollbackExecutor
+        from undo.validator import OperationValidator
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+
+        # Record inode from a file we immediately delete to simulate "gone".
+        dst.write_bytes(b"original")
+        st = dst.stat()
+        dst.unlink()
+
+        op = Operation(
+            operation_type=OperationType.MOVE,
+            timestamp=datetime.now(UTC),
+            source_path=src,
+            destination_path=dst,
+            status=OperationStatus.COMPLETED,
+            metadata={"dest_dev": st.st_dev, "dest_ino": st.st_ino},
+        )
+
+        journal = tmp_path / "test.journal"
+        validator = OperationValidator(journal_path=journal)
+        executor = RollbackExecutor(validator=validator, journal_path=journal)
+
+        with self._capture_security_log() as records:
+            result = executor.rollback_move(op)
+
+        assert result is False
+        assert not src.exists(), "source must NOT be re-created"
+        assert any("security_event undo_dst_missing" in r.getMessage() for r in records)
+
+    def test_undo_refuses_when_lstat_raises_oserror(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Undo refuses when os.lstat raises a generic OSError."""
+        from datetime import UTC, datetime
+
+        from history.models import Operation, OperationStatus, OperationType
+        from undo.rollback import RollbackExecutor
+        from undo.validator import OperationValidator
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        dst.write_bytes(b"content")
+        st = dst.stat()
+
+        op = Operation(
+            operation_type=OperationType.MOVE,
+            timestamp=datetime.now(UTC),
+            source_path=src,
+            destination_path=dst,
+            status=OperationStatus.COMPLETED,
+            metadata={"dest_dev": st.st_dev, "dest_ino": st.st_ino},
+        )
+
+        def _raise_oserror(_path: object) -> None:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr("undo.rollback.os.lstat", _raise_oserror)
+
+        journal = tmp_path / "test.journal"
+        validator = OperationValidator(journal_path=journal)
+        executor = RollbackExecutor(validator=validator, journal_path=journal)
+
+        with self._capture_security_log() as records:
+            result = executor.rollback_move(op)
+
+        assert result is False
+        assert any("security_event undo_dst_lstat_error" in r.getMessage() for r in records)
+
     # ------------------------------------------------------------------
     # Helper
     # ------------------------------------------------------------------

--- a/tests/security/test_symlink_safety.py
+++ b/tests/security/test_symlink_safety.py
@@ -523,10 +523,15 @@ class TestUndoSymlinkSafety:
         assert op.dest_ino == st.st_ino
 
         # Step 2: Attacker replaces destination with a different file.
-        destination.unlink()
-        destination.write_bytes(b"attacker content")
+        # Use rename rather than unlink+write so the replacement file gets a
+        # fresh inode even on Linux where deleted inodes are immediately reused.
+        replacement = output_dir / "A.replacement"
+        replacement.write_bytes(b"attacker content")
+        replacement_ino = replacement.stat().st_ino
+        replacement.rename(destination)
         new_st = destination.stat()
-        assert new_st.st_ino != st.st_ino, "sanity: new file must have a different inode"
+        assert new_st.st_ino == replacement_ino, "sanity: rename must preserve inode"
+        assert new_st.st_ino != st.st_ino, "sanity: replacement must have a different inode"
 
         # Step 3: Attempt undo — rollback_move should refuse.
         journal = tmp_path / "test.journal"


### PR DESCRIPTION
## Summary

Part of the PR5 epic (`epic/safedir-undo-pr5`) for issue #269 — undo TOCTOU hardening.

Depends on PR5a (#308 ✅ merged) and PR5b (#309, in CI).

- `RollbackExecutor.rollback_move` now verifies `(dev, ino)` of the destination before replaying an undo
- If the history row carries `dest_dev`/`dest_ino` (set by PR5a/PR5b) and the current `lstat` disagrees, refuse and log `security_event undo_inode_mismatch`
- `_verify_dst_inode` helper handles three cases:
  - `FileNotFoundError` → log `undo_dst_missing`, refuse
  - Other `OSError` → log `undo_dst_lstat_error`, refuse  
  - Inode mismatch → log `undo_inode_mismatch`, refuse
  - All error paths use `exc_info=True` (traceback-preservation guardrail)
- Legacy rows (`dest_dev is None`, pre-PR5) fall through unchanged — no behavior change for existing history
- Windows (`sys.platform == "win32"`) skips inode check entirely

## Test plan

- [x] `test_undo_refuses_replay_on_inode_change` (Test 6) — **un-skipped** from PR5 placeholder
  - Creates destination with pinned `(dev, ino)`, replaces with different file, verifies `rollback_move` returns `False`, replacement untouched, `security_event undo_inode_mismatch` logged
- [x] `test_undo_proceeds_when_inode_matches` — happy path: same inode → proceeds, file moved back
- [x] `test_undo_legacy_row_skips_inode_check` — `dest_dev=None` row → no check, proceeds normally
- [x] All 11 existing `tests/undo/test_rollback.py` tests pass

## Merge order

```
epic/safedir-undo-pr5-5a  →  epic/safedir-undo-pr5  ✅ merged
epic/safedir-undo-pr5-5b  →  epic/safedir-undo-pr5  🔄 PR #309
epic/safedir-undo-pr5-5c  →  epic/safedir-undo-pr5  (this PR, needs 5b for prod inode capture)
epic/safedir-undo-pr5-5d  →  epic/safedir-undo-pr5  (independent audit)
epic/safedir-undo-pr5     →  main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)