### PR TITLE
chore: cleanup queue — fix #291 #297 #298 (confirm #278 #280 done)

### DIFF
--- a/.github/workflows/ci-extras.yml
+++ b/.github/workflows/ci-extras.yml
@@ -28,8 +28,78 @@ permissions:
   contents: read
 
 jobs:
-  extras-validate:
+  # PR matrix: only cheap extras (≤20 min) so PR feedback is fast.
+  # Heavy extras (media ≥30 min, dedup-image ≥40 min) run on main push only.
+  extras-validate-pr:
     name: "Extras [${{ matrix.extra }}]"
+    if: github.event_name == 'pull_request'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: ${{ matrix.timeout_minutes }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - extra: dedup-text
+            os: ubuntu-latest
+            timeout_minutes: 20
+            key_import: "import sklearn; print('OK')"
+            smoke: "true"
+            test_file: tests/extras/test_extras_dedup_text.py
+          - extra: scientific
+            os: ubuntu-latest
+            timeout_minutes: 10
+            key_import: "import h5py; import netCDF4; import scipy; print('OK')"
+            smoke: "true"
+          - extra: cad
+            os: ubuntu-latest
+            timeout_minutes: 10
+            key_import: "import ezdxf; print('OK')"
+            smoke: "true"
+          - extra: cloud
+            os: ubuntu-latest
+            timeout_minutes: 10
+            key_import: "import openai; print('OK')"
+            smoke: "false"
+          - extra: claude
+            os: ubuntu-latest
+            timeout_minutes: 10
+            key_import: "import anthropic; print('OK')"
+            smoke: "false"
+          - extra: mlx
+            os: macos-latest
+            timeout_minutes: 15
+            key_import: "import mlx_lm; print('OK')"
+            smoke: "false"
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install extra with dev dependencies
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4.0.0
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: pip install -e ".[dev,${{ matrix.extra }}]"
+      - name: Verify key imports
+        run: python -c "${{ matrix.key_import }}"
+      - name: Run smoke canary
+        if: matrix.smoke == 'true'
+        run: |
+          TEST_FILE="${{ matrix.test_file || format('tests/extras/test_extras_{0}.py', matrix.extra) }}"
+          pytest "$TEST_FILE" \
+            -m "smoke" \
+            -x \
+            -v \
+            --override-ini="addopts="
+
+  # Main push matrix: full set including heavy extras (media, dedup-image, llama).
+  extras-validate-main:
+    name: "Extras [${{ matrix.extra }}]"
+    if: github.event_name == 'push'
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:

--- a/src/utils/readers/documents.py
+++ b/src/utils/readers/documents.py
@@ -173,16 +173,25 @@ def _extract_pdf_pages(doc: object, max_pages: int, label: str) -> str:
 
 
 def _parse_pdf_stream(fileobj: BinaryIO, max_pages: int, label: str) -> str:
-    """Parse PDF from a file-like by reading bytes and using fitz.open(stream=).
+    """Parse PDF from a SafeDir-opened fileobj without loading the full file.
 
-    Used only when the caller already has a fileobj (the SafeDir-friendly
-    entry point); the path branch streams from disk via ``fitz.open(path)``
-    to avoid loading the whole PDF into memory before ``max_pages`` is
-    applied.
+    Uses ``/dev/fd/{fd}`` (POSIX) so PyMuPDF streams lazily from the
+    already-open fd instead of materialising the entire file in memory
+    before the ``max_pages`` limit is applied (issue #298).
+
+    Falls back to ``fileobj.read()`` when the fileobj has no real fd
+    (e.g. ``io.BytesIO`` in tests, or any non-regular-file stream).
     """
-    data = fileobj.read()
-    with fitz.open(stream=data, filetype="pdf") as doc:
-        return _extract_pdf_pages(doc, max_pages, label)
+    try:
+        fd = fileobj.fileno()
+        with fitz.open(f"/dev/fd/{fd}") as doc:
+            return _extract_pdf_pages(doc, max_pages, label)
+    except OSError:
+        # fileno() raises io.UnsupportedOperation (OSError subclass) for
+        # BytesIO and similar in-memory objects — fall back to in-memory open.
+        data = fileobj.read()
+        with fitz.open(stream=data, filetype="pdf") as doc:
+            return _extract_pdf_pages(doc, max_pages, label)
 
 
 def read_pdf_file(

--- a/tests/test_audio_model.py
+++ b/tests/test_audio_model.py
@@ -21,7 +21,7 @@ def _restore_audio_transcriber_cache() -> Generator[None, None, None]:
     Prevents state leaking into subsequent tests when running under
     single-threaded -m ci order.
     """
-    from services.audio.transcriber import AudioTranscriber
+    from models.audio_transcriber import AudioTranscriber
 
     original = dict(AudioTranscriber._model_cache)
     try:

--- a/tests/test_audio_model.py
+++ b/tests/test_audio_model.py
@@ -2,13 +2,33 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("faster_whisper")
+
 from models.audio_model import AudioModel
 from models.base import ModelConfig, ModelType
+
+
+@pytest.fixture(autouse=True)
+def _restore_audio_transcriber_cache() -> Generator[None, None, None]:
+    """Restore AudioTranscriber._model_cache after each test (T12 / #291).
+
+    Prevents state leaking into subsequent tests when running under
+    single-threaded -m ci order.
+    """
+    from services.audio.transcriber import AudioTranscriber
+
+    original = dict(AudioTranscriber._model_cache)
+    try:
+        yield
+    finally:
+        AudioTranscriber._model_cache.clear()
+        AudioTranscriber._model_cache.update(original)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Addresses the 5 open cleanup issues from the hardening epic. Issues #278 and #280 were confirmed already fixed on main (no code changes needed).

- **#291** — Audio model singleton state leak in `-m ci` test order: adds `pytest.importorskip("faster_whisper")` guard + autouse `_restore_audio_transcriber_cache` fixture (T12 snapshot/restore pattern) to `tests/test_audio_model.py`
- **#297** — CI matrix split: `extras-validate` job split into `extras-validate-pr` (6 cheap extras, ≤20 min, PR-only) and `extras-validate-main` (full 9 extras, push-to-main only) — drops `media`/`dedup-image`/`llama` from the PR critical path
- **#298** — PDF streaming via `/dev/fd/{fd}`: `_parse_pdf_stream` now opens the already-held fd via `fitz.open(f"/dev/fd/{fd}")` so PyMuPDF streams lazily instead of loading the full file before `max_pages` is applied; falls back to `fileobj.read()` for `BytesIO`/non-regular files (`OSError` on `fileno()`)

## Test plan

- [ ] `pytest tests/utils/ -k pdf` — PDF streaming tests pass (7 tests)
- [ ] `pytest tests/test_audio_model.py` — skipped cleanly when `faster_whisper` absent; passes with media extra installed
- [ ] `pymarkdown scan` on workflow YAML — 0 violations
- [ ] CI green on push (extras-validate-main runs all 9; PR path runs 6)

Closes #291, #297, #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)