### PR TITLE
chore(release): 2.0.0-beta.3 version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-beta.3] - 2026-05-21
+
+### Fixed
+
+- **`_compat` module missing from installed wheel** — `fo version` crashed with
+  `ModuleNotFoundError: No module named '_compat'` on a clean `pipx install`
+  because `setuptools packages.find` only discovers packages (directories with
+  `__init__.py`), not bare `.py` files at the `src/` root. All 14 import sites
+  used only `StrEnum`, which is stdlib since Python 3.11 (our minimum). Replaced
+  every `from _compat import StrEnum` with `from enum import StrEnum` and deleted
+  `_compat.py` (#344).
+
 ## [2.0.0-beta.2] - 2026-05-21
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fo-core"
-version = "2.0.0-beta.2"
+version = "2.0.0-beta.3"
 description = "Streamlined CLI file organizer powered by local AI (Ollama)"
 authors = [
     {name = "fo-core Team", email = "noreply@example.com"}


### PR DESCRIPTION
## Summary

Patch release fixing the `_compat` packaging bug that made `fo-core==2.0.0b2` crash on a clean `pipx install`.

## What's fixed

- `ModuleNotFoundError: No module named '_compat'` on first run after `pipx install fo-core==2.0.0b2`
- Root cause: `src/_compat.py` was a bare module (not a package), so `setuptools packages.find` never included it in the wheel
- Fix: replaced all 14 `from _compat import StrEnum` sites with `from enum import StrEnum` (stdlib since Python 3.11) and deleted `_compat.py`

## Test plan
- [ ] CI green
- [ ] After merge: tag `v2.0.0-beta.3`, verify release workflow publishes to PyPI
- [ ] `pipx install "fo-core==2.0.0b3"` → `fo version` shows `2.0.0-beta.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)