### PR TITLE
chore(release): bump version to 2.0.0-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0-beta.7] - 2026-05-22
+
+### Added
+
+- **`fo doctor` optional PATH** — `fo doctor` with no arguments now scans the
+  current working directory instead of requiring a path. Actionable install
+  commands (per-group pip lines + `fo doctor --install` one-liner) are shown
+  when dependencies are missing. (#377)
+
+### Fixed
+
+- **Startup crash on Python 3.14** — `fo --help` and every other command was
+  importing scipy at startup via a three-hop chain:
+  `undo/durable_move → utils/__init__ → utils/readers → scipy`. scipy's C
+  extension init is slow and raises `KeyboardInterrupt` on Ctrl-C before the
+  CLI is ready. Fixed by importing `FileTooLargeError` from `utils.readers._base`
+  directly (bypassing the readers chain) and guarding the scientific reader
+  import with a try/except that falls back to lightweight stubs when
+  scipy/h5py are absent or fail to load. (#379)
+- **`imagededup` gated to Python < 3.14** — `fo-core[all]` and
+  `fo-core[dedup-image]` no longer fail to install on Python 3.14 due to
+  imagededup's Cython linker bug on arm64. (#377)
+
 ## [2.0.0-beta.6] - 2026-05-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/curdriceaurora/fo-core/actions/workflows/ci.yml/badge.svg)](https://github.com/curdriceaurora/fo-core/actions/workflows/ci.yml)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/downloads/)
-[![Version](https://img.shields.io/badge/version-2.0.0--beta.6-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-2.0.0--beta.7-blue)](CHANGELOG.md)
 
 ---
 
@@ -145,7 +145,7 @@ See [DEVELOPER.md](DEVELOPER.md) for architecture, local setup, testing, and con
 
 ## Releases
 
-Currently `2.0.0-beta.6`. The acceptance criteria that were required for this
+Currently `2.0.0-beta.7`. The acceptance criteria that were required for this
 promotion and the contract with public pre-release testers are documented in
 [docs/release/beta-criteria.md](docs/release/beta-criteria.md).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fo-core"
-version = "2.0.0-beta.6"
+version = "2.0.0-beta.7"
 description = "Streamlined CLI file organizer powered by local AI (Ollama)"
 authors = [
     {name = "fo-core Team", email = "noreply@example.com"}

--- a/src/version.py
+++ b/src/version.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-__version__ = "2.0.0-beta.6"
+__version__ = "2.0.0-beta.7"
 
 # Pattern for semantic versioning with optional pre-release and build metadata
 _VERSION_PATTERN = re.compile(


### PR DESCRIPTION
## What's in beta.7

| PR | Change |
|----|--------|
| #377 | fix(doctor): optional PATH + actionable install hints + imagededup Python 3.14 guard |
| #379 | fix(startup): prevent scipy from loading at CLI startup (crash on Python 3.14 / Ctrl-C) |

## Changes in this PR

- `pyproject.toml` + `src/version.py`: `2.0.0-beta.6` → `2.0.0-beta.7`
- `README.md`: version badge updated
- `CHANGELOG.md`: beta.7 entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `fo doctor` now defaults to scanning the current working directory when no PATH is provided
  * `fo doctor` displays installation commands for missing dependencies

* **Bug Fixes**
  * Resolved Python 3.14 startup crash
  * Improved Python 3.14 compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->