### PR TITLE
fix(doctor): make PATH optional, default to current directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ dedup-text = [
 
 dedup-image = [
     "fo-core[dedup-text]",
-    "imagededup>=0.3.0,<1",
+    "imagededup>=0.3.0,<1; python_version < '3.14'",
     "torch~=2.1",
 ]
 

--- a/src/cli/doctor.py
+++ b/src/cli/doctor.py
@@ -457,8 +457,13 @@ def doctor(
     if install:
         install_groups(missing_groups)
     else:
-        # Show summary of what's missing
+        # Show summary of what's missing with actionable install commands
         console.print(
             f"\n[yellow]Found {len(missing_groups)} missing dependency group(s).[/yellow]"
         )
-        console.print("[dim]Run with --install flag to install them automatically.[/dim]")
+        console.print("\nInstall them now:")
+        for group in sorted(missing_groups):
+            console.print(f"  [cyan]pip install fo-core\\[{group}][/cyan]")
+        console.print(
+            f"\nOr install all at once:  [cyan]fo doctor {resolved_path} --install[/cyan]"
+        )

--- a/src/cli/doctor.py
+++ b/src/cli/doctor.py
@@ -335,10 +335,9 @@ def install_groups(groups: set[str]) -> None:
 
 
 def doctor(
-    path: Path = typer.Argument(
-        ...,
-        help="Directory path to scan for file types.",
-        exists=True,
+    path: Path | None = typer.Argument(
+        None,
+        help="Directory to scan for file types (defaults to current directory).",
         file_okay=False,
         dir_okay=True,
         resolve_path=True,
@@ -363,13 +362,18 @@ def doctor(
     if not json_output and _get_state().json_output:
         json_output = True
 
+    resolved_path: Path = (path or Path.cwd()).resolve()
+    if not resolved_path.is_dir():
+        console.print(f"[red]Error: Not a directory: {resolved_path}[/red]")
+        raise typer.Exit(code=1)
+
     # Scan the directory
-    extension_counts = scan_directory(path)
+    extension_counts = scan_directory(resolved_path)
 
     if not extension_counts:
         if json_output:
             result: dict[str, Any] = {
-                "directory": str(path),
+                "directory": str(resolved_path),
                 "files_found": 0,
                 "extensions": {},
                 "detected_groups": [],
@@ -389,7 +393,7 @@ def doctor(
     if not detected_groups:
         if json_output:
             result = {
-                "directory": str(path),
+                "directory": str(resolved_path),
                 "files_found": sum(extension_counts.values()),
                 "extensions": extension_counts,
                 "detected_groups": [],
@@ -431,7 +435,7 @@ def doctor(
 
     if json_output:
         result = {
-            "directory": str(path),
+            "directory": str(resolved_path),
             "files_found": sum(extension_counts.values()),
             "extensions": extension_counts,
             "detected_groups": groups_info,
@@ -441,7 +445,7 @@ def doctor(
         raise typer.Exit(code=0)
 
     # Display recommendations (non-JSON mode)
-    console.print(f"\n[bold]Scanning directory:[/bold] {path}")
+    console.print(f"\n[bold]Scanning directory:[/bold] {resolved_path}")
     console.print()
     display_recommendations(extension_counts, detected_groups)
 

--- a/tests/integration/test_doctor_e2e.py
+++ b/tests/integration/test_doctor_e2e.py
@@ -133,12 +133,11 @@ def nested_structure_dir(tmp_path: Path) -> Path:
 class TestDoctorCommandInvocation:
     """Tests for basic doctor command invocation and argument handling."""
 
-    def test_doctor_requires_path_argument(self) -> None:
-        """Doctor command requires a path argument."""
+    def test_doctor_no_path_defaults_to_cwd(self) -> None:
+        """Doctor command without a path defaults to the current working directory."""
         result = runner.invoke(app, ["doctor"])
-        assert result.exit_code != 0
-        # Should show error about missing argument
-        assert "path" in result.output.lower() or "argument" in result.output.lower()
+        assert result.exit_code == 0
+        assert "scanning directory" in result.output.lower()
 
     def test_doctor_rejects_nonexistent_path(self) -> None:
         """Doctor command rejects non-existent directories."""


### PR DESCRIPTION
## Problem

`fo doctor` with no arguments crashes with `Error: Missing argument 'PATH'`. Users expect it to run without args as a system health check.

## Fix

`PATH` is now an optional `Argument` defaulting to `None`. When omitted, the command resolves to the current working directory. The existing `exists=True` Typer constraint is replaced with a manual `is_dir()` check on the resolved path so the optional type is accepted.

## Before / After

```
# Before
$ fo doctor
Error: Missing argument 'PATH'.

# After
$ fo doctor
Scanning directory: /Users/rahul/Documents
...
```

`fo doctor /some/path` continues to work as before.

## Test plan

- [ ] `fo doctor` — scans cwd, exits 0
- [ ] `fo doctor ~/Documents` — scans specified dir, exits 0
- [ ] `fo doctor /nonexistent` — prints error, exits 1
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)