### PR TITLE
chore(release): 2.0.0-beta.2 version bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fo-core"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 description = "Streamlined CLI file organizer powered by local AI (Ollama)"
 authors = [
     {name = "fo-core Team", email = "noreply@example.com"}


### PR DESCRIPTION
## Summary

Bumps version from `2.0.0-beta.1` → `2.0.0-beta.2` ahead of the beta.2 tag.

## What's in Beta 2 (33 commits since beta.1)

### Security hardening
- **SafeDir primitive** — POSIX-safe fd-pinned filesystem operations (#268)
- **SafeDir read-side hardening** (PR3 rollup) — all readers go through SafeDir (#267)
- **SafeDir watcher + move-destination TOCTOU** — inode-pin on watcher moves (#282)
- **Undo TOCTOU hardening** — inode-pin history + replay verification (#310)
- **Dedupe TOCTOU + defusedxml fail-closed** — inode-pin unlink, XXE prevention (#323)
- **Anchored-traversal migration** — extractor + hybrid_retriever (#325)
- **Watcher SafeDir 7 findings** — all remaining watcher SafeDir callsites (#322)
- **3 AST pre-commit rails** — `safedir-valueerror`, `defusedxml-fallback`, `textiowrapper-detach` (#329)

### Stability / CI
- Windows CI: 3 pre-existing failures fixed (`_vision_helpers` MIME, atomic-write skip, durable_move paths) (#341)
- Windows: `os.O_NOFOLLOW` fallback via `getattr` (#340)
- pytest-timeout re-pinned to `<2.4.0` (Windows teardown regression) (#330)
- Coverage hardening for 7 critical modules to ≥90% (#318)
- pip-audit allowlist cleaned of stale advisories (#317)

## Test plan
- [ ] CI passes on merge to main
- [ ] Tag `v2.0.0-beta.2` and verify release workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)