### PR TITLE
fix(windows): use getattr fallback for os.O_NOFOLLOW (Windows import crash)

### DIFF
--- a/src/undo/rollback.py
+++ b/src/undo/rollback.py
@@ -206,7 +206,11 @@ class RollbackExecutor:
     # only for os.fstat — it binds the inode check to the specific file that
     # existed at ``destination`` at the moment of the open, closing the TOCTOU
     # window that a plain ``os.lstat`` call leaves open.
-    _O_VERIFY: int = getattr(os, "O_PATH", os.O_RDONLY) | os.O_NOFOLLOW
+    # O_NOFOLLOW is POSIX-only; Windows has neither it nor O_PATH.  Fallback
+    # to 0 keeps the module importable on Windows — _verify_dst_inode is only
+    # reachable when dest_dev/dest_ino are set, which the POSIX-only inode
+    # capture path (sys.platform != "win32" guard in rollback_move) ensures.
+    _O_VERIFY: int = getattr(os, "O_PATH", os.O_RDONLY) | getattr(os, "O_NOFOLLOW", 0)
 
     def _verify_dst_inode(self, operation: Operation, destination: Path) -> bool:
         """Return True iff the file at *destination* matches the recorded inode.


### PR DESCRIPTION
## Summary

- `os.O_NOFOLLOW` is POSIX-only — Windows has neither it nor `O_PATH`
- PR #333 introduced `_O_VERIFY: int = ... | os.O_NOFOLLOW` as a class-level constant, evaluated at module import time on every platform
- On Windows this raises `AttributeError: module 'os' has no attribute 'O_NOFOLLOW'` crashing the entire test suite (every test that imports `undo.rollback`)
- Fix: `getattr(os, "O_NOFOLLOW", 0)` — one-character addition, mirrors the existing `O_PATH` fallback already in the same expression

## Safety

`_verify_dst_inode` is only reachable when `dest_dev`/`dest_ino` are set on an operation. The inode capture in `durable_move` is gated behind `sys.platform != "win32"`, so these fields are never set on Windows — the method is unreachable there, and the `0` fallback flag value is safe.

## Test plan
- [x] `mypy src/undo/rollback.py` — clean
- [x] `ruff check src/undo/rollback.py` — clean  
- [x] `tests/security/test_symlink_safety.py::TestUndoSymlinkSafety` — 10 passed
- [ ] CI Full Matrix Windows py3.12 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)