### PR TITLE
docs(security): anchored-traversal sweep audit (#286) (PR5d)

### DIFF
--- a/docs/internal/safedir-anchored-traversal-audit-pr5d.md
+++ b/docs/internal/safedir-anchored-traversal-audit-pr5d.md
@@ -1,0 +1,83 @@
+# PR5d — Anchored-Traversal Sweep Audit (#286)
+
+**Branch:** `epic/safedir-undo-pr5-5d`
+**Issue:** #286 (folded into PR5 epic, #269)
+**Date:** 2026-05-20
+
+---
+
+## Scope
+
+Files originally listed in issue #286:
+
+| File | Location |
+|------|----------|
+| `extractor.py` | `src/services/deduplication/extractor.py` |
+| `epub_enhanced.py` | `src/utils/epub_enhanced.py` |
+| `hybrid_retriever.py` | not found in tree (likely renamed/removed) |
+| `organizer/` | `src/core/organizer.py`, `src/services/{audio,video}/organizer.py` |
+| `undo/` | `src/undo/*.py` |
+
+---
+
+## Findings
+
+### In-scope files — all clear
+
+| File | `rglob`/`os.walk` sites | Verdict |
+|------|------------------------|---------|
+| `src/services/deduplication/extractor.py` | none | ✅ Clean |
+| `src/utils/epub_enhanced.py` | none | ✅ Clean |
+| `hybrid_retriever.py` | not present | ✅ N/A |
+| `src/core/organizer.py` | none | ✅ Clean |
+| `src/services/audio/organizer.py` | none | ✅ Clean |
+| `src/services/video/organizer.py` | none | ✅ Clean |
+| `src/undo/validator.py:543` | `self.trash_dir.rglob(filename)` | ✅ See note below |
+| All other `src/undo/*.py` | none | ✅ Clean |
+
+### `src/undo/validator.py:543` — system-managed root
+
+```python
+# safedir: ok — system-managed trash dir (not user-supplied root);
+# rglob target is self.trash_dir, always under the app state dir.
+for item in self.trash_dir.rglob(filename):  # noqa: safedir
+```
+
+`self.trash_dir` is constructed from the application's state directory
+(`~/.local/share/fo/trash/` or equivalent via `platformdirs`). It is never
+set from user-supplied CLI input — callers set it via `OperationValidator(trash_dir=…)`
+only in tests, always passing `tmp_path`-based paths.
+
+The rglob search string (`filename`) is `operation.source_path.name` — a bare
+filename with no path separators, so it cannot escape the trash root via `..`
+traversal.
+
+Verdict: **opted-out with documented rationale**; no code change required beyond
+the `# safedir: ok` comment added in this PR.
+
+---
+
+### Out-of-scope sites (noted for completeness)
+
+Two sites outside the #286 scope also use raw walkers:
+
+| File | Site | Note |
+|------|------|------|
+| `src/core/file_ops.py:47` | `os.walk(path)` in `collect_files` | User-supplied root; hidden files filtered but symlinks not. Out of PR5d scope — tracked as separate hardening work. |
+| `src/config/path_migration.py:63` | `self.legacy_path.rglob("*")` | System-managed legacy config path. Low risk; not in scope. |
+| `src/methodologies/para/ai/file_mover.py:295,360` | `self._rglob_provider(directory, "*")` | Injected seam; real callers pass user-supplied dirs. Out of scope. |
+
+`src/core/file_ops.py:47` is the most significant — it walks user-supplied input
+without symlink filtering. This should be replaced with `safe_walk` in a follow-up
+hardening PR (after PR6, which addresses the organize-path symlink vector).
+
+---
+
+## Conclusion
+
+All files in the #286 scope are confirmed safe or opted out with documented rationale.
+No functional code change was required beyond:
+
+1. `# safedir: ok` comment on `validator.py:543`
+
+Issue #286 can be closed.

--- a/src/undo/validator.py
+++ b/src/undo/validator.py
@@ -539,8 +539,10 @@ class OperationValidator:
                 return trash_path
 
         # Fallback: search by filename
+        # safedir: ok — system-managed trash dir (not user-supplied root);
+        # rglob target is self.trash_dir, always under the app state dir.
         filename = operation.source_path.name
-        for item in self.trash_dir.rglob(filename):
+        for item in self.trash_dir.rglob(filename):  # noqa: safedir
             if item.is_file():
                 return item
 


### PR DESCRIPTION
## Summary

Part of the PR5 epic (`epic/safedir-undo-pr5`) — issue #286 anchored-traversal sweep, folded into the epic.

This is an **independent audit pass** with no dependency on PR5a/b/c.

### In-scope files — all clean

| File | rglob/os.walk sites | Verdict |
|------|---------------------|---------|
| `src/services/deduplication/extractor.py` | none | ✅ Clean |
| `src/utils/epub_enhanced.py` | none | ✅ Clean |
| `hybrid_retriever.py` | not present | ✅ N/A |
| `src/core/organizer.py` + audio/video organizers | none | ✅ Clean |
| All other `src/undo/*.py` | none | ✅ Clean |
| `src/undo/validator.py:543` | `self.trash_dir.rglob(filename)` | ✅ opted-out (see below) |

### `validator.py:543` — system-managed root (opt-out)

`self.trash_dir` is always the application's state-dir trash (`~/.local/share/fo/trash/`), never user-supplied. The search string is a bare filename with no path separators — cannot escape via `..` traversal. Added `# safedir: ok` comment with rationale.

### Noted out-of-scope site

`src/core/file_ops.py:47` uses raw `os.walk` on user-supplied organize root without symlink filtering. Flagged for follow-up hardening after PR6.

## Changes

- `src/undo/validator.py:543` — add `# safedir: ok — system-managed trash dir` comment
- `docs/internal/safedir-anchored-traversal-audit-pr5d.md` — audit record

Closes #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)