### PR TITLE
Fix: Resolve Matrix CI failures (12 tests across PIL mocks + docs lints)

### DIFF
--- a/docs/internal/safedir-anchored-traversal-audit-pr5d.md
+++ b/docs/internal/safedir-anchored-traversal-audit-pr5d.md
@@ -15,7 +15,7 @@ Files originally listed in issue #286:
 | `extractor.py` | `src/services/deduplication/extractor.py` |
 | `epub_enhanced.py` | `src/utils/epub_enhanced.py` |
 | `hybrid_retriever.py` | not found in tree (likely renamed/removed) |
-| `organizer/` | `src/core/organizer.py`, `src/services/{audio,video}/organizer.py` |
+| `organizer/` | `src/core/organizer.py`, `src/services/audio/organizer.py`, `src/services/video/organizer.py` |
 | `undo/` | `src/undo/*.py` |
 
 ---
@@ -41,6 +41,7 @@ Files originally listed in issue #286:
 # safedir: ok — system-managed trash dir (not user-supplied root);
 # rglob target is self.trash_dir, always under the app state dir.
 for item in self.trash_dir.rglob(filename):  # noqa: safedir
+    ...
 ```
 
 `self.trash_dir` is constructed from the application's state directory

--- a/docs/internal/safedir-shutil-audit-pr3j.md
+++ b/docs/internal/safedir-shutil-audit-pr3j.md
@@ -163,7 +163,7 @@ to obtain `st_size`, `st_mtime`, `st_mode`, etc. The path-based
 | PR3e | `services/deduplication/extractor.py` | Streams content; size limits enforced from `_extract_from_fileobj` via `fileobj.read(n)` caps, not `path.stat()`. |
 | PR3f | `services/deduplication/{image_dedup,image_utils,viewer,quality}.py` | `os.fstat(fd)` used in `viewer.py` for `file_size` / `mtime` display — the explicit precedent for this decision. |
 | PR3g | `utils/epub_enhanced.py` | EPUB is read as a stream from the SafeDir fd; no metadata-then-content split. |
-| PR3h | `services/search/hybrid_retriever.py`, `core/organizer.py`, `methodologies/para/detection/heuristics.py` | All three new helpers read a bounded byte range from the SafeDir fd directly (`fileobj.read(limit)`). No `path.stat()` precedes the open. |
+| PR3h | `services/search/hybrid_retriever.py`, `src/core/organizer.py`, `methodologies/para/detection/heuristics.py` | All three new helpers read a bounded byte range from the SafeDir fd directly (`fileobj.read(limit)`). No `path.stat()` precedes the open. |
 
 ### Exceptions (with rationale)
 

--- a/tests/services/deduplication/test_quality.py
+++ b/tests/services/deduplication/test_quality.py
@@ -307,7 +307,7 @@ class TestExtractMetricsWithPil:
 
         _cm.__exit__ = MagicMock(return_value=False)
 
-        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+        with patch("services.deduplication.quality.safedir_image_open", return_value=_cm):
             m = analyzer._extract_metrics_with_pil(p)
         assert m is not None
         assert m.width == 1920
@@ -342,7 +342,7 @@ class TestExtractMetricsWithPil:
 
         _cm.__exit__ = MagicMock(return_value=False)
 
-        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+        with patch("services.deduplication.quality.safedir_image_open", return_value=_cm):
             m = analyzer._extract_metrics_with_pil(p)
         assert m.has_transparency is True
         assert m.color_depth == 32
@@ -370,7 +370,7 @@ class TestExtractMetricsWithPil:
 
         _cm.__exit__ = MagicMock(return_value=False)
 
-        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+        with patch("services.deduplication.quality.safedir_image_open", return_value=_cm):
             m = analyzer._extract_metrics_with_pil(p)
         assert m.has_transparency is True
         assert m.color_depth == 8  # P mode
@@ -398,7 +398,7 @@ class TestExtractMetricsWithPil:
 
         _cm.__exit__ = MagicMock(return_value=False)
 
-        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+        with patch("services.deduplication.quality.safedir_image_open", return_value=_cm):
             m = analyzer._extract_metrics_with_pil(p)
         assert m.has_transparency is True
 
@@ -425,7 +425,7 @@ class TestExtractMetricsWithPil:
 
         _cm.__exit__ = MagicMock(return_value=False)
 
-        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+        with patch("services.deduplication.quality.safedir_image_open", return_value=_cm):
             m = analyzer._extract_metrics_with_pil(p)
         assert m.color_depth == 24
 
@@ -452,7 +452,7 @@ class TestExtractMetricsWithPil:
 
         _cm.__exit__ = MagicMock(return_value=False)
 
-        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+        with patch("services.deduplication.quality.safedir_image_open", return_value=_cm):
             m = analyzer._extract_metrics_with_pil(p)
         assert m.aspect_ratio == 0
 
@@ -463,7 +463,7 @@ class TestExtractMetricsWithPil:
 
         # PR3f: quality.py now opens via safedir_image_open.
         with patch(
-            "services.deduplication.image_utils.safedir_image_open",
+            "services.deduplication.quality.safedir_image_open",
             side_effect=OSError("Corrupt image"),
         ):
             m = analyzer._extract_metrics_with_pil(p)
@@ -492,7 +492,7 @@ class TestExtractMetricsWithPil:
 
         _cm.__exit__ = MagicMock(return_value=False)
 
-        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+        with patch("services.deduplication.quality.safedir_image_open", return_value=_cm):
             m = analyzer._extract_metrics_with_pil(p)
         assert m.is_compressed is True
 
@@ -519,7 +519,7 @@ class TestExtractMetricsWithPil:
 
         _cm.__exit__ = MagicMock(return_value=False)
 
-        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+        with patch("services.deduplication.quality.safedir_image_open", return_value=_cm):
             m = analyzer._extract_metrics_with_pil(p)
         assert m.is_compressed is False
 
@@ -569,7 +569,7 @@ class TestGetQualityMetrics:
         _cm = MagicMock()
         _cm.__enter__ = MagicMock(return_value=(mock_img, None))
         _cm.__exit__ = MagicMock(return_value=False)
-        with patch("services.deduplication.image_utils.safedir_image_open", return_value=_cm):
+        with patch("services.deduplication.quality.safedir_image_open", return_value=_cm):
             m = analyzer.get_quality_metrics(p)
         assert m is not None
         assert m.width == 800


### PR DESCRIPTION
## Summary

The latest main push (`d18b997`) and the daily **CI Full Matrix** both went red across **Linux py3.11**, **Linux py3.12**, and (matrix) **Windows py3.12** with 12 deterministic test failures. None reproduce in the `-m "ci"` PR-CI subset — they only surface in the full suite. Three independent root causes; all fixed in this PR.

Failing runs:
- [CI Full Matrix · scheduled run 26147882991](https://github.com/curdriceaurora/fo-core/actions/runs/26147882991)
- [CI · push to main 26149414410](https://github.com/curdriceaurora/fo-core/actions/runs/26149414410)

## RCA per failure group

### 1. PIL mock target out-of-sync with F9 hoist (9 failures)

`tests/services/deduplication/test_quality.py` — `TestExtractMetricsWithPil` (8 tests) + `TestGetQualityMetrics::test_pil_extraction_used_when_available`.

Commit `c870fe0` (F9 hoist) moved the `from .image_utils import safedir_image_open` line out of `_extract_metrics_with_pil` and into module scope in `src/services/deduplication/quality.py`. Because the name is now locally bound at module-load time, the test's `patch("services.deduplication.image_utils.safedir_image_open", ...)` no longer intercepts the call — the unmocked `safedir_image_open` runs against the zero-byte test fixture and PIL raises `UnidentifiedImageError`, which the production code logs and converts into `None`.

**Fix**: patch the caller's namespace instead — `services.deduplication.quality.safedir_image_open` (10 sites in the file).

### 2. Empty `for` body in Python code fence (1 failure)

`tests/docs/test_code_examples.py::test_python_examples_parse` runs `ast.parse` against every ` ```python ` block under `docs/`. `docs/internal/safedir-anchored-traversal-audit-pr5d.md` ships a fragment whose `for item in self.trash_dir.rglob(filename):` line has no body — a `SyntaxError` for `ast.parse`.

**Fix**: add an `    ...` body so the snippet is syntactically valid Python while still reading as a "this is what the loop looks like" excerpt.

### 3. Stale / brace-expansion path references (2 failures)

`tests/docs/test_doc_file_paths.py::test_referenced_path_exists` extracts backtick-wrapped paths that begin with `src|core|tests|scripts|.github` and asserts each resolves on disk:

- `docs/internal/safedir-anchored-traversal-audit-pr5d.md` listed `` `src/services/{audio,video}/organizer.py` `` — brace expansion isn't matched by the doc test's glob detector (`*`/`?`/`[` only). Split into the two real files (`src/services/audio/organizer.py`, `src/services/video/organizer.py`).
- `docs/internal/safedir-shutil-audit-pr3j.md` referenced `` `core/organizer.py` `` from before the `src/` flattening; the file lives at `src/core/organizer.py`.

## Verification

Ran the exact `ci-full.yml` Linux command locally:

```bash
pytest tests/ \
  --ignore=tests/extras/test_extras_cad.py \
  --ignore=tests/extras/test_extras_dedup_image.py \
  --ignore=tests/extras/test_extras_media.py \
  --ignore=tests/extras/test_extras_scientific.py \
  -m "not benchmark and not e2e" --strict-markers \
  -n auto --dist=loadgroup --timeout=60 \
  --override-ini="addopts="
```

**Result: 17015 passed, 85 skipped, 1 xfailed, 0 failed in 100.34s.** Before the fixes: 12 failed, 17005 passed.

## Trade-offs

- All three groups are *correctness* fixes — none weaken tests or suppress signal. The mock-target fix restores the intended interception; the code fence becomes parseable without changing meaning; the path references now point to real files.
- The two pre-existing markdown lint findings in the touched docs files predate this PR (line-length on the same tables I edited) — verified by stashing the diff and re-running `pymarkdown scan`. Out of scope.

## Test plan

- [x] `tests/services/deduplication/test_quality.py` — all 73 tests pass
- [x] `tests/docs/test_doc_file_paths.py` + `tests/docs/test_code_examples.py` — all 95 pass, 1 skipped
- [x] Full ci-full.yml linux command — 17015 pass, 0 fail
- [ ] Matrix CI green on this PR (Linux py3.11 / py3.12; Windows py3.12; macOS py3.12)

https://claude.ai/code/session_013G3WeVBednmatkHAYxGTxM

---
_Generated by [Claude Code](https://claude.ai/code/session_013G3WeVBednmatkHAYxGTxM)_