### PR TITLE
feat(pipeline/writer): preserve mode+timestamps via fd-based fchmod/utime (issue #354 E1)

### DIFF
--- a/src/pipeline/stages/writer.py
+++ b/src/pipeline/stages/writer.py
@@ -79,15 +79,18 @@ class WriterStage:
                             written = 0
                             while written < len(view):
                                 written += os.write(dst_fd, view[written:])
+                    # E1 fix (issue #354): preserve mode and timestamps via fd-based
+                    # calls while the destination fd is still open — TOCTOU-free.
+                    # os.fchmod / os.utime on an open fd operate on the inode
+                    # directly, unlike shutil.copystat which re-opens the path and
+                    # creates a window for a symlink-swap attack (#322 / 1.7).
+                    try:
+                        src_stat = os.stat(context.file_path)
+                        os.fchmod(dst_fd, src_stat.st_mode & 0o777)
+                        os.utime(dst_fd, ns=(src_stat.st_atime_ns, src_stat.st_mtime_ns))
+                    except OSError:
+                        pass  # non-fatal: metadata loss is preferable to aborting the copy
                 finally:
-                    # 1.7 — Do NOT call shutil.copystat(src, dst_path) after
-                    # os.close(dst_fd): the destination fd is closed before
-                    # copystat re-opens the path, creating a TOCTOU window
-                    # where an attacker can swap the destination for a symlink
-                    # between close and re-open.  Metadata preservation is
-                    # intentionally omitted — the safer choice is to accept
-                    # default timestamps/mode rather than risk writing metadata
-                    # to an attacker-controlled target (#322 / 1.7).
                     os.close(dst_fd)
             else:
                 # Windows / SafeDir unavailable: legacy path-based copy.

--- a/tests/pipeline/test_stages.py
+++ b/tests/pipeline/test_stages.py
@@ -7,6 +7,7 @@ custom pipelines.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -586,6 +587,80 @@ class TestWriterSafeDirBranches:
         src.write_bytes(b"data")
 
         monkeypatch.setattr(shutil, "copystat", MagicMock(side_effect=OSError("perm")))
+
+        with SafeDir.open_root(out) as sd:
+            ctx = StageContext(
+                file_path=src,
+                destination=out / "src.txt",
+                dest_safedir=sd,
+                dry_run=False,
+            )
+            result = WriterStage().process(ctx)
+
+        assert not result.failed
+        assert (out / "src.txt").read_bytes() == b"data"
+
+    def test_fd_based_mode_and_timestamps_preserved(self, tmp_path: Path) -> None:
+        """E1 fix (issue #354): WriterStage preserves mode and mtime via fchmod/utime.
+
+        os.fchmod and os.utime on the open dst_fd are TOCTOU-free — no path
+        re-open, unlike the removed shutil.copystat call.
+        """
+        import sys
+        import time
+
+        if sys.platform == "win32":
+            pytest.skip("SafeDir path is POSIX-only")
+
+        from utils.safedir import SafeDir
+
+        out = tmp_path / "out"
+        out.mkdir()
+        src = tmp_path / "src.txt"
+        src.write_bytes(b"hello")
+
+        # Set a non-default mode and an old mtime on the source.
+        os.chmod(src, 0o640)
+        old_time = time.time() - 3600  # 1 hour ago
+        os.utime(src, (old_time, old_time))
+
+        with SafeDir.open_root(out) as sd:
+            ctx = StageContext(
+                file_path=src,
+                destination=out / "src.txt",
+                dest_safedir=sd,
+                dry_run=False,
+            )
+            result = WriterStage().process(ctx)
+
+        assert not result.failed
+        dst_stat = (out / "src.txt").stat()
+        src_stat = src.stat()
+
+        assert dst_stat.st_mode & 0o777 == src_stat.st_mode & 0o777, (
+            "destination mode must match source mode"
+        )
+        assert abs(dst_stat.st_mtime - src_stat.st_mtime) < 0.1, (
+            "destination mtime must match source mtime"
+        )
+
+    def test_fd_metadata_oserror_does_not_abort_copy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """E1 fix (issue #354): OSError from fchmod/utime is swallowed; copy still succeeds."""
+        import sys
+
+        if sys.platform == "win32":
+            pytest.skip("SafeDir path is POSIX-only")
+
+        from utils.safedir import SafeDir
+
+        out = tmp_path / "out"
+        out.mkdir()
+        src = tmp_path / "src.txt"
+        src.write_bytes(b"data")
+
+        monkeypatch.setattr(os, "fchmod", MagicMock(side_effect=OSError("perm")))
 
         with SafeDir.open_root(out) as sd:
             ctx = StageContext(


### PR DESCRIPTION
Implements E1 from issue #346 group E (Enhancement).

## Problem

After the `#322 / 1.7` fix removed `shutil.copystat`, the writer stage copied bytes correctly but silently dropped file mode and timestamps — the destination file always got default mode/timestamps rather than matching the source.

The reason `copystat` was removed: it re-opens the destination path _after_ closing the fd, creating a TOCTOU window where an attacker can swap the file for a symlink between `os.close(dst_fd)` and `copystat`'s open.

## Solution

Before closing `dst_fd`, apply `os.fchmod` and `os.utime` on the open file descriptor. Both calls operate directly on the open inode — no path re-resolution, no TOCTOU window.

```python
try:
    src_stat = os.stat(context.file_path)
    os.fchmod(dst_fd, src_stat.st_mode & 0o777)
    os.utime(dst_fd, ns=(src_stat.st_atime_ns, src_stat.st_mtime_ns))
except OSError:
    pass  # non-fatal: metadata loss is preferable to aborting the copy
finally:
    os.close(dst_fd)
```

`OSError` from either call is swallowed — metadata loss is preferable to aborting the copy.

## Tests Added

- `test_fd_based_mode_and_timestamps_preserved` — verifies that after a write, `dst.stat().st_mode & 0o777 == src.stat().st_mode & 0o777` and `abs(dst.mtime - src.mtime) < 0.1s`.
- `test_fd_metadata_oserror_does_not_abort_copy` — patches `os.fchmod` to raise `OSError`, verifies the copy still succeeds and the file contents are correct.

## Parent
Closes #354. Part of epic #346.