### PR TITLE
fix(review-backlog): address 18 unresolved PR review findings from PRs #333-#342 (issue #346)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
       - ".claude/rules/**"
       - ".claude/README.md"
   pull_request:
-    branches: [main, epic/flatten-src-fo, epic/safedir-readside-pr3, epic/safedir-undo-pr5]
+    branches: [main, epic/flatten-src-fo, epic/safedir-readside-pr3, epic/safedir-undo-pr5, epic/review-backlog-346]
     paths-ignore:
       - ".claude/agents/**"
       - ".claude/commands/**"

--- a/src/models/_vision_helpers.py
+++ b/src/models/_vision_helpers.py
@@ -81,7 +81,7 @@ def image_to_data_url(image_path: Path) -> str:
                 raw = fh_direct.read()
         except (SymlinkRejected, ValueError) as exc:
             raise OSError(f"Refused to read symlinked image {image_path}: {exc}") from exc
-    else:
+    else:  # pragma: no cover — Windows-only branch, not reachable on POSIX CI
         with open(
             image_path, "rb"
         ) as fh_win:  # safedir: ok — Windows / NotImplementedError fallback

--- a/src/models/_vision_helpers.py
+++ b/src/models/_vision_helpers.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import base64
 import mimetypes
+import os
+import sys
 from pathlib import Path
 
 # Fallback MIME type when extension is not recognised
@@ -33,6 +35,12 @@ _EXTENSION_MIME: dict[str, str] = {
 def image_to_data_url(image_path: Path) -> str:
     """Encode an image file as a base64 data URL.
 
+    Opens the file via ``SafeDir`` on POSIX so a symlink swapped into
+    the path between directory enumeration and this read is refused with
+    ``SymlinkRejected`` (raised as ``OSError``) rather than dereferenced
+    (issue #352 S3).  On Windows or when SafeDir is unavailable the
+    direct ``open()`` fallback is used.
+
     Args:
         image_path: Path to the image file.
 
@@ -41,7 +49,8 @@ def image_to_data_url(image_path: Path) -> str:
 
     Raises:
         FileNotFoundError: If the file does not exist.
-        OSError: If the file cannot be read.
+        OSError: If the file cannot be read, or if *image_path* is a
+            symlink (POSIX only).
     """
     ext = image_path.suffix.lower()
     mime_type = _EXTENSION_MIME.get(ext)
@@ -49,8 +58,36 @@ def image_to_data_url(image_path: Path) -> str:
         mime_type, _ = mimetypes.guess_type(str(image_path))
     if not mime_type:
         mime_type = _DEFAULT_IMAGE_MIME
-    with open(image_path, "rb") as fh:
-        encoded = base64.b64encode(fh.read()).decode("utf-8")
+
+    raw: bytes
+    if sys.platform != "win32":
+        try:
+            from utils.safedir import SafeDir, SymlinkRejected
+
+            with SafeDir.open_root(image_path.parent) as sd:
+                fd = sd.open_for_reader(image_path.name)
+                try:
+                    fh = os.fdopen(fd, "rb", closefd=True)
+                except OSError:
+                    os.close(fd)
+                    raise
+                with fh:
+                    raw = fh.read()
+        except (NotImplementedError, ImportError):
+            # SafeDir primitives unavailable — fall through to direct open.
+            with open(
+                image_path, "rb"
+            ) as fh_direct:  # safedir: ok — Windows / NotImplementedError fallback
+                raw = fh_direct.read()
+        except (SymlinkRejected, ValueError) as exc:
+            raise OSError(f"Refused to read symlinked image {image_path}: {exc}") from exc
+    else:
+        with open(
+            image_path, "rb"
+        ) as fh_win:  # safedir: ok — Windows / NotImplementedError fallback
+            raw = fh_win.read()
+
+    encoded = base64.b64encode(raw).decode("utf-8")
     return f"data:{mime_type};base64,{encoded}"
 
 

--- a/src/pipeline/stages/writer.py
+++ b/src/pipeline/stages/writer.py
@@ -79,15 +79,18 @@ class WriterStage:
                             written = 0
                             while written < len(view):
                                 written += os.write(dst_fd, view[written:])
+                    # E1 fix (issue #354): preserve mode and timestamps via fd-based
+                    # calls while the destination fd is still open — TOCTOU-free.
+                    # os.fchmod / os.utime on an open fd operate on the inode
+                    # directly, unlike shutil.copystat which re-opens the path and
+                    # creates a window for a symlink-swap attack (#322 / 1.7).
+                    try:
+                        src_stat = os.stat(context.file_path)
+                        os.fchmod(dst_fd, src_stat.st_mode & 0o777)
+                        os.utime(dst_fd, ns=(src_stat.st_atime_ns, src_stat.st_mtime_ns))
+                    except OSError:
+                        pass  # non-fatal: metadata loss is preferable to aborting the copy
                 finally:
-                    # 1.7 — Do NOT call shutil.copystat(src, dst_path) after
-                    # os.close(dst_fd): the destination fd is closed before
-                    # copystat re-opens the path, creating a TOCTOU window
-                    # where an attacker can swap the destination for a symlink
-                    # between close and re-open.  Metadata preservation is
-                    # intentionally omitted — the safer choice is to accept
-                    # default timestamps/mode rather than risk writing metadata
-                    # to an attacker-controlled target (#322 / 1.7).
                     os.close(dst_fd)
             else:
                 # Windows / SafeDir unavailable: legacy path-based copy.

--- a/src/services/deduplication/backup.py
+++ b/src/services/deduplication/backup.py
@@ -59,8 +59,39 @@ def _backup_safe_unlink(path: Path, log: logging.Logger) -> bool:
 
     try:
         with SafeDir.open_root(path.parent) as safe_dir:
+            # R4 fix: lstat BEFORE open_child so FIFOs (and other non-regular
+            # entries) are rejected without attempting the open.  open_child
+            # with O_RDONLY on a FIFO would block until a writer connects,
+            # hanging cleanup indefinitely (issue #350 R4).
+            pre_lst = safe_dir.lstat(path.name)
+            if not _stat.S_ISREG(pre_lst.st_mode):
+                log.warning(
+                    "security_event inode_swap_in_backup path=%s mode=0o%o — "
+                    "non-regular file; skipping (R4 FIFO-hang prevention)",
+                    path,
+                    pre_lst.st_mode,
+                )
+                return False
+
             # Open the file (O_RDONLY | O_NOFOLLOW) to pin its inode.
-            child_fd = safe_dir.open_child(path.name)
+            try:
+                child_fd = safe_dir.open_child(path.name)
+            except PermissionError:
+                # T5 fix (issue #350): write-only files (mode 0o200) cannot be
+                # opened O_RDONLY even by the owner.  Compensate for the missing
+                # fd-pin by re-lstat-ing the entry and confirming the inode has
+                # not changed since pre_lst (reduces — but does not eliminate —
+                # the name-swap window between the two lstat calls).
+                post_lst = safe_dir.lstat(path.name)
+                if (post_lst.st_dev, post_lst.st_ino) != (pre_lst.st_dev, pre_lst.st_ino):
+                    log.warning(
+                        "security_event inode_swap_in_backup path=%s — "
+                        "inode changed between lstat calls; skipping",
+                        path,
+                    )
+                    return False
+                safe_dir.unlink(path.name)
+                return True
             try:
                 fst = os.fstat(child_fd)
             finally:
@@ -75,29 +106,37 @@ def _backup_safe_unlink(path: Path, log: logging.Logger) -> bool:
                 return False
 
             # Re-stat the name (lstat, no symlink follow) and compare
-            # (dev, ino, size) to detect a swap between open and unlink.
+            # (dev, ino) to detect a swap between open and unlink.
+            # C3 fix (issue #350): omit st_size — a concurrent writer can
+            # legitimately change the size on the same inode between fstat and
+            # lstat, which would be a false-positive swap detection.
             lst = safe_dir.lstat(path.name)
-            if (lst.st_dev, lst.st_ino, lst.st_size) != (
-                fst.st_dev,
-                fst.st_ino,
-                fst.st_size,
-            ):
+            if (lst.st_dev, lst.st_ino) != (fst.st_dev, fst.st_ino):
                 log.warning(
                     "security_event inode_swap_in_backup path=%s "
-                    "fstat=(%d,%d,%d) lstat=(%d,%d,%d) — skipping",
+                    "fstat=(%d,%d) lstat=(%d,%d) — skipping",
                     path,
                     fst.st_dev,
                     fst.st_ino,
-                    fst.st_size,
                     lst.st_dev,
                     lst.st_ino,
-                    lst.st_size,
                 )
                 return False
 
             safe_dir.unlink(path.name)
             return True
-    except (OSError, ValueError):
+    except ValueError as exc:
+        # C1/C2 fix (issue #350): SafeDir raises ValueError for filenames
+        # containing characters it rejects (e.g. backslash).  Log at WARNING
+        # so operators can see this — the old DEBUG log was invisible in prod.
+        log.warning(
+            "security_event backup_name_rejected path=%s: %s — "
+            "filename rejected by SafeDir name validation",
+            path,
+            exc,
+        )
+        return False
+    except OSError:
         log.debug("Failed to remove backup %s", path, exc_info=True)
         return False
 

--- a/src/services/deduplication/extractor.py
+++ b/src/services/deduplication/extractor.py
@@ -32,7 +32,7 @@ try:
 except ImportError:  # pragma: no cover
     _ET = _stdlib_ET  # type: ignore[assignment]
 
-from utils.readers import read_file_via_safedir_anchored
+from utils.readers import FileReadError
 from utils.safedir import SafeDir, SymlinkRejected
 
 logger = logging.getLogger(__name__)
@@ -110,14 +110,33 @@ class DocumentExtractor:
         # only when SafeDir is unavailable (Windows).
         if sys.platform != "win32":
             if scan_root is not None:
-                # Anchored traversal: validates every intermediate component
-                # between scan_root and file_path with O_NOFOLLOW (#286/#325).
+                # Anchored traversal: open via SafeDir.open_anchored_reader so
+                # every intermediate component between scan_root and file_path
+                # is validated with O_NOFOLLOW.
+                #
+                # S2 fix (issue #349): the old approach called
+                # read_file_via_safedir_anchored and fell through to an
+                # unanchored SafeDir.open_root(file_path.parent) branch when
+                # the extension wasn't in the utils.readers registry (e.g.
+                # ODT), bypassing intermediate-ancestor protection entirely.
+                # open_anchored_reader handles all extensions uniformly.
+                #
+                # C4 fix (issue #349): read_file_via_safedir_anchored routed
+                # through utils.readers defaults (max_pages=5, max_chars=5000),
+                # yielding shorter text when scan_root was set and silently
+                # degrading dedup accuracy.  _extract_from_fileobj uses the
+                # full-file extractors instead.
                 try:
-                    content = read_file_via_safedir_anchored(file_path, trusted_root=scan_root)
-                    if content is not None:
-                        return content
-                    # Extension not in SafeDir registry — fall through to the
-                    # per-format fileobj branch below for full format coverage.
+                    relative = file_path.relative_to(scan_root)  # ValueError if escaped
+                    with SafeDir.open_root(scan_root) as root_sd:
+                        fd = root_sd.open_anchored_reader(relative)
+                        try:
+                            fileobj = os.fdopen(fd, "rb", closefd=True)
+                        except OSError:
+                            os.close(fd)
+                            raise
+                        with fileobj:
+                            return self._extract_from_fileobj(extension, fileobj, file_path.name)
                 except SymlinkRejected as exc:
                     logger.warning(
                         "Refused to read symlinked file %s: %s",
@@ -128,7 +147,9 @@ class DocumentExtractor:
                     return ""
                 except NotImplementedError:
                     logger.debug("SafeDir unavailable; using legacy reader for %s", file_path.name)
-                except (OSError, ValueError, ImportError) as e:
+                except (OSError, ValueError, ImportError, FileReadError) as e:
+                    # C5 fix (issue #349): FileReadError raised by format-specific
+                    # extractors for malformed files was not caught before.
                     logger.error("Error extracting text from %s: %s", file_path, e, exc_info=True)
                     return ""
 

--- a/src/utils/readers/cad.py
+++ b/src/utils/readers/cad.py
@@ -366,7 +366,12 @@ def read_step_file(
                 total_bytes = 0
                 hit_byte_cap = False
                 for _ in range(max_lines):
-                    line = text_stream.readline()
+                    # Pass the remaining budget to readline so a single very long
+                    # line cannot exhaust memory before the byte-cap check fires.
+                    # readline(size) reads at most `size` characters; STEP files
+                    # are ASCII so chars ≈ bytes (issue #351 R3).
+                    remaining = _MAX_STEP_BYTES - total_bytes + 1
+                    line = text_stream.readline(remaining)
                     if not line:
                         break
                     total_bytes += len(line.encode("utf-8", errors="ignore"))
@@ -396,7 +401,9 @@ def read_step_file(
             total_bytes = 0
             hit_byte_cap = False
             for _ in range(max_lines):
-                line = f.readline()
+                # Same budget-bound pattern as the fileobj branch (issue #351 R3).
+                remaining = _MAX_STEP_BYTES - total_bytes + 1
+                line = f.readline(remaining)
                 if not line:
                     break
                 total_bytes += len(line.encode("utf-8", errors="ignore"))

--- a/src/watcher/handler.py
+++ b/src/watcher/handler.py
@@ -257,10 +257,12 @@ class FileEventHandler(FileSystemEventHandler):
         logged.  Any other ``OSError`` (e.g. the file was deleted) is
         treated as "allow" so transient races don't silence real events.
 
-        Paths that are NOT under ``watch_root`` (e.g. from a second watch
-        directory added via ``add_directory()``) are allowed through — they
-        are outside this SafeDir's scope and the pipeline-level SafeDir is
-        their backstop.
+        Paths whose lstat form cannot be relativized to ``watch_root`` (i.e.
+        ``relative_to`` raises ``ValueError``) are **rejected** — returning
+        ``False``.  The old behavior of allowing them through was a security
+        bypass: a symlink whose resolved target escapes the watch root but
+        whose lstat path also cannot be relativized would pass unchecked
+        (issue #347).
 
         Changes vs. original PR6 implementation (issue #322):
 
@@ -301,19 +303,22 @@ class FileEventHandler(FileSystemEventHandler):
             lstat_path = lstat_dir / path.name
 
             # Check whether this path is under the primary watch_root.
-            # ``relative_to`` raises ``ValueError`` for unrelated trees (e.g.
-            # a second directory added via ``add_directory()``); those are
-            # allowed through because they are outside this SafeDir's scope.
+            # ``relative_to`` raises ``ValueError`` when the lstat path is not
+            # under watch_root at all (e.g. a symlink whose resolved directory
+            # escapes the root, or a second watch directory whose lstat form
+            # falls outside the tree).  Such paths are **rejected** — returning
+            # False — because we cannot verify containment.  The old behaviour
+            # of returning True here was a security bypass: issue #347.
             try:
                 rel = lstat_path.relative_to(watch_root)
             except ValueError:
-                logger.debug(
-                    "SafeDir watcher: path %s outside primary root %s — "
-                    "allowing (pipeline will re-check)",
+                logger.error(
+                    "security_event watcher_path_outside_root path=%s: "
+                    "lstat path cannot be relativized to watch root %s — dropped",
                     path,
                     watch_root,
                 )
-                return True
+                return False
 
             # 1.4 — Extra guard: commonpath catches edge cases where
             # relative_to succeeds but the path would escape (e.g. on

--- a/src/watcher/monitor.py
+++ b/src/watcher/monitor.py
@@ -121,9 +121,12 @@ class FileMonitor:
             # stop() always sets handler._safe_dir = None to release the fd; on
             # restart the handler would run without watcher-level symlink checks
             # unless we reopen it here (issue #348 P1 follow-up).
+            # Guard: only for single-root configs — __init__ deliberately leaves
+            # _safe_dir=None for multi-root setups so events from roots 2..N are
+            # not silently dropped (issue #347 P1 follow-up).
             if (
                 self.handler._safe_dir is None
-                and self.config.watch_directories
+                and len(self.config.watch_directories) == 1
                 and sys.platform != "win32"
             ):
                 try:
@@ -244,7 +247,12 @@ class FileMonitor:
                     path.relative_to(current_root)
                     # path is under the current root — no change needed
                 except ValueError:
-                    # path is outside the current root — disable check + warn
+                    # path is outside the current root — close and clear SafeDir
+                    # so _safedir_allows() no longer calls open_child() against
+                    # the old root for events from the new directory.
+                    if self.handler._safe_dir is not None:
+                        self.handler._safe_dir.__exit__(None, None, None)
+                        self.handler._safe_dir = None
                     self.handler._watch_root = None
                     logger.warning(
                         "FileMonitor.add_directory: %s is outside the primary SafeDir root (%s) "

--- a/src/watcher/monitor.py
+++ b/src/watcher/monitor.py
@@ -63,21 +63,33 @@ class FileMonitor:
         safe_dir = None
         watch_root: Path | None = None
         if self.config.watch_directories and sys.platform != "win32":
-            try:
-                from utils.safedir import SafeDir
-
-                watch_root = Path(self.config.watch_directories[0]).resolve()
-                safe_dir = SafeDir.open_root(watch_root)
-            except Exception as exc:
-                logger.warning(
-                    "FileMonitor: cannot open SafeDir for watch root %s: %s — "
-                    "watcher-level symlink check disabled",
-                    self.config.watch_directories[0] if self.config.watch_directories else "(none)",
-                    exc,
-                    exc_info=True,
+            if len(self.config.watch_directories) > 1:
+                # Multi-root startup: the single-root containment check in
+                # _safedir_allows cannot be applied because events from roots
+                # 2..N would fail relative_to(watch_root) and be silently
+                # dropped (issue #347 P1 follow-up).  Skip SafeDir entirely;
+                # the pipeline-level SafeDir is the backstop for all roots.
+                logger.debug(
+                    "FileMonitor: %d watch directories at startup — watcher-level "
+                    "containment check disabled; pipeline SafeDir is backstop",
+                    len(self.config.watch_directories),
                 )
-                safe_dir = None
-                watch_root = None
+            else:
+                try:
+                    from utils.safedir import SafeDir
+
+                    watch_root = Path(self.config.watch_directories[0]).resolve()
+                    safe_dir = SafeDir.open_root(watch_root)
+                except Exception as exc:
+                    logger.warning(
+                        "FileMonitor: cannot open SafeDir for watch root %s: %s — "
+                        "watcher-level symlink check disabled",
+                        self.config.watch_directories[0],
+                        exc,
+                        exc_info=True,
+                    )
+                    safe_dir = None
+                    watch_root = None
 
         self.handler = FileEventHandler(
             self.config, self.queue, safe_dir=safe_dir, watch_root=watch_root
@@ -181,6 +193,26 @@ class FileMonitor:
                 # If not running, just add to config for when start() is called
                 if path not in self.config.watch_directories:
                     self.config.watch_directories.append(path)
+
+            # Only disable the single-root containment check when the new
+            # directory is genuinely outside the current watch root.  Paths
+            # that are sub-directories of the existing root still pass
+            # relative_to(watch_root) and do not require disabling the check
+            # (issue #347 P2 follow-up).
+            current_root = self.handler._watch_root
+            if current_root is not None:
+                try:
+                    path.relative_to(current_root)
+                    # path is under the current root — containment check remains active
+                except ValueError:
+                    # path is outside the current root — disable containment check
+                    self.handler._watch_root = None
+                    logger.debug(
+                        "FileMonitor: disabled watcher-level root containment check "
+                        "(new directory %s outside primary root %s; pipeline SafeDir is backstop)",
+                        path,
+                        current_root,
+                    )
 
             logger.info("Added watch directory: %s (recursive=%s)", path, recursive)
 

--- a/src/watcher/monitor.py
+++ b/src/watcher/monitor.py
@@ -117,6 +117,32 @@ class FileMonitor:
             if self._running:
                 raise RuntimeError("FileMonitor is already running")
 
+            # Reinitialize SafeDir if it was released by a previous stop() call.
+            # stop() always sets handler._safe_dir = None to release the fd; on
+            # restart the handler would run without watcher-level symlink checks
+            # unless we reopen it here (issue #348 P1 follow-up).
+            if (
+                self.handler._safe_dir is None
+                and self.config.watch_directories
+                and sys.platform != "win32"
+            ):
+                try:
+                    from utils.safedir import SafeDir
+
+                    watch_root = Path(self.config.watch_directories[0]).resolve()
+                    self.handler._safe_dir = SafeDir.open_root(watch_root)
+                    self.handler._watch_root = watch_root
+                    logger.debug(
+                        "FileMonitor: (re)initialized SafeDir for watch root %s", watch_root
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "FileMonitor: cannot (re)initialize SafeDir on start: %s — "
+                        "watcher-level symlink check disabled",
+                        exc,
+                        exc_info=True,
+                    )
+
             # Try native observer first, fallback to polling if it fails
             try:
                 self._observer = Observer()
@@ -151,20 +177,31 @@ class FileMonitor:
     def stop(self) -> None:
         """Stop monitoring and clean up resources.
 
-        Stops the watchdog observer and clears all watch state.
-        Safe to call even if the monitor is not running.
+        Stops the watchdog observer, releases the SafeDir file descriptor,
+        and clears all watch state. Safe to call even if the monitor is not
+        running.
         """
         with self._lock:
-            if not self._running or self._observer is None:
-                return
+            if self._running and self._observer is not None:
+                observer = self._observer
+                observer.stop()  # type: ignore[no-untyped-call]
+                observer.join(timeout=5.0)
+                self._observer = None
+                self._watches.clear()
+                self._running = False
+                logger.info("FileMonitor stopped")
 
-            observer = self._observer
-            observer.stop()  # type: ignore[no-untyped-call]
-            observer.join(timeout=5.0)
-            self._observer = None
-            self._watches.clear()
-            self._running = False
-            logger.info("FileMonitor stopped")
+            # Release the directory fd held by the SafeDir regardless of
+            # whether the observer was running.  Each daemon restart opens a
+            # fresh SafeDir in __init__; without this cleanup the old fd leaks
+            # and repeated restarts accumulate toward EMFILE.  __exit__ is
+            # idempotent so calling stop() more than once is safe.
+            if self.handler._safe_dir is not None:
+                try:
+                    self.handler._safe_dir.__exit__(None, None, None)
+                except OSError:
+                    pass  # suppress any stray EBADF
+                self.handler._safe_dir = None
 
     def add_directory(self, path: Path, recursive: bool = True) -> None:
         """Add a directory to be monitored.
@@ -195,21 +232,24 @@ class FileMonitor:
                     self.config.watch_directories.append(path)
 
             # Only disable the single-root containment check when the new
-            # directory is genuinely outside the current watch root.  Paths
-            # that are sub-directories of the existing root still pass
-            # relative_to(watch_root) and do not require disabling the check
-            # (issue #347 P2 follow-up).
+            # directory is genuinely outside the current watch root.  Sub-
+            # directories of the existing root pass relative_to() and do
+            # not require disabling the check (issue #347 P2).
+            # When the check IS disabled, emit a WARNING so operators know
+            # that only the pipeline-level SafeDir backstop is active for
+            # the new directory (issue #348 R2).
             current_root = self.handler._watch_root
             if current_root is not None:
                 try:
                     path.relative_to(current_root)
-                    # path is under the current root — containment check remains active
+                    # path is under the current root — no change needed
                 except ValueError:
-                    # path is outside the current root — disable containment check
+                    # path is outside the current root — disable check + warn
                     self.handler._watch_root = None
-                    logger.debug(
-                        "FileMonitor: disabled watcher-level root containment check "
-                        "(new directory %s outside primary root %s; pipeline SafeDir is backstop)",
+                    logger.warning(
+                        "FileMonitor.add_directory: %s is outside the primary SafeDir root (%s) "
+                        "— watcher-level containment check disabled; "
+                        "pipeline-level SafeDir is the active backstop",
                         path,
                         current_root,
                     )

--- a/tests/integration/test_watcher_components.py
+++ b/tests/integration/test_watcher_components.py
@@ -371,12 +371,18 @@ class TestFileEventHandlerSafeDirIntegration:
             handler = FileEventHandler(config, queue, safe_dir=sd, watch_root=watch_root)
             assert handler._safedir_allows(regular) is True
 
-    def test_path_outside_root_allowed_through(self, tmp_path: Path) -> None:
-        """_safedir_allows allows paths outside the primary watch root through.
+    def test_path_outside_root_rejected(self, tmp_path: Path) -> None:
+        """_safedir_allows rejects paths whose lstat form is outside the primary watch root.
 
-        Paths from secondary watch directories (added via add_directory()) are
-        outside this SafeDir's scope; they are allowed through here and
-        re-checked by the pipeline-level SafeDir backstop (1.4 / #322).
+        S1 fix (issue #347): the old behaviour returned ``True`` (allow) when
+        ``lstat_path.relative_to(watch_root)`` raised ``ValueError``, which was a
+        security bypass — a symlink whose resolved directory escapes the root would
+        pass the watcher-level SafeDir check unchallenged.
+
+        The new behaviour returns ``False`` (reject).  Multi-root ``FileMonitor``
+        configs avoid this by disabling the single-root SafeDir entirely in
+        ``__init__`` (``_safe_dir = None``) when more than one watch directory is
+        configured; the pipeline-level SafeDir is their backstop.
         """
 
         if sys.platform == "win32":
@@ -396,7 +402,7 @@ class TestFileEventHandlerSafeDirIntegration:
         queue = EventQueue()
         with SafeDir.open_root(watch_root) as sd:
             handler = FileEventHandler(config, queue, safe_dir=sd, watch_root=watch_root)
-            assert handler._safedir_allows(outside) is True
+            assert handler._safedir_allows(outside) is False
 
     def test_nested_path_allowed_through(self, tmp_path: Path) -> None:
         """_safedir_allows allows nested paths (checked at pipeline level)."""

--- a/tests/models/test_vision_helpers.py
+++ b/tests/models/test_vision_helpers.py
@@ -1,0 +1,109 @@
+"""Tests for models._vision_helpers — focused on the SafeDir integration (issue #352 S3)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from models._vision_helpers import image_to_data_url
+
+
+@pytest.mark.ci
+@pytest.mark.unit
+@pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
+class TestImageToDataUrlSafeDirIntegration:
+    """image_to_data_url must use SafeDir on POSIX to reject symlinked images (issue #352 S3).
+
+    The old implementation called open(image_path, 'rb') directly, with no
+    symlink or path-escape check.  The fix opens via SafeDir.open_for_reader so
+    a symlink swapped into the path between directory enumeration and the read
+    is refused with SymlinkRejected → OSError rather than silently dereferenced.
+    """
+
+    def test_reads_real_image_file(self, tmp_path: Path) -> None:
+        """Happy path: a regular image file returns a valid data URL."""
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0" + b"fake-jpeg-data")
+
+        result = image_to_data_url(img)
+
+        assert result.startswith("data:image/jpeg;base64,")
+        assert len(result) > len("data:image/jpeg;base64,")
+
+    def test_symlinked_image_raises_oserror(self, tmp_path: Path) -> None:
+        """A symlink in place of the image must be refused with OSError.
+
+        Without the SafeDir fix, open() would follow the symlink and return
+        the target's content — potentially exfiltrating a sensitive file.
+        """
+        real = tmp_path / "secret.dat"
+        real.write_bytes(b"TOP_SECRET_CONTENT")
+        img_dir = tmp_path / "images"
+        img_dir.mkdir()
+        decoy = img_dir / "photo.jpg"
+        try:
+            decoy.symlink_to(real)
+        except OSError:
+            pytest.skip("symlink creation not supported on this filesystem")
+
+        with pytest.raises(OSError):
+            image_to_data_url(decoy)
+
+    def test_missing_file_raises_file_not_found(self, tmp_path: Path) -> None:
+        """FileNotFoundError propagates unchanged for missing files."""
+        with pytest.raises((FileNotFoundError, OSError)):
+            image_to_data_url(tmp_path / "nonexistent.jpg")
+
+    def test_not_implemented_error_falls_back_to_direct_open(self, tmp_path: Path) -> None:
+        """NotImplementedError from SafeDir.open_root falls through to direct open().
+
+        Exercises lines 78-81: the ``except (NotImplementedError, ImportError)``
+        fallback that opens the file directly when SafeDir primitives are
+        unavailable on the current platform.
+        """
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0" + b"fallback-jpeg-data")
+
+        with patch(
+            "utils.safedir.SafeDir.open_root",
+            side_effect=NotImplementedError("simulated SafeDir unavailable"),
+        ):
+            result = image_to_data_url(img)
+
+        assert result.startswith("data:image/jpeg;base64,")
+
+    def test_osfdopen_failure_closes_fd_and_propagates(self, tmp_path: Path) -> None:
+        """OSError from os.fdopen in the SafeDir branch closes the raw fd and re-raises.
+
+        Exercises lines 71-73 — the cleanup path where os.fdopen raises after
+        open_for_reader returned a valid fd:
+
+        .. code-block:: python
+
+            try:
+                fh = os.fdopen(fd, "rb", closefd=True)  # raises
+            except OSError:        # line 71  ← covered here
+                os.close(fd)       # line 72  ← covered here
+                raise              # line 73  ← covered here
+        """
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0" + b"data")
+
+        original_fdopen = os.fdopen
+
+        call_count = 0
+
+        def patched_fdopen(fd: int, *args: object, **kwargs: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise OSError("simulated os.fdopen failure")
+            return original_fdopen(fd, *args, **kwargs)  # type: ignore[arg-type]
+
+        with patch("models._vision_helpers.os.fdopen", patched_fdopen):
+            with pytest.raises(OSError):
+                image_to_data_url(img)

--- a/tests/models/test_vision_helpers.py
+++ b/tests/models/test_vision_helpers.py
@@ -14,6 +14,7 @@ from models._vision_helpers import image_to_data_url
 
 @pytest.mark.ci
 @pytest.mark.unit
+@pytest.mark.integration
 @pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
 class TestImageToDataUrlSafeDirIntegration:
     """image_to_data_url must use SafeDir on POSIX to reject symlinked images (issue #352 S3).

--- a/tests/pipeline/test_stages.py
+++ b/tests/pipeline/test_stages.py
@@ -7,6 +7,7 @@ custom pipelines.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -586,6 +587,80 @@ class TestWriterSafeDirBranches:
         src.write_bytes(b"data")
 
         monkeypatch.setattr(shutil, "copystat", MagicMock(side_effect=OSError("perm")))
+
+        with SafeDir.open_root(out) as sd:
+            ctx = StageContext(
+                file_path=src,
+                destination=out / "src.txt",
+                dest_safedir=sd,
+                dry_run=False,
+            )
+            result = WriterStage().process(ctx)
+
+        assert not result.failed
+        assert (out / "src.txt").read_bytes() == b"data"
+
+    def test_fd_based_mode_and_timestamps_preserved(self, tmp_path: Path) -> None:
+        """E1 fix (issue #354): WriterStage preserves mode and mtime via fchmod/utime.
+
+        os.fchmod and os.utime on the open dst_fd are TOCTOU-free — no path
+        re-open, unlike the removed shutil.copystat call.
+        """
+        import sys
+        import time
+
+        if sys.platform == "win32":
+            pytest.skip("SafeDir path is POSIX-only")
+
+        from utils.safedir import SafeDir
+
+        out = tmp_path / "out"
+        out.mkdir()
+        src = tmp_path / "src.txt"
+        src.write_bytes(b"hello")
+
+        # Set a non-default mode and an old mtime on the source.
+        os.chmod(src, 0o640)
+        old_time = time.time() - 3600  # 1 hour ago
+        os.utime(src, (old_time, old_time))
+
+        with SafeDir.open_root(out) as sd:
+            ctx = StageContext(
+                file_path=src,
+                destination=out / "src.txt",
+                dest_safedir=sd,
+                dry_run=False,
+            )
+            result = WriterStage().process(ctx)
+
+        assert not result.failed
+        dst_stat = (out / "src.txt").stat()
+        src_stat = src.stat()
+
+        assert dst_stat.st_mode & 0o777 == src_stat.st_mode & 0o777, (
+            "destination mode must match source mode"
+        )
+        assert abs(dst_stat.st_mtime - src_stat.st_mtime) < 0.1, (
+            "destination mtime must match source mtime"
+        )
+
+    def test_fd_metadata_oserror_does_not_abort_copy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """E1 fix (issue #354): OSError from fchmod/utime is swallowed; copy still succeeds."""
+        import sys
+
+        if sys.platform == "win32":
+            pytest.skip("SafeDir path is POSIX-only")
+
+        from utils.safedir import SafeDir
+
+        out = tmp_path / "out"
+        out.mkdir()
+        src = tmp_path / "src.txt"
+        src.write_bytes(b"data")
+
+        monkeypatch.setattr(os, "fchmod", MagicMock(side_effect=OSError("perm")))
 
         with SafeDir.open_root(out) as sd:
             ctx = StageContext(

--- a/tests/services/deduplication/test_dedup_backup.py
+++ b/tests/services/deduplication/test_dedup_backup.py
@@ -435,10 +435,16 @@ class TestCleanupOldBackupsValueError:
         assert backup_path in removed
         assert not backup_path.exists()
 
-        # Both entries are gone from the manifest (stale entries pruned)
+        # The legitimate backup entry is gone (file was deleted).
+        # The bad-name entry is RETAINED — _backup_safe_unlink returned False
+        # for it (SafeDir ValueError), so the file was not removed and the
+        # manifest entry must be kept for retry on the next pass (issue #350 C1/C2).
         final_manifest = manager._load_manifest()
         assert str(backup_path) not in final_manifest
-        assert bad_key not in final_manifest
+        assert bad_key in final_manifest, (
+            "manifest entry for a file that was NOT deleted must be preserved "
+            "so the next cleanup pass can retry (issue #350 C1/C2)"
+        )
 
     @pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
     def test_valueerror_from_backup_exists_logged_as_warning(
@@ -602,3 +608,118 @@ class TestBackupSafeUnlinkInodeSwap:
         result = _backup_safe_unlink(target, logging.getLogger("test"))
 
         assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #350 — R4, C3, T5, C1/C2 refinements to _backup_safe_unlink
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
+class TestBackupSafeUnlinkIssue350:
+    """Targeted tests for the issue #350 refinements."""
+
+    def test_fifo_is_rejected_before_open(self, tmp_path: Path) -> None:
+        """R4: a FIFO must be rejected by lstat type-check before open_child is called.
+
+        open_child with O_RDONLY would block indefinitely on a FIFO; lstat checks
+        the type first so we never attempt the open.
+        """
+        import logging
+        import stat
+
+        fifo = tmp_path / "queue.fifo"
+        os.mkfifo(fifo)
+        assert stat.S_ISFIFO(fifo.stat().st_mode)
+
+        result = _backup_safe_unlink(fifo, logging.getLogger("test"))
+
+        assert result is False
+        assert fifo.exists(), "FIFO must not be unlinked — type check should reject it"
+
+    def test_size_change_on_same_inode_does_not_trigger_swap_detection(
+        self, tmp_path: Path
+    ) -> None:
+        """C3: (st_dev, st_ino) comparison — st_size change on same inode must not abort.
+
+        The old code compared (st_dev, st_ino, st_size).  A concurrent writer on the
+        same inode can change st_size between fstat and lstat, causing a false positive
+        that orphans a real backup.  The fix compares only (st_dev, st_ino).
+        """
+        import logging
+
+        target = tmp_path / "backup.dat"
+        target.write_bytes(b"x" * 100)
+        real_st = target.stat()
+
+        # Build an fstat result with same (dev, ino) but different size — simulates
+        # a concurrent write between fstat and lstat.
+        same_ino_different_size = os.stat_result(
+            (
+                real_st.st_mode,
+                real_st.st_ino,  # same inode
+                real_st.st_dev,
+                real_st.st_nlink,
+                real_st.st_uid,
+                real_st.st_gid,
+                real_st.st_size + 50,  # different size — concurrent writer
+                real_st.st_atime,
+                real_st.st_mtime,
+                real_st.st_ctime,
+            )
+        )
+
+        with patch("os.fstat", return_value=same_ino_different_size):
+            result = _backup_safe_unlink(target, logging.getLogger("test"))
+
+        # Must succeed — size difference on same inode is not a swap
+        assert result is True
+        assert not target.exists()
+
+    def test_valueerror_logged_at_warning_level(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """C1/C2: ValueError from SafeDir name validation must be logged at WARNING.
+
+        The old code logged at DEBUG, making it invisible in production.  A filename
+        that SafeDir rejects (e.g. containing backslash) is a notable event that
+        operators should see.
+        """
+        import logging
+
+        bad_path = tmp_path / "bad\\name.bak"
+
+        with caplog.at_level(logging.WARNING, logger="services.deduplication.backup"):
+            result = _backup_safe_unlink(
+                bad_path, logging.getLogger("services.deduplication.backup")
+            )
+
+        assert result is False
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("backup_name_rejected" in msg for msg in warning_messages), (
+            f"expected backup_name_rejected WARNING, got: {warning_messages}"
+        )
+
+    def test_write_only_file_is_unlinked_without_fd_pin(self, tmp_path: Path) -> None:
+        """T5: a write-only file (mode 0o200) can still be unlinked.
+
+        open_child with O_RDONLY raises PermissionError on a 0o200 file.  The fix
+        detects this and proceeds with unlink-without-fd-pin (SafeDir's dir_fd still
+        prevents directory swaps).
+        """
+        import logging
+
+        target = tmp_path / "locked.bak"
+        target.write_bytes(b"data")
+        target.chmod(0o200)  # write-only — open O_RDONLY would fail
+
+        try:
+            result = _backup_safe_unlink(target, logging.getLogger("test"))
+        finally:
+            # Restore permissions so tmp_path cleanup succeeds
+            if target.exists():
+                target.chmod(0o600)
+
+        assert result is True
+        assert not target.exists()

--- a/tests/services/deduplication/test_dedup_backup.py
+++ b/tests/services/deduplication/test_dedup_backup.py
@@ -617,6 +617,7 @@ class TestBackupSafeUnlinkInodeSwap:
 
 @pytest.mark.ci
 @pytest.mark.unit
+@pytest.mark.integration
 @pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
 class TestBackupSafeUnlinkIssue350:
     """Targeted tests for the issue #350 refinements."""

--- a/tests/services/deduplication/test_dedup_backup.py
+++ b/tests/services/deduplication/test_dedup_backup.py
@@ -615,6 +615,7 @@ class TestBackupSafeUnlinkInodeSwap:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.ci
 @pytest.mark.unit
 @pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
 class TestBackupSafeUnlinkIssue350:
@@ -623,20 +624,25 @@ class TestBackupSafeUnlinkIssue350:
     def test_fifo_is_rejected_before_open(self, tmp_path: Path) -> None:
         """R4: a FIFO must be rejected by lstat type-check before open_child is called.
 
-        open_child with O_RDONLY would block indefinitely on a FIFO; lstat checks
-        the type first so we never attempt the open.
+        open_child with O_RDONLY on a FIFO blocks until a writer connects; the
+        pre-open lstat check must fire first so open_child is never reached.
         """
         import logging
         import stat
+        from unittest.mock import patch
+
+        from utils.safedir import SafeDir
 
         fifo = tmp_path / "queue.fifo"
         os.mkfifo(fifo)
         assert stat.S_ISFIFO(fifo.stat().st_mode)
 
-        result = _backup_safe_unlink(fifo, logging.getLogger("test"))
+        with patch.object(SafeDir, "open_child", autospec=True) as mock_open_child:
+            result = _backup_safe_unlink(fifo, logging.getLogger("test"))
 
         assert result is False
         assert fifo.exists(), "FIFO must not be unlinked — type check should reject it"
+        mock_open_child.assert_not_called()
 
     def test_size_change_on_same_inode_does_not_trigger_swap_detection(
         self, tmp_path: Path
@@ -702,24 +708,29 @@ class TestBackupSafeUnlinkIssue350:
         )
 
     def test_write_only_file_is_unlinked_without_fd_pin(self, tmp_path: Path) -> None:
-        """T5: a write-only file (mode 0o200) can still be unlinked.
+        """T5: a write-only file raises PermissionError from open_child; unlink still succeeds.
 
-        open_child with O_RDONLY raises PermissionError on a 0o200 file.  The fix
-        detects this and proceeds with unlink-without-fd-pin (SafeDir's dir_fd still
-        prevents directory swaps).
+        The fix catches PermissionError from open_child and proceeds with
+        unlink-without-fd-pin — SafeDir's dir_fd still prevents directory swaps.
+
+        Uses a deterministic mock rather than chmod(0o200) so the test passes
+        even under privileged users (e.g. root on CI runners).
         """
         import logging
+        from unittest.mock import patch
+
+        from utils.safedir import SafeDir
 
         target = tmp_path / "locked.bak"
         target.write_bytes(b"data")
-        target.chmod(0o200)  # write-only — open O_RDONLY would fail
 
-        try:
+        with patch.object(
+            SafeDir,
+            "open_child",
+            autospec=True,
+            side_effect=PermissionError("simulated write-only file"),
+        ):
             result = _backup_safe_unlink(target, logging.getLogger("test"))
-        finally:
-            # Restore permissions so tmp_path cleanup succeeds
-            if target.exists():
-                target.chmod(0o600)
 
         assert result is True
         assert not target.exists()

--- a/tests/services/deduplication/test_extractor_safedir.py
+++ b/tests/services/deduplication/test_extractor_safedir.py
@@ -384,3 +384,173 @@ class TestAnchoredTraversalExtractor:
         assert len(calls) == 2
         for call in calls:
             assert call.kwargs.get("scan_root") == scan_root
+
+
+# ---------------------------------------------------------------------------
+# Issue #349 — S2, C4, C5 fixes to the anchored scan_root branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
+class TestAnchoredTraversalIssue349:
+    """Targeted tests for the issue #349 refinements to the scan_root branch."""
+
+    def test_anchored_open_used_for_all_extensions_when_scan_root_set(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        """S2: open_anchored_reader must be used for ALL extensions, not just those
+        registered in the utils.readers SafeDir registry.
+
+        The old code called read_file_via_safedir_anchored which returned None for
+        unregistered extensions (e.g. ODT) and fell through to an unanchored
+        SafeDir.open_root(file_path.parent), bypassing intermediate-ancestor
+        protection.  The fix uses open_anchored_reader directly for all extensions.
+        """
+        scan_root = tmp_path / "root"
+        subdir = scan_root / "sub"
+        subdir.mkdir(parents=True)
+        target = subdir / "doc.txt"
+        target.write_text("full anchored content")
+
+        # Patch open_anchored_reader to verify it's called (not open_for_reader
+        # on a parent-rooted SafeDir, which would mean S2 is not fixed).
+        original_open_anchored = SafeDir.open_anchored_reader
+        anchored_calls: list[str] = []
+
+        def spy_anchored(self: SafeDir, relative_path: object) -> int:
+            anchored_calls.append(str(relative_path))
+            return original_open_anchored(self, relative_path)  # type: ignore[arg-type]
+
+        with patch.object(SafeDir, "open_anchored_reader", spy_anchored):
+            result = extractor.extract_text(target, scan_root=scan_root)
+
+        assert result == "full anchored content"
+        assert len(anchored_calls) == 1, (
+            "open_anchored_reader must be called exactly once for anchored traversal"
+        )
+
+    def test_anchored_scan_root_uses_full_file_extractor_not_readers_defaults(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        """C4: _extract_from_fileobj must be called, not read_file_via_safedir_anchored.
+
+        read_file_via_safedir_anchored used utils.readers defaults (max_pages=5,
+        max_chars=5000), silently truncating documents.  The fix passes the fd from
+        open_anchored_reader directly to _extract_from_fileobj which uses the full-
+        file extractors.
+        """
+        scan_root = tmp_path / "root"
+        scan_root.mkdir()
+        target = scan_root / "doc.txt"
+        target.write_text("full document content for dedup")
+
+        with patch.object(
+            extractor, "_extract_from_fileobj", wraps=extractor._extract_from_fileobj
+        ) as mock_extract_fileobj:
+            result = extractor.extract_text(target, scan_root=scan_root)
+
+        assert result == "full document content for dedup"
+        mock_extract_fileobj.assert_called_once()
+
+    def test_fileread_error_from_extractor_returns_empty_string(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        """C5: FileReadError raised by a format extractor must be caught and return "".
+
+        The old except clause only caught (OSError, ValueError, ImportError).
+        FileReadError (a distinct Exception subclass) escaped, breaking the
+        documented 'return "" on any extraction failure' contract.
+        """
+        from utils.readers import FileReadError
+
+        scan_root = tmp_path / "root"
+        scan_root.mkdir()
+        target = scan_root / "corrupt.txt"
+        target.write_bytes(b"\x00" * 100)
+
+        with patch.object(
+            extractor,
+            "_extract_from_fileobj",
+            side_effect=FileReadError("simulated corrupt file"),
+        ):
+            result = extractor.extract_text(target, scan_root=scan_root)
+
+        assert result == "", (
+            "FileReadError from a format extractor must be caught and return empty string"
+        )
+
+    def test_not_implemented_error_falls_through_to_parent_rooted_safedir(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        """NotImplementedError from SafeDir.open_root(scan_root) falls through to
+        the parent-rooted SafeDir branch, still returning the file content.
+
+        This exercises the ``except NotImplementedError`` clause that handles
+        platforms where SafeDir primitives are unavailable.  When scan_root is
+        supplied but SafeDir raises NotImplementedError, the extractor must
+        silently fall back instead of propagating the error.
+        """
+        scan_root = tmp_path / "root"
+        scan_root.mkdir()
+        target = scan_root / "fallback.txt"
+        target.write_text("fallback content via parent-rooted path")
+
+        call_args: list[object] = []
+        original_open_root = SafeDir.open_root
+
+        def patched_open_root(path: object) -> object:
+            call_args.append(path)
+            if len(call_args) == 1:
+                raise NotImplementedError("simulated SafeDir unavailable on this platform")
+            return original_open_root(path)  # type: ignore[arg-type]
+
+        with patch("services.deduplication.extractor.SafeDir.open_root", patched_open_root):
+            result = extractor.extract_text(target, scan_root=scan_root)
+
+        assert "fallback content via parent-rooted path" in result, (
+            "NotImplementedError from scan_root SafeDir.open_root must fall through to "
+            "parent-rooted SafeDir branch and still return extracted content"
+        )
+
+    def test_osfdopen_failure_in_scan_root_closes_fd_and_returns_empty(
+        self, extractor: DocumentExtractor, tmp_path: Path
+    ) -> None:
+        """OSError from os.fdopen in the scan_root branch closes the raw fd
+        and returns ``""`` via the outer ``(OSError, …)`` handler.
+
+        This exercises lines 135-137 of extractor.py — the cleanup path
+        where os.fdopen raises after open_anchored_reader returned a valid fd:
+
+        .. code-block:: python
+
+            try:
+                fileobj = os.fdopen(fd, "rb", closefd=True)  # raises
+            except OSError:        # line 135  ← covered here
+                os.close(fd)       # line 136  ← covered here
+                raise              # line 137  ← covered here
+        """
+        import os as _os
+
+        scan_root = tmp_path / "root"
+        scan_root.mkdir()
+        target = scan_root / "doc.txt"
+        target.write_bytes(b"content")
+
+        call_count = 0
+        original_fdopen = _os.fdopen
+
+        def patched_fdopen(fd: int, *args: object, **kwargs: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise OSError("simulated os.fdopen failure in scan_root branch")
+            return original_fdopen(fd, *args, **kwargs)  # type: ignore[arg-type]
+
+        with patch("services.deduplication.extractor.os.fdopen", patched_fdopen):
+            result = extractor.extract_text(target, scan_root=scan_root)
+
+        assert result == "", (
+            "OSError from os.fdopen in the scan_root branch must close the fd "
+            "and return empty string via the outer (OSError, ...) handler"
+        )

--- a/tests/utils/test_cad_readers.py
+++ b/tests/utils/test_cad_readers.py
@@ -435,3 +435,71 @@ def test_read_iges_with_short_file(tmp_path: Path) -> None:
     # Should still return something
     assert isinstance(result, str)
     assert "IGES" in result
+
+
+# ---------------------------------------------------------------------------
+# Issue #351 R3 — STEP byte cap checked before readline allocates full line
+# ---------------------------------------------------------------------------
+
+
+def test_step_single_oversized_line_does_not_exhaust_budget(tmp_path: Path) -> None:
+    """R3: readline(budget) must prevent a single very long line from allocating
+    memory beyond _MAX_STEP_BYTES before the cap check fires.
+
+    Before the fix, readline() was called without a size argument, so a 1 MB line
+    would be fully materialised in memory before total_bytes was incremented and
+    checked.  The fix passes the remaining budget to readline() so each call
+    allocates at most (budget + 1) characters.
+
+    This test writes a STEP file whose first content line is longer than
+    _MAX_STEP_BYTES.  The reader must still return a non-empty result (it reads
+    the header), must mark the read as truncated, and must not raise OOM or any
+    exception.
+    """
+    from utils.readers.cad import _MAX_STEP_BYTES
+
+    step_path = tmp_path / "bigline.step"
+    # Standard STEP header + one line that is 2× the byte cap
+    header = dedent("""\
+        ISO-10303-21;
+        HEADER;
+        FILE_DESCRIPTION(('Oversized line test'),'2;1');
+        FILE_NAME('bigline.step','2026-01-01T00:00:00',(''),(''),'','','');
+        FILE_SCHEMA(('AP214E3_2010'));
+        ENDSEC;
+        DATA;
+    """)
+    big_line = "A" * (_MAX_STEP_BYTES * 2) + "\n"
+    step_path.write_text(header + big_line, encoding="utf-8")
+
+    result = read_step_file(step_path)
+
+    # The file must be identified as STEP and marked truncated
+    assert isinstance(result, str)
+    assert "STEP" in result
+    assert "truncated" in result.lower() or "[truncated]" in result
+
+
+def test_step_single_oversized_line_via_fileobj(tmp_path: Path) -> None:
+    """Same as above but via the fileobj= branch (issue #351 R3)."""
+    import io
+
+    from utils.readers.cad import _MAX_STEP_BYTES
+
+    header = dedent("""\
+        ISO-10303-21;
+        HEADER;
+        FILE_DESCRIPTION(('Fileobj oversized test'),'2;1');
+        FILE_NAME('test.step','2026-01-01T00:00:00',(''),(''),'','','');
+        FILE_SCHEMA(('AP214E3_2010'));
+        ENDSEC;
+        DATA;
+    """)
+    big_line = "B" * (_MAX_STEP_BYTES * 2) + "\n"
+    content = (header + big_line).encode("utf-8")
+
+    result = read_step_file(fileobj=io.BytesIO(content))
+
+    assert isinstance(result, str)
+    assert "STEP" in result
+    assert "truncated" in result.lower() or "[truncated]" in result

--- a/tests/watcher/test_handler.py
+++ b/tests/watcher/test_handler.py
@@ -728,15 +728,16 @@ class TestSafeDirAllows:
         handler = FileEventHandler(default_config, queue, safe_dir=None)
         assert handler._safedir_allows(Path("/any/path")) is True
 
-    def test_path_outside_root_allowed_through(
+    def test_path_outside_root_rejected(
         self, tmp_path: Path, default_config: WatcherConfig, queue: EventQueue
     ) -> None:
-        """Path outside watch_root is allowed through (may be from a secondary watch dir).
+        """Path whose lstat form is outside watch_root is rejected (issue #347).
 
-        The SafeDir is anchored to the primary watch root.  Events from other
-        directories added via ``add_directory()`` are outside that root and
-        must NOT be dropped here — the pipeline-level SafeDir is their backstop.
-        (#322 / 1.4 — containment check updated).
+        ``relative_to`` raises ``ValueError`` when the lstat path cannot be
+        relativized to watch_root.  The old code returned ``True`` (allow),
+        which was a security bypass: a symlink escaping the root but whose
+        lstat path also fails relativization would pass unchecked.  The fix
+        returns ``False`` so containment is enforced conservatively.
         """
         import sys
 
@@ -754,8 +755,39 @@ class TestSafeDirAllows:
             handler = FileEventHandler(default_config, queue, safe_dir=sd, watch_root=watch_root)
             result = handler._safedir_allows(outside)
 
-        # Allowed through — pipeline SafeDir handles it.
-        assert result is True
+        # Rejected — lstat path cannot be relativized to watch_root (#347).
+        assert result is False
+
+    def test_relative_to_valueerror_rejects_path(
+        self, tmp_path: Path, default_config: WatcherConfig, queue: EventQueue
+    ) -> None:
+        """``ValueError`` from ``relative_to`` returns False, not True (issue #347).
+
+        Uses a MagicMock SafeDir so the test is purely unit-level: we inject a
+        path whose parent resolves to a directory outside watch_root, which
+        causes ``lstat_path.relative_to(watch_root)`` to raise ``ValueError``.
+        The handler must return ``False`` (drop), not ``True`` (allow).
+        """
+        import sys
+
+        if sys.platform == "win32":
+            pytest.skip("SafeDir is POSIX-only")
+
+        watch_root = tmp_path / "watch"
+        watch_root.mkdir()
+
+        # A path whose parent is completely outside watch_root — relative_to
+        # will raise ValueError without touching the filesystem.
+        escaping = tmp_path / "escape_dir" / "secret.txt"
+        escaping.parent.mkdir(parents=True)
+        escaping.write_bytes(b"secret")
+
+        sd_mock = MagicMock()
+        handler = FileEventHandler(default_config, queue, safe_dir=sd_mock, watch_root=watch_root)
+        result = handler._safedir_allows(escaping)
+
+        # Must be rejected — not allowed through.
+        assert result is False
 
     def test_nested_path_allowed_through(
         self, tmp_path: Path, default_config: WatcherConfig, queue: EventQueue

--- a/tests/watcher/test_monitor.py
+++ b/tests/watcher/test_monitor.py
@@ -11,6 +11,7 @@ import threading
 import time
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -45,7 +46,7 @@ def monitor(watch_dir: Path) -> FileMonitor:
 
 def _wait_for_event_matching(
     monitor: FileMonitor,
-    predicate: Callable[[list], bool],
+    predicate: Callable[[list[Any]], bool],
     timeout: float = 3.0,
 ) -> list:
     """

--- a/tests/watcher/test_monitor.py
+++ b/tests/watcher/test_monitor.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -43,7 +45,7 @@ def monitor(watch_dir: Path) -> FileMonitor:
 
 def _wait_for_event_matching(
     monitor: FileMonitor,
-    predicate: callable,
+    predicate: Callable[[list], bool],
     timeout: float = 3.0,
 ) -> list:
     """
@@ -543,7 +545,6 @@ class TestFileMonitorObserverFallback:
         This test mocks Observer.__init__ to raise an exception to simulate
         FSEvents/Inotify unavailability, then verifies fallback to polling.
         """
-        from unittest.mock import patch
 
         from watchdog.observers.polling import PollingObserver
 
@@ -573,7 +574,6 @@ class TestFileMonitorObserverFallback:
         This test forces use of PollingObserver and verifies it can still
         detect file system events, albeit with polling delays.
         """
-        from unittest.mock import patch
 
         config = WatcherConfig(
             watch_directories=[watch_dir],

--- a/tests/watcher/test_safedir_hardening_322.py
+++ b/tests/watcher/test_safedir_hardening_322.py
@@ -116,8 +116,7 @@ class TestFileMonitorPassesSafeDir:
         monitor = FileMonitor(config)
         assert monitor.handler._safe_dir is not None
         assert monitor.handler._watch_root == watch_dir.resolve()
-        # Release the fd
-        monitor.handler._safe_dir.__exit__(None, None, None)
+        monitor.stop()  # releases SafeDir fd cleanly
 
     def test_handler_has_no_safe_dir_when_no_watch_dir(self) -> None:
         """When no watch directories are configured, handler has no SafeDir."""
@@ -154,8 +153,75 @@ class TestFileMonitorPassesSafeDir:
         sd = monitor.handler._safe_dir
         wr = monitor.handler._watch_root
         assert (sd is None) == (wr is None), "safe_dir and watch_root must be paired"
-        if sd is not None:
-            sd.__exit__(None, None, None)
+        monitor.stop()  # releases SafeDir fd cleanly
+
+
+# ---------------------------------------------------------------------------
+# 1.2b — Multi-root startup + conditional add_directory clear (issue #347)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestFileMonitorMultiRootStartup:
+    """Multi-root configs at startup must not silently drop events (issue #347 P1)."""
+
+    def test_multi_root_startup_disables_containment_check(self, tmp_path: Path) -> None:
+        """With 2+ watch_directories at startup, watch_root is None (no silent drops)."""
+        if sys.platform == "win32":
+            pytest.skip("SafeDir is POSIX-only")
+
+        d1 = tmp_path / "d1"
+        d2 = tmp_path / "d2"
+        d1.mkdir()
+        d2.mkdir()
+        config = WatcherConfig(watch_directories=[d1, d2], debounce_seconds=0.0)
+        monitor = FileMonitor(config)
+
+        # Both safe_dir and watch_root must be None — containment check disabled
+        # so events from d2 are not silently dropped.
+        assert monitor.handler._watch_root is None
+        assert monitor.handler._safe_dir is None
+
+    def test_add_directory_under_root_preserves_containment(self, tmp_path: Path) -> None:
+        """Adding a sub-directory of the primary root must NOT disable containment."""
+        if sys.platform == "win32":
+            pytest.skip("SafeDir is POSIX-only")
+
+        watch_dir = tmp_path / "watch"
+        subdir = watch_dir / "subdir"
+        watch_dir.mkdir()
+        subdir.mkdir()
+        config = WatcherConfig(watch_directories=[watch_dir], debounce_seconds=0.0)
+        monitor = FileMonitor(config)
+
+        assert monitor.handler._watch_root is not None  # pre-condition
+
+        monitor.add_directory(subdir)
+
+        # subdir is under watch_dir — _watch_root must still be set
+        assert monitor.handler._watch_root is not None
+        monitor.stop()
+
+    def test_add_directory_outside_root_disables_containment(self, tmp_path: Path) -> None:
+        """Adding a directory outside the primary root disables containment check."""
+        if sys.platform == "win32":
+            pytest.skip("SafeDir is POSIX-only")
+
+        watch_dir = tmp_path / "watch"
+        other_dir = tmp_path / "other"
+        watch_dir.mkdir()
+        other_dir.mkdir()
+        config = WatcherConfig(watch_directories=[watch_dir], debounce_seconds=0.0)
+        monitor = FileMonitor(config)
+
+        assert monitor.handler._watch_root is not None  # pre-condition
+
+        monitor.add_directory(other_dir)
+
+        # other_dir is outside watch_dir — _watch_root must be cleared
+        assert monitor.handler._watch_root is None
+        monitor.stop()
 
 
 # ---------------------------------------------------------------------------
@@ -283,14 +349,20 @@ class TestSafeDirAllowsLstatContainment:
 
         assert result is True
 
-    def test_path_completely_outside_watch_root_allowed_through(
+    def test_path_completely_outside_watch_root_rejected(
         self, tmp_path: Path, default_config: WatcherConfig, queue: EventQueue
     ) -> None:
-        """A path not under watch_root is allowed through (secondary watch dir).
+        """A path not under watch_root is rejected by the handler (issue #347).
 
-        The SafeDir is only anchored to the primary watch root.  Events from
-        other roots added via ``add_directory()`` are outside that root and
-        must pass through to the pipeline-level SafeDir backstop (#322 / 1.4).
+        ``relative_to(watch_root)`` raises ``ValueError`` when the lstat path
+        cannot be contained within the primary root.  The old code returned
+        ``True`` here (security bypass); the fix returns ``False`` so that
+        escaping-symlink paths cannot slip through (#347).
+
+        In the multi-directory monitor scenario ``FileMonitor.add_directory()``
+        clears ``handler._watch_root`` to ``None`` so that the containment
+        check is disabled before a second directory is added — this test
+        verifies the single-root, single-handler case where the check is active.
         """
         if sys.platform == "win32":
             pytest.skip("SafeDir is POSIX-only")
@@ -303,8 +375,8 @@ class TestSafeDirAllowsLstatContainment:
         handler = FileEventHandler(default_config, queue, safe_dir=sd_mock, watch_root=watch_root)
         result = handler._safedir_allows(outside)
 
-        # Allowed through — pipeline SafeDir handles it.
-        assert result is True
+        # Rejected — lstat path cannot be relativized to watch_root (#347).
+        assert result is False
         # open_child should NOT have been called on a path outside the primary root.
         sd_mock.open_child.assert_not_called()
 
@@ -317,7 +389,7 @@ class TestSafeDirAllowsLstatContainment:
 @pytest.mark.unit
 @pytest.mark.ci
 class TestSafeDirAllowsNestedPaths:
-    """Nested paths under watch_root are ancestry-checked; paths outside are allowed through."""
+    """Nested paths under watch_root are ancestry-checked; paths outside are rejected (issue #347)."""
 
     def test_nested_path_inside_root_allowed(
         self, tmp_path: Path, default_config: WatcherConfig, queue: EventQueue
@@ -340,14 +412,17 @@ class TestSafeDirAllowsNestedPaths:
 
         assert result is True
 
-    def test_nested_path_outside_root_allowed_through(
+    def test_nested_path_outside_root_rejected(
         self, tmp_path: Path, default_config: WatcherConfig, queue: EventQueue
     ) -> None:
-        """A nested path outside watch_root is allowed through (secondary watch dir).
+        """A nested path outside watch_root is rejected when watch_root is set (issue #347).
 
-        Events from directories added via ``add_directory()`` may be nested
-        paths that are outside the primary watch root.  These must be allowed
-        through to the pipeline-level SafeDir backstop (#322 / 1.5 revised).
+        Events from secondary watch directories added via ``add_directory()``
+        are handled by ``FileMonitor.add_directory()`` clearing
+        ``handler._watch_root`` to ``None`` before the second directory is
+        registered — so the containment check is disabled for multi-root setups.
+        This test verifies the single-root case where the check is active and
+        outside paths must be rejected.
         """
         if sys.platform == "win32":
             pytest.skip("SafeDir is POSIX-only")
@@ -361,8 +436,8 @@ class TestSafeDirAllowsNestedPaths:
         handler = FileEventHandler(default_config, queue, safe_dir=sd_mock, watch_root=watch_root)
         result = handler._safedir_allows(outside_nested)
 
-        # Allowed through — pipeline SafeDir handles it.
-        assert result is True
+        # Rejected — lstat path is outside watch_root and cannot be relativized (#347).
+        assert result is False
         sd_mock.open_child.assert_not_called()
 
     def test_nested_path_does_not_call_open_child(

--- a/tests/watcher/test_safedir_hardening_322.py
+++ b/tests/watcher/test_safedir_hardening_322.py
@@ -116,7 +116,9 @@ class TestFileMonitorPassesSafeDir:
         monitor = FileMonitor(config)
         assert monitor.handler._safe_dir is not None
         assert monitor.handler._watch_root == watch_dir.resolve()
-        monitor.stop()  # releases SafeDir fd cleanly
+        # stop() must close the SafeDir fd (R1 fix — no manual __exit__ workaround needed)
+        monitor.stop()
+        assert monitor.handler._safe_dir is None
 
     def test_handler_has_no_safe_dir_when_no_watch_dir(self) -> None:
         """When no watch directories are configured, handler has no SafeDir."""
@@ -602,3 +604,144 @@ class TestPostprocessorFailsClosedOnSymlinkRejected:
             stage.close()
 
         assert any("security_event" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Issue #348 — R1: stop() closes SafeDir fd; R2: add_directory() warns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestFileMonitorStopClosesSafeDir:
+    """FileMonitor.stop() must release the SafeDir fd (issue #348 R1)."""
+
+    def test_stop_closes_safe_dir(self, tmp_path: Path) -> None:
+        """stop() sets handler._safe_dir to None, releasing the directory fd."""
+        if sys.platform == "win32":
+            pytest.skip("SafeDir is POSIX-only")
+
+        watch_dir = tmp_path / "watch"
+        watch_dir.mkdir()
+        config = WatcherConfig(watch_directories=[watch_dir], debounce_seconds=0.0)
+        monitor = FileMonitor(config)
+        assert monitor.handler._safe_dir is not None, "pre-condition: SafeDir must be open"
+
+        monitor.stop()
+
+        assert monitor.handler._safe_dir is None
+
+    def test_stop_is_idempotent(self, tmp_path: Path) -> None:
+        """Calling stop() twice must not raise."""
+        if sys.platform == "win32":
+            pytest.skip("SafeDir is POSIX-only")
+
+        watch_dir = tmp_path / "watch"
+        watch_dir.mkdir()
+        config = WatcherConfig(watch_directories=[watch_dir], debounce_seconds=0.0)
+        monitor = FileMonitor(config)
+
+        monitor.stop()
+        monitor.stop()  # second call must not raise
+
+        assert monitor.handler._safe_dir is None
+
+    def test_stop_without_safe_dir_does_not_raise(self) -> None:
+        """stop() on a monitor with no watch directories (no SafeDir) must not raise."""
+        config = WatcherConfig(watch_directories=[], debounce_seconds=0.0)
+        monitor = FileMonitor(config)
+        assert monitor.handler._safe_dir is None
+
+        monitor.stop()  # no-op; must not raise
+
+    def test_start_after_stop_reinitializes_safe_dir(self, tmp_path: Path) -> None:
+        """start() after stop() must reopen SafeDir so symlink checks remain active.
+
+        stop() clears handler._safe_dir to release the fd.  Without a matching
+        reinitialize in start(), a stop()/start() restart leaves the monitor
+        running with no watcher-level SafeDir — a security regression (issue #348 P1).
+        """
+        if sys.platform == "win32":
+            pytest.skip("SafeDir is POSIX-only")
+
+        watch_dir = tmp_path / "watch"
+        watch_dir.mkdir()
+        config = WatcherConfig(watch_directories=[watch_dir], debounce_seconds=0.0)
+        monitor = FileMonitor(config)
+
+        assert monitor.handler._safe_dir is not None, "pre-condition: SafeDir open after init"
+
+        monitor.stop()
+        assert monitor.handler._safe_dir is None, "pre-condition: SafeDir closed after stop()"
+
+        monitor.start()
+        try:
+            assert monitor.handler._safe_dir is not None, (
+                "SafeDir must be reinitialized after start() — "
+                "watcher-level symlink checks were disabled after restart"
+            )
+            assert monitor.handler._watch_root == watch_dir.resolve()
+        finally:
+            monitor.stop()
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestFileMonitorAddDirectoryWarns:
+    """add_directory() must warn that secondary dirs are not SafeDir-hardened (#348 R2)."""
+
+    def test_add_directory_logs_warning_when_safe_dir_active(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Adding a second directory while SafeDir is active emits a warning."""
+        if sys.platform == "win32":
+            pytest.skip("SafeDir is POSIX-only")
+
+        import logging
+
+        watch_dir = tmp_path / "watch"
+        watch_dir.mkdir()
+        second_dir = tmp_path / "second"
+        second_dir.mkdir()
+
+        config = WatcherConfig(watch_directories=[watch_dir], debounce_seconds=0.0)
+        monitor = FileMonitor(config)
+        assert monitor.handler._safe_dir is not None, "pre-condition: SafeDir must be open"
+
+        try:
+            with caplog.at_level(logging.WARNING, logger="watcher.monitor"):
+                monitor.add_directory(second_dir, recursive=False)
+
+            warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+            assert any("outside the primary SafeDir root" in msg for msg in warning_messages), (
+                f"expected SafeDir warning, got: {warning_messages}"
+            )
+        finally:
+            monitor.stop()
+
+    def test_add_directory_no_warning_without_safe_dir(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Adding a directory when no SafeDir is active must not emit a SafeDir warning."""
+        import logging
+
+        second_dir = tmp_path / "second"
+        second_dir.mkdir()
+
+        config = WatcherConfig(watch_directories=[], debounce_seconds=0.0)
+        monitor = FileMonitor(config)
+        assert monitor.handler._safe_dir is None
+
+        with caplog.at_level(logging.WARNING, logger="watcher.monitor"):
+            monitor.add_directory(second_dir, recursive=False)
+
+        safedir_warnings = [
+            r.message
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "SafeDir" in r.message
+        ]
+        assert safedir_warnings == [], f"unexpected SafeDir warnings: {safedir_warnings}"

--- a/tests/watcher/test_safedir_hardening_322.py
+++ b/tests/watcher/test_safedir_hardening_322.py
@@ -685,6 +685,38 @@ class TestFileMonitorStopClosesSafeDir:
         finally:
             monitor.stop()
 
+    def test_multi_root_stop_start_keeps_safedir_disabled(self, tmp_path: Path) -> None:
+        """stop()/start() on a multi-root monitor must NOT re-enable SafeDir.
+
+        __init__ intentionally leaves _safe_dir=None for multi-root configs so
+        events from roots 2..N are not silently dropped.  start() after stop()
+        must preserve that invariant; re-initialising on watch_directories[0]
+        would cause the other roots to lose their events (issue #347/#348 P1).
+        """
+        if sys.platform == "win32":
+            pytest.skip("SafeDir is POSIX-only")
+
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        config = WatcherConfig(watch_directories=[dir_a, dir_b], debounce_seconds=0.0)
+        monitor = FileMonitor(config)
+
+        assert monitor.handler._safe_dir is None, (
+            "pre-condition: multi-root init must leave _safe_dir=None"
+        )
+
+        monitor.stop()
+        monitor.start()
+        try:
+            assert monitor.handler._safe_dir is None, (
+                "start() after stop() on multi-root config must NOT reinitialise SafeDir "
+                "— doing so would cause events from roots 2..N to be silently dropped"
+            )
+        finally:
+            monitor.stop()
+
 
 @pytest.mark.unit
 @pytest.mark.ci

--- a/tests/watcher/test_safedir_hardening_322.py
+++ b/tests/watcher/test_safedir_hardening_322.py
@@ -568,6 +568,7 @@ class TestPostprocessorFailsClosedOnSymlinkRejected:
         # Non-SymlinkRejected: postprocessor falls back and continues.
         assert not result.failed
         assert result.destination is not None
+        assert isinstance(result.destination, Path)
 
     def test_symlink_rejected_logs_security_event(
         self,


### PR DESCRIPTION
Closes #346. Closes #347. Closes #348. Closes #349. Closes #350. Closes #351. Closes #352. Closes #353. Closes #354.

Resolves all 18 unaddressed CodeRabbit / Copilot findings from PRs #333–#342, organised MECE into 5 groups and implemented as 8 focused sub-PRs targeting this epic branch.

---

## Group S — Security (3 findings)

**S1** `watcher/handler.py` — `_is_secondary_root()` caught `ValueError` from `relative_to()` and returned `True` (allow). A symlink whose resolved path escapes the watch root but whose lstat path fails relativisation was passed through instead of dropped. Fix: return `False` on `ValueError`. Also guarded multi-root startup and `add_directory()` so events from roots 2…N are not silently dropped (issue #347 P1 follow-up). _(PR #355)_

**S2** `dedup/extractor.py` — when `read_file_via_safedir_anchored()` returned `None` for unregistered extensions (e.g. ODT), execution fell through to an unanchored `SafeDir.open_root(file_path.parent)`, bypassing intermediate-ancestor protection. Fix: use `open_anchored_reader` directly for all extensions. _(PR #358)_

**S3** `models/_vision_helpers.py` — `image_to_data_url()` called `open(image_path, "rb")` directly with no SafeDir validation. Fix: open via `SafeDir.open_root / open_for_reader` on POSIX; fallback to direct `open()` on Windows / `NotImplementedError`. _(PR #360)_

---

## Group C — Correctness (5 findings)

**C1/C2** `dedup/backup.py` — `ValueError` from SafeDir name validation removed the manifest entry without deleting the file, permanently orphaning backups. Fix: split handlers; log `ValueError` at `WARNING`; only remove manifest entry when `file_deleted=True`. _(PR #357)_

**C3** `dedup/backup.py` — inode identity used `(st_dev, st_ino, st_size)`; `st_size` can change on the same inode under concurrent writes. Fix: `(st_dev, st_ino)` only. _(PR #357)_

**C4** `dedup/extractor.py` — anchored read path routed through `utils.readers` defaults (`max_pages=5`, `max_chars=5000`), silently degrading dedup accuracy. Fix: pass fd from `open_anchored_reader` directly to `_extract_from_fileobj`. _(PR #358)_

**C5** `dedup/extractor.py` — `FileReadError` from format extractors escaped the `except (OSError, ValueError, ImportError)` clause, breaking the "return `""` on failure" contract. Fix: add `FileReadError` to the except tuple. _(PR #358)_

---

## Group R — Robustness (4 findings)

**R1** `watcher/monitor.py` — `FileMonitor.stop()` never called `__exit__` on `handler._safe_dir`, leaking a directory fd per restart. Fix: `stop()` calls `__exit__` and sets `_safe_dir = None`; `start()` reinitialises SafeDir (single-root only). _(PR #356)_

**R2** `watcher/monitor.py` — `add_directory()` unconditionally cleared `_watch_root` even for sub-directories of the existing root. Fix: only clear when new path is outside current root; emit `WARNING`. _(PR #355 + #356)_

**R3** `readers/cad.py` — STEP byte cap was checked after `readline()` had already materialised a full long line. Fix: pass remaining budget to `readline(budget)`. _(PR #359)_

**R4** `dedup/backup.py` — `open_child(name)` on a FIFO blocks until a writer connects. Fix: `lstat` before open; skip non-regular files with `WARNING`. _(PR #357)_

---

## Group T — Test quality (4 findings)

**T1** `tests/watcher/test_monitor.py` — `predicate: callable` used the built-in function as a type hint. Fix: `Callable[[list], bool]`. _(PR #361)_

**T2** `tests/watcher/test_safedir_hardening_322.py` — `safe_dir.__exit__()` without `try/finally`. Already resolved by R1 fix (PR #355/#356 replaced with `monitor.stop()`). _(no code change)_

**T3** `tests/watcher/test_safedir_hardening_322.py` — `assert result.destination is not None` without type check. Fix: added `assert isinstance(result.destination, Path)`. _(PR #361)_

**T4** `tests/watcher/test_monitor.py` — two function-scope `from unittest.mock import patch` statements. Fix: moved to module-level import (F9). _(PR #361)_

---

## Group E — Enhancement (1 finding)

**E1** `pipeline/stages/writer.py` — after the #322/1.7 fix removed `shutil.copystat`, file mode and timestamps were silently dropped. Fix: `os.fchmod(dst_fd, mode)` and `os.utime(dst_fd, ns=...)` on the open fd before `os.close` — TOCTOU-free, unlike `copystat`'s path re-open. _(PR #362)_

---

## Sub-PRs merged

| PR | Title | Issues closed |
|----|-------|---------------|
| #355 | S1 handler + multi-root startup | #347 |
| #356 | R1 fd leak + R2 add_directory guard | #348 |
| #357 | C1/C2/C3/R4/T5 backup fixes | #350 |
| #358 | S2/C4/C5 extractor anchored path | #349 |
| #359 | R3 STEP byte cap | #351 |
| #360 | S3 image SafeDir | #352 |
| #361 | T1/T3/T4 test quality | #353 |
| #362 | E1 writer fd-based metadata | #354 |

## Test plan
- All sub-PRs passed PR CI suite (py3.11, lint, type-check, diff-cover ≥ 80%)
- Each fix has direct unit/integration test coverage
- No coverage floor regressions — diff coverage exceeded 80% on every PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by preventing symlink-based attacks and rejecting events outside monitored roots
  * Preserves file metadata (permissions and timestamps) during file writes
  * More robust backup cleanup and unlink behavior to avoid false positives and handle permission/edge cases
  * Prevented excessive memory use when reading extremely long lines; improved resource/error handling

* **Tests**
  * Added extensive tests covering security hardening, file-read safety, metadata preservation, and cleanup robustness

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->