### PR TITLE
chore(release): bump version to 2.0.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-beta.6] - 2026-05-22
+
+### Added
+
+- **Rotating JSON file log** — every CLI invocation now writes WARNING+ events
+  to a platform-appropriate state directory (`~/Library/Application Support/fo/logs/fo.log`
+  on macOS, `~/.local/state/fo/logs/fo.log` on Linux). Policy: 10 MB rotation,
+  7-day retention, gzip compression, NDJSON format. `--debug` lowers the level to
+  DEBUG. `diagnose=False` ensures local variable values (secrets, PII) are never
+  written to disk. Errors survive the terminal session and are available for
+  post-run analysis. (#372)
+
+### Fixed
+
+- **Parallel timeout cascade abort** — timed-out worker threads were previously
+  marking the entire batch as aborted when a future could not be cancelled (threads
+  are not cancellable in Python). Timed-out tasks are now individually failed and
+  abandoned; remaining queued files continue processing normally. A saturation guard
+  detects permanently hung pools (all workers blocked past `2 × timeout_per_file`)
+  and aborts only in that case. Timeout errors are non-retryable. (#370)
+- **Timeout increased to 300 s** — the per-file timeout for vision/text processing
+  was raised from 60 s to 300 s to accommodate large files on slower hardware.
+- **WEBP / HEIC / HEIF support** — these image formats are now recognised by the
+  pipeline router, vision processor, and MIME-type table. (#370)
+- **Vision circuit breaker** — Ollama OOM errors (`model failed to load`,
+  `resource limitations`) now trip the circuit breaker, preventing repeated
+  traceback spam for every subsequent file when a model fails to load. (#370)
+
+### Changed
+
+- **Default model: `gemma3:4b`** — replaces the dual `qwen2.5:3b-instruct` (text)
+  + `qwen2.5vl:7b` (vision) pair with a single multimodal model. Eliminates
+  out-of-memory crashes from loading two large models simultaneously on 8 GB
+  machines. (#370)
+- **Centralized model defaults** — `DEFAULT_MODEL = "gemma3:4b"` and
+  `DEFAULT_LARGE_MODEL = "gemma3:12b"` are now defined once in `config.defaults`
+  and imported everywhere; changing the default going forward requires a single
+  edit. (#375)
+
 ## [2.0.0-beta.5] - 2026-05-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/curdriceaurora/fo-core/actions/workflows/ci.yml/badge.svg)](https://github.com/curdriceaurora/fo-core/actions/workflows/ci.yml)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/downloads/)
-[![Version](https://img.shields.io/badge/version-2.0.0--beta.5-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-2.0.0--beta.6-blue)](CHANGELOG.md)
 
 ---
 
@@ -145,7 +145,7 @@ See [DEVELOPER.md](DEVELOPER.md) for architecture, local setup, testing, and con
 
 ## Releases
 
-Currently `2.0.0-beta.5`. The acceptance criteria that were required for this
+Currently `2.0.0-beta.6`. The acceptance criteria that were required for this
 promotion and the contract with public pre-release testers are documented in
 [docs/release/beta-criteria.md](docs/release/beta-criteria.md).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fo-core"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.6"
 description = "Streamlined CLI file organizer powered by local AI (Ollama)"
 authors = [
     {name = "fo-core Team", email = "noreply@example.com"}

--- a/src/version.py
+++ b/src/version.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-__version__ = "2.0.0-beta.5"
+__version__ = "2.0.0-beta.6"
 
 # Pattern for semantic versioning with optional pre-release and build metadata
 _VERSION_PATTERN = re.compile(


### PR DESCRIPTION
## What's in beta.6

Three PRs since beta.5:

| PR | Change |
|----|--------|
| #370 | fix(parallel): abandon timed-out threads; WEBP/HEIC/HEIF; vision OOM circuit breaker; 300 s timeout |
| #372 | feat(logging): rotating JSON file log to CLI state dir |
| #375 | refactor(config): centralize `DEFAULT_MODEL` into `config.defaults` |

## Changes in this PR

- `pyproject.toml` + `src/version.py`: `2.0.0-beta.5` → `2.0.0-beta.6`
- `README.md`: version badge updated
- `CHANGELOG.md`: beta.6 entry added

## Test plan

- [ ] CI green
- [ ] `fo version` prints `2.0.0-beta.6` after merge
- [ ] PyPI publish workflow triggers on tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rotating JSON file logging capability.

* **Bug Fixes**
  * Fixed parallel timeout handling.
  * Improved per-file timeout behavior.
  * Enhanced image format support.
  * Fixed vision/Ollama circuit breaker.

* **Chores**
  * Released version 2.0.0-beta.6.
  * Updated default model configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->