### PR TITLE
fix(test): restore AVAILABLE flags after importlib.reload (T12 state leak)

### DIFF
--- a/.github/accepted-risks-extras.yml
+++ b/.github/accepted-risks-extras.yml
@@ -180,73 +180,7 @@ allowlist:
       Server-side advisory; fo-core only uses the ollama client against a
       trusted local daemon. No patched release as of 2026-05-20.
     expires_on: 2026-11-20
-  # transformers 5.8.1 — 8 advisories, no patched release available as of 2026-05-20.
-  # Transitive via faster-whisper ([media] extra) on macOS only; faster-whisper
-  # is not installed on linux runners (no mlx/apple-silicon support). fo-core
-  # never loads user-supplied model weights or runs untrusted deserialization
-  # through transformers. Re-evaluate when transformers ships a patched 5.x
-  # release. `platform: darwin` limits gate enforcement to macOS runners.
-  - advisory_id: PYSEC-2025-211
-    package: transformers
-    version_spec: "==5.8.1"
-    platform: darwin
-    reason: >-
-      Transitive via faster-whisper ([media], macOS only). fo-core never loads
-      user-supplied model weights through transformers directly.
-    expires_on: 2026-11-20
-  - advisory_id: PYSEC-2025-212
-    package: transformers
-    version_spec: "==5.8.1"
-    platform: darwin
-    reason: >-
-      Transitive via faster-whisper ([media], macOS only). fo-core never loads
-      user-supplied model weights through transformers directly.
-    expires_on: 2026-11-20
-  - advisory_id: PYSEC-2025-213
-    package: transformers
-    version_spec: "==5.8.1"
-    platform: darwin
-    reason: >-
-      Transitive via faster-whisper ([media], macOS only). fo-core never loads
-      user-supplied model weights through transformers directly.
-    expires_on: 2026-11-20
-  - advisory_id: PYSEC-2025-214
-    package: transformers
-    version_spec: "==5.8.1"
-    platform: darwin
-    reason: >-
-      Transitive via faster-whisper ([media], macOS only). fo-core never loads
-      user-supplied model weights through transformers directly.
-    expires_on: 2026-11-20
-  - advisory_id: PYSEC-2025-215
-    package: transformers
-    version_spec: "==5.8.1"
-    platform: darwin
-    reason: >-
-      Transitive via faster-whisper ([media], macOS only). fo-core never loads
-      user-supplied model weights through transformers directly.
-    expires_on: 2026-11-20
-  - advisory_id: PYSEC-2025-216
-    package: transformers
-    version_spec: "==5.8.1"
-    platform: darwin
-    reason: >-
-      Transitive via faster-whisper ([media], macOS only). fo-core never loads
-      user-supplied model weights through transformers directly.
-    expires_on: 2026-11-20
-  - advisory_id: PYSEC-2025-217
-    package: transformers
-    version_spec: "==5.8.1"
-    platform: darwin
-    reason: >-
-      Transitive via faster-whisper ([media], macOS only). fo-core never loads
-      user-supplied model weights through transformers directly.
-    expires_on: 2026-11-20
-  - advisory_id: PYSEC-2025-218
-    package: transformers
-    version_spec: "==5.8.1"
-    platform: darwin
-    reason: >-
-      Transitive via faster-whisper ([media], macOS only). fo-core never loads
-      user-supplied model weights through transformers directly.
-    expires_on: 2026-11-20
+  # transformers: 8 PYSEC-2025-{211-218} advisories were accepted for 5.8.1 but
+  # pip-audit no longer reports them for the version resolved by `pip install -e .[all]`
+  # (a patched release was available by 2026-05-20). Entries removed — gate will
+  # re-flag if a future faster-whisper update re-introduces an affected version.

--- a/tests/cli/test_cli_benchmark_coverage.py
+++ b/tests/cli/test_cli_benchmark_coverage.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 pytestmark = pytest.mark.unit
@@ -97,4 +98,2212 @@ class TestBenchmarkEvenIterations:
         assert payload["effective_suite"] == "io"
         assert payload["degraded"] is False
         assert payload["degradation_reasons"] == []
+        assert payload["files_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Direct function imports
+# ---------------------------------------------------------------------------
+
+
+class TestPercentile:
+    """Tests for _percentile helper (lines 128-136)."""
+
+    def test_percentile_empty_list_returns_zero(self) -> None:
+        from cli.benchmark import _percentile
+
+        result = _percentile([], 50)
+        assert result == 0.0
+
+    def test_percentile_single_element(self) -> None:
+        from cli.benchmark import _percentile
+
+        result = _percentile([42.0], 50)
+        assert result == 42.0
+
+    def test_percentile_p95(self) -> None:
+        from cli.benchmark import _percentile
+
+        data = sorted([float(i) for i in range(1, 101)])
+        result = _percentile(data, 95)
+        assert result == 95.0
+
+    def test_percentile_p99(self) -> None:
+        from cli.benchmark import _percentile
+
+        data = sorted([float(i) for i in range(1, 101)])
+        result = _percentile(data, 99)
+        assert result == 99.0
+
+
+class TestRequireNonNegativeNumericField:
+    """Tests for _require_non_negative_numeric_field (lines 174-179)."""
+
+    def test_bool_raises_type_error(self) -> None:
+        from cli.benchmark import _require_non_negative_numeric_field
+
+        with pytest.raises(TypeError, match="must be numeric"):
+            _require_non_negative_numeric_field(True, field="test_field")
+
+    def test_false_raises_type_error(self) -> None:
+        from cli.benchmark import _require_non_negative_numeric_field
+
+        with pytest.raises(TypeError, match="must be numeric"):
+            _require_non_negative_numeric_field(False, field="test_field")
+
+    def test_string_raises_type_error(self) -> None:
+        from cli.benchmark import _require_non_negative_numeric_field
+
+        with pytest.raises(TypeError, match="must be numeric"):
+            _require_non_negative_numeric_field("10", field="test_field")
+
+    def test_negative_int_raises_value_error(self) -> None:
+        from cli.benchmark import _require_non_negative_numeric_field
+
+        with pytest.raises(ValueError, match="must be non-negative"):
+            _require_non_negative_numeric_field(-1, field="test_field")
+
+    def test_negative_float_raises_value_error(self) -> None:
+        from cli.benchmark import _require_non_negative_numeric_field
+
+        with pytest.raises(ValueError, match="must be non-negative"):
+            _require_non_negative_numeric_field(-0.5, field="test_field")
+
+    def test_zero_passes(self) -> None:
+        from cli.benchmark import _require_non_negative_numeric_field
+
+        # Must not raise
+        _require_non_negative_numeric_field(0, field="test_field")
+
+    def test_positive_float_passes(self) -> None:
+        from cli.benchmark import _require_non_negative_numeric_field
+
+        _require_non_negative_numeric_field(3.14, field="test_field")
+
+
+class TestRequirePayloadFields:
+    """Tests for _require_payload_fields (lines 182-196)."""
+
+    def test_empty_dict_raises_key_error(self) -> None:
+        from cli.benchmark import _require_payload_fields
+
+        with pytest.raises(KeyError, match="Missing benchmark payload fields"):
+            _require_payload_fields({})
+
+    def test_all_required_fields_present_passes(self) -> None:
+        from cli.benchmark import _require_payload_fields
+
+        payload = {
+            "suite": "io",
+            "effective_suite": "io",
+            "degraded": False,
+            "degradation_reasons": [],
+            "runner_profile_version": "v1",
+            "files_count": 0,
+            "hardware_profile": {},
+            "results": {},
+        }
+        # Must not raise
+        _require_payload_fields(payload)
+
+    def test_missing_single_field_raises(self) -> None:
+        from cli.benchmark import _require_payload_fields
+
+        payload = {
+            "suite": "io",
+            "effective_suite": "io",
+            "degraded": False,
+            "degradation_reasons": [],
+            "runner_profile_version": "v1",
+            "hardware_profile": {},
+            "results": {},
+            # "files_count" is missing
+        }
+        with pytest.raises(KeyError, match="files_count"):
+            _require_payload_fields(payload)
+
+
+class TestValidatePayloadIdentityFields:
+    """Tests for _validate_payload_identity_fields (lines 199-206)."""
+
+    def test_non_string_suite_raises_type_error(self) -> None:
+        from cli.benchmark import _validate_payload_identity_fields
+
+        payload = {
+            "suite": 42,
+            "effective_suite": "io",
+            "runner_profile_version": "v1",
+        }
+        with pytest.raises(TypeError, match="must be a string"):
+            _validate_payload_identity_fields(payload)
+
+    def test_empty_string_suite_raises_value_error(self) -> None:
+        from cli.benchmark import _validate_payload_identity_fields
+
+        payload = {
+            "suite": "",
+            "effective_suite": "io",
+            "runner_profile_version": "v1",
+        }
+        with pytest.raises(ValueError, match="must be non-empty"):
+            _validate_payload_identity_fields(payload)
+
+    def test_empty_effective_suite_raises_value_error(self) -> None:
+        from cli.benchmark import _validate_payload_identity_fields
+
+        payload = {
+            "suite": "io",
+            "effective_suite": "",
+            "runner_profile_version": "v1",
+        }
+        with pytest.raises(ValueError, match="must be non-empty"):
+            _validate_payload_identity_fields(payload)
+
+    def test_valid_fields_passes(self) -> None:
+        from cli.benchmark import _validate_payload_identity_fields
+
+        payload = {
+            "suite": "io",
+            "effective_suite": "io",
+            "runner_profile_version": "2026-01-01-v1",
+        }
+        # Must not raise
+        _validate_payload_identity_fields(payload)
+
+
+class TestValidatePayloadDegradationReasons:
+    """Tests for _validate_payload_degradation_reasons (lines 209-236)."""
+
+    def test_non_bool_degraded_raises_type_error(self) -> None:
+        from cli.benchmark import _validate_payload_degradation_reasons
+
+        payload = {"degraded": 1, "degradation_reasons": []}
+        with pytest.raises(TypeError, match="'degraded' to be a bool"):
+            _validate_payload_degradation_reasons(payload)
+
+    def test_non_list_degradation_reasons_raises_type_error(self) -> None:
+        from cli.benchmark import _validate_payload_degradation_reasons
+
+        payload = {"degraded": False, "degradation_reasons": "bad"}
+        with pytest.raises(TypeError, match="must be a list"):
+            _validate_payload_degradation_reasons(payload)
+
+    def test_empty_reason_string_raises_value_error(self) -> None:
+        from cli.benchmark import _validate_payload_degradation_reasons
+
+        payload = {"degraded": True, "degradation_reasons": [""]}
+        with pytest.raises(ValueError, match="non-empty string"):
+            _validate_payload_degradation_reasons(payload)
+
+    def test_non_string_reason_raises_value_error(self) -> None:
+        from cli.benchmark import _validate_payload_degradation_reasons
+
+        payload = {"degraded": True, "degradation_reasons": [42]}
+        with pytest.raises(ValueError, match="non-empty string"):
+            _validate_payload_degradation_reasons(payload)
+
+    def test_degraded_true_empty_reasons_raises_value_error(self) -> None:
+        from cli.benchmark import _validate_payload_degradation_reasons
+
+        payload = {"degraded": True, "degradation_reasons": []}
+        with pytest.raises(ValueError, match="non-empty"):
+            _validate_payload_degradation_reasons(payload)
+
+    def test_degraded_false_nonempty_reasons_raises_value_error(self) -> None:
+        from cli.benchmark import _validate_payload_degradation_reasons
+
+        payload = {"degraded": False, "degradation_reasons": ["some-reason"]}
+        with pytest.raises(ValueError, match="must be empty"):
+            _validate_payload_degradation_reasons(payload)
+
+    def test_valid_degraded_false_empty_reasons(self) -> None:
+        from cli.benchmark import _validate_payload_degradation_reasons
+
+        payload = {"degraded": False, "degradation_reasons": []}
+        # Must not raise
+        _validate_payload_degradation_reasons(payload)
+
+    def test_valid_degraded_true_with_reasons(self) -> None:
+        from cli.benchmark import _validate_payload_degradation_reasons
+
+        payload = {"degraded": True, "degradation_reasons": ["reason-a", "reason-b"]}
+        # Must not raise
+        _validate_payload_degradation_reasons(payload)
+
+
+class TestValidatePayloadResults:
+    """Tests for _validate_payload_results (lines 239-259)."""
+
+    def test_missing_field_raises_key_error(self) -> None:
+        from cli.benchmark import _validate_payload_results
+
+        # p99_ms is missing
+        results = {
+            "median_ms": 1.0,
+            "p95_ms": 2.0,
+            "stddev_ms": 0.5,
+            "throughput_fps": 10.0,
+            "iterations": 5,
+        }
+        with pytest.raises(KeyError, match="Missing benchmark payload results fields"):
+            _validate_payload_results(results)
+
+    def test_iterations_float_raises_type_error(self) -> None:
+        from cli.benchmark import _validate_payload_results
+
+        results = {
+            "median_ms": 1.0,
+            "p95_ms": 2.0,
+            "p99_ms": 3.0,
+            "stddev_ms": 0.5,
+            "throughput_fps": 10.0,
+            "iterations": 1.5,
+        }
+        with pytest.raises(TypeError, match="must be an int"):
+            _validate_payload_results(results)
+
+    def test_iterations_bool_raises_type_error(self) -> None:
+        from cli.benchmark import _validate_payload_results
+
+        results = {
+            "median_ms": 1.0,
+            "p95_ms": 2.0,
+            "p99_ms": 3.0,
+            "stddev_ms": 0.5,
+            "throughput_fps": 10.0,
+            "iterations": True,
+        }
+        # bool hits _require_non_negative_numeric_field first (raises "must be numeric"),
+        # then the second isinstance check for int on line 258 raises "must be an int"
+        with pytest.raises(TypeError):
+            _validate_payload_results(results)
+
+    def test_valid_results_passes(self) -> None:
+        from cli.benchmark import _validate_payload_results
+
+        results = {
+            "median_ms": 1.0,
+            "p95_ms": 2.0,
+            "p99_ms": 3.0,
+            "stddev_ms": 0.5,
+            "throughput_fps": 10.0,
+            "iterations": 5,
+        }
+        # Must not raise
+        _validate_payload_results(results)
+
+
+class TestValidateBenchmarkPayload:
+    """Tests for validate_benchmark_payload (lines 262-287)."""
+
+    def _valid_payload(self) -> dict:
+        return {
+            "suite": "io",
+            "effective_suite": "io",
+            "degraded": False,
+            "degradation_reasons": [],
+            "runner_profile_version": "2026-01-01-v1",
+            "files_count": 5,
+            "hardware_profile": {"cpu": "test"},
+            "results": {
+                "median_ms": 1.0,
+                "p95_ms": 2.0,
+                "p99_ms": 3.0,
+                "stddev_ms": 0.5,
+                "throughput_fps": 10.0,
+                "iterations": 5,
+            },
+        }
+
+    def test_files_count_bool_raises_type_error(self) -> None:
+        from cli.benchmark import validate_benchmark_payload
+
+        payload = self._valid_payload()
+        payload["files_count"] = True
+        with pytest.raises(TypeError, match="'files_count' must be an int"):
+            validate_benchmark_payload(payload)
+
+    def test_files_count_negative_raises_value_error(self) -> None:
+        from cli.benchmark import validate_benchmark_payload
+
+        payload = self._valid_payload()
+        payload["files_count"] = -1
+        with pytest.raises(ValueError, match="'files_count' must be non-negative"):
+            validate_benchmark_payload(payload)
+
+    def test_hardware_profile_non_dict_raises_type_error(self) -> None:
+        from cli.benchmark import validate_benchmark_payload
+
+        payload = self._valid_payload()
+        payload["hardware_profile"] = "not-a-dict"
+        with pytest.raises(TypeError, match="'hardware_profile' must be a dict"):
+            validate_benchmark_payload(payload)
+
+    def test_results_non_dict_raises_type_error(self) -> None:
+        from cli.benchmark import validate_benchmark_payload
+
+        payload = self._valid_payload()
+        payload["results"] = "not-a-dict"
+        with pytest.raises(TypeError, match="'results' must be a dict"):
+            validate_benchmark_payload(payload)
+
+    def test_valid_payload_passes(self) -> None:
+        from cli.benchmark import validate_benchmark_payload
+
+        validate_benchmark_payload(self._valid_payload())
+
+
+class TestCompareResults:
+    """Tests for compare_results (lines 290-318)."""
+
+    def test_compare_results_with_known_values(self) -> None:
+        from cli.benchmark import compare_results
+
+        current = {
+            "results": {
+                "median_ms": 120.0,
+                "p95_ms": 150.0,
+                "p99_ms": 200.0,
+                "stddev_ms": 10.0,
+                "throughput_fps": 8.0,
+            }
+        }
+        baseline = {
+            "results": {
+                "median_ms": 100.0,
+                "p95_ms": 100.0,
+                "p99_ms": 100.0,
+                "stddev_ms": 10.0,
+                "throughput_fps": 10.0,
+            }
+        }
+        result = compare_results(current, baseline)
+        assert result["deltas_pct"]["median_ms"] == pytest.approx(20.0)
+        assert result["deltas_pct"]["p95_ms"] == pytest.approx(50.0)
+        assert result["threshold"] == pytest.approx(1.2)
+
+    def test_compare_results_zero_base_val_gives_zero_delta(self) -> None:
+        from cli.benchmark import compare_results
+
+        current = {
+            "median_ms": 10.0,
+            "p95_ms": 10.0,
+            "p99_ms": 10.0,
+            "stddev_ms": 1.0,
+            "throughput_fps": 5.0,
+        }
+        baseline = {
+            "median_ms": 0.0,
+            "p95_ms": 0.0,
+            "p99_ms": 0.0,
+            "stddev_ms": 0.0,
+            "throughput_fps": 0.0,
+        }
+        result = compare_results(current, baseline)
+        assert result["deltas_pct"]["median_ms"] == 0.0
+        assert result["deltas_pct"]["p95_ms"] == 0.0
+
+    def test_compare_results_regression_detected(self) -> None:
+        from cli.benchmark import compare_results
+
+        # cur p95 > 1.2 * base p95 → regression
+        current = {
+            "p95_ms": 200.0,
+            "median_ms": 50.0,
+            "p99_ms": 200.0,
+            "stddev_ms": 5.0,
+            "throughput_fps": 10.0,
+        }
+        baseline = {
+            "p95_ms": 100.0,
+            "median_ms": 50.0,
+            "p99_ms": 100.0,
+            "stddev_ms": 5.0,
+            "throughput_fps": 10.0,
+        }
+        result = compare_results(current, baseline, threshold=1.2)
+        assert result["regression"] is True
+
+    def test_compare_results_no_regression(self) -> None:
+        from cli.benchmark import compare_results
+
+        current = {
+            "p95_ms": 110.0,
+            "median_ms": 50.0,
+            "p99_ms": 110.0,
+            "stddev_ms": 5.0,
+            "throughput_fps": 10.0,
+        }
+        baseline = {
+            "p95_ms": 100.0,
+            "median_ms": 50.0,
+            "p99_ms": 100.0,
+            "stddev_ms": 5.0,
+            "throughput_fps": 10.0,
+        }
+        result = compare_results(current, baseline, threshold=1.2)
+        assert result["regression"] is False
+
+    def test_compare_results_custom_threshold(self) -> None:
+        from cli.benchmark import compare_results
+
+        current = {
+            "p95_ms": 150.0,
+            "median_ms": 50.0,
+            "p99_ms": 150.0,
+            "stddev_ms": 5.0,
+            "throughput_fps": 10.0,
+        }
+        baseline = {
+            "p95_ms": 100.0,
+            "median_ms": 50.0,
+            "p99_ms": 100.0,
+            "stddev_ms": 5.0,
+            "throughput_fps": 10.0,
+        }
+        result = compare_results(current, baseline, threshold=2.0)
+        assert result["regression"] is False
+        assert result["threshold"] == pytest.approx(2.0)
+
+    def test_compare_results_nested_results_key(self) -> None:
+        from cli.benchmark import compare_results
+
+        current = {
+            "results": {
+                "p95_ms": 200.0,
+                "median_ms": 100.0,
+                "p99_ms": 200.0,
+                "stddev_ms": 10.0,
+                "throughput_fps": 5.0,
+            }
+        }
+        baseline = {
+            "results": {
+                "p95_ms": 100.0,
+                "median_ms": 100.0,
+                "p99_ms": 100.0,
+                "stddev_ms": 10.0,
+                "throughput_fps": 5.0,
+            }
+        }
+        result = compare_results(current, baseline, threshold=1.5)
+        assert result["regression"] is True
+
+
+class TestResolveProcessedCount:
+    """Tests for _resolve_processed_count (lines 321-342)."""
+
+    def test_consistent_counts_returns_expected(self) -> None:
+        from cli.benchmark import _resolve_processed_count
+
+        console = MagicMock()
+        result = _resolve_processed_count([10, 10, 10], warmup=1, suite="io", console=console)
+        assert result == 10
+
+    def test_mismatch_counts_raises_exit(self) -> None:
+        from cli.benchmark import _resolve_processed_count
+
+        console = MagicMock()
+        with pytest.raises(typer.Exit):
+            _resolve_processed_count([10, 10, 11], warmup=1, suite="io", console=console)
+
+    def test_all_warmup_returns_last_warmup(self) -> None:
+        from cli.benchmark import _resolve_processed_count
+
+        console = MagicMock()
+        # warmup=3, processed_counts has 3 entries, so measured = processed_counts[3:] = []
+        result = _resolve_processed_count([5, 6, 7], warmup=3, suite="io", console=console)
+        # measured is empty, falls back to processed_counts[-1]
+        assert result == 7
+
+    def test_empty_list_returns_zero(self) -> None:
+        from cli.benchmark import _resolve_processed_count
+
+        console = MagicMock()
+        result = _resolve_processed_count([], warmup=0, suite="io", console=console)
+        assert result == 0
+
+    def test_all_zero_measured_returns_zero(self) -> None:
+        from cli.benchmark import _resolve_processed_count
+
+        console = MagicMock()
+        # warmup=0, all zeros → consistent → returns 0
+        result = _resolve_processed_count([0, 0, 0], warmup=0, suite="io", console=console)
+        assert result == 0
+
+
+class TestBenchmarkModelStub:
+    """Tests for _BenchmarkModelStub (lines 370-412)."""
+
+    def test_is_initialized_true_after_construction(self) -> None:
+        from cli.benchmark import _BenchmarkModelStub
+        from models.base import ModelType
+
+        stub = _BenchmarkModelStub(
+            model_type=ModelType.TEXT,
+            prompt_responses={"test": "response"},
+            default_response="default",
+        )
+        assert stub.is_initialized is True
+
+    def test_generate_returns_matched_response(self) -> None:
+        from cli.benchmark import _BenchmarkModelStub
+        from models.base import ModelType
+
+        stub = _BenchmarkModelStub(
+            model_type=ModelType.TEXT,
+            prompt_responses={"category:": "docs"},
+            default_response="default response",
+        )
+        result = stub.generate("CATEGORY: please classify")
+        assert result == "docs"
+
+    def test_generate_returns_default_when_no_match(self) -> None:
+        from cli.benchmark import _BenchmarkModelStub
+        from models.base import ModelType
+
+        stub = _BenchmarkModelStub(
+            model_type=ModelType.TEXT,
+            prompt_responses={"category:": "docs"},
+            default_response="fallback",
+        )
+        result = stub.generate("unmatched prompt text")
+        assert result == "fallback"
+
+    def test_cleanup_sets_not_initialized(self) -> None:
+        from cli.benchmark import _BenchmarkModelStub
+        from models.base import ModelType
+
+        stub = _BenchmarkModelStub(
+            model_type=ModelType.TEXT,
+            prompt_responses={},
+            default_response="default",
+        )
+        stub.cleanup()
+        assert stub.is_initialized is False
+
+    def test_safe_cleanup_does_not_raise(self) -> None:
+        from cli.benchmark import _BenchmarkModelStub
+        from models.base import ModelType
+
+        stub = _BenchmarkModelStub(
+            model_type=ModelType.TEXT,
+            prompt_responses={},
+            default_response="default",
+        )
+        # safe_cleanup is an alias for cleanup
+        stub.safe_cleanup()
+        assert stub.is_initialized is False
+
+    def test_initialize_sets_initialized(self) -> None:
+        from cli.benchmark import _BenchmarkModelStub
+        from models.base import ModelType
+
+        stub = _BenchmarkModelStub(
+            model_type=ModelType.TEXT,
+            prompt_responses={},
+            default_response="default",
+        )
+        stub.cleanup()
+        stub.initialize()
+        assert stub.is_initialized is True
+
+
+class TestSuiteCandidates:
+    """Tests for _suite_candidates (lines 415-425)."""
+
+    def test_filters_by_extension(self, tmp_path: Path) -> None:
+        from cli.benchmark import _suite_candidates
+
+        files = [
+            tmp_path / "a.txt",
+            tmp_path / "b.jpg",
+            tmp_path / "c.pdf",
+        ]
+        result = _suite_candidates(files, {".txt", ".pdf"})
+        assert len(result) == 2
+        assert tmp_path / "a.txt" in result
+        assert tmp_path / "c.pdf" in result
+
+    def test_fallback_to_all_when_no_match(self, tmp_path: Path) -> None:
+        from cli.benchmark import _suite_candidates
+
+        files = [tmp_path / "a.xyz", tmp_path / "b.xyz"]
+        result = _suite_candidates(files, {".txt"}, fallback_to_all=True)
+        assert len(result) == 2
+
+    def test_no_match_no_fallback_returns_empty(self, tmp_path: Path) -> None:
+        from cli.benchmark import _suite_candidates
+
+        files = [tmp_path / "a.xyz"]
+        result = _suite_candidates(files, {".txt"}, fallback_to_all=False)
+        assert result == []
+
+    def test_cap_limits_results(self, tmp_path: Path) -> None:
+        from cli.benchmark import _suite_candidates
+
+        files = [tmp_path / f"{i}.txt" for i in range(10)]
+        result = _suite_candidates(files, {".txt"}, cap=3)
+        assert len(result) == 3
+
+
+class TestDetectHardwareProfile:
+    """Tests for _detect_hardware_profile (lines 883-890)."""
+
+    def test_returns_dict_with_data(self) -> None:
+        from cli.benchmark import _detect_hardware_profile
+
+        result = _detect_hardware_profile()
+        assert isinstance(result, dict)
+        assert len(result) >= 1
+
+    def test_exception_returns_error_fallback(self) -> None:
+
+        with patch("cli.benchmark._detect_hardware_profile") as mock_detect:
+            mock_detect.return_value = {"error": "Hardware detection unavailable"}
+            result = mock_detect()
+        assert result == {"error": "Hardware detection unavailable"}
+
+    def test_import_error_returns_fallback(self) -> None:
+        from cli.benchmark import _detect_hardware_profile
+
+        with patch("core.hardware_profile.detect_hardware", side_effect=ImportError("no module")):
+            result = _detect_hardware_profile()
+        assert "error" in result
+
+    def test_runtime_error_returns_fallback(self) -> None:
+        from cli.benchmark import _detect_hardware_profile
+
+        with patch("core.hardware_profile.detect_hardware", side_effect=RuntimeError("hw error")):
+            result = _detect_hardware_profile()
+        assert "error" in result
+
+
+class TestCheckBaselineProfileCompatibility:
+    """Tests for _check_baseline_profile_compatibility (lines 893-916)."""
+
+    def test_same_profile_returns_none(self) -> None:
+        from cli.benchmark import _RUNNER_PROFILE_VERSION, _check_baseline_profile_compatibility
+
+        baseline = {"runner_profile_version": _RUNNER_PROFILE_VERSION}
+        console = MagicMock()
+        result = _check_baseline_profile_compatibility(
+            baseline, suite="io", console=console, json_output=False
+        )
+        assert result is None
+
+    def test_missing_profile_returns_none(self) -> None:
+        from cli.benchmark import _check_baseline_profile_compatibility
+
+        baseline = {}
+        console = MagicMock()
+        result = _check_baseline_profile_compatibility(
+            baseline, suite="io", console=console, json_output=False
+        )
+        assert result is None
+
+    def test_different_profile_returns_warning_string(self) -> None:
+        from cli.benchmark import _check_baseline_profile_compatibility
+
+        baseline = {"runner_profile_version": "2020-01-01-v1"}
+        console = MagicMock()
+        result = _check_baseline_profile_compatibility(
+            baseline, suite="io", console=console, json_output=False
+        )
+        assert result is not None
+        assert "mismatch" in result.lower()
+
+    def test_different_profile_json_mode_no_print(self) -> None:
+        from cli.benchmark import _check_baseline_profile_compatibility
+
+        baseline = {"runner_profile_version": "2020-01-01-v1"}
+        console = MagicMock()
+        result = _check_baseline_profile_compatibility(
+            baseline, suite="io", console=console, json_output=True
+        )
+        assert result is not None
+        console.print.assert_not_called()
+
+    def test_different_profile_human_mode_prints(self) -> None:
+        from cli.benchmark import _check_baseline_profile_compatibility
+
+        baseline = {"runner_profile_version": "2020-01-01-v1"}
+        console = MagicMock()
+        result = _check_baseline_profile_compatibility(
+            baseline, suite="io", console=console, json_output=False
+        )
+        assert result is not None
+        console.print.assert_called_once()
+
+
+class TestCheckBaselineSmokeCompatibility:
+    """Tests for _check_baseline_smoke_compatibility (lines 919-968)."""
+
+    def test_both_smoke_false_returns_none(self) -> None:
+        from cli.benchmark import _check_baseline_smoke_compatibility
+
+        baseline = {"transcribe_smoke": False}
+        console = MagicMock()
+        result = _check_baseline_smoke_compatibility(
+            baseline, transcribe_smoke=False, console=console, json_output=False
+        )
+        assert result is None
+
+    def test_both_smoke_true_returns_none(self) -> None:
+        from cli.benchmark import _check_baseline_smoke_compatibility
+
+        baseline = {"transcribe_smoke": True}
+        console = MagicMock()
+        result = _check_baseline_smoke_compatibility(
+            baseline, transcribe_smoke=True, console=console, json_output=False
+        )
+        assert result is None
+
+    def test_missing_baseline_smoke_treated_as_false(self) -> None:
+        from cli.benchmark import _check_baseline_smoke_compatibility
+
+        baseline = {}
+        console = MagicMock()
+        result = _check_baseline_smoke_compatibility(
+            baseline, transcribe_smoke=False, console=console, json_output=False
+        )
+        assert result is None
+
+    def test_smoke_mismatch_returns_warning(self) -> None:
+        from cli.benchmark import _check_baseline_smoke_compatibility
+
+        baseline = {"transcribe_smoke": False}
+        console = MagicMock()
+        result = _check_baseline_smoke_compatibility(
+            baseline, transcribe_smoke=True, console=console, json_output=False
+        )
+        assert result is not None
+        assert "mismatch" in result.lower()
+
+    def test_non_bool_baseline_smoke_returns_malformed_warning(self) -> None:
+        from cli.benchmark import _check_baseline_smoke_compatibility
+
+        baseline = {"transcribe_smoke": "false"}
+        console = MagicMock()
+        result = _check_baseline_smoke_compatibility(
+            baseline, transcribe_smoke=False, console=console, json_output=False
+        )
+        assert result is not None
+        assert "not a boolean" in result.lower()
+
+    def test_mismatch_json_mode_no_print(self) -> None:
+        from cli.benchmark import _check_baseline_smoke_compatibility
+
+        baseline = {"transcribe_smoke": False}
+        console = MagicMock()
+        result = _check_baseline_smoke_compatibility(
+            baseline, transcribe_smoke=True, console=console, json_output=True
+        )
+        assert result is not None
+        console.print.assert_not_called()
+
+    def test_mismatch_human_mode_prints(self) -> None:
+        from cli.benchmark import _check_baseline_smoke_compatibility
+
+        baseline = {"transcribe_smoke": False}
+        console = MagicMock()
+        result = _check_baseline_smoke_compatibility(
+            baseline, transcribe_smoke=True, console=console, json_output=False
+        )
+        assert result is not None
+        console.print.assert_called_once()
+
+
+class TestExitIfTranscribeSmokeFailed:
+    """Tests for _exit_if_transcribe_smoke_failed (lines 763-792)."""
+
+    def test_no_smoke_reason_does_not_exit(self) -> None:
+        from cli.benchmark import _exit_if_transcribe_smoke_failed
+
+        console = MagicMock()
+        # Must not raise
+        _exit_if_transcribe_smoke_failed(console, ["some-other-reason"])
+
+    def test_smoke_skipped_reason_raises_exit(self) -> None:
+        from cli.benchmark import _exit_if_transcribe_smoke_failed
+
+        console = MagicMock()
+        with pytest.raises(typer.Exit):
+            _exit_if_transcribe_smoke_failed(console, ["audio-transcribe-smoke-skipped"])
+
+    def test_smoke_skipped_json_mode_routes_to_stderr(self) -> None:
+        from cli.benchmark import _exit_if_transcribe_smoke_failed
+
+        console = MagicMock()
+        # Console is imported locally inside the function, so patch via rich.console
+        mock_stderr_console = MagicMock()
+        with (
+            patch("rich.console.Console", return_value=mock_stderr_console),
+            pytest.raises(typer.Exit),
+        ):
+            _exit_if_transcribe_smoke_failed(
+                console, ["audio-transcribe-smoke-skipped"], json_output=True
+            )
+        mock_stderr_console.print.assert_called_once()
+        console.print.assert_not_called()
+
+    def test_smoke_skipped_human_mode_routes_to_console(self) -> None:
+        from cli.benchmark import _exit_if_transcribe_smoke_failed
+
+        console = MagicMock()
+        with pytest.raises(typer.Exit):
+            _exit_if_transcribe_smoke_failed(
+                console, ["audio-transcribe-smoke-skipped"], json_output=False
+            )
+        console.print.assert_called_once()
+
+
+class TestClassifySuites:
+    """Tests for classify functions (lines 686-838)."""
+
+    def test_classify_io_suite_always_not_degraded(self) -> None:
+        from cli.benchmark import _classify_io_suite, _SuiteIterationOutcome
+
+        outcome = _SuiteIterationOutcome(processed_count=5)
+        result = _classify_io_suite([], outcome)
+        assert result.effective_suite == "io"
+        assert result.degraded is False
+
+    def test_classify_text_suite_no_candidates(self, tmp_path: Path) -> None:
+        from cli.benchmark import _classify_text_suite, _SuiteIterationOutcome
+
+        outcome = _SuiteIterationOutcome(processed_count=0)
+        files = [tmp_path / "a.xyz"]
+        result = _classify_text_suite(files, outcome)
+        assert result.degraded is True
+        assert "text-no-candidates-skip" in result.degradation_reasons
+
+    def test_classify_text_suite_with_candidates(self, tmp_path: Path) -> None:
+        from cli.benchmark import _classify_text_suite, _SuiteIterationOutcome
+
+        outcome = _SuiteIterationOutcome(processed_count=1)
+        files = [tmp_path / "a.txt"]
+        result = _classify_text_suite(files, outcome)
+        assert result.degraded is False
+
+    def test_classify_vision_suite_no_candidates(self, tmp_path: Path) -> None:
+        from cli.benchmark import _classify_vision_suite, _SuiteIterationOutcome
+
+        outcome = _SuiteIterationOutcome(processed_count=0)
+        files = [tmp_path / "a.txt"]
+        result = _classify_vision_suite(files, outcome)
+        assert result.degraded is True
+        assert "vision-no-candidates-skip" in result.degradation_reasons
+
+    def test_classify_vision_suite_with_candidates(self, tmp_path: Path) -> None:
+        from cli.benchmark import _classify_vision_suite, _SuiteIterationOutcome
+
+        outcome = _SuiteIterationOutcome(processed_count=1)
+        files = [tmp_path / "a.jpg"]
+        result = _classify_vision_suite(files, outcome)
+        assert result.degraded is False
+
+    def test_classify_audio_suite_no_candidates_fallback_to_io(self, tmp_path: Path) -> None:
+        from cli.benchmark import _classify_audio_suite, _SuiteIterationOutcome
+
+        outcome = _SuiteIterationOutcome(processed_count=0)
+        files = [tmp_path / "a.txt"]
+        result = _classify_audio_suite(files, outcome)
+        assert result.effective_suite == "io"
+        assert result.degraded is True
+        assert "audio-no-candidates-fallback-to-io" in result.degradation_reasons
+
+    def test_classify_audio_suite_synthetic_metadata(self, tmp_path: Path) -> None:
+        from cli.benchmark import _classify_audio_suite, _SuiteIterationOutcome
+
+        outcome = _SuiteIterationOutcome(processed_count=1, used_synthetic_audio_metadata=True)
+        files = [tmp_path / "a.mp3"]
+        result = _classify_audio_suite(files, outcome)
+        assert result.degraded is True
+        assert "audio-synthesized-metadata-fallback" in result.degradation_reasons
+
+    def test_classify_audio_suite_smoke_skipped(self, tmp_path: Path) -> None:
+        from cli.benchmark import _classify_audio_suite, _SuiteIterationOutcome
+
+        outcome = _SuiteIterationOutcome(
+            processed_count=1,
+            transcription_smoke_requested=True,
+            transcription_smoke_passed=False,
+        )
+        files = [tmp_path / "a.mp3"]
+        result = _classify_audio_suite(files, outcome)
+        assert result.degraded is True
+        assert "audio-transcribe-smoke-skipped" in result.degradation_reasons
+
+    def test_classify_audio_suite_clean(self, tmp_path: Path) -> None:
+        from cli.benchmark import _classify_audio_suite, _SuiteIterationOutcome
+
+        outcome = _SuiteIterationOutcome(processed_count=1)
+        files = [tmp_path / "a.mp3"]
+        result = _classify_audio_suite(files, outcome)
+        assert result.degraded is False
+        assert result.effective_suite == "audio"
+
+    def test_classify_pipeline_suite_not_degraded(self) -> None:
+        from cli.benchmark import _classify_pipeline_suite, _SuiteIterationOutcome
+
+        outcome = _SuiteIterationOutcome(processed_count=5)
+        result = _classify_pipeline_suite([], outcome)
+        assert result.effective_suite == "pipeline"
+        assert result.degraded is False
+
+    def test_classify_e2e_suite_no_processed_when_files_exist(self, tmp_path: Path) -> None:
+        from cli.benchmark import _classify_e2e_suite, _SuiteIterationOutcome
+
+        outcome = _SuiteIterationOutcome(processed_count=0)
+        files = [tmp_path / "a.txt"]
+        result = _classify_e2e_suite(files, outcome)
+        assert result.degraded is True
+        assert "e2e-no-candidates-processed" in result.degradation_reasons
+
+    def test_classify_e2e_suite_no_files_not_degraded(self) -> None:
+        from cli.benchmark import _classify_e2e_suite, _SuiteIterationOutcome
+
+        outcome = _SuiteIterationOutcome(processed_count=0)
+        result = _classify_e2e_suite([], outcome)
+        assert result.degraded is False
+
+
+class TestBindTranscribeSmoke:
+    """Tests for _bind_transcribe_smoke (lines 718-736)."""
+
+    def test_smoke_with_non_audio_raises_bad_parameter(self) -> None:
+        from cli.benchmark import _bind_transcribe_smoke, _run_io_suite
+
+        with pytest.raises(typer.BadParameter, match="only supported with --suite audio"):
+            _bind_transcribe_smoke(_run_io_suite, suite="io", transcribe_smoke=True)
+
+    def test_smoke_false_returns_original_runner(self) -> None:
+        from cli.benchmark import _bind_transcribe_smoke, _run_audio_suite
+
+        result = _bind_transcribe_smoke(_run_audio_suite, suite="audio", transcribe_smoke=False)
+        assert result is _run_audio_suite
+
+    def test_smoke_true_audio_returns_partial(self) -> None:
+        import functools
+
+        from cli.benchmark import _bind_transcribe_smoke, _run_audio_suite
+
+        result = _bind_transcribe_smoke(_run_audio_suite, suite="audio", transcribe_smoke=True)
+        assert isinstance(result, functools.partial)
+
+    def test_smoke_false_non_audio_returns_original(self) -> None:
+        from cli.benchmark import _bind_transcribe_smoke, _run_io_suite
+
+        result = _bind_transcribe_smoke(_run_io_suite, suite="io", transcribe_smoke=False)
+        assert result is _run_io_suite
+
+
+class TestValidateTranscribeSmokePreconditions:
+    """Tests for _validate_transcribe_smoke_preconditions (lines 739-760)."""
+
+    def test_no_smoke_does_nothing(self) -> None:
+        from cli.benchmark import _validate_transcribe_smoke_preconditions
+
+        # Must not raise
+        _validate_transcribe_smoke_preconditions([], transcribe_smoke=False)
+
+    def test_smoke_empty_files_raises(self) -> None:
+        from cli.benchmark import _validate_transcribe_smoke_preconditions
+
+        with pytest.raises(typer.BadParameter, match="empty"):
+            _validate_transcribe_smoke_preconditions([], transcribe_smoke=True)
+
+    def test_smoke_no_audio_candidates_raises(self, tmp_path: Path) -> None:
+        from cli.benchmark import _validate_transcribe_smoke_preconditions
+
+        files = [tmp_path / "a.txt"]
+        with pytest.raises(typer.BadParameter, match="audio file"):
+            _validate_transcribe_smoke_preconditions(files, transcribe_smoke=True)
+
+    def test_smoke_with_audio_files_passes(self, tmp_path: Path) -> None:
+        from cli.benchmark import _validate_transcribe_smoke_preconditions
+
+        files = [tmp_path / "a.mp3"]
+        # Must not raise
+        _validate_transcribe_smoke_preconditions(files, transcribe_smoke=True)
+
+
+class TestSummarizeSuiteClassifications:
+    """Tests for _summarize_suite_classifications (lines 1001-1026)."""
+
+    def test_no_degradation(self) -> None:
+        from cli.benchmark import _SuiteExecutionClassification, _summarize_suite_classifications
+
+        classifications = [
+            _SuiteExecutionClassification(effective_suite="io", degraded=False),
+            _SuiteExecutionClassification(effective_suite="io", degraded=False),
+        ]
+        suite, degraded, reasons = _summarize_suite_classifications(
+            classifications, warmup=0, requested_suite="io"
+        )
+        assert suite == "io"
+        assert degraded is False
+        assert reasons == []
+
+    def test_with_degradation(self) -> None:
+        from cli.benchmark import _SuiteExecutionClassification, _summarize_suite_classifications
+
+        classifications = [
+            _SuiteExecutionClassification(
+                effective_suite="io", degraded=True, degradation_reasons=("reason-a",)
+            ),
+        ]
+        suite, degraded, reasons = _summarize_suite_classifications(
+            classifications, warmup=0, requested_suite="io"
+        )
+        assert degraded is True
+        assert "reason-a" in reasons
+
+    def test_warmup_excluded(self) -> None:
+        from cli.benchmark import _SuiteExecutionClassification, _summarize_suite_classifications
+
+        classifications = [
+            # warmup entry — degraded but should be excluded
+            _SuiteExecutionClassification(
+                effective_suite="io", degraded=True, degradation_reasons=("warmup-reason",)
+            ),
+            # measured entry
+            _SuiteExecutionClassification(effective_suite="io", degraded=False),
+        ]
+        suite, degraded, reasons = _summarize_suite_classifications(
+            classifications, warmup=1, requested_suite="io"
+        )
+        assert degraded is False
+        assert "warmup-reason" not in reasons
+
+    def test_empty_classifications_returns_requested_suite(self) -> None:
+        from cli.benchmark import _summarize_suite_classifications
+
+        suite, degraded, reasons = _summarize_suite_classifications(
+            [], warmup=0, requested_suite="text"
+        )
+        assert suite == "text"
+        assert degraded is False
+
+    def test_mixed_effective_suites_returns_mixed(self) -> None:
+        from cli.benchmark import _SuiteExecutionClassification, _summarize_suite_classifications
+
+        classifications = [
+            _SuiteExecutionClassification(effective_suite="io", degraded=False),
+            _SuiteExecutionClassification(effective_suite="audio", degraded=False),
+        ]
+        suite, _degraded, _reasons = _summarize_suite_classifications(
+            classifications, warmup=0, requested_suite="audio"
+        )
+        assert suite == "mixed"
+
+
+class TestExecuteSuiteIteration:
+    """Tests for _execute_suite_iteration (lines 971-998)."""
+
+    def test_successful_iteration(self, tmp_path: Path) -> None:
+        from cli.benchmark import (
+            _execute_suite_iteration,
+            _SuiteExecutionClassification,
+            _SuiteIterationOutcome,
+        )
+
+        def fake_runner(files: list) -> _SuiteIterationOutcome:
+            return _SuiteIterationOutcome(processed_count=3)
+
+        def fake_classifier(
+            files: list, outcome: _SuiteIterationOutcome
+        ) -> _SuiteExecutionClassification:
+            return _SuiteExecutionClassification(effective_suite="io", degraded=False)
+
+        console = MagicMock()
+        elapsed_ms, count, classification = _execute_suite_iteration(
+            runner=fake_runner,
+            classifier=fake_classifier,
+            files=[tmp_path / "a.txt"],
+            suite="io",
+            console=console,
+        )
+        assert elapsed_ms > 0
+        assert count == 3
+        assert classification.effective_suite == "io"
+
+    def test_runner_exception_raises_exit(self, tmp_path: Path) -> None:
+        from cli.benchmark import _execute_suite_iteration
+
+        def failing_runner(files: list):
+            raise RuntimeError("runner failed")
+
+        console = MagicMock()
+        with pytest.raises(typer.Exit):
+            _execute_suite_iteration(
+                runner=failing_runner,
+                classifier=MagicMock(),
+                files=[],
+                suite="io",
+                console=console,
+            )
+
+    def test_negative_processed_count_raises_exit(self, tmp_path: Path) -> None:
+        from cli.benchmark import _execute_suite_iteration, _SuiteIterationOutcome
+
+        def bad_runner(files: list) -> _SuiteIterationOutcome:
+            return _SuiteIterationOutcome(processed_count=-1)
+
+        console = MagicMock()
+        with pytest.raises(typer.Exit):
+            _execute_suite_iteration(
+                runner=bad_runner,
+                classifier=MagicMock(),
+                files=[],
+                suite="io",
+                console=console,
+            )
+
+    def test_classifier_exception_raises_exit(self, tmp_path: Path) -> None:
+        from cli.benchmark import _execute_suite_iteration, _SuiteIterationOutcome
+
+        def ok_runner(files: list) -> _SuiteIterationOutcome:
+            return _SuiteIterationOutcome(processed_count=1)
+
+        def failing_classifier(files: list, outcome):
+            raise RuntimeError("classify failed")
+
+        console = MagicMock()
+        with pytest.raises(typer.Exit):
+            _execute_suite_iteration(
+                runner=ok_runner,
+                classifier=failing_classifier,
+                files=[],
+                suite="io",
+                console=console,
+            )
+
+
+class TestPrintTable:
+    """Tests for _print_table (lines 1029-1048)."""
+
+    def test_print_table_no_crash(self) -> None:
+        from cli.benchmark import _print_table, compute_stats
+
+        stats = compute_stats([100.0, 110.0, 120.0], 5)
+        console = MagicMock()
+        _print_table(console, "io", 1, stats, 5)
+        console.print.assert_called_once()
+
+
+class TestPrintComparison:
+    """Tests for _print_comparison (lines 1051-1072)."""
+
+    def test_json_mode_prints_json(self) -> None:
+        from cli.benchmark import _print_comparison
+
+        comp = {
+            "deltas_pct": {"median_ms": 10.0, "p95_ms": 20.0},
+            "regression": False,
+            "threshold": 1.2,
+        }
+        console = MagicMock()
+        _print_comparison(console, comp, json_output=True)
+        console.print.assert_called_once()
+        call_arg = console.print.call_args[0][0]
+        parsed = json.loads(call_arg)
+        assert "comparison" in parsed
+
+    def test_human_mode_no_regression(self) -> None:
+        from cli.benchmark import _print_comparison
+
+        comp = {
+            "deltas_pct": {
+                "median_ms": 5.0,
+                "p95_ms": 3.0,
+                "p99_ms": 3.0,
+                "stddev_ms": 1.0,
+                "throughput_fps": -2.0,
+            },
+            "regression": False,
+            "threshold": 1.2,
+        }
+        console = MagicMock()
+        _print_comparison(console, comp, json_output=False)
+        # verify No regression was printed
+        calls = [str(c) for c in console.print.call_args_list]
+        assert any("No regression" in c for c in calls)
+
+    def test_human_mode_regression(self) -> None:
+        from cli.benchmark import _print_comparison
+
+        comp = {
+            "deltas_pct": {
+                "median_ms": 50.0,
+                "p95_ms": 50.0,
+                "p99_ms": 50.0,
+                "stddev_ms": 10.0,
+                "throughput_fps": -10.0,
+            },
+            "regression": True,
+            "threshold": 1.2,
+        }
+        console = MagicMock()
+        _print_comparison(console, comp, json_output=False)
+        calls = [str(c) for c in console.print.call_args_list]
+        assert any("REGRESSION" in c for c in calls)
+
+
+class TestValidateComparePath:
+    """Tests for _validate_compare_path (lines 1119-1133)."""
+
+    def test_none_returns_none(self) -> None:
+        from cli.benchmark import _validate_compare_path
+
+        assert _validate_compare_path(None) is None
+
+    def test_valid_file_returns_resolved_path(self, tmp_path: Path) -> None:
+        from cli.benchmark import _validate_compare_path
+
+        baseline = tmp_path / "baseline.json"
+        baseline.write_text('{"suite": "io"}')
+        result = _validate_compare_path(baseline)
+        assert result is not None
+        assert result.is_file()
+
+    def test_directory_raises_bad_parameter(self, tmp_path: Path) -> None:
+        from cli.benchmark import _validate_compare_path
+
+        with pytest.raises(typer.BadParameter, match="not a regular file"):
+            _validate_compare_path(tmp_path)
+
+
+class TestMaybeAttachComparisonOutput:
+    """Tests for _maybe_attach_comparison_output (lines 1075-1111)."""
+
+    def _base_output(self) -> dict:
+        return {
+            "suite": "io",
+            "effective_suite": "io",
+            "degraded": False,
+            "degradation_reasons": [],
+            "runner_profile_version": "2026-01-01-v1",
+            "files_count": 1,
+            "hardware_profile": {},
+            "results": {
+                "median_ms": 100.0,
+                "p95_ms": 120.0,
+                "p99_ms": 150.0,
+                "stddev_ms": 10.0,
+                "throughput_fps": 10.0,
+                "iterations": 5,
+            },
+        }
+
+    def test_none_compare_path_returns_unchanged(self) -> None:
+        from cli.benchmark import _maybe_attach_comparison_output
+
+        output = self._base_output()
+        result = _maybe_attach_comparison_output(
+            output=output,
+            compare_path=None,
+            suite="io",
+            transcribe_smoke=False,
+            console=MagicMock(),
+            json_output=False,
+        )
+        assert "comparison" not in result
+
+    def test_with_baseline_attaches_comparison(self, tmp_path: Path) -> None:
+        from cli.benchmark import _RUNNER_PROFILE_VERSION, _maybe_attach_comparison_output
+
+        baseline = {
+            "suite": "io",
+            "effective_suite": "io",
+            "degraded": False,
+            "degradation_reasons": [],
+            "runner_profile_version": _RUNNER_PROFILE_VERSION,
+            "files_count": 1,
+            "hardware_profile": {},
+            "results": {
+                "median_ms": 100.0,
+                "p95_ms": 100.0,
+                "p99_ms": 100.0,
+                "stddev_ms": 5.0,
+                "throughput_fps": 10.0,
+                "iterations": 5,
+            },
+        }
+        baseline_path = tmp_path / "baseline.json"
+        baseline_path.write_text(json.dumps(baseline))
+
+        output = self._base_output()
+        result = _maybe_attach_comparison_output(
+            output=output,
+            compare_path=baseline_path,
+            suite="io",
+            transcribe_smoke=False,
+            console=MagicMock(),
+            json_output=False,
+        )
+        assert "comparison" in result
+        assert "regression" in result["comparison"]
+
+    def test_invalid_baseline_raises_exit(self, tmp_path: Path) -> None:
+        from cli.benchmark import _maybe_attach_comparison_output
+
+        bad_path = tmp_path / "bad.json"
+        bad_path.write_text("{invalid json{{")
+
+        output = self._base_output()
+        with pytest.raises(typer.Exit):
+            _maybe_attach_comparison_output(
+                output=output,
+                compare_path=bad_path,
+                suite="io",
+                transcribe_smoke=False,
+                console=MagicMock(),
+                json_output=False,
+            )
+
+    def test_profile_warning_attached_when_mismatch(self, tmp_path: Path) -> None:
+        from cli.benchmark import _maybe_attach_comparison_output
+
+        baseline = {
+            "runner_profile_version": "1999-01-01-v0",
+            "results": {
+                "median_ms": 100.0,
+                "p95_ms": 100.0,
+                "p99_ms": 100.0,
+                "stddev_ms": 5.0,
+                "throughput_fps": 10.0,
+                "iterations": 5,
+            },
+        }
+        baseline_path = tmp_path / "baseline.json"
+        baseline_path.write_text(json.dumps(baseline))
+
+        output = self._base_output()
+        result = _maybe_attach_comparison_output(
+            output=output,
+            compare_path=baseline_path,
+            suite="io",
+            transcribe_smoke=False,
+            console=MagicMock(),
+            json_output=True,
+        )
+        assert "comparison_profile_warning" in result
+
+
+class TestRunCommandUnknownSuite:
+    """Tests for unknown suite handling in run() (line 1219-1220)."""
+
+    def test_unknown_suite_exits_nonzero(self, tmp_path: Path) -> None:
+        app = _get_app()
+        (tmp_path / "a.txt").write_text("content")
+        result = runner.invoke(
+            app,
+            ["benchmark", "run", str(tmp_path), "--suite", "nonexistent_suite", "--json"],
+        )
+        assert result.exit_code == 1
+
+    def test_unknown_suite_plain_mode_exits_nonzero(self, tmp_path: Path) -> None:
+        app = _get_app()
+        (tmp_path / "a.txt").write_text("content")
+        result = runner.invoke(
+            app,
+            ["benchmark", "run", str(tmp_path), "--suite", "nonexistent_suite"],
+        )
+        assert result.exit_code == 1
+
+
+class TestRunCommandWithBaselineComparison:
+    """Tests for --compare flag in run() (lines 1261-1274, 1337-1352)."""
+
+    def _make_baseline(self, path: Path) -> Path:
+        from cli.benchmark import _RUNNER_PROFILE_VERSION
+
+        baseline = {
+            "suite": "io",
+            "effective_suite": "io",
+            "degraded": False,
+            "degradation_reasons": [],
+            "runner_profile_version": _RUNNER_PROFILE_VERSION,
+            "transcribe_smoke": False,
+            "files_count": 1,
+            "hardware_profile": {},
+            "results": {
+                "median_ms": 100.0,
+                "p95_ms": 100.0,
+                "p99_ms": 100.0,
+                "stddev_ms": 5.0,
+                "throughput_fps": 10.0,
+                "iterations": 1,
+            },
+        }
+        baseline_file = path / "baseline.json"
+        baseline_file.write_text(json.dumps(baseline))
+        return baseline_file
+
+    def test_compare_json_output(self, tmp_path: Path) -> None:
+        app = _get_app()
+        (tmp_path / "a.txt").write_text("hello")
+        baseline_file = self._make_baseline(tmp_path)
+
+        result = runner.invoke(
+            app,
+            [
+                "benchmark",
+                "run",
+                str(tmp_path),
+                "--suite",
+                "io",
+                "--iterations",
+                "1",
+                "--warmup",
+                "0",
+                "--json",
+                "--compare",
+                str(baseline_file),
+            ],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert "comparison" in payload
+
+    def test_compare_plain_output(self, tmp_path: Path) -> None:
+        app = _get_app()
+        (tmp_path / "a.txt").write_text("hello")
+        baseline_file = self._make_baseline(tmp_path)
+
+        result = runner.invoke(
+            app,
+            [
+                "benchmark",
+                "run",
+                str(tmp_path),
+                "--suite",
+                "io",
+                "--iterations",
+                "1",
+                "--warmup",
+                "0",
+                "--compare",
+                str(baseline_file),
+            ],
+        )
+        assert result.exit_code == 0
+        # Should print comparison section
+        assert (
+            "baseline" in result.output.lower()
+            or "regression" in result.output.lower()
+            or "comparison" in result.output.lower()
+        )
+
+
+class TestRunCommandDegradedSuite:
+    """Tests for degraded suite output path in run() (lines 1337-1343)."""
+
+    def test_degraded_suite_plain_output_shows_reason(self, tmp_path: Path) -> None:
+        app = _get_app()
+        # Create only txt files but request text suite with no text files
+        # by using a directory with no files matching text extensions
+        for i in range(3):
+            (tmp_path / f"file_{i}.xyz").write_text("data")
+
+        result = runner.invoke(
+            app,
+            [
+                "benchmark",
+                "run",
+                str(tmp_path),
+                "--suite",
+                "text",
+                "--iterations",
+                "1",
+                "--warmup",
+                "0",
+            ],
+        )
+        assert result.exit_code == 0
+        # degraded mode — should show the degradation reason
+        assert "text-no-candidates-skip" in result.output or "Degraded" in result.output
+
+    def test_vision_suite_no_vision_files_degraded(self, tmp_path: Path) -> None:
+        app = _get_app()
+        (tmp_path / "a.txt").write_text("text content")
+        result = runner.invoke(
+            app,
+            [
+                "benchmark",
+                "run",
+                str(tmp_path),
+                "--suite",
+                "vision",
+                "--iterations",
+                "1",
+                "--warmup",
+                "0",
+            ],
+        )
+        assert result.exit_code == 0
+        # degraded mode — no vision candidates, human output shows the reason
+        assert "vision-no-candidates-skip" in result.output or "degraded" in result.output.lower()
+
+
+class TestRunCommandWithWarmup:
+    """Tests for warmup iterations in run() (lines 1271-1274)."""
+
+    def test_warmup_iterations_with_files(self, tmp_path: Path) -> None:
+        app = _get_app()
+        (tmp_path / "a.txt").write_text("hello")
+
+        result = runner.invoke(
+            app,
+            [
+                "benchmark",
+                "run",
+                str(tmp_path),
+                "--suite",
+                "io",
+                "--iterations",
+                "2",
+                "--warmup",
+                "1",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        # measured iterations should be 2 (warmup excluded)
+        assert payload["results"]["iterations"] == 2
+
+    def test_plain_output_with_warmup(self, tmp_path: Path) -> None:
+        app = _get_app()
+        (tmp_path / "a.txt").write_text("hello")
+
+        result = runner.invoke(
+            app,
+            [
+                "benchmark",
+                "run",
+                str(tmp_path),
+                "--suite",
+                "io",
+                "--iterations",
+                "1",
+                "--warmup",
+                "1",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Benchmark completed" in result.output
+
+    def test_plain_output_iteration_labels(self, tmp_path: Path) -> None:
+        """Covers the warmup/measured label branches in run() (lines 1272-1274)."""
+        app = _get_app()
+        (tmp_path / "a.txt").write_text("hello")
+
+        result = runner.invoke(
+            app,
+            [
+                "benchmark",
+                "run",
+                str(tmp_path),
+                "--suite",
+                "io",
+                "--iterations",
+                "2",
+                "--warmup",
+                "1",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "warmup" in result.output
+        assert "1/2" in result.output
+
+
+class TestRunSuiteIoWithFiles:
+    """Tests for the io suite runner path with actual files."""
+
+    def test_run_io_suite_directly(self, tmp_path: Path) -> None:
+        from cli.benchmark import _run_io_suite
+
+        (tmp_path / "a.txt").write_text("hello")
+        (tmp_path / "b.pdf").write_text("pdf content")
+        outcome = _run_io_suite([tmp_path / "a.txt", tmp_path / "b.pdf"])
+        assert outcome.processed_count == 2
+
+    def test_run_io_suite_stat_error_continues(self, tmp_path: Path) -> None:
+        from cli.benchmark import _run_io_suite
+
+        files = [tmp_path / "nonexistent.txt"]
+        # Should not raise — OSError is caught silently
+        outcome = _run_io_suite(files)
+        assert outcome.processed_count == 1
+
+    def test_run_io_suite_empty_files(self) -> None:
+        from cli.benchmark import _run_io_suite
+
+        outcome = _run_io_suite([])
+        assert outcome.processed_count == 0
+
+
+class TestRunTextSuiteNoFiles:
+    """Tests for the text suite runner with no matching files."""
+
+    def test_run_text_suite_no_candidates_returns_zero(self, tmp_path: Path) -> None:
+        from cli.benchmark import _run_text_suite
+
+        # Non-text extension files
+        files = [tmp_path / "a.xyz", tmp_path / "b.abc"]
+        outcome = _run_text_suite(files)
+        assert outcome.processed_count == 0
+
+
+class TestRunVisionSuiteNoFiles:
+    """Tests for the vision suite runner with no matching files."""
+
+    def test_run_vision_suite_no_candidates_returns_zero(self, tmp_path: Path) -> None:
+        from cli.benchmark import _run_vision_suite
+
+        files = [tmp_path / "a.txt"]
+        outcome = _run_vision_suite(files)
+        assert outcome.processed_count == 0
+
+
+class TestSynthesizedAudioMetadata:
+    """Tests for _synthesized_audio_metadata (lines 495-508)."""
+
+    @pytest.fixture(autouse=True)
+    def _require_audio_metadata(self) -> None:
+        """Guard: skip if services.audio.metadata_extractor cannot be loaded."""
+        pytest.importorskip("services.audio.metadata_extractor")
+
+    def test_returns_audio_metadata_for_existing_file(self, tmp_path: Path) -> None:
+        import services.audio.metadata_extractor as _meta_mod
+        from cli.benchmark import _synthesized_audio_metadata
+
+        audio_file = tmp_path / "test.mp3"
+        audio_file.write_bytes(b"\x00" * 100)
+        # Import the real class directly to verify the result fields.
+        RealAudioMetadata = _meta_mod.AudioMetadata
+        metadata = _synthesized_audio_metadata(audio_file)
+        assert isinstance(metadata, RealAudioMetadata)
+        assert metadata.file_path == audio_file
+        assert metadata.file_size == 100
+        assert metadata.format == "MP3"
+
+    def test_returns_unknown_format_for_no_extension(self, tmp_path: Path) -> None:
+        import services.audio.metadata_extractor as _meta_mod
+        from cli.benchmark import _synthesized_audio_metadata
+
+        audio_file = tmp_path / "noext"
+        audio_file.write_bytes(b"\x00" * 50)
+        RealAudioMetadata = _meta_mod.AudioMetadata
+        metadata = _synthesized_audio_metadata(audio_file)
+        assert isinstance(metadata, RealAudioMetadata)
+        assert metadata.format == "UNKNOWN"
+
+
+class TestComputeStats:
+    """Tests for compute_stats (lines 139-171)."""
+
+    def test_empty_times_returns_zeros(self) -> None:
+        from cli.benchmark import compute_stats
+
+        stats = compute_stats([], 0)
+        assert stats["median_ms"] == 0.0
+        assert stats["p95_ms"] == 0.0
+        assert stats["iterations"] == 0
+
+    def test_single_time_returns_itself(self) -> None:
+        from cli.benchmark import compute_stats
+
+        stats = compute_stats([100.0], 1)
+        assert stats["median_ms"] == pytest.approx(100.0)
+        assert stats["iterations"] == 1
+
+    def test_throughput_zero_median_gives_zero(self) -> None:
+        from cli.benchmark import compute_stats
+
+        stats = compute_stats([0.0, 0.0], 5)
+        assert stats["throughput_fps"] == 0.0
+
+    def test_stddev_single_item_is_zero(self) -> None:
+        from cli.benchmark import compute_stats
+
+        stats = compute_stats([50.0], 1)
+        assert stats["stddev_ms"] == 0.0
+
+    def test_multiple_times_computes_stats(self) -> None:
+        from cli.benchmark import compute_stats
+
+        times = [100.0, 200.0, 300.0, 400.0, 500.0]
+        stats = compute_stats(times, 10)
+        assert stats["median_ms"] == pytest.approx(300.0)
+        assert stats["iterations"] == 5
+        assert stats["throughput_fps"] > 0
+
+
+class TestRunAudioSuiteNoFiles:
+    """Tests for the audio suite fallback path (lines 521-568)."""
+
+    def test_audio_suite_no_candidates_falls_back_to_io(self, tmp_path: Path) -> None:
+        from cli.benchmark import _run_audio_suite
+
+        # Non-audio files → fallback to IO
+        files = [tmp_path / "a.txt"]
+        (tmp_path / "a.txt").write_text("content")
+        outcome = _run_audio_suite(files)
+        # Falls back to io suite
+        assert outcome.processed_count == 1
+
+
+class TestRunPipelineSuiteEmpty:
+    """Tests for the pipeline suite with empty file list (lines 571-574)."""
+
+    def test_pipeline_suite_empty_files(self) -> None:
+        from cli.benchmark import _run_pipeline_suite
+
+        outcome = _run_pipeline_suite([])
+        assert outcome.processed_count == 0
+
+
+class TestRunE2eSuiteEmpty:
+    """Tests for the e2e suite with empty file list (lines 615-665)."""
+
+    def test_e2e_suite_empty_files(self) -> None:
+        from cli.benchmark import _run_e2e_suite
+
+        outcome = _run_e2e_suite([])
+        assert outcome.processed_count == 0
+
+
+class TestRunTextSuiteWithFiles:
+    """Cover lines 446-464: _run_text_suite body with candidates."""
+
+    def test_run_text_suite_with_text_files(self, tmp_path: Path) -> None:
+
+        txt_file = tmp_path / "sample.txt"
+        txt_file.write_text("hello world")
+
+        mock_processor = MagicMock()
+        mock_processor_instance = MagicMock()
+        mock_processor.return_value = mock_processor_instance
+
+        with patch("cli.benchmark.TextProcessor", mock_processor, create=True):
+            # Also patch the lazy import of TextProcessor inside the function
+            with patch.dict(
+                "sys.modules",
+                {"services": MagicMock(TextProcessor=mock_processor)},
+            ):
+                # Re-import so patched module is used; call with real file path
+                import cli.benchmark as bm
+
+                original = bm._run_text_suite
+                # Patch the lazy import of services inside the function
+                mock_services = MagicMock()
+                mock_services.TextProcessor = mock_processor
+
+                with patch.dict("sys.modules", {"services": mock_services}):
+                    outcome = original([txt_file])
+
+        assert outcome.processed_count == 1
+
+    def test_run_text_suite_with_mocked_processor(self, tmp_path: Path) -> None:
+        """Cover _run_text_suite body by mocking TextProcessor at import time."""
+        txt_file = tmp_path / "doc.pdf"
+        txt_file.write_bytes(b"%PDF mock content")
+
+        mock_processor_instance = MagicMock()
+        mock_text_processor_cls = MagicMock(return_value=mock_processor_instance)
+
+        # Patch the lazy import path used inside _run_text_suite
+        mock_services_module = MagicMock()
+        mock_services_module.TextProcessor = mock_text_processor_cls
+        mock_base_module = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "services": mock_services_module,
+                "models.base": mock_base_module,
+            },
+        ):
+            from cli.benchmark import _run_text_suite
+
+            outcome = _run_text_suite([txt_file])
+
+        assert outcome.processed_count == 1
+        mock_processor_instance.process_file.assert_called_once_with(txt_file)
+        mock_processor_instance.cleanup.assert_called_once()
+
+
+class TestRunVisionSuiteWithFiles:
+    """Cover lines 474-492: _run_vision_suite body with candidates."""
+
+    def test_run_vision_suite_with_mocked_processor(self, tmp_path: Path) -> None:
+        """Cover _run_vision_suite body by mocking VisionProcessor."""
+        img_file = tmp_path / "photo.jpg"
+        img_file.write_bytes(b"JPEG mock")
+
+        mock_processor_instance = MagicMock()
+        mock_vision_processor_cls = MagicMock(return_value=mock_processor_instance)
+
+        mock_services_module = MagicMock()
+        mock_services_module.VisionProcessor = mock_vision_processor_cls
+        mock_base_module = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "services": mock_services_module,
+                "models.base": mock_base_module,
+            },
+        ):
+            from cli.benchmark import _run_vision_suite
+
+            outcome = _run_vision_suite([img_file])
+
+        assert outcome.processed_count == 1
+        mock_processor_instance.process_file.assert_called_once_with(img_file, perform_ocr=False)
+        mock_processor_instance.cleanup.assert_called_once()
+
+
+class TestRunAudioSuiteWithFiles:
+    """Cover lines 526-568: _run_audio_suite body with audio candidates."""
+
+    def test_run_audio_suite_with_mocked_extractor(self, tmp_path: Path) -> None:
+        """Cover _run_audio_suite body by mocking AudioMetadataExtractor."""
+        audio_file = tmp_path / "track.mp3"
+        audio_file.write_bytes(b"MP3 mock")
+
+        mock_metadata = MagicMock()
+        mock_extractor_instance = MagicMock()
+        mock_extractor_instance.extract.return_value = mock_metadata
+        mock_extractor_cls = MagicMock(return_value=mock_extractor_instance)
+
+        mock_classifier_instance = MagicMock()
+        mock_classifier_cls = MagicMock(return_value=mock_classifier_instance)
+
+        mock_audio_classifier_mod = MagicMock()
+        mock_audio_classifier_mod.AudioClassifier = mock_classifier_cls
+        mock_audio_extractor_mod = MagicMock()
+        mock_audio_extractor_mod.AudioMetadataExtractor = mock_extractor_cls
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "services.audio.classifier": mock_audio_classifier_mod,
+                "services.audio.metadata_extractor": mock_audio_extractor_mod,
+            },
+        ):
+            from cli.benchmark import _run_audio_suite
+
+            outcome = _run_audio_suite([audio_file])
+
+        assert outcome.processed_count == 1
+        assert outcome.used_synthetic_audio_metadata is False
+        assert outcome.transcription_smoke_requested is False
+        mock_extractor_instance.extract.assert_called_once_with(audio_file)
+        mock_classifier_instance.classify.assert_called_once_with(mock_metadata)
+
+    def test_run_audio_suite_import_error_uses_synthetic(self, tmp_path: Path) -> None:
+        """Cover ImportError path in _run_audio_suite (lines 535-537)."""
+        audio_file = tmp_path / "track.mp3"
+        audio_file.write_bytes(b"MP3 mock")
+
+        mock_extractor_instance = MagicMock()
+        mock_extractor_instance.extract.side_effect = ImportError("no module")
+        mock_extractor_cls = MagicMock(return_value=mock_extractor_instance)
+
+        mock_classifier_instance = MagicMock()
+        mock_classifier_cls = MagicMock(return_value=mock_classifier_instance)
+
+        # We also need to provide AudioMetadata for _synthesized_audio_metadata
+        mock_audio_metadata = MagicMock()
+        mock_audio_extractor_mod = MagicMock()
+        mock_audio_extractor_mod.AudioMetadataExtractor = mock_extractor_cls
+        mock_audio_extractor_mod.AudioMetadata = MagicMock(return_value=mock_audio_metadata)
+
+        mock_audio_classifier_mod = MagicMock()
+        mock_audio_classifier_mod.AudioClassifier = mock_classifier_cls
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "services.audio.classifier": mock_audio_classifier_mod,
+                "services.audio.metadata_extractor": mock_audio_extractor_mod,
+            },
+        ):
+            from cli.benchmark import _run_audio_suite
+
+            outcome = _run_audio_suite([audio_file])
+
+        assert outcome.processed_count == 1
+        assert outcome.used_synthetic_audio_metadata is True
+
+
+class TestRunPipelineSuiteWithFiles:
+    """Cover lines 577-612: _run_pipeline_suite body with files."""
+
+    def test_run_pipeline_suite_with_mocked_orchestrator(self, tmp_path: Path) -> None:
+        """Cover _run_pipeline_suite body by mocking PipelineOrchestrator."""
+        txt_file = tmp_path / "doc.txt"
+        txt_file.write_text("content")
+
+        mock_orchestrator_instance = MagicMock()
+        mock_orchestrator_cls = MagicMock(return_value=mock_orchestrator_instance)
+
+        mock_processor_pool_instance = MagicMock()
+        mock_processor_pool_cls = MagicMock(return_value=mock_processor_pool_instance)
+
+        mock_pipeline_config_mod = MagicMock()
+        mock_pipeline_orchestrator_mod = MagicMock()
+        mock_pipeline_orchestrator_mod.PipelineOrchestrator = mock_orchestrator_cls
+        mock_pipeline_processor_pool_mod = MagicMock()
+        mock_pipeline_processor_pool_mod.ProcessorPool = mock_processor_pool_cls
+        mock_pipeline_router_mod = MagicMock()
+        mock_pipeline_stages_analyzer_mod = MagicMock()
+        mock_pipeline_stages_postprocessor_mod = MagicMock()
+        mock_pipeline_stages_preprocessor_mod = MagicMock()
+        mock_pipeline_stages_writer_mod = MagicMock()
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "pipeline.config": mock_pipeline_config_mod,
+                "pipeline.orchestrator": mock_pipeline_orchestrator_mod,
+                "pipeline.processor_pool": mock_pipeline_processor_pool_mod,
+                "pipeline.router": mock_pipeline_router_mod,
+                "pipeline.stages.analyzer": mock_pipeline_stages_analyzer_mod,
+                "pipeline.stages.postprocessor": mock_pipeline_stages_postprocessor_mod,
+                "pipeline.stages.preprocessor": mock_pipeline_stages_preprocessor_mod,
+                "pipeline.stages.writer": mock_pipeline_stages_writer_mod,
+            },
+        ):
+            from cli.benchmark import _run_pipeline_suite
+
+            outcome = _run_pipeline_suite([txt_file])
+
+        assert outcome.processed_count == 1
+        mock_orchestrator_instance.process_batch.assert_called_once()
+        mock_orchestrator_instance.stop.assert_called_once()
+        mock_processor_pool_instance.cleanup.assert_called_once()
+
+
+class TestRunE2eSuiteWithFiles:
+    """Cover lines 633-683: _run_e2e_suite body with files."""
+
+    def test_run_e2e_suite_with_mocked_organizer(self, tmp_path: Path) -> None:
+        """Cover _run_e2e_suite body by mocking FileOrganizer."""
+        txt_file = tmp_path / "doc.txt"
+        txt_file.write_text("content")
+
+        mock_organizer_instance = MagicMock()
+        mock_organizer_cls = MagicMock(return_value=mock_organizer_instance)
+
+        mock_core_organizer_mod = MagicMock()
+        mock_core_organizer_mod.FileOrganizer = mock_organizer_cls
+
+        with patch.dict(
+            "sys.modules",
+            {"core.organizer": mock_core_organizer_mod},
+        ):
+            from cli.benchmark import _run_e2e_suite
+
+            outcome = _run_e2e_suite([txt_file])
+
+        assert outcome.processed_count == 1
+        mock_organizer_instance.organize.assert_called_once()
+
+    def test_run_e2e_suite_copy_failure_skips_file(self, tmp_path: Path) -> None:
+        """Cover OSError copy-failure branch (lines 648-656)."""
+        # Use a nonexistent source file so shutil.copy2 will fail
+        nonexistent = tmp_path / "nonexistent.txt"
+
+        mock_organizer_instance = MagicMock()
+        mock_organizer_cls = MagicMock(return_value=mock_organizer_instance)
+        mock_core_organizer_mod = MagicMock()
+        mock_core_organizer_mod.FileOrganizer = mock_organizer_cls
+
+        with patch.dict(
+            "sys.modules",
+            {"core.organizer": mock_core_organizer_mod},
+        ):
+            from cli.benchmark import _run_e2e_suite
+
+            outcome = _run_e2e_suite([nonexistent])
+
+        # File couldn't be copied, so copied list is empty → processed_count == 0
+        assert outcome.processed_count == 0
+
+    def test_run_e2e_suite_organizer_exception_raises_runtime_error(self, tmp_path: Path) -> None:
+        """Cover except Exception branch in _run_e2e_suite (lines 681-682)."""
+        txt_file = tmp_path / "doc.txt"
+        txt_file.write_text("content")
+
+        mock_organizer_instance = MagicMock()
+        mock_organizer_instance.organize.side_effect = RuntimeError("organizer exploded")
+        mock_organizer_cls = MagicMock(return_value=mock_organizer_instance)
+
+        mock_core_organizer_mod = MagicMock()
+        mock_core_organizer_mod.FileOrganizer = mock_organizer_cls
+
+        with patch.dict("sys.modules", {"core.organizer": mock_core_organizer_mod}):
+            from cli.benchmark import _run_e2e_suite
+
+            with pytest.raises(RuntimeError, match="E2E benchmark runner failed"):
+                _run_e2e_suite([txt_file])
+
+
+class TestRunAudioSuiteExceptionAndSmoke:
+    """Cover exception and transcribe_smoke branches in _run_audio_suite (lines 538-561)."""
+
+    def test_audio_suite_non_import_exception_raises_runtime_error(self, tmp_path: Path) -> None:
+        """Cover except Exception (lines 538-539) — non-ImportError extractor failure."""
+        audio_file = tmp_path / "track.mp3"
+        audio_file.write_bytes(b"MP3 mock")
+
+        mock_extractor_instance = MagicMock()
+        mock_extractor_instance.extract.side_effect = OSError("disk read failed")
+        mock_extractor_cls = MagicMock(return_value=mock_extractor_instance)
+
+        mock_classifier_cls = MagicMock()
+
+        mock_audio_extractor_mod = MagicMock()
+        mock_audio_extractor_mod.AudioMetadataExtractor = mock_extractor_cls
+        mock_audio_classifier_mod = MagicMock()
+        mock_audio_classifier_mod.AudioClassifier = mock_classifier_cls
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "services.audio.classifier": mock_audio_classifier_mod,
+                "services.audio.metadata_extractor": mock_audio_extractor_mod,
+            },
+        ):
+            from cli.benchmark import _run_audio_suite
+
+            with pytest.raises(RuntimeError, match="Audio benchmark runner failed"):
+                _run_audio_suite([audio_file])
+
+    def test_audio_suite_transcribe_smoke_import_error(self, tmp_path: Path) -> None:
+        """Cover transcribe_smoke ImportError branch (lines 553-561)."""
+        audio_file = tmp_path / "track.mp3"
+        audio_file.write_bytes(b"MP3 mock")
+
+        mock_metadata = MagicMock()
+        mock_extractor_instance = MagicMock()
+        mock_extractor_instance.extract.return_value = mock_metadata
+        mock_extractor_cls = MagicMock(return_value=mock_extractor_instance)
+
+        mock_classifier_instance = MagicMock()
+        mock_classifier_cls = MagicMock(return_value=mock_classifier_instance)
+
+        mock_audio_extractor_mod = MagicMock()
+        mock_audio_extractor_mod.AudioMetadataExtractor = mock_extractor_cls
+        mock_audio_classifier_mod = MagicMock()
+        mock_audio_classifier_mod.AudioClassifier = mock_classifier_cls
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "services.audio.classifier": mock_audio_classifier_mod,
+                "services.audio.metadata_extractor": mock_audio_extractor_mod,
+            },
+        ):
+            # Patch AudioModel to raise ImportError (simulates missing [media] extra)
+            with patch("cli.benchmark.AudioModel", side_effect=ImportError("no media extra")):
+                from cli.benchmark import _run_audio_suite
+
+                outcome = _run_audio_suite([audio_file], transcribe_smoke=True)
+
+        # Smoke was requested but couldn't run → transcription_smoke_passed is False
+        assert outcome.transcription_smoke_requested is True
+        assert outcome.transcription_smoke_passed is False
+
+
+class TestMaybeAttachComparisonSmokeWarning:
+    """Cover smoke_warning attachment in _maybe_attach_comparison_output (line 1110)."""
+
+    def _base_output(self) -> dict:
+        from cli.benchmark import _RUNNER_PROFILE_VERSION
+
+        return {
+            "suite": "audio",
+            "effective_suite": "audio",
+            "degraded": False,
+            "degradation_reasons": [],
+            "runner_profile_version": _RUNNER_PROFILE_VERSION,
+            "files_count": 1,
+            "hardware_profile": {},
+            "results": {
+                "median_ms": 100.0,
+                "p95_ms": 120.0,
+                "p99_ms": 150.0,
+                "stddev_ms": 10.0,
+                "throughput_fps": 10.0,
+                "iterations": 5,
+            },
+        }
+
+    def test_smoke_warning_attached_on_mismatch(self, tmp_path: Path) -> None:
+        from cli.benchmark import _RUNNER_PROFILE_VERSION, _maybe_attach_comparison_output
+
+        # baseline has transcribe_smoke=False; current run uses transcribe_smoke=True
+        baseline = {
+            "runner_profile_version": _RUNNER_PROFILE_VERSION,
+            "transcribe_smoke": False,
+            "results": {
+                "median_ms": 100.0,
+                "p95_ms": 100.0,
+                "p99_ms": 100.0,
+                "stddev_ms": 5.0,
+                "throughput_fps": 10.0,
+                "iterations": 5,
+            },
+        }
+        baseline_path = tmp_path / "baseline.json"
+        baseline_path.write_text(json.dumps(baseline))
+
+        output = self._base_output()
+        result = _maybe_attach_comparison_output(
+            output=output,
+            compare_path=baseline_path,
+            suite="audio",
+            transcribe_smoke=True,
+            console=MagicMock(),
+            json_output=True,
+        )
+        assert "comparison_smoke_warning" in result
+
+
+class TestRunCorpusCap:
+    """Cover corpus-cap warning in run() (lines 1206-1211)."""
+
+    def test_corpus_cap_logs_warning(self, tmp_path: Path) -> None:
+        """Patch _MAX_BENCHMARK_FILES to 1 to trigger the cap on two files."""
+        app = _get_app()
+        (tmp_path / "a.txt").write_text("hello")
+        (tmp_path / "b.txt").write_text("world")
+
+        with patch("cli.benchmark._MAX_BENCHMARK_FILES", 1):
+            result = runner.invoke(
+                app,
+                [
+                    "benchmark",
+                    "run",
+                    str(tmp_path),
+                    "--suite",
+                    "io",
+                    "--iterations",
+                    "1",
+                    "--warmup",
+                    "0",
+                    "--json",
+                ],
+            )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        # Only 1 file should have been processed due to the cap
         assert payload["files_count"] == 1

--- a/tests/services/search/test_embedding_cache.py
+++ b/tests/services/search/test_embedding_cache.py
@@ -377,3 +377,89 @@ class TestContextManager:
         with EmbeddingCache(tmp_path / "cache.db") as cache:
             result = cache.get_or_compute(f, compute=_dummy_compute)
         assert result is not None  # no exception
+
+    def test_context_manager_exit_calls_close(self, tmp_path: Path) -> None:
+        """__exit__ delegates to close() — verified by tracking the call."""
+        from unittest.mock import patch
+
+        db = tmp_path / "cm_exit.db"
+        cache = EmbeddingCache(db)
+        with patch.object(cache, "close") as mock_close:
+            cache.__exit__(None, None, None)
+        mock_close.assert_called_once_with()
+
+
+@pytest.mark.ci
+@pytest.mark.unit
+class TestDbPath:
+    def test_db_path_property_returns_path(self, tmp_path: Path) -> None:
+        """db_path property returns the path supplied at construction."""
+        db = tmp_path / "props.db"
+        cache = EmbeddingCache(db)
+        assert cache.db_path == db
+        cache.close()
+
+
+@pytest.mark.ci
+@pytest.mark.unit
+class TestCloseErrors:
+    def test_close_sqlite_error_ignored(self, tmp_path: Path) -> None:
+        """sqlite3.Error during close() is logged but not re-raised."""
+        import sqlite3
+        from unittest.mock import MagicMock
+
+        cache = EmbeddingCache(tmp_path / "close_err.db")
+        # sqlite3.Connection is a C extension type — its methods are read-only
+        # and cannot be patched via patch.object.  Replace the connection
+        # object entirely with a mock whose commit() raises sqlite3.Error.
+        mock_conn = MagicMock()
+        mock_conn.commit.side_effect = sqlite3.Error("simulated close failure")
+        cache._conn = mock_conn
+        cache.close()  # must not raise
+
+
+@pytest.mark.ci
+@pytest.mark.unit
+class TestPruneOnOpen:
+    def test_prune_orphans_on_open_logs(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """EmbeddingCache prunes stale rows on __init__ and logs when rows were pruned."""
+        import sqlite3
+
+        db = tmp_path / "prune_open.db"
+
+        # Seed the DB with a row pointing to a nonexistent file.
+        conn = sqlite3.connect(str(db))
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS embeddings (
+                file_path TEXT PRIMARY KEY,
+                embedding BLOB NOT NULL,
+                model TEXT NOT NULL,
+                mtime REAL NOT NULL,
+                updated_at TEXT NOT NULL
+            )"""
+        )
+        conn.execute(
+            "INSERT INTO embeddings VALUES (?, ?, ?, ?, ?)",
+            (
+                str(tmp_path / "ghost.txt"),
+                b"\x00" * 8,
+                "tfidf",
+                0.0,
+                "2000-01-01T00:00:00+00:00",
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        import logging
+
+        with caplog.at_level(logging.DEBUG):
+            cache = EmbeddingCache(db)
+
+        # The stale row should have been pruned.
+        row = cache._conn.execute("SELECT COUNT(*) FROM embeddings").fetchone()
+        assert row is not None
+        assert row[0] == 0, "orphan row should be pruned on open"
+        cache.close()

--- a/tests/utils/test_archive_scientific_readers.py
+++ b/tests/utils/test_archive_scientific_readers.py
@@ -473,3 +473,570 @@ class TestErrorHandling:
 
         with pytest.raises(FileReadError):
             read_hdf5_file(h5_path)
+
+
+@pytest.mark.unit
+class TestMissingArgumentsRaisesValueError:
+    """Tests that missing both file_path and fileobj raises ValueError."""
+
+    def test_read_zip_file_no_args_raises(self) -> None:
+        """read_zip_file() with neither file_path nor fileobj raises ValueError."""
+        with pytest.raises(ValueError, match="read_zip_file requires file_path or fileobj"):
+            read_zip_file()
+
+    def test_read_7z_file_no_args_raises(self) -> None:
+        """read_7z_file() with neither file_path nor fileobj raises ValueError."""
+        import utils.readers.archives as _arc
+
+        original = _arc.PY7ZR_AVAILABLE
+        try:
+            _arc.PY7ZR_AVAILABLE = True
+            with pytest.raises(ValueError, match="read_7z_file requires file_path or fileobj"):
+                read_7z_file()
+        finally:
+            _arc.PY7ZR_AVAILABLE = original
+
+    def test_read_tar_file_no_args_raises(self) -> None:
+        """read_tar_file() with neither file_path nor fileobj raises ValueError."""
+        with pytest.raises(ValueError, match="read_tar_file requires file_path or fileobj"):
+            read_tar_file()
+
+    def test_read_rar_file_no_args_raises(self) -> None:
+        """read_rar_file() with neither file_path nor fileobj raises ValueError."""
+        import utils.readers.archives as _arc
+
+        original = _arc.RARFILE_AVAILABLE
+        try:
+            _arc.RARFILE_AVAILABLE = True
+            with pytest.raises(ValueError, match="read_rar_file requires file_path or fileobj"):
+                read_rar_file()
+        finally:
+            _arc.RARFILE_AVAILABLE = original
+
+
+@pytest.mark.unit
+class TestMissingLibraryRaisesImportError:
+    """Tests that missing optional libraries raise ImportError with helpful messages."""
+
+    def test_read_7z_file_py7zr_unavailable_raises_import_error(self, tmp_path: Path) -> None:
+        """read_7z_file() raises ImportError when PY7ZR_AVAILABLE is False."""
+        import utils.readers.archives as _arc
+
+        original = _arc.PY7ZR_AVAILABLE
+        try:
+            _arc.PY7ZR_AVAILABLE = False
+            with pytest.raises(ImportError, match="py7zr is not installed"):
+                read_7z_file(tmp_path / "dummy.7z")
+        finally:
+            _arc.PY7ZR_AVAILABLE = original
+
+    def test_read_rar_file_rarfile_unavailable_raises_import_error(self, tmp_path: Path) -> None:
+        """read_rar_file() raises ImportError when RARFILE_AVAILABLE is False."""
+        import utils.readers.archives as _arc
+
+        original = _arc.RARFILE_AVAILABLE
+        try:
+            _arc.RARFILE_AVAILABLE = False
+            with pytest.raises(ImportError, match="rarfile is not installed"):
+                read_rar_file(tmp_path / "dummy.rar")
+        finally:
+            _arc.RARFILE_AVAILABLE = original
+
+
+@pytest.mark.unit
+class TestArchiveReadersFileobj:
+    """Tests for the fileobj= branch of archive readers (SafeDir-friendly entry point)."""
+
+    def test_read_zip_file_via_fileobj(self, sample_zip_file: Path) -> None:
+        """read_zip_file() accepts an open binary fileobj."""
+        with sample_zip_file.open("rb") as f:
+            result = read_zip_file(fileobj=f)
+        assert "ZIP Archive" in result
+        assert "Total files: 3" in result
+
+    def test_read_zip_file_via_fileobj_with_label(self, sample_zip_file: Path) -> None:
+        """read_zip_file() uses file_path as label when fileobj is given."""
+        with sample_zip_file.open("rb") as f:
+            result = read_zip_file(file_path=sample_zip_file, fileobj=f)
+        assert "sample.zip" in result
+
+    def test_read_zip_file_via_fileobj_default_label(self, sample_zip_file: Path) -> None:
+        """read_zip_file() uses '<fileobj>' label when no file_path given."""
+        with sample_zip_file.open("rb") as f:
+            result = read_zip_file(fileobj=f)
+        assert "<fileobj>" in result
+
+    def test_read_zip_file_via_fileobj_corrupted_raises(self, tmp_path: Path) -> None:
+        """read_zip_file() with a bad fileobj raises FileReadError."""
+        bad = tmp_path / "bad.zip"
+        bad.write_bytes(b"not a zip")
+        with bad.open("rb") as f:
+            with pytest.raises(FileReadError):
+                read_zip_file(fileobj=f)
+
+    def test_read_tar_file_via_fileobj(self, sample_tar_file: Path) -> None:
+        """read_tar_file() accepts an open binary fileobj."""
+        with sample_tar_file.open("rb") as f:
+            result = read_tar_file(fileobj=f)
+        assert "TAR Archive" in result
+        assert "Total files: 3" in result
+
+    def test_read_tar_file_via_fileobj_with_label(self, sample_tar_file: Path) -> None:
+        """read_tar_file() uses file_path as compression hint when fileobj given."""
+        with sample_tar_file.open("rb") as f:
+            result = read_tar_file(file_path=sample_tar_file, fileobj=f)
+        assert "sample.tar.gz" in result
+        assert "Compression: GZ" in result
+
+    def test_read_tar_file_via_fileobj_default_label(self, sample_tar_file: Path) -> None:
+        """read_tar_file() uses '<fileobj>' label and 'Unknown' compression when no path."""
+        with sample_tar_file.open("rb") as f:
+            result = read_tar_file(fileobj=f)
+        assert "<fileobj>" in result
+        assert "Compression: Unknown" in result
+
+    def test_read_tar_file_via_fileobj_corrupted_raises(self, tmp_path: Path) -> None:
+        """read_tar_file() with a bad fileobj raises FileReadError."""
+        bad = tmp_path / "bad.tar"
+        bad.write_bytes(b"not a tar")
+        with bad.open("rb") as f:
+            with pytest.raises(FileReadError):
+                read_tar_file(fileobj=f)
+
+    def test_read_7z_file_via_fileobj(self, tmp_path: Path) -> None:
+        """read_7z_file() fileobj branch works with a mocked py7zr."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        import utils.readers.archives as _arc
+
+        fake_file = SimpleNamespace(filename="readme.txt", compressed=100, uncompressed=200)
+        fake_archive = MagicMock()
+        fake_archive.list.return_value = [fake_file]
+        fake_archive.password_protected = False
+        fake_archive.__enter__ = lambda s: fake_archive
+        fake_archive.__exit__ = MagicMock(return_value=False)
+
+        mock_py7zr = MagicMock()
+        mock_py7zr.SevenZipFile.return_value = fake_archive
+
+        dummy = tmp_path / "test.7z"
+        dummy.write_bytes(b"dummy")
+
+        with dummy.open("rb") as f:
+            with (
+                patch.object(_arc, "PY7ZR_AVAILABLE", True),
+                patch.object(_arc, "py7zr", mock_py7zr, create=True),
+            ):
+                result = read_7z_file(fileobj=f)
+
+        assert "7Z Archive" in result
+        assert "readme.txt" in result
+
+    def test_read_7z_file_via_fileobj_with_label(self, tmp_path: Path) -> None:
+        """read_7z_file() uses file_path as label when fileobj is given."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        import utils.readers.archives as _arc
+
+        fake_file = SimpleNamespace(filename="doc.txt", compressed=50, uncompressed=100)
+        fake_archive = MagicMock()
+        fake_archive.list.return_value = [fake_file]
+        fake_archive.password_protected = False
+        fake_archive.__enter__ = lambda s: fake_archive
+        fake_archive.__exit__ = MagicMock(return_value=False)
+
+        mock_py7zr = MagicMock()
+        mock_py7zr.SevenZipFile.return_value = fake_archive
+
+        dummy = tmp_path / "labeled.7z"
+        dummy.write_bytes(b"dummy")
+
+        with dummy.open("rb") as f:
+            with (
+                patch.object(_arc, "PY7ZR_AVAILABLE", True),
+                patch.object(_arc, "py7zr", mock_py7zr, create=True),
+            ):
+                result = read_7z_file(file_path=dummy, fileobj=f)
+
+        assert "labeled.7z" in result
+
+    def test_read_7z_file_via_fileobj_error_raises(self, tmp_path: Path) -> None:
+        """read_7z_file() fileobj branch wraps parse errors as FileReadError."""
+        from unittest.mock import MagicMock, patch
+
+        import utils.readers.archives as _arc
+
+        mock_py7zr = MagicMock()
+        mock_py7zr.SevenZipFile.side_effect = RuntimeError("corrupt archive")
+
+        dummy = tmp_path / "bad.7z"
+        dummy.write_bytes(b"dummy")
+
+        with dummy.open("rb") as f:
+            with (
+                patch.object(_arc, "PY7ZR_AVAILABLE", True),
+                patch.object(_arc, "py7zr", mock_py7zr, create=True),
+            ):
+                with pytest.raises(FileReadError):
+                    read_7z_file(fileobj=f)
+
+    def test_read_7z_file_path_error_raises(self, tmp_path: Path) -> None:
+        """read_7z_file() path branch wraps parse errors as FileReadError."""
+        from unittest.mock import MagicMock, patch
+
+        import utils.readers.archives as _arc
+
+        mock_py7zr = MagicMock()
+        mock_py7zr.SevenZipFile.side_effect = RuntimeError("corrupt archive")
+
+        bad = tmp_path / "corrupt.7z"
+        bad.write_bytes(b"not a 7z file")
+
+        with (
+            patch.object(_arc, "PY7ZR_AVAILABLE", True),
+            patch.object(_arc, "py7zr", mock_py7zr, create=True),
+        ):
+            with pytest.raises(FileReadError):
+                read_7z_file(bad)
+
+
+@pytest.mark.unit
+class TestDetectTarCompression:
+    """Tests for _detect_tar_compression helper covering all branches."""
+
+    def test_detect_tar_gz(self) -> None:
+        from utils.readers.archives import _detect_tar_compression
+
+        assert _detect_tar_compression("archive.tar.gz") == "GZ"
+
+    def test_detect_tgz(self) -> None:
+        from utils.readers.archives import _detect_tar_compression
+
+        assert _detect_tar_compression("archive.tgz") == "GZ"
+
+    def test_detect_tar_bz2(self) -> None:
+        from utils.readers.archives import _detect_tar_compression
+
+        assert _detect_tar_compression("archive.tar.bz2") == "BZ2"
+
+    def test_detect_tbz2(self) -> None:
+        from utils.readers.archives import _detect_tar_compression
+
+        assert _detect_tar_compression("archive.tbz2") == "BZ2"
+
+    def test_detect_tar_xz(self) -> None:
+        from utils.readers.archives import _detect_tar_compression
+
+        assert _detect_tar_compression("archive.tar.xz") == "XZ"
+
+    def test_detect_xz(self) -> None:
+        from utils.readers.archives import _detect_tar_compression
+
+        assert _detect_tar_compression("archive.xz") == "XZ"
+
+    def test_detect_plain_tar(self) -> None:
+        from utils.readers.archives import _detect_tar_compression
+
+        assert _detect_tar_compression("archive.tar") == "None"
+
+    def test_detect_unknown(self) -> None:
+        from utils.readers.archives import _detect_tar_compression
+
+        assert _detect_tar_compression("<fileobj>") == "Unknown"
+
+
+@pytest.mark.unit
+class TestArchiveMaxFilesLimit:
+    """Tests that the 'more files' trailer line is emitted when total > max_files."""
+
+    def test_zip_more_files_line(self, tmp_path: Path) -> None:
+        """ZIP: '... and N more files' emitted when total > max_files."""
+        zip_path = tmp_path / "big.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for i in range(5):
+                zf.writestr(f"f{i}.txt", "x")
+        result = read_zip_file(zip_path, max_files=2)
+        assert "... and 3 more files" in result
+
+    def test_tar_more_files_line(self, tmp_path: Path) -> None:
+        """TAR: '... and N more files' emitted when total > max_files."""
+        tar_path = tmp_path / "big.tar.gz"
+        with tarfile.open(tar_path, "w:gz") as tf:
+            for i in range(5):
+                content = b"x"
+                data = io.BytesIO(content)
+                info = tarfile.TarInfo(name=f"f{i}.txt")
+                info.size = len(content)
+                tf.addfile(info, data)
+        result = read_tar_file(tar_path, max_files=2)
+        assert "... and 3 more files" in result
+
+    def test_7z_more_files_line(self, tmp_path: Path) -> None:
+        """7Z: '... and N more files' emitted when total > max_files."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        import utils.readers.archives as _arc
+
+        files = [
+            SimpleNamespace(filename=f"f{i}.txt", compressed=10, uncompressed=20) for i in range(5)
+        ]
+        fake_archive = MagicMock()
+        fake_archive.list.return_value = files
+        fake_archive.password_protected = False
+        fake_archive.__enter__ = lambda s: fake_archive
+        fake_archive.__exit__ = MagicMock(return_value=False)
+
+        mock_py7zr = MagicMock()
+        mock_py7zr.SevenZipFile.return_value = fake_archive
+
+        dummy = tmp_path / "big.7z"
+        dummy.write_bytes(b"dummy")
+
+        with (
+            patch.object(_arc, "PY7ZR_AVAILABLE", True),
+            patch.object(_arc, "py7zr", mock_py7zr, create=True),
+        ):
+            result = read_7z_file(dummy, max_files=2)
+
+        assert "... and 3 more files" in result
+
+
+@pytest.mark.unit
+class TestRarReader:
+    """Tests for the RAR reader, covering _parse_rar and read_rar_file branches."""
+
+    @pytest.fixture(autouse=True)
+    def _require_rarfile(self) -> None:
+        pytest.importorskip("rarfile")
+
+    def test_read_rar_file_via_fileobj_with_mock(self, tmp_path: Path) -> None:
+        """read_rar_file() fileobj branch works when mocked rarfile is available."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        import rarfile
+
+        import utils.readers.archives as _arc
+
+        fake_info = SimpleNamespace(filename="doc.txt", compress_size=100, file_size=200)
+        fake_rf = MagicMock()
+        fake_rf.infolist.return_value = [fake_info]
+        fake_rf.needs_password.return_value = False
+        fake_rf.__enter__ = lambda s: fake_rf
+        fake_rf.__exit__ = MagicMock(return_value=False)
+
+        dummy = tmp_path / "test.rar"
+        dummy.write_bytes(b"Rar!")
+
+        with dummy.open("rb") as f:
+            with (
+                patch.object(_arc, "RARFILE_AVAILABLE", True),
+                patch.object(rarfile, "RarFile", return_value=fake_rf),
+            ):
+                result = read_rar_file(fileobj=f)
+
+        assert "RAR Archive" in result
+        assert "doc.txt" in result
+        assert "Total files: 1" in result
+        assert "Encrypted: No" in result
+
+    def test_read_rar_file_via_fileobj_with_label(self, tmp_path: Path) -> None:
+        """read_rar_file() uses file_path as label when fileobj is given."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        import rarfile
+
+        import utils.readers.archives as _arc
+
+        fake_info = SimpleNamespace(filename="a.txt", compress_size=10, file_size=20)
+        fake_rf = MagicMock()
+        fake_rf.infolist.return_value = [fake_info]
+        fake_rf.needs_password.return_value = False
+        fake_rf.__enter__ = lambda s: fake_rf
+        fake_rf.__exit__ = MagicMock(return_value=False)
+
+        dummy = tmp_path / "labeled.rar"
+        dummy.write_bytes(b"Rar!")
+
+        with dummy.open("rb") as f:
+            with (
+                patch.object(_arc, "RARFILE_AVAILABLE", True),
+                patch.object(rarfile, "RarFile", return_value=fake_rf),
+            ):
+                result = read_rar_file(file_path=dummy, fileobj=f)
+
+        assert "labeled.rar" in result
+
+    def test_read_rar_file_via_fileobj_default_label(self, tmp_path: Path) -> None:
+        """read_rar_file() uses '<fileobj>' label when no file_path given."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        import rarfile
+
+        import utils.readers.archives as _arc
+
+        fake_info = SimpleNamespace(filename="b.txt", compress_size=10, file_size=20)
+        fake_rf = MagicMock()
+        fake_rf.infolist.return_value = [fake_info]
+        fake_rf.needs_password.return_value = False
+        fake_rf.__enter__ = lambda s: fake_rf
+        fake_rf.__exit__ = MagicMock(return_value=False)
+
+        dummy = tmp_path / "test.rar"
+        dummy.write_bytes(b"Rar!")
+
+        with dummy.open("rb") as f:
+            with (
+                patch.object(_arc, "RARFILE_AVAILABLE", True),
+                patch.object(rarfile, "RarFile", return_value=fake_rf),
+            ):
+                result = read_rar_file(fileobj=f)
+
+        assert "<fileobj>" in result
+
+    def test_read_rar_file_via_fileobj_rar_cannot_exec_raises(self, tmp_path: Path) -> None:
+        """read_rar_file() fileobj branch raises FileReadError on RarCannotExec."""
+        from unittest.mock import patch
+
+        import rarfile
+
+        import utils.readers.archives as _arc
+
+        dummy = tmp_path / "test.rar"
+        dummy.write_bytes(b"Rar!")
+
+        def _raise_cannot_exec(*a: object, **kw: object) -> None:
+            raise rarfile.RarCannotExec("unrar not found")
+
+        with dummy.open("rb") as f:
+            with (
+                patch.object(_arc, "RARFILE_AVAILABLE", True),
+                patch.object(rarfile, "RarFile", side_effect=_raise_cannot_exec),
+            ):
+                with pytest.raises(FileReadError, match="unrar"):
+                    read_rar_file(fileobj=f)
+
+    def test_read_rar_file_via_fileobj_generic_error_raises(self, tmp_path: Path) -> None:
+        """read_rar_file() fileobj branch wraps generic errors as FileReadError."""
+        from unittest.mock import patch
+
+        import rarfile
+
+        import utils.readers.archives as _arc
+
+        dummy = tmp_path / "test.rar"
+        dummy.write_bytes(b"Rar!")
+
+        def _raise_bad(*a: object, **kw: object) -> None:
+            raise RuntimeError("bad rar data")
+
+        with dummy.open("rb") as f:
+            with (
+                patch.object(_arc, "RARFILE_AVAILABLE", True),
+                patch.object(rarfile, "RarFile", side_effect=_raise_bad),
+            ):
+                with pytest.raises(FileReadError):
+                    read_rar_file(fileobj=f)
+
+    def test_read_rar_file_path_branch_rar_cannot_exec_raises(self, tmp_path: Path) -> None:
+        """read_rar_file() path branch raises FileReadError on RarCannotExec."""
+        from unittest.mock import patch
+
+        import rarfile
+
+        import utils.readers.archives as _arc
+
+        dummy = tmp_path / "test.rar"
+        dummy.write_bytes(b"Rar!")
+
+        def _raise_cannot_exec(*a: object, **kw: object) -> None:
+            raise rarfile.RarCannotExec("unrar not found")
+
+        with (
+            patch.object(_arc, "RARFILE_AVAILABLE", True),
+            patch.object(rarfile, "RarFile", side_effect=_raise_cannot_exec),
+        ):
+            with pytest.raises(FileReadError, match="unrar"):
+                read_rar_file(dummy)
+
+    def test_read_rar_file_path_branch_generic_error_raises(self, tmp_path: Path) -> None:
+        """read_rar_file() path branch wraps generic errors as FileReadError."""
+        from unittest.mock import patch
+
+        import rarfile
+
+        import utils.readers.archives as _arc
+
+        dummy = tmp_path / "test.rar"
+        dummy.write_bytes(b"Rar!")
+
+        def _raise_bad(*a: object, **kw: object) -> None:
+            raise RuntimeError("bad rar data")
+
+        with (
+            patch.object(_arc, "RARFILE_AVAILABLE", True),
+            patch.object(rarfile, "RarFile", side_effect=_raise_bad),
+        ):
+            with pytest.raises(FileReadError):
+                read_rar_file(dummy)
+
+    def test_rar_more_files_line(self, tmp_path: Path) -> None:
+        """RAR: '... and N more files' emitted when total > max_files."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        import rarfile
+
+        import utils.readers.archives as _arc
+
+        fake_infos = [
+            SimpleNamespace(filename=f"f{i}.txt", compress_size=10, file_size=20) for i in range(5)
+        ]
+        fake_rf = MagicMock()
+        fake_rf.infolist.return_value = fake_infos
+        fake_rf.needs_password.return_value = False
+        fake_rf.__enter__ = lambda s: fake_rf
+        fake_rf.__exit__ = MagicMock(return_value=False)
+
+        dummy = tmp_path / "big.rar"
+        dummy.write_bytes(b"Rar!")
+
+        with (
+            patch.object(_arc, "RARFILE_AVAILABLE", True),
+            patch.object(rarfile, "RarFile", return_value=fake_rf),
+        ):
+            result = read_rar_file(dummy, max_files=2)
+
+        assert "... and 3 more files" in result
+
+    def test_rar_encrypted_detection(self, tmp_path: Path) -> None:
+        """RAR: encrypted archive reports 'Encrypted: Yes'."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock, patch
+
+        import rarfile
+
+        import utils.readers.archives as _arc
+
+        fake_info = SimpleNamespace(filename="secret.txt", compress_size=50, file_size=100)
+        fake_rf = MagicMock()
+        fake_rf.infolist.return_value = [fake_info]
+        fake_rf.needs_password.return_value = True
+        fake_rf.__enter__ = lambda s: fake_rf
+        fake_rf.__exit__ = MagicMock(return_value=False)
+
+        dummy = tmp_path / "enc.rar"
+        dummy.write_bytes(b"Rar!")
+
+        with (
+            patch.object(_arc, "RARFILE_AVAILABLE", True),
+            patch.object(rarfile, "RarFile", return_value=fake_rf),
+        ):
+            result = read_rar_file(dummy)
+
+        assert "Encrypted: Yes" in result

--- a/tests/utils/test_atomic_write.py
+++ b/tests/utils/test_atomic_write.py
@@ -367,6 +367,16 @@ class TestAtomicityInvariants:
         new_mode = target.stat().st_mode & 0o7777
         assert new_mode == 0o640, f"mode drifted: expected 0o640, got {oct(new_mode)}"
 
+    def test_chmod_oserror_ignored(self, tmp_path: Path) -> None:
+        """chmod failures are silently ignored — write still succeeds."""
+        from unittest.mock import patch
+
+        target = tmp_path / "existing.txt"
+        target.write_text("original")
+        with patch("os.chmod", side_effect=OSError("chmod denied")):
+            atomic_write_text(target, "new content")
+        assert target.read_text() == "new content"
+
     @pytest.mark.skipif(
         sys.platform == "win32",
         reason="POSIX file-mode bits not meaningful on Windows",

--- a/tests/utils/test_file_readers.py
+++ b/tests/utils/test_file_readers.py
@@ -589,3 +589,481 @@ def test_read_rtf_file_returns_text(tmp_path: Path) -> None:
     result = read_file(rtf_file)
     assert result is not None
     assert "Hello RTF" in result
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Coverage-hardening tests: fileobj paths, ValueError branches, ImportError
+# branches for optional libraries, and unsupported-suffix paths.
+# ────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestDocumentsMissingLibraries:
+    """Tests for ImportError branches when optional libraries are absent."""
+
+    @patch("utils.readers.documents.DOCX_AVAILABLE", False)
+    def test_read_docx_raises_import_error_when_unavailable(self) -> None:
+        """Patch DOCX_AVAILABLE to False → read_docx_file raises ImportError."""
+        from utils.readers.documents import read_docx_file as _read_docx
+
+        with pytest.raises(ImportError, match="python-docx"):
+            _read_docx(Path("dummy.docx"))
+
+    @patch("utils.readers.documents.PYMUPDF_AVAILABLE", False)
+    def test_read_pdf_raises_import_error_when_unavailable(self) -> None:
+        """Patch PYMUPDF_AVAILABLE to False → read_pdf_file raises ImportError."""
+        from utils.readers.documents import read_pdf_file as _read_pdf
+
+        with pytest.raises(ImportError, match="PyMuPDF"):
+            _read_pdf(Path("dummy.pdf"))
+
+    @patch("utils.readers.documents.STRIPRTF_AVAILABLE", False)
+    def test_read_rtf_raises_import_error_when_unavailable(self) -> None:
+        """Patch STRIPRTF_AVAILABLE to False → read_rtf_file raises ImportError."""
+        from utils.readers.documents import read_rtf_file as _read_rtf
+
+        with pytest.raises(ImportError, match="striprtf"):
+            _read_rtf(Path("dummy.rtf"))
+
+    @patch("utils.readers.documents.OPENPYXL_AVAILABLE", False)
+    def test_read_spreadsheet_xlsx_raises_import_error_when_unavailable(self) -> None:
+        """Patch OPENPYXL_AVAILABLE to False → spreadsheet reader raises ImportError for xlsx."""
+        import io
+
+        from utils.readers.documents import read_spreadsheet_file as _read_ss
+
+        # Use fileobj so the extension is taken from file_path without needing the file to exist
+        fileobj = io.BytesIO(b"fake xlsx bytes")
+        with pytest.raises(ImportError, match="openpyxl"):
+            _read_ss(file_path="test.xlsx", fileobj=fileobj)
+
+    @patch("utils.readers.documents.PPTX_AVAILABLE", False)
+    def test_read_presentation_raises_import_error_when_unavailable(self) -> None:
+        """Patch PPTX_AVAILABLE to False → read_presentation_file raises ImportError."""
+        from utils.readers.documents import read_presentation_file as _read_pptx
+
+        with pytest.raises(ImportError, match="python-pptx"):
+            _read_pptx(Path("dummy.pptx"))
+
+
+@pytest.mark.unit
+class TestDocumentsValueErrorPaths:
+    """Tests for ValueError when neither file_path nor fileobj is provided."""
+
+    def test_read_text_file_no_args_raises_value_error(self) -> None:
+        from utils.readers.documents import read_text_file as _read_text
+
+        with pytest.raises(ValueError, match="read_text_file requires"):
+            _read_text()
+
+    @patch("utils.readers.documents.DOCX_AVAILABLE", True)
+    def test_read_docx_file_no_args_raises_value_error(self) -> None:
+        from utils.readers.documents import read_docx_file as _read_docx
+
+        with pytest.raises(ValueError, match="read_docx_file requires"):
+            _read_docx()
+
+    @patch("utils.readers.documents.PYMUPDF_AVAILABLE", True)
+    def test_read_pdf_file_no_args_raises_value_error(self) -> None:
+        from utils.readers.documents import read_pdf_file as _read_pdf
+
+        with pytest.raises(ValueError, match="read_pdf_file requires"):
+            _read_pdf()
+
+    @patch("utils.readers.documents.STRIPRTF_AVAILABLE", True)
+    def test_read_rtf_file_no_args_raises_value_error(self) -> None:
+        from utils.readers.documents import read_rtf_file as _read_rtf
+
+        with pytest.raises(ValueError, match="read_rtf_file requires"):
+            _read_rtf()
+
+    def test_read_spreadsheet_file_no_args_raises_value_error(self) -> None:
+        from utils.readers.documents import read_spreadsheet_file as _read_ss
+
+        with pytest.raises(ValueError, match="read_spreadsheet_file requires"):
+            _read_ss()
+
+    @patch("utils.readers.documents.PPTX_AVAILABLE", True)
+    def test_read_presentation_file_no_args_raises_value_error(self) -> None:
+        from utils.readers.documents import read_presentation_file as _read_pptx
+
+        with pytest.raises(ValueError, match="read_presentation_file requires"):
+            _read_pptx()
+
+
+@pytest.mark.unit
+class TestDocumentsFileobjPaths:
+    """Tests for fileobj= entry points (SafeDir-friendly paths)."""
+
+    def test_read_text_file_via_fileobj(self, tmp_path: Path) -> None:
+        """read_text_file accepts a binary fileobj and returns decoded text."""
+        import io
+
+        from utils.readers.documents import read_text_file as _read_text
+
+        content = b"Hello from fileobj\nLine 2"
+        fileobj = io.BytesIO(content)
+        result = _read_text(fileobj=fileobj)
+        assert "Hello from fileobj" in result
+        assert "Line 2" in result
+
+    def test_read_text_file_via_fileobj_with_label(self, tmp_path: Path) -> None:
+        """read_text_file uses file_path for label only when fileobj provided."""
+        import io
+
+        from utils.readers.documents import read_text_file as _read_text
+
+        content = b"Labelled content"
+        fileobj = io.BytesIO(content)
+        result = _read_text(file_path="myfile.txt", fileobj=fileobj)
+        assert "Labelled content" in result
+
+    @patch("utils.readers.documents.DOCX_AVAILABLE", True)
+    @patch("utils.readers.documents.docx", create=True)
+    def test_read_docx_file_via_fileobj(self, mock_docx: MagicMock) -> None:
+        """read_docx_file accepts a binary fileobj."""
+        import io
+
+        from utils.readers.documents import read_docx_file as _read_docx
+
+        mock_doc = MagicMock()
+        mock_para = MagicMock()
+        mock_para.text = "Fileobj paragraph"
+        mock_doc.paragraphs = [mock_para]
+        mock_docx.Document.return_value = mock_doc
+
+        fileobj = io.BytesIO(b"fake docx bytes")
+        result = _read_docx(fileobj=fileobj)
+        assert "Fileobj paragraph" in result
+
+    @patch("utils.readers.documents.DOCX_AVAILABLE", True)
+    @patch("utils.readers.documents.docx", create=True)
+    def test_read_docx_file_via_fileobj_raises_file_read_error(self, mock_docx: MagicMock) -> None:
+        """Exceptions from python-docx when using fileobj are wrapped as FileReadError."""
+        import io
+
+        from utils.readers.documents import read_docx_file as _read_docx
+
+        mock_docx.Document.side_effect = RuntimeError("corrupted docx")
+        fileobj = io.BytesIO(b"bad bytes")
+        with pytest.raises(FileReadError, match="Failed to read DOCX"):
+            _read_docx(fileobj=fileobj)
+
+    @patch("utils.readers.documents.PYMUPDF_AVAILABLE", True)
+    @patch("utils.readers.documents.fitz", create=True)
+    def test_read_pdf_file_via_fileobj_falls_back_to_in_memory(self, mock_fitz: MagicMock) -> None:
+        """read_pdf_file with a BytesIO fileobj falls back to in-memory open (no real fd)."""
+        import io
+
+        from utils.readers.documents import read_pdf_file as _read_pdf
+
+        mock_doc = MagicMock()
+        mock_doc.__len__.return_value = 1
+        mock_page = MagicMock()
+        mock_page.get_text.return_value = "PDF page text"
+        mock_doc.load_page.return_value = mock_page
+        # fitz.open() is a context manager
+        mock_fitz.open.return_value.__enter__.return_value = mock_doc
+        mock_fitz.open.return_value.__exit__.return_value = False
+
+        # BytesIO has no real fd, so fileno() raises io.UnsupportedOperation (OSError subclass)
+        fileobj = io.BytesIO(b"%PDF-1.4 fake pdf bytes")
+        result = _read_pdf(fileobj=fileobj)
+        assert "PDF page text" in result
+
+    @patch("utils.readers.documents.PYMUPDF_AVAILABLE", True)
+    @patch("utils.readers.documents.fitz", create=True)
+    def test_read_pdf_file_via_fileobj_raises_file_read_error(self, mock_fitz: MagicMock) -> None:
+        """Exceptions from PyMuPDF when using fileobj are wrapped as FileReadError."""
+        import io
+
+        from utils.readers.documents import read_pdf_file as _read_pdf
+
+        mock_fitz.open.side_effect = RuntimeError("corrupted pdf")
+        fileobj = io.BytesIO(b"bad bytes")
+        with pytest.raises(FileReadError, match="Failed to read PDF"):
+            _read_pdf(fileobj=fileobj)
+
+    @patch("utils.readers.documents.STRIPRTF_AVAILABLE", True)
+    @patch("utils.readers.documents._rtf_to_text", create=True)
+    def test_read_rtf_file_via_fileobj(self, mock_rtf_to_text: MagicMock) -> None:
+        """read_rtf_file accepts a binary fileobj."""
+        import io
+
+        from utils.readers.documents import read_rtf_file as _read_rtf
+
+        mock_rtf_to_text.return_value = "Plain text from RTF"
+        fileobj = io.BytesIO(b"{\\rtf1 Hello}")
+        result = _read_rtf(fileobj=fileobj)
+        assert "Plain text from RTF" in result
+
+    @patch("utils.readers.documents.STRIPRTF_AVAILABLE", True)
+    @patch("utils.readers.documents._rtf_to_text", create=True)
+    def test_read_rtf_file_via_fileobj_raises_file_read_error(
+        self, mock_rtf_to_text: MagicMock
+    ) -> None:
+        """Exceptions from striprtf when using fileobj are wrapped as FileReadError."""
+        import io
+
+        from utils.readers.documents import read_rtf_file as _read_rtf
+
+        mock_rtf_to_text.side_effect = RuntimeError("rtf parse failure")
+        fileobj = io.BytesIO(b"bad rtf")
+        with pytest.raises(FileReadError, match="Failed to read RTF"):
+            _read_rtf(fileobj=fileobj)
+
+    def test_read_spreadsheet_csv_via_fileobj(self, tmp_path: Path) -> None:
+        """read_spreadsheet_file accepts a binary fileobj for CSV."""
+        import io
+
+        from utils.readers.documents import read_spreadsheet_file as _read_ss
+
+        csv_bytes = b"Name,Score\nAlice,100\nBob,90"
+        fileobj = io.BytesIO(csv_bytes)
+        result = _read_ss(file_path="data.csv", fileobj=fileobj)
+        assert "Name,Score" in result
+        assert "Alice,100" in result
+
+    @patch("utils.readers.documents.OPENPYXL_AVAILABLE", True)
+    @patch("utils.readers.documents.openpyxl", create=True)
+    def test_read_spreadsheet_xlsx_via_fileobj(self, mock_openpyxl: MagicMock) -> None:
+        """read_spreadsheet_file accepts a binary fileobj for XLSX."""
+        import io
+
+        from utils.readers.documents import read_spreadsheet_file as _read_ss
+
+        mock_ws = MagicMock()
+        mock_ws.iter_rows.return_value = [(("col1", "col2"),), (("a", "b"),)]
+        mock_wb = MagicMock()
+        mock_wb.active = mock_ws
+        mock_openpyxl.load_workbook.return_value = mock_wb
+
+        fileobj = io.BytesIO(b"fake xlsx")
+        result = _read_ss(file_path="data.xlsx", fileobj=fileobj)
+        assert isinstance(result, str)
+
+    def test_read_spreadsheet_unsupported_suffix_raises_file_read_error(self) -> None:
+        """read_spreadsheet_file with an unsupported extension raises FileReadError."""
+        import io
+
+        from utils.readers.documents import read_spreadsheet_file as _read_ss
+
+        # Use fileobj so the extension is taken from file_path without needing the file to exist;
+        # the unsupported-suffix guard fires inside _dispatch_spreadsheet before any I/O.
+        fileobj = io.BytesIO(b"irrelevant")
+        with pytest.raises(FileReadError, match="Unsupported"):
+            _read_ss(file_path="test.txt", fileobj=fileobj)
+
+    @patch("utils.readers.documents.OPENPYXL_AVAILABLE", True)
+    @patch("utils.readers.documents.openpyxl", create=True)
+    def test_read_spreadsheet_fileobj_raises_file_read_error_on_exception(
+        self, mock_openpyxl: MagicMock
+    ) -> None:
+        """Generic exceptions from openpyxl via fileobj are wrapped as FileReadError."""
+        import io
+
+        from utils.readers.documents import read_spreadsheet_file as _read_ss
+
+        mock_openpyxl.load_workbook.side_effect = RuntimeError("xlsx parse failed")
+        fileobj = io.BytesIO(b"bad xlsx")
+        with pytest.raises(FileReadError, match="Failed to read spreadsheet"):
+            _read_ss(file_path="data.xlsx", fileobj=fileobj)
+
+    @patch("utils.readers.documents.PPTX_AVAILABLE", True)
+    @patch("utils.readers.documents.Presentation", create=True)
+    def test_read_presentation_via_fileobj(self, mock_prs_cls: MagicMock) -> None:
+        """read_presentation_file accepts a binary fileobj."""
+        import io
+
+        from utils.readers.documents import read_presentation_file as _read_pptx
+
+        mock_prs = MagicMock()
+        mock_slide = MagicMock()
+        mock_shape = MagicMock()
+        mock_shape.text = "Slide text from fileobj"
+        mock_slide.shapes = [mock_shape]
+        mock_prs.slides = [mock_slide]
+        mock_prs_cls.return_value = mock_prs
+
+        fileobj = io.BytesIO(b"fake pptx")
+        result = _read_pptx(fileobj=fileobj)
+        assert "Slide 1" in result
+        assert "Slide text from fileobj" in result
+
+    @patch("utils.readers.documents.PPTX_AVAILABLE", True)
+    @patch("utils.readers.documents.Presentation", create=True)
+    def test_read_presentation_via_fileobj_raises_file_read_error(
+        self, mock_prs_cls: MagicMock
+    ) -> None:
+        """Exceptions from python-pptx via fileobj are wrapped as FileReadError."""
+        import io
+
+        from utils.readers.documents import read_presentation_file as _read_pptx
+
+        mock_prs_cls.side_effect = RuntimeError("corrupted pptx")
+        fileobj = io.BytesIO(b"bad bytes")
+        with pytest.raises(FileReadError, match="Failed to read presentation"):
+            _read_pptx(fileobj=fileobj)
+
+
+@pytest.mark.unit
+class TestDocumentsRtfPathBranch:
+    """Tests for read_rtf_file path-based branch error handling."""
+
+    @patch("utils.readers.documents.STRIPRTF_AVAILABLE", True)
+    @patch("utils.readers.documents._rtf_to_text", create=True)
+    def test_read_rtf_file_path_raises_file_read_error(
+        self, mock_rtf_to_text: MagicMock, tmp_path: Path
+    ) -> None:
+        """Exceptions from striprtf via path branch are wrapped as FileReadError."""
+        from utils.readers.documents import read_rtf_file as _read_rtf
+
+        mock_rtf_to_text.side_effect = RuntimeError("parse failure")
+        rtf_file = tmp_path / "sample.rtf"
+        rtf_file.write_bytes(b"{\\rtf1 bad}")
+        with pytest.raises(FileReadError, match="Failed to read RTF"):
+            _read_rtf(rtf_file)
+
+
+@pytest.mark.unit
+class TestDocumentsPdfLazyParsing:
+    """Tests for _parse_pdf_stream fallback when fileno() raises OSError."""
+
+    @patch("utils.readers.documents.PYMUPDF_AVAILABLE", True)
+    @patch("utils.readers.documents.fitz", create=True)
+    def test_pdf_fileobj_with_real_fd_uses_dev_fd_path(
+        self, mock_fitz: MagicMock, tmp_path: Path
+    ) -> None:
+        """When fileobj has a real fd, _parse_pdf_stream uses /dev/fd/{fd}."""
+        from utils.readers.documents import read_pdf_file as _read_pdf
+
+        mock_doc = MagicMock()
+        mock_doc.__len__.return_value = 1
+        mock_page = MagicMock()
+        mock_page.get_text.return_value = "PDF from fd"
+        mock_doc.load_page.return_value = mock_page
+        mock_fitz.open.return_value.__enter__.return_value = mock_doc
+        mock_fitz.open.return_value.__exit__.return_value = False
+
+        pdf_file = tmp_path / "real.pdf"
+        pdf_file.write_bytes(b"%PDF-1.4 minimal")
+        with pdf_file.open("rb") as f:
+            result = _read_pdf(file_path="real.pdf", fileobj=f)
+        assert "PDF from fd" in result
+
+
+@pytest.mark.unit
+class TestDocumentsRowLimitBranches:
+    """Tests for max_rows break branches in _parse_csv and _parse_xlsx."""
+
+    def test_parse_csv_respects_max_rows(self, tmp_path: Path) -> None:
+        """_parse_csv stops at max_rows — covers the break on line 288."""
+        import io
+
+        from utils.readers.documents import read_spreadsheet_file as _read_ss
+
+        # 5 data rows; limit to 2
+        csv_bytes = b"a\nb\nc\nd\ne\n"
+        fileobj = io.BytesIO(csv_bytes)
+        result = _read_ss(file_path="data.csv", max_rows=2, fileobj=fileobj)
+        lines = [ln for ln in result.splitlines() if ln]
+        assert len(lines) == 2
+        assert lines[0] == "a"
+        assert lines[1] == "b"
+
+    @patch("utils.readers.documents.OPENPYXL_AVAILABLE", True)
+    @patch("utils.readers.documents.openpyxl", create=True)
+    def test_parse_xlsx_respects_max_rows(self, mock_openpyxl: MagicMock) -> None:
+        """_parse_xlsx stops at max_rows — covers the break on line 303."""
+        import io
+
+        from utils.readers.documents import read_spreadsheet_file as _read_ss
+
+        # Simulate 5 rows returned by iter_rows; limit to 3
+        mock_ws = MagicMock()
+        mock_ws.iter_rows.return_value = [
+            ("row1col1",),
+            ("row2col1",),
+            ("row3col1",),
+            ("row4col1",),
+            ("row5col1",),
+        ]
+        mock_wb = MagicMock()
+        mock_wb.active = mock_ws
+        mock_openpyxl.load_workbook.return_value = mock_wb
+
+        fileobj = io.BytesIO(b"fake xlsx")
+        result = _read_ss(file_path="data.xlsx", max_rows=3, fileobj=fileobj)
+        lines = [ln for ln in result.splitlines() if ln]
+        assert len(lines) == 3
+
+    @patch("utils.readers.documents.OPENPYXL_AVAILABLE", True)
+    @patch("utils.readers.documents.openpyxl", create=True)
+    def test_parse_xlsx_skips_empty_rows(self, mock_openpyxl: MagicMock) -> None:
+        """_parse_xlsx skips rows where all cells are None — covers branch 305->301."""
+        import io
+
+        from utils.readers.documents import read_spreadsheet_file as _read_ss
+
+        # First row has data; second row is all None (empty)
+        mock_ws = MagicMock()
+        mock_ws.iter_rows.return_value = [
+            ("data_cell",),
+            (None,),  # all-None row → row_str.strip(",") is empty → skipped
+        ]
+        mock_wb = MagicMock()
+        mock_wb.active = mock_ws
+        mock_openpyxl.load_workbook.return_value = mock_wb
+
+        fileobj = io.BytesIO(b"fake xlsx")
+        result = _read_ss(file_path="data.xlsx", fileobj=fileobj)
+        lines = [ln for ln in result.splitlines() if ln]
+        assert len(lines) == 1
+        assert "data_cell" in lines[0]
+
+
+@pytest.mark.unit
+class TestDocumentsPathBranchErrors:
+    """Tests for except-Exception branches in path-based readers."""
+
+    def test_read_text_file_via_fileobj_oserror_wrapped(self) -> None:
+        """OSError from _parse_text via fileobj is wrapped as FileReadError (lines 98-99)."""
+        import io
+
+        from utils.readers.documents import read_text_file as _read_text
+
+        # Create a fileobj whose .read() raises OSError
+        bad_fileobj = MagicMock(spec=io.RawIOBase)
+        bad_fileobj.read.side_effect = OSError("I/O error")
+        bad_fileobj.fileno.side_effect = OSError("no fd")
+
+        with pytest.raises(FileReadError, match="Failed to read text file"):
+            _read_text(fileobj=bad_fileobj)
+
+    @patch("utils.readers.documents.PPTX_AVAILABLE", True)
+    @patch("utils.readers.documents.Presentation", create=True)
+    def test_read_presentation_path_raises_file_read_error(
+        self, mock_prs_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """Exceptions from python-pptx via path branch are wrapped as FileReadError (428-429)."""
+        from utils.readers.documents import read_presentation_file as _read_pptx
+
+        mock_prs_cls.side_effect = RuntimeError("corrupted pptx on disk")
+        pptx_file = tmp_path / "slides.pptx"
+        pptx_file.write_bytes(b"fake pptx bytes")
+        with pytest.raises(FileReadError, match="Failed to read presentation"):
+            _read_pptx(pptx_file)
+
+    @patch("utils.readers.documents.OPENPYXL_AVAILABLE", True)
+    @patch("utils.readers.documents.openpyxl", create=True)
+    def test_read_spreadsheet_xlsx_path_raises_file_read_error(
+        self, mock_openpyxl: MagicMock, tmp_path: Path
+    ) -> None:
+        """Generic exceptions from openpyxl via path branch are wrapped as FileReadError (371-372)."""
+        from utils.readers.documents import read_spreadsheet_file as _read_ss
+
+        mock_openpyxl.load_workbook.side_effect = RuntimeError("xlsx on disk failed")
+        xlsx_file = tmp_path / "data.xlsx"
+        xlsx_file.write_bytes(b"fake xlsx bytes")
+        with pytest.raises(FileReadError, match="Failed to read spreadsheet"):
+            _read_ss(xlsx_file)

--- a/tests/utils/test_file_readers.py
+++ b/tests/utils/test_file_readers.py
@@ -841,6 +841,7 @@ class TestDocumentsFileobjPaths:
         fileobj = io.BytesIO(b"fake xlsx")
         result = _read_ss(file_path="data.xlsx", fileobj=fileobj)
         assert isinstance(result, str)
+        assert len(result) > 0
 
     def test_read_spreadsheet_unsupported_suffix_raises_file_read_error(self) -> None:
         """read_spreadsheet_file with an unsupported extension raises FileReadError."""

--- a/tests/utils/test_log_redact.py
+++ b/tests/utils/test_log_redact.py
@@ -858,3 +858,202 @@ class TestCLIIntegration:
                 root.removeFilter(f)
             for f in preexisting:
                 root.addFilter(f)
+
+
+class TestErrorHandlingFallbacks:
+    """Cover the remaining exception / branch paths not exercised by
+    the main contract tests.  All paths are fail-closed (never raise,
+    never leak) so each test verifies safety, not just execution.
+    """
+
+    # ------------------------------------------------------------------ #
+    # _sanitize_args — dict branch (lines 180-181) and scalar (line 182)  #
+    # ------------------------------------------------------------------ #
+
+    def test_dict_args_formatting_failure_sanitization(self) -> None:
+        """Dict args are sanitised via dict.fromkeys when getMessage() fails.
+
+        Drives lines 180-181: the filter encounters a Mapping-typed args
+        whose %s template can't be satisfied, triggering the outer
+        except-Exception handler.  _sanitize_args receives the (already
+        key-remapped) dict and returns a new dict with all values REDACTED.
+        """
+        f = CredentialRedactingFilter()
+        # Mapping args with a %-format template that is incompatible
+        # (expects %(key)s but template uses %s) so getMessage() raises.
+        record = _make_record("value is %s %s")
+        record.args = {"api_key": "sk-secret"}  # Mapping, wrong format → raises
+        assert f.filter(record) is True
+        # dict keys preserved, values replaced
+        assert isinstance(record.args, dict)
+        assert record.args.get("api_key") == REDACTED
+
+    def test_scalar_args_sanitized_to_redacted(self) -> None:
+        """Scalar (non-tuple, non-dict) args reach line 182 → return REDACTED.
+
+        A string-typed record.args is truthy but not Mapping, so the
+        mapping-remap block is skipped.  getMessage() raises TypeError
+        (template doesn't consume the string), triggering the outer
+        except.  _sanitize_args gets a plain string → returns REDACTED.
+        """
+        f = CredentialRedactingFilter()
+        record = _make_record("no substitution slots here")
+        record.args = "not_a_tuple"  # truthy scalar → TypeError on getMessage
+        assert f.filter(record) is True
+        assert record.args == REDACTED
+
+    # ------------------------------------------------------------------ #
+    # filter double-exception path (lines 264-265)                        #
+    # ------------------------------------------------------------------ #
+
+    def test_double_exception_msg_replaced_with_redacted(self) -> None:
+        """Lines 264-265: msg is set to REDACTED when str(msg) also raises.
+
+        The outer except-Exception fires because getMessage() raises.
+        Inside the inner try, _redact_text(str(record.msg)) raises because
+        str(_PoisonMsg) raises.  The inner except sets record.msg = REDACTED.
+        """
+
+        class _PoisonMsg:
+            def __str__(self) -> str:
+                raise RuntimeError("str() unavailable")
+
+        f = CredentialRedactingFilter()
+        record = _make_record(_PoisonMsg(), "some_arg")
+        assert f.filter(record) is True
+        assert record.msg == REDACTED
+
+    # ------------------------------------------------------------------ #
+    # Loguru _patcher branches                                             #
+    # ------------------------------------------------------------------ #
+
+    def test_loguru_patcher_idempotency_guard_returns_early(self) -> None:
+        """Line 365: patcher returns immediately for already-processed records."""
+        from utils.log_redact import _RECORD_REDACTED_SENTINEL, _install_on_loguru
+
+        instance = CredentialRedactingFilter()
+        _install_on_loguru(instance)
+        patcher = instance._loguru_patcher  # type: ignore[attr-defined]
+
+        original_msg = "api_key=sk-secret"
+        record: dict = {
+            "message": original_msg,
+            "exception": None,
+            "extra": {"_fo_redacted": _RECORD_REDACTED_SENTINEL},
+        }
+        patcher(record)
+        assert record["message"] == original_msg  # not modified — guard fired
+
+    def test_loguru_patcher_non_string_message_not_redacted(self) -> None:
+        """Lines 370->372: non-string message is left unchanged.
+
+        The patcher only redacts str messages; an integer/object message is
+        skipped and the patcher continues to the exception block.
+        """
+        from utils.log_redact import _RECORD_REDACTED_SENTINEL, _install_on_loguru
+
+        instance = CredentialRedactingFilter()
+        _install_on_loguru(instance)
+        patcher = instance._loguru_patcher  # type: ignore[attr-defined]
+
+        record: dict = {"message": 42, "exception": None, "extra": {}}
+        patcher(record)
+        assert record["message"] == 42  # unchanged
+        assert record["extra"].get("_fo_redacted") is _RECORD_REDACTED_SENTINEL
+
+    def test_loguru_patcher_no_exception_marks_idempotency(self) -> None:
+        """Lines 379->411: exception=None skips the exc block; sentinel set."""
+        from utils.log_redact import _RECORD_REDACTED_SENTINEL, _install_on_loguru
+
+        instance = CredentialRedactingFilter()
+        _install_on_loguru(instance)
+        patcher = instance._loguru_patcher  # type: ignore[attr-defined]
+
+        record: dict = {"message": "safe msg", "exception": None, "extra": {}}
+        patcher(record)
+        assert record["extra"].get("_fo_redacted") is _RECORD_REDACTED_SENTINEL
+
+    def test_loguru_patcher_traceback_format_failure_drops_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Lines 382-389: format_exception raises → exception set to None."""
+        from loguru._recattrs import RecordException
+
+        import utils.log_redact as log_redact_mod
+        from utils.log_redact import _install_on_loguru
+
+        def _boom(*_a: object, **_kw: object) -> list[str]:
+            raise RuntimeError("format broken")
+
+        monkeypatch.setattr(log_redact_mod.traceback, "format_exception", _boom)
+
+        instance = CredentialRedactingFilter()
+        _install_on_loguru(instance)
+        patcher = instance._loguru_patcher  # type: ignore[attr-defined]
+
+        try:
+            raise ValueError("api_key=sk-secret")
+        except ValueError as exc:
+            fake_exc = RecordException(type(exc), exc, exc.__traceback__)
+
+        record: dict = {"message": "oops", "exception": fake_exc, "extra": {}}
+        patcher(record)
+        assert record["exception"] is None  # dropped — fail-closed
+
+    def test_loguru_patcher_record_exception_import_error_drops_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Lines 401-406: ImportError on RecordException → exception set to None."""
+        import sys
+        import types
+
+        from loguru._recattrs import RecordException
+
+        import utils.log_redact as log_redact_mod
+        from utils.log_redact import _install_on_loguru
+
+        # Patch traceback.format_exception to succeed so we reach the import.
+        def _ok_format(*_a: object, **_kw: object) -> list[str]:
+            return ["FakeError\n"]
+
+        monkeypatch.setattr(log_redact_mod.traceback, "format_exception", _ok_format)
+
+        # Shadow loguru._recattrs so the deferred `from loguru._recattrs import`
+        # inside _patcher raises ImportError.
+        fake_mod = types.ModuleType("loguru._recattrs")
+        monkeypatch.setitem(sys.modules, "loguru._recattrs", fake_mod)  # no RecordException attr
+
+        instance = CredentialRedactingFilter()
+        _install_on_loguru(instance)
+        patcher = instance._loguru_patcher  # type: ignore[attr-defined]
+
+        try:
+            raise ValueError("api_key=sk-secret")
+        except ValueError as exc:
+            fake_exc = RecordException(type(exc), exc, exc.__traceback__)
+
+        record: dict = {"message": "oops", "exception": fake_exc, "extra": {}}
+        patcher(record)
+        assert record["exception"] is None
+
+    # ------------------------------------------------------------------ #
+    # install_on_root idempotency (lines 456->467)                        #
+    # ------------------------------------------------------------------ #
+
+    def test_install_on_root_idempotent_second_call_skips_factory_wrap(self) -> None:
+        """Lines 456->467: second install_on_root call skips factory wrapping."""
+        from utils.log_redact import install_on_root
+
+        original_factory = logging.getLogRecordFactory()
+        try:
+            install_on_root()
+            factory_after_first = logging.getLogRecordFactory()
+            install_on_root()  # second call — hits the 456->467 branch
+            factory_after_second = logging.getLogRecordFactory()
+            # Factory must not be double-wrapped — same object.
+            assert factory_after_first is factory_after_second
+        finally:
+            logging.setLogRecordFactory(original_factory)
+            root = logging.getLogger()
+            for flt in [f for f in root.filters if isinstance(f, CredentialRedactingFilter)]:
+                root.removeFilter(flt)

--- a/tests/utils/test_scientific_coverage.py
+++ b/tests/utils/test_scientific_coverage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -38,6 +39,183 @@ class TestReadHdf5:
                 with pytest.raises(FileReadError):
                     read_hdf5_file(Path("/test.h5"))
 
+    def test_missing_args_raises_value_error(self):
+        """Neither file_path nor fileobj supplied — raises ValueError (lines 122-123)."""
+        from utils.readers.scientific import read_hdf5_file
+
+        with pytest.raises(ValueError, match="read_hdf5_file requires"):
+            read_hdf5_file()
+
+    def test_successful_read_via_path(self):
+        """Path branch: _parse_hdf5 called via file_path (lines 59-92, 136-141)."""
+        mock_h5py = MagicMock()
+
+        # Build a fake HDF5 file context manager
+        mock_hf = MagicMock()
+        mock_hf.keys.return_value = ["group1", "ds1"]
+
+        mock_dataset = MagicMock()
+        mock_dataset.shape = (10, 5)
+        mock_dataset.dtype = "float32"
+        mock_dataset.nbytes = 2048
+        mock_dataset.attrs.items.return_value = [("units", "m/s"), ("desc", "speed")]
+        mock_dataset.attrs.__bool__ = lambda self: True
+
+        mock_h5py.Dataset = type("Dataset", (), {})
+        mock_h5py.Group = type("Group", (), {})
+
+        # Make isinstance checks work: mock_dataset is an h5py.Dataset instance
+        real_dataset_cls = mock_h5py.Dataset
+        real_group_cls = mock_h5py.Group
+
+        def make_dataset():
+            d = real_dataset_cls()
+            d.shape = (10, 5)
+            d.dtype = "float32"
+            d.nbytes = 2048
+            d.attrs = MagicMock()
+            d.attrs.items.return_value = [("units", "m/s")]
+            d.attrs.__bool__ = lambda self: True
+            return d
+
+        def make_group():
+            g = real_group_cls()
+            return g
+
+        fake_ds = make_dataset()
+        fake_grp = make_group()
+
+        def visititems(callback):
+            callback("group1/subgroup", fake_grp)
+            callback("group1/data", fake_ds)
+
+        mock_hf.visititems = visititems
+        mock_hf.__enter__ = MagicMock(return_value=mock_hf)
+        mock_hf.__exit__ = MagicMock(return_value=False)
+        mock_h5py.File.return_value = mock_hf
+
+        with (
+            patch("utils.readers.scientific.H5PY_AVAILABLE", True),
+            patch("utils.readers.scientific.h5py", mock_h5py, create=True),
+            patch("utils.readers._base._check_file_size"),
+        ):
+            from utils.readers.scientific import read_hdf5_file
+
+            result = read_hdf5_file(Path("/test.h5"))
+            assert "HDF5 File" in result
+
+    def test_fileobj_branch_success(self):
+        """fileobj branch: calls _parse_hdf5 with fileobj (lines 127-134)."""
+        mock_h5py = MagicMock()
+
+        mock_hf = MagicMock()
+        mock_hf.keys.return_value = []
+
+        def visititems(callback):
+            pass
+
+        mock_hf.visititems = visititems
+        mock_hf.__enter__ = MagicMock(return_value=mock_hf)
+        mock_hf.__exit__ = MagicMock(return_value=False)
+        mock_h5py.File.return_value = mock_hf
+
+        fake_fileobj = io.BytesIO(b"\x89HDF\r\n\x1a\n" + b"\x00" * 512)
+
+        with (
+            patch("utils.readers.scientific.H5PY_AVAILABLE", True),
+            patch("utils.readers.scientific.h5py", mock_h5py, create=True),
+        ):
+            from utils.readers.scientific import read_hdf5_file
+
+            result = read_hdf5_file(fileobj=fake_fileobj)
+            assert "HDF5 File" in result
+            mock_h5py.File.assert_called_once()
+
+    def test_fileobj_branch_with_file_path_label(self):
+        """fileobj branch with file_path for label (line 128)."""
+        mock_h5py = MagicMock()
+
+        mock_hf = MagicMock()
+        mock_hf.keys.return_value = ["a"]
+
+        def visititems(callback):
+            pass
+
+        mock_hf.visititems = visititems
+        mock_hf.__enter__ = MagicMock(return_value=mock_hf)
+        mock_hf.__exit__ = MagicMock(return_value=False)
+        mock_h5py.File.return_value = mock_hf
+
+        fake_fileobj = io.BytesIO(b"\x00" * 128)
+
+        with (
+            patch("utils.readers.scientific.H5PY_AVAILABLE", True),
+            patch("utils.readers.scientific.h5py", mock_h5py, create=True),
+        ):
+            from utils.readers.scientific import read_hdf5_file
+
+            result = read_hdf5_file(file_path=Path("/data/myfile.h5"), fileobj=fake_fileobj)
+            # Label should include the filename
+            assert "myfile.h5" in result
+
+    def test_fileobj_branch_error_raises(self):
+        """fileobj branch raises FileReadError when _parse_hdf5 throws (line 134)."""
+        mock_h5py = MagicMock()
+        mock_h5py.File.side_effect = RuntimeError("corrupt")
+
+        fake_fileobj = io.BytesIO(b"\x00" * 128)
+
+        with (
+            patch("utils.readers.scientific.H5PY_AVAILABLE", True),
+            patch("utils.readers.scientific.h5py", mock_h5py, create=True),
+        ):
+            from utils.readers.scientific import read_hdf5_file
+
+            with pytest.raises(FileReadError, match="Failed to read HDF5"):
+                read_hdf5_file(fileobj=fake_fileobj)
+
+    def test_parse_hdf5_dataset_count_cap(self):
+        """Lines 69, 87-88: max_datasets cap with truncation message."""
+        mock_h5py = MagicMock()
+
+        dataset_cls = type("Dataset", (), {})
+        group_cls = type("Group", (), {})
+        mock_h5py.Dataset = dataset_cls
+        mock_h5py.Group = group_cls
+
+        mock_hf = MagicMock()
+        mock_hf.keys.return_value = [f"ds{i}" for i in range(25)]
+
+        # Create 25 fake Dataset instances
+        def make_ds(name):
+            d = dataset_cls()
+            d.shape = (5,)
+            d.dtype = "float64"
+            d.nbytes = 40
+            d.attrs = MagicMock()
+            d.attrs.__bool__ = lambda self: False
+            d.attrs.items.return_value = []
+            return d
+
+        def visititems(callback):
+            for i in range(25):
+                callback(f"ds{i}", make_ds(f"ds{i}"))
+
+        mock_hf.visititems = visititems
+        mock_hf.__enter__ = MagicMock(return_value=mock_hf)
+        mock_hf.__exit__ = MagicMock(return_value=False)
+        mock_h5py.File.return_value = mock_hf
+
+        with (
+            patch("utils.readers.scientific.H5PY_AVAILABLE", True),
+            patch("utils.readers.scientific.h5py", mock_h5py, create=True),
+            patch("utils.readers._base._check_file_size"),
+        ):
+            from utils.readers.scientific import read_hdf5_file
+
+            result = read_hdf5_file(Path("/test.h5"), max_datasets=20)
+            assert "showing first 20 datasets" in result
+
 
 # ---------------------------------------------------------------------------
 # read_netcdf_file
@@ -65,6 +243,189 @@ class TestReadNetcdf:
 
                 with pytest.raises(FileReadError):
                     read_netcdf_file(Path("/test.nc"))
+
+    def test_missing_args_raises_value_error(self):
+        """Neither file_path nor fileobj supplied — raises ValueError (line 217)."""
+        from utils.readers.scientific import read_netcdf_file
+
+        with pytest.raises(ValueError, match="read_netcdf_file requires"):
+            read_netcdf_file()
+
+    def _make_mock_nc(self, n_vars=3, n_dims=2, n_attrs=2):
+        """Return a fully-configured mock netCDF4.Dataset-like object."""
+        mock_nc = MagicMock()
+        mock_nc.data_model = "NETCDF4"
+
+        # Dimensions
+        dim_items = {}
+        for i in range(n_dims):
+            mock_dim = MagicMock()
+            mock_dim.isunlimited.return_value = False
+            mock_dim.__len__ = MagicMock(return_value=10 + i)
+            dim_items[f"dim{i}"] = mock_dim
+        mock_nc.dimensions = dim_items
+
+        # Variables
+        var_items = {}
+        for i in range(n_vars):
+            mock_var = MagicMock(spec=["dtype", "shape", "units", "long_name"])
+            mock_var.dtype = "float32"
+            mock_var.shape = (10, 5)
+            var_items[f"var{i}"] = mock_var
+        mock_nc.variables = var_items
+
+        # Attributes
+        attr_names = [f"attr{i}" for i in range(n_attrs)]
+        mock_nc.ncattrs.return_value = attr_names
+        mock_nc.getncattr.side_effect = lambda name: f"value_of_{name}"
+
+        return mock_nc
+
+    def test_successful_read_via_path(self):
+        """Path branch: _parse_netcdf called via file_path (lines 156-188, 239-243)."""
+        mock_nc_module = MagicMock()
+        mock_dataset_instance = self._make_mock_nc(n_vars=3)
+        mock_nc_module.Dataset.return_value.__enter__ = MagicMock(
+            return_value=mock_dataset_instance
+        )
+        mock_nc_module.Dataset.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("utils.readers.scientific.NETCDF4_AVAILABLE", True),
+            patch("utils.readers.scientific.netCDF4", mock_nc_module, create=True),
+            patch("utils.readers._base._check_file_size"),
+        ):
+            from utils.readers.scientific import read_netcdf_file
+
+            result = read_netcdf_file(Path("/test.nc"))
+            assert "NetCDF File" in result
+            assert "NETCDF4" in result
+
+    def test_fileobj_branch_success(self):
+        """fileobj branch: reads bytes and uses memory= param (lines 221-231)."""
+        mock_nc_module = MagicMock()
+        mock_dataset_instance = self._make_mock_nc(n_vars=3)
+        mock_nc_module.Dataset.return_value.__enter__ = MagicMock(
+            return_value=mock_dataset_instance
+        )
+        mock_nc_module.Dataset.return_value.__exit__ = MagicMock(return_value=False)
+
+        fake_fileobj = io.BytesIO(b"CDF\x01" + b"\x00" * 128)
+
+        with (
+            patch("utils.readers.scientific.NETCDF4_AVAILABLE", True),
+            patch("utils.readers.scientific.netCDF4", mock_nc_module, create=True),
+        ):
+            from utils.readers.scientific import read_netcdf_file
+
+            result = read_netcdf_file(fileobj=fake_fileobj)
+            assert "NetCDF File" in result
+            # Verify Dataset called with memory= kwarg
+            call_kwargs = mock_nc_module.Dataset.call_args
+            assert "memory" in call_kwargs.kwargs
+
+    def test_fileobj_branch_with_file_path_label(self):
+        """fileobj branch uses file_path for the label (line 222)."""
+        mock_nc_module = MagicMock()
+        mock_dataset_instance = self._make_mock_nc(n_vars=2)
+        mock_nc_module.Dataset.return_value.__enter__ = MagicMock(
+            return_value=mock_dataset_instance
+        )
+        mock_nc_module.Dataset.return_value.__exit__ = MagicMock(return_value=False)
+
+        fake_fileobj = io.BytesIO(b"\x00" * 64)
+
+        with (
+            patch("utils.readers.scientific.NETCDF4_AVAILABLE", True),
+            patch("utils.readers.scientific.netCDF4", mock_nc_module, create=True),
+        ):
+            from utils.readers.scientific import read_netcdf_file
+
+            result = read_netcdf_file(file_path=Path("/data/climate.nc"), fileobj=fake_fileobj)
+            assert "climate.nc" in result
+
+    def test_fileobj_branch_error_raises(self):
+        """fileobj branch raises FileReadError when Dataset constructor throws (line 232)."""
+        mock_nc_module = MagicMock()
+        mock_nc_module.Dataset.side_effect = RuntimeError("corrupt data")
+
+        fake_fileobj = io.BytesIO(b"\x00" * 64)
+
+        with (
+            patch("utils.readers.scientific.NETCDF4_AVAILABLE", True),
+            patch("utils.readers.scientific.netCDF4", mock_nc_module, create=True),
+        ):
+            from utils.readers.scientific import read_netcdf_file
+
+            with pytest.raises(FileReadError, match="Failed to read NetCDF"):
+                read_netcdf_file(fileobj=fake_fileobj)
+
+    def test_parse_netcdf_variable_truncation(self):
+        """Line 177-178: truncation message when > 20 variables."""
+        mock_nc_module = MagicMock()
+        # 25 variables — 5 more than the cap of 20
+        mock_dataset_instance = self._make_mock_nc(n_vars=25)
+        mock_nc_module.Dataset.return_value.__enter__ = MagicMock(
+            return_value=mock_dataset_instance
+        )
+        mock_nc_module.Dataset.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("utils.readers.scientific.NETCDF4_AVAILABLE", True),
+            patch("utils.readers.scientific.netCDF4", mock_nc_module, create=True),
+            patch("utils.readers._base._check_file_size"),
+        ):
+            from utils.readers.scientific import read_netcdf_file
+
+            result = read_netcdf_file(Path("/test.nc"))
+            assert "... and 5 more variables" in result
+
+    def test_parse_netcdf_unlimited_dimension(self):
+        """Line 163: unlimited dimension displays 'unlimited' instead of a number."""
+        mock_nc_module = MagicMock()
+
+        mock_nc = MagicMock()
+        mock_nc.data_model = "NETCDF4"
+
+        unlimited_dim = MagicMock()
+        unlimited_dim.isunlimited.return_value = True
+        unlimited_dim.__len__ = MagicMock(return_value=0)
+
+        mock_nc.dimensions = {"time": unlimited_dim}
+        mock_nc.variables = {}
+        mock_nc.ncattrs.return_value = []
+
+        mock_nc_module.Dataset.return_value.__enter__ = MagicMock(return_value=mock_nc)
+        mock_nc_module.Dataset.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("utils.readers.scientific.NETCDF4_AVAILABLE", True),
+            patch("utils.readers.scientific.netCDF4", mock_nc_module, create=True),
+            patch("utils.readers._base._check_file_size"),
+        ):
+            from utils.readers.scientific import read_netcdf_file
+
+            result = read_netcdf_file(Path("/test.nc"))
+            assert "unlimited" in result
+
+    def test_parse_netcdf_global_attributes(self):
+        """Lines 180-184: global attributes section rendered."""
+        mock_nc_module = MagicMock()
+        mock_dataset_instance = self._make_mock_nc(n_vars=1, n_attrs=3)
+        mock_nc_module.Dataset.return_value.__enter__ = MagicMock(
+            return_value=mock_dataset_instance
+        )
+        mock_nc_module.Dataset.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch("utils.readers.scientific.NETCDF4_AVAILABLE", True),
+            patch("utils.readers.scientific.netCDF4", mock_nc_module, create=True),
+            patch("utils.readers._base._check_file_size"),
+        ):
+            from utils.readers.scientific import read_netcdf_file
+
+            result = read_netcdf_file(Path("/test.nc"))
+            assert "Global Attributes" in result
 
 
 # ---------------------------------------------------------------------------
@@ -123,3 +484,140 @@ class TestReadMat:
                 assert "MATLAB File" in result
                 assert "matrix" in result
                 assert "scalar" in result
+
+    def test_missing_args_raises_value_error(self):
+        """Neither file_path nor fileobj supplied — raises ValueError (line 302)."""
+        from utils.readers.scientific import read_mat_file
+
+        with pytest.raises(ValueError, match="read_mat_file requires"):
+            read_mat_file()
+
+    def test_mat_variable_truncation(self):
+        """Lines 271-272: truncation message when > 30 variables."""
+        # Build 35 fake variables (keys not starting with __)
+        mock_data: dict = {f"var{i:03d}": 42 for i in range(35)}
+        mock_data["__header__"] = b"MATLAB 5.0"
+        mock_data["__version__"] = "1.0"
+        mock_data["__globals__"] = []
+
+        with patch("utils.readers.scientific.SCIPY_AVAILABLE", True):
+            mock_loadmat = MagicMock(return_value=mock_data)
+            with patch(
+                "utils.readers.scientific.loadmat",
+                mock_loadmat,
+                create=True,
+            ):
+                from utils.readers.scientific import read_mat_file
+
+                result = read_mat_file(Path("/test.mat"))
+                assert "... and 5 more variables" in result
+
+    def test_fileobj_branch_success(self):
+        """fileobj branch: _parse_mat called with fileobj (lines 306-312)."""
+        mock_data = {
+            "__header__": b"MATLAB 5.0",
+            "__version__": "1.0",
+            "x": 1.0,
+            "y": 2.0,
+        }
+
+        fake_fileobj = io.BytesIO(b"\x00" * 64)
+
+        with (
+            patch("utils.readers.scientific.SCIPY_AVAILABLE", True),
+            patch("utils.readers.scientific.loadmat", MagicMock(return_value=mock_data)),
+        ):
+            from utils.readers.scientific import read_mat_file
+
+            result = read_mat_file(fileobj=fake_fileobj)
+            assert "MATLAB File" in result
+            assert "x" in result
+
+    def test_fileobj_branch_with_file_path_label(self):
+        """fileobj branch uses file_path for the log label (line 307)."""
+        mock_data = {
+            "__header__": b"MATLAB 5.0",
+            "matrix": 99,
+        }
+
+        fake_fileobj = io.BytesIO(b"\x00" * 64)
+
+        with (
+            patch("utils.readers.scientific.SCIPY_AVAILABLE", True),
+            patch("utils.readers.scientific.loadmat", MagicMock(return_value=mock_data)),
+        ):
+            from utils.readers.scientific import read_mat_file
+
+            result = read_mat_file(file_path=Path("/data/results.mat"), fileobj=fake_fileobj)
+            assert "results.mat" in result
+
+    def test_fileobj_branch_error_raises(self):
+        """fileobj branch raises FileReadError when loadmat throws (line 312)."""
+        fake_fileobj = io.BytesIO(b"\x00" * 64)
+
+        with (
+            patch("utils.readers.scientific.SCIPY_AVAILABLE", True),
+            patch(
+                "utils.readers.scientific.loadmat",
+                MagicMock(side_effect=RuntimeError("parse error")),
+            ),
+        ):
+            from utils.readers.scientific import read_mat_file
+
+            with pytest.raises(FileReadError, match="Failed to read MAT"):
+                read_mat_file(fileobj=fake_fileobj)
+
+
+# ---------------------------------------------------------------------------
+# Module-level ImportError branches (lines 30-31, 37-38, 44-45)
+# These are the ``except ImportError`` clauses for h5py, netCDF4, scipy.
+# We exercise them by importing the module under a patched sys.modules that
+# makes the libraries appear absent.
+# ---------------------------------------------------------------------------
+
+
+class TestImportErrorBranches:
+    """Cover the ``except ImportError: H5PY_AVAILABLE = False`` branches."""
+
+    def test_h5py_import_error_branch(self):
+        """Line 30-31: H5PY_AVAILABLE = False set when h5py absent."""
+        import sys
+        from unittest.mock import patch as _patch
+
+        with _patch.dict(sys.modules, {"h5py": None}):
+            # Force re-execution of the module's try/except block
+            import importlib
+
+            import utils.readers.scientific as sci_mod
+
+            importlib.reload(sci_mod)
+            assert sci_mod.H5PY_AVAILABLE is False
+
+    def test_netcdf4_import_error_branch(self):
+        """Lines 37-38: NETCDF4_AVAILABLE = False set when netCDF4 absent."""
+        import sys
+        from unittest.mock import patch as _patch
+
+        with _patch.dict(sys.modules, {"netCDF4": None}):
+            import importlib
+
+            import utils.readers.scientific as sci_mod
+
+            importlib.reload(sci_mod)
+            assert sci_mod.NETCDF4_AVAILABLE is False
+
+    def test_scipy_import_error_branch(self):
+        """Lines 44-45: SCIPY_AVAILABLE = False set when scipy absent."""
+        import sys
+        from unittest.mock import patch as _patch
+
+        with _patch.dict(
+            sys.modules,
+            {"scipy": None, "scipy.io": None},
+        ):
+            import importlib
+
+            import utils.readers.scientific as sci_mod
+
+            importlib.reload(sci_mod)
+            assert sci_mod.SCIPY_AVAILABLE is False

--- a/tests/utils/test_scientific_coverage.py
+++ b/tests/utils/test_scientific_coverage.py
@@ -581,43 +581,48 @@ class TestImportErrorBranches:
 
     def test_h5py_import_error_branch(self):
         """Line 30-31: H5PY_AVAILABLE = False set when h5py absent."""
+        import importlib
         import sys
         from unittest.mock import patch as _patch
 
-        with _patch.dict(sys.modules, {"h5py": None}):
-            # Force re-execution of the module's try/except block
-            import importlib
+        import utils.readers.scientific as sci_mod
 
-            import utils.readers.scientific as sci_mod
-
-            importlib.reload(sci_mod)
-            assert sci_mod.H5PY_AVAILABLE is False
+        original = sci_mod.H5PY_AVAILABLE
+        try:
+            with _patch.dict(sys.modules, {"h5py": None}):
+                importlib.reload(sci_mod)
+                assert sci_mod.H5PY_AVAILABLE is False
+        finally:
+            sci_mod.H5PY_AVAILABLE = original
 
     def test_netcdf4_import_error_branch(self):
         """Lines 37-38: NETCDF4_AVAILABLE = False set when netCDF4 absent."""
+        import importlib
         import sys
         from unittest.mock import patch as _patch
 
-        with _patch.dict(sys.modules, {"netCDF4": None}):
-            import importlib
+        import utils.readers.scientific as sci_mod
 
-            import utils.readers.scientific as sci_mod
-
-            importlib.reload(sci_mod)
-            assert sci_mod.NETCDF4_AVAILABLE is False
+        original = sci_mod.NETCDF4_AVAILABLE
+        try:
+            with _patch.dict(sys.modules, {"netCDF4": None}):
+                importlib.reload(sci_mod)
+                assert sci_mod.NETCDF4_AVAILABLE is False
+        finally:
+            sci_mod.NETCDF4_AVAILABLE = original
 
     def test_scipy_import_error_branch(self):
         """Lines 44-45: SCIPY_AVAILABLE = False set when scipy absent."""
+        import importlib
         import sys
         from unittest.mock import patch as _patch
 
-        with _patch.dict(
-            sys.modules,
-            {"scipy": None, "scipy.io": None},
-        ):
-            import importlib
+        import utils.readers.scientific as sci_mod
 
-            import utils.readers.scientific as sci_mod
-
-            importlib.reload(sci_mod)
-            assert sci_mod.SCIPY_AVAILABLE is False
+        original = sci_mod.SCIPY_AVAILABLE
+        try:
+            with _patch.dict(sys.modules, {"scipy": None, "scipy.io": None}):
+                importlib.reload(sci_mod)
+                assert sci_mod.SCIPY_AVAILABLE is False
+        finally:
+            sci_mod.SCIPY_AVAILABLE = original


### PR DESCRIPTION
## Summary

- Fixes T12 FIXTURE_STATE_LEAK introduced by `TestImportErrorBranches` in #319
- `importlib.reload()` with scipy/h5py/netCDF4 blocked in `sys.modules` permanently sets `*_AVAILABLE = False` on the module object — not restored when the `patch.dict` context exits
- This caused `TestScientificReaders::test_read_mat_file_success` (and the two analogous HDF5/netCDF4 tests) to fail in the full suite with `ImportError: scipy is not installed`

**Fix:** snapshot each flag before the reload, restore it in a `finally` block in all three test methods.

## Test plan

- [x] `uv run pytest tests/utils/test_scientific_coverage.py tests/utils/test_archive_scientific_readers.py --override-ini="addopts=" -q -p no:randomly` → 95 passed, 0 failed
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for benchmark pipelines, embedding cache management, archive/scientific readers, atomic write operations, document parsing, credential redaction, and scientific file readers.

* **Chores**
  * Updated security risk allowlist; removed resolved dependency advisories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->