### PR TITLE
fix(vision): open image via SafeDir to reject symlinks (issue #352 S3)

### DIFF
--- a/src/models/_vision_helpers.py
+++ b/src/models/_vision_helpers.py
@@ -79,7 +79,7 @@ def image_to_data_url(image_path: Path) -> str:
                 image_path, "rb"
             ) as fh_direct:  # safedir: ok — Windows / NotImplementedError fallback
                 raw = fh_direct.read()
-        except SymlinkRejected as exc:
+        except (SymlinkRejected, ValueError) as exc:
             raise OSError(f"Refused to read symlinked image {image_path}: {exc}") from exc
     else:
         with open(

--- a/src/models/_vision_helpers.py
+++ b/src/models/_vision_helpers.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import base64
 import mimetypes
+import os
+import sys
 from pathlib import Path
 
 # Fallback MIME type when extension is not recognised
@@ -33,6 +35,12 @@ _EXTENSION_MIME: dict[str, str] = {
 def image_to_data_url(image_path: Path) -> str:
     """Encode an image file as a base64 data URL.
 
+    Opens the file via ``SafeDir`` on POSIX so a symlink swapped into
+    the path between directory enumeration and this read is refused with
+    ``SymlinkRejected`` (raised as ``OSError``) rather than dereferenced
+    (issue #352 S3).  On Windows or when SafeDir is unavailable the
+    direct ``open()`` fallback is used.
+
     Args:
         image_path: Path to the image file.
 
@@ -41,7 +49,8 @@ def image_to_data_url(image_path: Path) -> str:
 
     Raises:
         FileNotFoundError: If the file does not exist.
-        OSError: If the file cannot be read.
+        OSError: If the file cannot be read, or if *image_path* is a
+            symlink (POSIX only).
     """
     ext = image_path.suffix.lower()
     mime_type = _EXTENSION_MIME.get(ext)
@@ -49,8 +58,36 @@ def image_to_data_url(image_path: Path) -> str:
         mime_type, _ = mimetypes.guess_type(str(image_path))
     if not mime_type:
         mime_type = _DEFAULT_IMAGE_MIME
-    with open(image_path, "rb") as fh:
-        encoded = base64.b64encode(fh.read()).decode("utf-8")
+
+    raw: bytes
+    if sys.platform != "win32":
+        try:
+            from utils.safedir import SafeDir, SymlinkRejected
+
+            with SafeDir.open_root(image_path.parent) as sd:
+                fd = sd.open_for_reader(image_path.name)
+                try:
+                    fh = os.fdopen(fd, "rb", closefd=True)
+                except OSError:
+                    os.close(fd)
+                    raise
+                with fh:
+                    raw = fh.read()
+        except (NotImplementedError, ImportError):
+            # SafeDir primitives unavailable — fall through to direct open.
+            with open(
+                image_path, "rb"
+            ) as fh_direct:  # safedir: ok — Windows / NotImplementedError fallback
+                raw = fh_direct.read()
+        except SymlinkRejected as exc:
+            raise OSError(f"Refused to read symlinked image {image_path}: {exc}") from exc
+    else:
+        with open(
+            image_path, "rb"
+        ) as fh_win:  # safedir: ok — Windows / NotImplementedError fallback
+            raw = fh_win.read()
+
+    encoded = base64.b64encode(raw).decode("utf-8")
     return f"data:{mime_type};base64,{encoded}"
 
 

--- a/tests/models/test_vision_helpers.py
+++ b/tests/models/test_vision_helpers.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from models._vision_helpers import image_to_data_url
 
 
+@pytest.mark.ci
 @pytest.mark.unit
 @pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
 class TestImageToDataUrlSafeDirIntegration:
@@ -54,3 +57,53 @@ class TestImageToDataUrlSafeDirIntegration:
         """FileNotFoundError propagates unchanged for missing files."""
         with pytest.raises((FileNotFoundError, OSError)):
             image_to_data_url(tmp_path / "nonexistent.jpg")
+
+    def test_not_implemented_error_falls_back_to_direct_open(self, tmp_path: Path) -> None:
+        """NotImplementedError from SafeDir.open_root falls through to direct open().
+
+        Exercises lines 78-81: the ``except (NotImplementedError, ImportError)``
+        fallback that opens the file directly when SafeDir primitives are
+        unavailable on the current platform.
+        """
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0" + b"fallback-jpeg-data")
+
+        with patch(
+            "utils.safedir.SafeDir.open_root",
+            side_effect=NotImplementedError("simulated SafeDir unavailable"),
+        ):
+            result = image_to_data_url(img)
+
+        assert result.startswith("data:image/jpeg;base64,")
+
+    def test_osfdopen_failure_closes_fd_and_propagates(self, tmp_path: Path) -> None:
+        """OSError from os.fdopen in the SafeDir branch closes the raw fd and re-raises.
+
+        Exercises lines 71-73 — the cleanup path where os.fdopen raises after
+        open_for_reader returned a valid fd:
+
+        .. code-block:: python
+
+            try:
+                fh = os.fdopen(fd, "rb", closefd=True)  # raises
+            except OSError:        # line 71  ← covered here
+                os.close(fd)       # line 72  ← covered here
+                raise              # line 73  ← covered here
+        """
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0" + b"data")
+
+        original_fdopen = os.fdopen
+
+        call_count = 0
+
+        def patched_fdopen(fd: int, *args: object, **kwargs: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise OSError("simulated os.fdopen failure")
+            return original_fdopen(fd, *args, **kwargs)  # type: ignore[arg-type]
+
+        with patch("models._vision_helpers.os.fdopen", patched_fdopen):
+            with pytest.raises(OSError):
+                image_to_data_url(img)

--- a/tests/models/test_vision_helpers.py
+++ b/tests/models/test_vision_helpers.py
@@ -1,0 +1,56 @@
+"""Tests for models._vision_helpers — focused on the SafeDir integration (issue #352 S3)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from models._vision_helpers import image_to_data_url
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
+class TestImageToDataUrlSafeDirIntegration:
+    """image_to_data_url must use SafeDir on POSIX to reject symlinked images (issue #352 S3).
+
+    The old implementation called open(image_path, 'rb') directly, with no
+    symlink or path-escape check.  The fix opens via SafeDir.open_for_reader so
+    a symlink swapped into the path between directory enumeration and the read
+    is refused with SymlinkRejected → OSError rather than silently dereferenced.
+    """
+
+    def test_reads_real_image_file(self, tmp_path: Path) -> None:
+        """Happy path: a regular image file returns a valid data URL."""
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0" + b"fake-jpeg-data")
+
+        result = image_to_data_url(img)
+
+        assert result.startswith("data:image/jpeg;base64,")
+        assert len(result) > len("data:image/jpeg;base64,")
+
+    def test_symlinked_image_raises_oserror(self, tmp_path: Path) -> None:
+        """A symlink in place of the image must be refused with OSError.
+
+        Without the SafeDir fix, open() would follow the symlink and return
+        the target's content — potentially exfiltrating a sensitive file.
+        """
+        real = tmp_path / "secret.dat"
+        real.write_bytes(b"TOP_SECRET_CONTENT")
+        img_dir = tmp_path / "images"
+        img_dir.mkdir()
+        decoy = img_dir / "photo.jpg"
+        try:
+            decoy.symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        with pytest.raises(OSError):
+            image_to_data_url(decoy)
+
+    def test_missing_file_raises_file_not_found(self, tmp_path: Path) -> None:
+        """FileNotFoundError propagates unchanged for missing files."""
+        with pytest.raises((FileNotFoundError, OSError)):
+            image_to_data_url(tmp_path / "nonexistent.jpg")


### PR DESCRIPTION
## Summary

S3 from issue #352: `image_to_data_url()` called `open(image_path, "rb")` directly with no symlink or path-escape check. A symlink swapped into the image path between directory enumeration and the read would be silently followed, enabling path-escape attacks.

Fix: on POSIX, open via `SafeDir.open_root(image_path.parent).open_for_reader(image_path.name)` so `O_NOFOLLOW` rejects symlinks; `SymlinkRejected` is re-raised as `OSError`. On Windows or `NotImplementedError` falls back to direct `open()`.

## Test plan
- [ ] CI green
- [ ] `TestImageToDataUrlSafeDirIntegration` — 3 tests (happy path, symlink → OSError, missing file)

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)