### PR TITLE
fix(tests/watcher): T1 type annotation, T3 isinstance assert, T4 deferred import (issue #353)

### DIFF
--- a/tests/watcher/test_monitor.py
+++ b/tests/watcher/test_monitor.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -43,7 +45,7 @@ def monitor(watch_dir: Path) -> FileMonitor:
 
 def _wait_for_event_matching(
     monitor: FileMonitor,
-    predicate: callable,
+    predicate: Callable[[list], bool],
     timeout: float = 3.0,
 ) -> list:
     """
@@ -543,7 +545,6 @@ class TestFileMonitorObserverFallback:
         This test mocks Observer.__init__ to raise an exception to simulate
         FSEvents/Inotify unavailability, then verifies fallback to polling.
         """
-        from unittest.mock import patch
 
         from watchdog.observers.polling import PollingObserver
 
@@ -573,7 +574,6 @@ class TestFileMonitorObserverFallback:
         This test forces use of PollingObserver and verifies it can still
         detect file system events, albeit with polling delays.
         """
-        from unittest.mock import patch
 
         config = WatcherConfig(
             watch_directories=[watch_dir],

--- a/tests/watcher/test_safedir_hardening_322.py
+++ b/tests/watcher/test_safedir_hardening_322.py
@@ -568,6 +568,7 @@ class TestPostprocessorFailsClosedOnSymlinkRejected:
         # Non-SymlinkRejected: postprocessor falls back and continues.
         assert not result.failed
         assert result.destination is not None
+        assert isinstance(result.destination, Path)
 
     def test_symlink_rejected_logs_security_event(
         self,


### PR DESCRIPTION
Fixes issue #353 — test quality group T (T1–T4) from the PR review backlog (#346).

## Changes

**T1** `tests/watcher/test_monitor.py:48`  
`predicate: callable` used the built-in function `callable` as a type hint — not a valid type annotation, suppressed with `# type: ignore`. Fixed to `predicate: Callable[[list], bool]` with `from collections.abc import Callable` import.

**T2** `tests/watcher/test_safedir_hardening_322.py`  
`safe_dir.__exit__()` calls without `try/finally` — already resolved by prior PRs (#355/#356) which replaced them with `monitor.stop()`. No code change needed here.

**T3** `tests/watcher/test_safedir_hardening_322.py:571`  
`assert result.destination is not None` alone does not catch wrong return types. Added `assert isinstance(result.destination, Path)` after the guard.

**T4** `tests/watcher/test_monitor.py`  
Two function-scope `from unittest.mock import patch` statements moved to a single module-level import (F9 anti-pattern fix).

## Parent
Closes #353. Part of epic #346.