### PR TITLE
fix(test): setup-gate import safety + inode-reuse flake (issue #327)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,26 +238,26 @@ def provider_env(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
 # `@pytest.mark.uses_setup_gate`.
 # Those tests configure the on-disk `setup_completed` flag via a
 # tmp_path config dir and need the gate to actually run.
-# Pre-import ``cli.organize`` so the ``_bypass_setup_gate`` patch below
-# can resolve ``cli.organize._check_setup_completed``. ``cli/__init__.py``
-# uses ``__getattr__`` for lazy attribute imports but does NOT pre-register
-# submodules — ``getattr(cli, "organize")`` therefore raises AttributeError
-# the first time ``mock.patch`` resolves the dotted name, unless some
-# earlier test in the session already imported the submodule explicitly.
-# Hook-driven single-test invocations (e.g. ``pre-commit run search-corpus-
-# safety``) have no such earlier import, so the autouse fixture errors at
-# setup and the hook fails. Pre-importing here makes the submodule a real
-# attribute on ``cli`` before any test runs.
-import cli.organize  # noqa: F401,E402
 
 
 @pytest.fixture(autouse=True)
 def _bypass_setup_gate(request: pytest.FixtureRequest) -> object:
-    """Default-bypass the global setup gate; opt-out via `uses_setup_gate` marker."""
+    """Default-bypass the global setup gate; opt-out via ``uses_setup_gate`` marker.
+
+    ``cli/__init__.py`` lazy-loads submodules via ``__getattr__``, so
+    ``cli.organize`` is not a registered attribute until it is imported
+    explicitly.  Hook-driven single-test invocations (e.g. ``pre-commit run
+    search-corpus-safety``) start with a fresh interpreter that has never
+    touched ``cli.organize``.  Import it here, inside the fixture body,
+    before the patch is applied so the fixture is self-contained and safe
+    regardless of module-load order or worker isolation.
+    """
     if request.node.get_closest_marker("uses_setup_gate") is not None:
         yield
         return
     from unittest.mock import patch
+
+    import cli.organize  # noqa: F401 — ensure submodule exists before patch
 
     with patch("cli.organize._check_setup_completed", return_value=True):
         yield

--- a/tests/security/test_symlink_safety.py
+++ b/tests/security/test_symlink_safety.py
@@ -624,7 +624,8 @@ class TestUndoSymlinkSafety:
         replacement.rename(destination)
         new_st = destination.stat()
         assert new_st.st_ino == replacement_ino, "sanity: rename must preserve inode"
-        assert new_st.st_ino != st.st_ino, "sanity: replacement must have a different inode"
+        if new_st.st_ino == st.st_ino:
+            pytest.skip("filesystem reuses inodes immediately; inode-change test is vacuous")
 
         # Step 3: Attempt undo — rollback_move should refuse.
         journal = tmp_path / "test.journal"


### PR DESCRIPTION
## Summary

Fixes two test reliability issues from [#327](https://github.com/curdriceaurora/fo-core/issues/327):

- **6.1 — `_bypass_setup_gate` fixture import safety**: Moved `import cli.organize` from a bare module-level statement (`# noqa: E402`) into the fixture body, just before `patch()` is applied. The module-level placement was fragile: hook-driven single-test invocations start a fresh interpreter without any prior `cli.organize` import, causing `AttributeError` in the autouse fixture at setup time. The import is now self-contained in the fixture and safe regardless of module-load order or xdist worker isolation.

- **6.2 — Inode-reuse flake in `test_undo_refuses_replay_on_inode_change`**: Replaced `assert new_st.st_ino != st.st_ino` with `pytest.skip(...)` when inodes are equal. On certain filesystems (tmpfs on some Linux kernels, macOS APFS in CI sandboxes) a rename-based replacement can receive the same inode as the original. Skipping is correct: if the filesystem cannot produce a distinguishable inode, the security test cannot be exercised.

## Test plan

- [x] `uv run pytest tests/ci/test_symlink_safety_lints.py --override-ini="addopts=" -v` — 54 passed
- [x] `uv run pytest tests/security/test_symlink_safety.py::TestUndoSymlinkSafety::test_undo_refuses_replay_on_inode_change --override-ini="addopts=" -v` — 1 passed
- [x] `ruff check tests/conftest.py tests/security/test_symlink_safety.py` — all checks passed

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)