### PR TITLE
fix(review): address 9 CodeRabbit/Copilot threads on PR #363 (monitor, backup, tests)

### DIFF
--- a/src/models/_vision_helpers.py
+++ b/src/models/_vision_helpers.py
@@ -81,7 +81,7 @@ def image_to_data_url(image_path: Path) -> str:
                 raw = fh_direct.read()
         except (SymlinkRejected, ValueError) as exc:
             raise OSError(f"Refused to read symlinked image {image_path}: {exc}") from exc
-    else:
+    else:  # pragma: no cover — Windows-only branch, not reachable on POSIX CI
         with open(
             image_path, "rb"
         ) as fh_win:  # safedir: ok — Windows / NotImplementedError fallback

--- a/src/services/deduplication/backup.py
+++ b/src/services/deduplication/backup.py
@@ -78,9 +78,18 @@ def _backup_safe_unlink(path: Path, log: logging.Logger) -> bool:
                 child_fd = safe_dir.open_child(path.name)
             except PermissionError:
                 # T5 fix (issue #350): write-only files (mode 0o200) cannot be
-                # opened O_RDONLY even by the owner.  The inode-pin is skipped,
-                # but SafeDir's dir_fd still binds the unlink to the correct
-                # directory entry — directory-swap protection is preserved.
+                # opened O_RDONLY even by the owner.  Compensate for the missing
+                # fd-pin by re-lstat-ing the entry and confirming the inode has
+                # not changed since pre_lst (reduces — but does not eliminate —
+                # the name-swap window between the two lstat calls).
+                post_lst = safe_dir.lstat(path.name)
+                if (post_lst.st_dev, post_lst.st_ino) != (pre_lst.st_dev, pre_lst.st_ino):
+                    log.warning(
+                        "security_event inode_swap_in_backup path=%s — "
+                        "inode changed between lstat calls; skipping",
+                        path,
+                    )
+                    return False
                 safe_dir.unlink(path.name)
                 return True
             try:

--- a/src/services/deduplication/backup.py
+++ b/src/services/deduplication/backup.py
@@ -59,8 +59,30 @@ def _backup_safe_unlink(path: Path, log: logging.Logger) -> bool:
 
     try:
         with SafeDir.open_root(path.parent) as safe_dir:
+            # R4 fix: lstat BEFORE open_child so FIFOs (and other non-regular
+            # entries) are rejected without attempting the open.  open_child
+            # with O_RDONLY on a FIFO would block until a writer connects,
+            # hanging cleanup indefinitely (issue #350 R4).
+            pre_lst = safe_dir.lstat(path.name)
+            if not _stat.S_ISREG(pre_lst.st_mode):
+                log.warning(
+                    "security_event inode_swap_in_backup path=%s mode=0o%o — "
+                    "non-regular file; skipping (R4 FIFO-hang prevention)",
+                    path,
+                    pre_lst.st_mode,
+                )
+                return False
+
             # Open the file (O_RDONLY | O_NOFOLLOW) to pin its inode.
-            child_fd = safe_dir.open_child(path.name)
+            try:
+                child_fd = safe_dir.open_child(path.name)
+            except PermissionError:
+                # T5 fix (issue #350): write-only files (mode 0o200) cannot be
+                # opened O_RDONLY even by the owner.  The inode-pin is skipped,
+                # but SafeDir's dir_fd still binds the unlink to the correct
+                # directory entry — directory-swap protection is preserved.
+                safe_dir.unlink(path.name)
+                return True
             try:
                 fst = os.fstat(child_fd)
             finally:
@@ -75,29 +97,37 @@ def _backup_safe_unlink(path: Path, log: logging.Logger) -> bool:
                 return False
 
             # Re-stat the name (lstat, no symlink follow) and compare
-            # (dev, ino, size) to detect a swap between open and unlink.
+            # (dev, ino) to detect a swap between open and unlink.
+            # C3 fix (issue #350): omit st_size — a concurrent writer can
+            # legitimately change the size on the same inode between fstat and
+            # lstat, which would be a false-positive swap detection.
             lst = safe_dir.lstat(path.name)
-            if (lst.st_dev, lst.st_ino, lst.st_size) != (
-                fst.st_dev,
-                fst.st_ino,
-                fst.st_size,
-            ):
+            if (lst.st_dev, lst.st_ino) != (fst.st_dev, fst.st_ino):
                 log.warning(
                     "security_event inode_swap_in_backup path=%s "
-                    "fstat=(%d,%d,%d) lstat=(%d,%d,%d) — skipping",
+                    "fstat=(%d,%d) lstat=(%d,%d) — skipping",
                     path,
                     fst.st_dev,
                     fst.st_ino,
-                    fst.st_size,
                     lst.st_dev,
                     lst.st_ino,
-                    lst.st_size,
                 )
                 return False
 
             safe_dir.unlink(path.name)
             return True
-    except (OSError, ValueError):
+    except ValueError as exc:
+        # C1/C2 fix (issue #350): SafeDir raises ValueError for filenames
+        # containing characters it rejects (e.g. backslash).  Log at WARNING
+        # so operators can see this — the old DEBUG log was invisible in prod.
+        log.warning(
+            "security_event backup_name_rejected path=%s: %s — "
+            "filename rejected by SafeDir name validation",
+            path,
+            exc,
+        )
+        return False
+    except OSError:
         log.debug("Failed to remove backup %s", path, exc_info=True)
         return False
 

--- a/src/watcher/monitor.py
+++ b/src/watcher/monitor.py
@@ -121,9 +121,12 @@ class FileMonitor:
             # stop() always sets handler._safe_dir = None to release the fd; on
             # restart the handler would run without watcher-level symlink checks
             # unless we reopen it here (issue #348 P1 follow-up).
+            # Guard: only for single-root configs — __init__ deliberately leaves
+            # _safe_dir=None for multi-root setups so events from roots 2..N are
+            # not silently dropped (issue #347 P1 follow-up).
             if (
                 self.handler._safe_dir is None
-                and self.config.watch_directories
+                and len(self.config.watch_directories) == 1
                 and sys.platform != "win32"
             ):
                 try:
@@ -244,7 +247,12 @@ class FileMonitor:
                     path.relative_to(current_root)
                     # path is under the current root — no change needed
                 except ValueError:
-                    # path is outside the current root — disable check + warn
+                    # path is outside the current root — close and clear SafeDir
+                    # so _safedir_allows() no longer calls open_child() against
+                    # the old root for events from the new directory.
+                    if self.handler._safe_dir is not None:
+                        self.handler._safe_dir.__exit__(None, None, None)
+                        self.handler._safe_dir = None
                     self.handler._watch_root = None
                     logger.warning(
                         "FileMonitor.add_directory: %s is outside the primary SafeDir root (%s) "

--- a/tests/models/test_vision_helpers.py
+++ b/tests/models/test_vision_helpers.py
@@ -14,6 +14,7 @@ from models._vision_helpers import image_to_data_url
 
 @pytest.mark.ci
 @pytest.mark.unit
+@pytest.mark.integration
 @pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
 class TestImageToDataUrlSafeDirIntegration:
     """image_to_data_url must use SafeDir on POSIX to reject symlinked images (issue #352 S3).

--- a/tests/services/deduplication/test_dedup_backup.py
+++ b/tests/services/deduplication/test_dedup_backup.py
@@ -615,6 +615,7 @@ class TestBackupSafeUnlinkInodeSwap:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.ci
 @pytest.mark.unit
 @pytest.mark.skipif(sys.platform == "win32", reason="SafeDir is POSIX-only")
 class TestBackupSafeUnlinkIssue350:
@@ -623,20 +624,25 @@ class TestBackupSafeUnlinkIssue350:
     def test_fifo_is_rejected_before_open(self, tmp_path: Path) -> None:
         """R4: a FIFO must be rejected by lstat type-check before open_child is called.
 
-        open_child with O_RDONLY would block indefinitely on a FIFO; lstat checks
-        the type first so we never attempt the open.
+        open_child with O_RDONLY on a FIFO blocks until a writer connects; the
+        pre-open lstat check must fire first so open_child is never reached.
         """
         import logging
         import stat
+        from unittest.mock import patch
+
+        from utils.safedir import SafeDir
 
         fifo = tmp_path / "queue.fifo"
         os.mkfifo(fifo)
         assert stat.S_ISFIFO(fifo.stat().st_mode)
 
-        result = _backup_safe_unlink(fifo, logging.getLogger("test"))
+        with patch.object(SafeDir, "open_child", autospec=True) as mock_open_child:
+            result = _backup_safe_unlink(fifo, logging.getLogger("test"))
 
         assert result is False
         assert fifo.exists(), "FIFO must not be unlinked — type check should reject it"
+        mock_open_child.assert_not_called()
 
     def test_size_change_on_same_inode_does_not_trigger_swap_detection(
         self, tmp_path: Path
@@ -702,24 +708,29 @@ class TestBackupSafeUnlinkIssue350:
         )
 
     def test_write_only_file_is_unlinked_without_fd_pin(self, tmp_path: Path) -> None:
-        """T5: a write-only file (mode 0o200) can still be unlinked.
+        """T5: a write-only file raises PermissionError from open_child; unlink still succeeds.
 
-        open_child with O_RDONLY raises PermissionError on a 0o200 file.  The fix
-        detects this and proceeds with unlink-without-fd-pin (SafeDir's dir_fd still
-        prevents directory swaps).
+        The fix catches PermissionError from open_child and proceeds with
+        unlink-without-fd-pin — SafeDir's dir_fd still prevents directory swaps.
+
+        Uses a deterministic mock rather than chmod(0o200) so the test passes
+        even under privileged users (e.g. root on CI runners).
         """
         import logging
+        from unittest.mock import patch
+
+        from utils.safedir import SafeDir
 
         target = tmp_path / "locked.bak"
         target.write_bytes(b"data")
-        target.chmod(0o200)  # write-only — open O_RDONLY would fail
 
-        try:
+        with patch.object(
+            SafeDir,
+            "open_child",
+            autospec=True,
+            side_effect=PermissionError("simulated write-only file"),
+        ):
             result = _backup_safe_unlink(target, logging.getLogger("test"))
-        finally:
-            # Restore permissions so tmp_path cleanup succeeds
-            if target.exists():
-                target.chmod(0o600)
 
         assert result is True
         assert not target.exists()

--- a/tests/watcher/test_monitor.py
+++ b/tests/watcher/test_monitor.py
@@ -11,6 +11,7 @@ import threading
 import time
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -45,7 +46,7 @@ def monitor(watch_dir: Path) -> FileMonitor:
 
 def _wait_for_event_matching(
     monitor: FileMonitor,
-    predicate: Callable[[list], bool],
+    predicate: Callable[[list[Any]], bool],
     timeout: float = 3.0,
 ) -> list:
     """

--- a/tests/watcher/test_safedir_hardening_322.py
+++ b/tests/watcher/test_safedir_hardening_322.py
@@ -685,6 +685,38 @@ class TestFileMonitorStopClosesSafeDir:
         finally:
             monitor.stop()
 
+    def test_multi_root_stop_start_keeps_safedir_disabled(self, tmp_path: Path) -> None:
+        """stop()/start() on a multi-root monitor must NOT re-enable SafeDir.
+
+        __init__ intentionally leaves _safe_dir=None for multi-root configs so
+        events from roots 2..N are not silently dropped.  start() after stop()
+        must preserve that invariant; re-initialising on watch_directories[0]
+        would cause the other roots to lose their events (issue #347/#348 P1).
+        """
+        if sys.platform == "win32":
+            pytest.skip("SafeDir is POSIX-only")
+
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        config = WatcherConfig(watch_directories=[dir_a, dir_b], debounce_seconds=0.0)
+        monitor = FileMonitor(config)
+
+        assert monitor.handler._safe_dir is None, (
+            "pre-condition: multi-root init must leave _safe_dir=None"
+        )
+
+        monitor.stop()
+        monitor.start()
+        try:
+            assert monitor.handler._safe_dir is None, (
+                "start() after stop() on multi-root config must NOT reinitialise SafeDir "
+                "— doing so would cause events from roots 2..N to be silently dropped"
+            )
+        finally:
+            monitor.stop()
+
 
 @pytest.mark.unit
 @pytest.mark.ci


### PR DESCRIPTION
Addresses all 9 unresolved review threads on PR #363.

## Code fixes (production)

**monitor.py — threads 1/3/8** (P1 Codex × 2, Major CodeRabbit)
`start()` reinit block lacked `len(watch_directories) == 1` guard. A stop/start cycle on a multi-root monitor would incorrectly re-enable SafeDir on `watch_directories[0]`, silently dropping events from roots 2…N.

**monitor.py — threads 2/9** (P2 Codex × 2)
`add_directory()` cleared `_watch_root` but left `_safe_dir` anchored. After adding a directory outside the root, `_safedir_allows()` still called `open_child()` against the original root. Fix: close and clear `_safe_dir` together with `_watch_root`.

**backup.py — R4 (pre-lstat before open_child)**
The epic branch described but never implemented the lstat-before-open guard. `open_child` with `O_RDONLY` on a FIFO blocks indefinitely; lstat must reject non-regular files first.

**backup.py — T5 (PermissionError fallback)**
Write-only files (mode 0o200) couldn't be unlocked because `open_child` raised `PermissionError` which fell into the generic `OSError` handler returning `False`. Fix: catch `PermissionError` separately and do unlink-without-fd-pin via SafeDir's dir_fd.

**backup.py — C3 (st_size removed from comparison)**
The epic branch still compared `(dev, ino, size)` instead of `(dev, ino)`. `st_size` can change legitimately on the same inode under concurrent writes, causing false-positive swap detection.

**backup.py — C1/C2 (ValueError at WARNING)**
The `except (OSError, ValueError)` block logged at DEBUG. Split into separate `except ValueError` (WARNING with `backup_name_rejected` marker) and `except OSError` (DEBUG).

## Test fixes

**Thread 4** — FIFO test: assert `open_child.assert_not_called()` (locks in R4 contract)
**Thread 5** — T5 test: patch `open_child` directly instead of `chmod(0o200)` (deterministic under root)
**Thread 6** — `Callable[[list], bool]` → `Callable[[list[Any]], bool]`
**Thread 7** — Add `test_multi_root_stop_start_keeps_safedir_disabled` to `TestFileMonitorStopClosesSafeDir`