### PR TITLE
chore(release): bump version to 2.0.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-beta.5] - 2026-05-22
+
+### Fixed
+
+- **`fo setup` crash on first run** — `setup_callback` called `ctx.invoke(setup_run)`
+  without explicit keyword arguments; Click/Typer passed the raw `typer.OptionInfo`
+  default objects as parameter values, causing `AttributeError: 'OptionInfo' object
+  has no attribute 'lower'` on the first call to `mode.lower()`. Fix: pass
+  `mode="quick-start"`, `profile="default"`, `dry_run=False` explicitly
+  (PR #368).
+
+### Tests
+
+- Added `tests/integration/test_cli_e2e_first_run.py` (14 tests) covering the
+  no-subcommand callback path, real config-on-disk write, `_check_setup_completed`
+  gate logic, and validation error paths (PR #368).
+
 ## [2.0.0-beta.4] - 2026-05-22
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fo-core"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 description = "Streamlined CLI file organizer powered by local AI (Ollama)"
 authors = [
     {name = "fo-core Team", email = "noreply@example.com"}

--- a/src/version.py
+++ b/src/version.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-__version__ = "2.0.0-beta.4"
+__version__ = "2.0.0-beta.5"
 
 # Pattern for semantic versioning with optional pre-release and build metadata
 _VERSION_PATTERN = re.compile(


### PR DESCRIPTION
## Summary

- Bumps version from `2.0.0-beta.4` to `2.0.0-beta.5`
- The original beta.4 PyPI wheel was published from the version-bump commit, before PR #368 (the `fo setup` crash fix) merged — PyPI is immutable, so a re-upload of the same filename is rejected
- This bump lets the release workflow publish a corrected wheel to PyPI

## Changes vs beta.4 wheel

- **fix**: `fo setup` crash on first run (`OptionInfo` as parameter values, PR #368)
- **test**: 14 e2e CLI first-run tests (PR #368)

## Test plan

- [ ] CI green
- [ ] Release workflow publishes `fo_core-2.0.0b5` to PyPI
- [ ] `pipx install 'fo-core==2.0.0b5'` installs successfully
- [ ] `fo setup` runs without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)