### PR TITLE
docs: resolve SafeDir scope contradiction in hardening roadmap (#328)

### DIFF
--- a/docs/superpowers/specs/2026-04-22-hardening-roadmap-design.md
+++ b/docs/superpowers/specs/2026-04-22-hardening-roadmap-design.md
@@ -463,13 +463,16 @@ Source of truth: `src/cli/main.py` registers each sub-app with a plain name (`ap
 | `src/cli/doctor.py` | `fo doctor` (single top-level command, not a sub-app) | `path` | 357 |
 | `src/cli/profile.py` | `fo profile import` / `export` | path args (Click group, lazy-loaded) | deferred in main.py:245 |
 
+Out of scope for A2: `fo copilot` (free-text `message`), `fo undo`/`redo`/`history` (operation IDs only),
+`fo version`/`hardware-info`/`config`/`model`/`setup`/`update`/`completion` (no path args).
+
 ## Parallel epics
 
 The SafeDir read-side hardening epic (#264 / #267 PR3 / #268 PR4 / #269 PR5 / #270 PR6)
 addresses TOCTOU and symlink-swap vectors across content readers, dedup, undo, and watcher.
-Tracked separately; not part of the A–G roadmap above.
+SafeDir security primitives are integral to the overall security hardening work and complement
+Epics A–G; they are maintained as a dedicated module and epic series rather than being
+folded into the A–G tracking issues above.
 
 See `docs/internal/safedir-shutil-audit-pr3j.md` for the PR3 closeout audit and
 `docs/developer/safedir-readers.md` for the contributor guide.
-
-Each of the above wires through `validate_within_roots()` as a commit inside `epic-a-cli`. Out of scope for A2: `fo copilot` (free-text `message`), `fo undo`/`redo`/`history` (operation IDs only), `fo version`/`hardware-info`/`config`/`model`/`setup`/`update`/`completion` (no path args).


### PR DESCRIPTION
## Summary

- Resolves the contradiction in `docs/superpowers/specs/2026-04-22-hardening-roadmap-design.md` around the "Parallel epics" / SafeDir section
- The "Out of scope for A2" note was misplaced after the SafeDir paragraph, making its pronoun "Each of the above" appear to reference SafeDir entries and wire them through `epic-a-cli` — directly contradicting the "not part of the A–G roadmap" claim
- Moved the "Out of scope for A2" sentence to immediately follow the A.4 table it belongs to
- Replaced "Tracked separately; not part of the A–G roadmap above" with accurate language: SafeDir security primitives are integral to the hardening work and complement Epics A–G, maintained as a dedicated module/epic series

## Test plan

- [x] `uv run pymarkdown --config .pymarkdown.json scan docs/superpowers/specs/2026-04-22-hardening-roadmap-design.md` — 0 violations
- [x] `bash .claude/scripts/pre-commit-validation.sh` — PyMarkdown, codespell, coverage drift (C4), and search corpus safety (S1/S2) all pass; remaining failures are pre-existing on the branch and unrelated to this doc change

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated technical specifications documentation with reorganized sections for improved clarity and better accessibility of scope definitions and planning information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->