### PR TITLE
fix(ci): resolve Matrix CI failures on main (compat, dedup-image, cleanup_old_backups)

### DIFF
--- a/src/services/deduplication/backup.py
+++ b/src/services/deduplication/backup.py
@@ -296,6 +296,8 @@ class BackupManager:
         cutoff_date = datetime.now(UTC) - timedelta(days=max_age_days)
         manifest = self._load_manifest()
         removed_backups: list[Path] = []
+        # Resolve once so chdir() mid-run can't shift the anchor.
+        backup_root = self.backup_dir.resolve()
 
         # Find and remove old backups
         for backup_key, metadata in list(manifest.items()):
@@ -311,7 +313,7 @@ class BackupManager:
                 # rail); relative_to raises ValueError for outside-root.
                 try:
                     backup_path = Path(backup_key).resolve()
-                    backup_path.relative_to(self.backup_dir.resolve())
+                    backup_path.relative_to(backup_root)
                 except (ValueError, RuntimeError, OSError):
                     logger.warning(
                         "cleanup_old_backups: manifest entry %r is outside the "

--- a/src/services/deduplication/backup.py
+++ b/src/services/deduplication/backup.py
@@ -304,7 +304,20 @@ class BackupManager:
                 backup_time = backup_time.replace(tzinfo=UTC)
 
             if backup_time < cutoff_date:
-                backup_path = Path(backup_key)
+                backup_path = Path(backup_key).resolve()
+
+                # Guard against a corrupted or tampered manifest: skip any
+                # entry whose resolved path falls outside backup_dir.
+                try:
+                    backup_path.relative_to(self.backup_dir.resolve())
+                except ValueError:
+                    logger.warning(
+                        "cleanup_old_backups: manifest entry %r resolves to %s "
+                        "which is outside the backup directory — skipping",
+                        backup_key,
+                        backup_path,
+                    )
+                    continue
 
                 # Drop the manifest entry only when the file was actually
                 # unlinked OR when it's confirmed gone with a SafeDir-safe

--- a/src/services/deduplication/backup.py
+++ b/src/services/deduplication/backup.py
@@ -33,6 +33,20 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# Path components SafeDir rejects (mirrors utils.safedir._INVALID_NAME_CHARS and
+# _RESERVED_NAMES).  Used to decide whether a missing backup file represents a
+# stale manifest entry safe to drop, or a name we should preserve so an operator
+# can investigate (issue #350 C1/C2).
+_SAFEDIR_FORBIDDEN_CHARS = frozenset({"/", "\\", "\x00"})
+_SAFEDIR_RESERVED_NAMES = frozenset({"", ".", ".."})
+
+
+def _is_safedir_safe_name(name: str) -> bool:
+    """Return True iff ``name`` would pass SafeDir's component validation."""
+    if name in _SAFEDIR_RESERVED_NAMES:
+        return False
+    return not any(ch in _SAFEDIR_FORBIDDEN_CHARS for ch in name)
+
 
 def _backup_safe_unlink(path: Path, log: logging.Logger) -> bool:
     """Unlink a backup file with inode-swap TOCTOU protection via SafeDir.
@@ -292,14 +306,24 @@ class BackupManager:
             if backup_time < cutoff_date:
                 backup_path = Path(backup_key)
 
+                # Drop the manifest entry only when the file was actually
+                # unlinked OR when it's confirmed gone with a SafeDir-safe
+                # name.  Entries for names SafeDir rejects (e.g. backslash)
+                # are preserved so a human / next pass can inspect them
+                # instead of silently losing data (issue #350 C1/C2).
                 try:
-                    # Remove backup file if it exists.
-                    # ValueError is raised by SafeDir for filenames that
-                    # contain characters illegal on POSIX (e.g. backslash)
-                    # — catch it per-file so one bad name does not abort
-                    # the whole cleanup pass.
-                    if backup_path.exists() and _backup_safe_unlink(backup_path, logger):
-                        removed_backups.append(backup_path)
+                    if backup_path.exists():
+                        if _backup_safe_unlink(backup_path, logger):
+                            removed_backups.append(backup_path)
+                            del manifest[backup_key]
+                        # else: unlink failed (bad name or OS error) —
+                        # preserve entry for retry.
+                    elif _is_safedir_safe_name(backup_path.name):
+                        # File is gone and name is well-formed — drop the
+                        # stale manifest entry.
+                        del manifest[backup_key]
+                    # else: file missing AND name is unsafe; preserve so
+                    # the next cleanup pass (or an operator) can act on it.
                 except (OSError, ValueError) as exc:
                     logger.warning(
                         "cleanup_old_backups: skipping unlink of %s: %s",
@@ -307,10 +331,7 @@ class BackupManager:
                         exc,
                         exc_info=True,
                     )
-
-                # Remove from manifest regardless of unlink outcome so
-                # stale manifest entries don't accumulate.
-                del manifest[backup_key]
+                    # Preserve the manifest entry for retry on the next pass.
 
         # Save updated manifest
         self._save_manifest(manifest)

--- a/src/services/deduplication/backup.py
+++ b/src/services/deduplication/backup.py
@@ -304,18 +304,20 @@ class BackupManager:
                 backup_time = backup_time.replace(tzinfo=UTC)
 
             if backup_time < cutoff_date:
-                backup_path = Path(backup_key).resolve()
-
                 # Guard against a corrupted or tampered manifest: skip any
                 # entry whose resolved path falls outside backup_dir.
+                # Path.resolve() raises RuntimeError on Python <3.13 for
+                # symlink loops and OSError on Python ≥3.13 (F11-resolve
+                # rail); relative_to raises ValueError for outside-root.
                 try:
+                    backup_path = Path(backup_key).resolve()
                     backup_path.relative_to(self.backup_dir.resolve())
-                except ValueError:
+                except (ValueError, RuntimeError, OSError):
                     logger.warning(
-                        "cleanup_old_backups: manifest entry %r resolves to %s "
-                        "which is outside the backup directory — skipping",
+                        "cleanup_old_backups: manifest entry %r is outside the "
+                        "backup directory or cannot be resolved — skipping",
                         backup_key,
-                        backup_path,
+                        exc_info=True,
                     )
                     continue
 

--- a/src/services/deduplication/image_dedup.py
+++ b/src/services/deduplication/image_dedup.py
@@ -30,7 +30,7 @@ try:
     import numpy as np
 
     _NUMPY_AVAILABLE = True
-except ImportError:  # pragma: no cover - numpy is optional (install fo-core[search] or fo-core[dedup-text])
+except ImportError:  # pragma: no cover - numpy is optional (install fo-core[search] or fo-core[dedup-image])
     # The ignore is only emitted when numpy IS resolvable (then mypy sees a
     # type clash with the inferred Module).  When numpy is absent (the
     # type-check job's [dev] env), mypy follows the ImportError branch and

--- a/src/services/deduplication/image_dedup.py
+++ b/src/services/deduplication/image_dedup.py
@@ -30,7 +30,7 @@ try:
     import numpy as np
 
     _NUMPY_AVAILABLE = True
-except ImportError:  # pragma: no cover - numpy is optional (install fo-core[search] or fo-core[dedup-image])
+except ImportError:  # pragma: no cover - numpy is optional (fo-core[search]/[dedup-image])
     # The ignore is only emitted when numpy IS resolvable (then mypy sees a
     # type clash with the inferred Module).  When numpy is absent (the
     # type-check job's [dev] env), mypy follows the ImportError branch and

--- a/src/services/deduplication/image_dedup.py
+++ b/src/services/deduplication/image_dedup.py
@@ -31,7 +31,7 @@ try:
 
     _NUMPY_AVAILABLE = True
 except ImportError:  # pragma: no cover - numpy always installed in CI
-    np = None
+    np = None  # type: ignore[assignment]
     _NUMPY_AVAILABLE = False
 
 from PIL.Image import (  # noqa: E402

--- a/src/services/deduplication/image_dedup.py
+++ b/src/services/deduplication/image_dedup.py
@@ -82,7 +82,7 @@ class ImageDeduplicator:
 
         Raises:
             ImportError: If imagededup is not installed.
-                Install with: ``pip install 'fo-core[dedup]'``
+                Install with: ``pip install 'fo-core[dedup-image]'``
             ValueError: If hash_method is not supported or threshold is invalid
         """
         if not _IMAGEDEDUP_AVAILABLE:

--- a/src/services/deduplication/image_dedup.py
+++ b/src/services/deduplication/image_dedup.py
@@ -31,7 +31,11 @@ try:
 
     _NUMPY_AVAILABLE = True
 except ImportError:  # pragma: no cover - numpy always installed in CI
-    np = None  # type: ignore[assignment]
+    # The ignore is only emitted when numpy IS resolvable (then mypy sees a
+    # type clash with the inferred Module).  When numpy is absent (the
+    # type-check job's [dev] env), mypy follows the ImportError branch and
+    # the ignore would otherwise be flagged "unused-ignore".  Suppress both.
+    np = None  # type: ignore[assignment,unused-ignore]
     _NUMPY_AVAILABLE = False
 
 from PIL.Image import (  # noqa: E402

--- a/src/services/deduplication/image_dedup.py
+++ b/src/services/deduplication/image_dedup.py
@@ -30,7 +30,7 @@ try:
     import numpy as np
 
     _NUMPY_AVAILABLE = True
-except ImportError:  # pragma: no cover - numpy always installed in CI
+except ImportError:  # pragma: no cover - numpy is optional (install fo-core[search] or fo-core[dedup-text])
     # The ignore is only emitted when numpy IS resolvable (then mypy sees a
     # type clash with the inferred Module).  When numpy is absent (the
     # type-check job's [dev] env), mypy follows the ImportError branch and

--- a/tests/integration/test_dedup_backup.py
+++ b/tests/integration/test_dedup_backup.py
@@ -284,7 +284,10 @@ class TestBackupManagerManifest:
             removed = backup_mgr.cleanup_old_backups(max_age_days=1)
 
         assert removed == []
-        assert backup_mgr._load_manifest() == {}
+        # When unlink fails but the file is still on disk, the manifest
+        # entry is preserved so the next cleanup pass can retry
+        # (issue #350 C1/C2).
+        assert str(backup_path) in backup_mgr._load_manifest()
 
     def test_cleanup_old_backups_removes_file_and_returns_path(
         self, backup_mgr: BackupManager, tmp_path: Path

--- a/tests/integration/test_dedup_backup.py
+++ b/tests/integration/test_dedup_backup.py
@@ -309,3 +309,50 @@ class TestBackupManagerManifest:
         assert backup_path in removed
         assert not backup_path.exists()
         assert backup_mgr._load_manifest() == {}
+
+    def test_cleanup_old_backups_drops_stale_safe_name_entry(
+        self, backup_mgr: BackupManager, tmp_path: Path
+    ) -> None:
+        """A missing file with a SafeDir-safe name is treated as a stale entry."""
+        # Inject a manifest entry for a file that doesn't exist but has a
+        # well-formed name — cleanup should drop the entry.
+        stale_key = str(backup_mgr.backup_dir / "vanished.bak")
+        manifest = {
+            stale_key: {
+                "original_path": str(tmp_path / "vanished"),
+                "backup_path": stale_key,
+                "backup_time": "2000-01-01T00:00:00Z",
+                "file_size": 0,
+                "original_mtime": "2000-01-01T00:00:00Z",
+            }
+        }
+        backup_mgr.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        removed = backup_mgr.cleanup_old_backups(max_age_days=1)
+
+        assert removed == []
+        assert stale_key not in backup_mgr._load_manifest()
+
+    def test_cleanup_old_backups_preserves_missing_file_with_unsafe_name(
+        self, backup_mgr: BackupManager, tmp_path: Path
+    ) -> None:
+        """A missing file with a SafeDir-rejected name is preserved for retry."""
+        # backslash makes the name unsafe under SafeDir validation; even though
+        # the file doesn't exist, the manifest entry must be preserved so an
+        # operator can act on it (issue #350 C1/C2).
+        bad_key = str(backup_mgr.backup_dir / "bad\\name.bak")
+        manifest = {
+            bad_key: {
+                "original_path": str(tmp_path / "bad"),
+                "backup_path": bad_key,
+                "backup_time": "2000-01-01T00:00:00Z",
+                "file_size": 0,
+                "original_mtime": "2000-01-01T00:00:00Z",
+            }
+        }
+        backup_mgr.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        removed = backup_mgr.cleanup_old_backups(max_age_days=1)
+
+        assert removed == []
+        assert bad_key in backup_mgr._load_manifest()

--- a/tests/services/deduplication/test_dedup_backup.py
+++ b/tests/services/deduplication/test_dedup_backup.py
@@ -735,3 +735,79 @@ class TestBackupSafeUnlinkIssue350:
 
         assert result is True
         assert not target.exists()
+
+
+# ---------------------------------------------------------------------------
+# _is_safedir_safe_name helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestIsSafedirSafeName:
+    """The helper mirrors SafeDir._validate_name's component check."""
+
+    def test_reserved_names_are_unsafe(self) -> None:
+        from services.deduplication.backup import _is_safedir_safe_name
+
+        assert _is_safedir_safe_name("") is False
+        assert _is_safedir_safe_name(".") is False
+        assert _is_safedir_safe_name("..") is False
+
+    def test_path_separator_chars_are_unsafe(self) -> None:
+        from services.deduplication.backup import _is_safedir_safe_name
+
+        assert _is_safedir_safe_name("a/b.bak") is False
+        assert _is_safedir_safe_name("a\\b.bak") is False
+        assert _is_safedir_safe_name("with\x00null") is False
+
+    def test_plain_names_are_safe(self) -> None:
+        from services.deduplication.backup import _is_safedir_safe_name
+
+        assert _is_safedir_safe_name("backup.bak") is True
+        assert _is_safedir_safe_name("file-with-dashes_and_underscores.txt") is True
+
+
+# ---------------------------------------------------------------------------
+# cleanup_old_backups: manifest entries pointing outside backup_dir
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+@pytest.mark.skipif(sys.platform == "win32", reason="path resolution is POSIX-specific")
+class TestCleanupOldBackupsOutsideBackupDir:
+    """A corrupted manifest pointing outside backup_dir must be skipped."""
+
+    def test_entry_outside_backup_dir_is_skipped_and_preserved(
+        self, manager: BackupManager, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Manifest entry whose resolved path falls outside backup_dir is skipped.
+
+        The entry is preserved in the manifest so an operator can inspect
+        the corruption — silent deletion would mask a tampering event.
+        """
+        import logging
+
+        # Point the manifest at a path well outside backup_dir.
+        outside_key = str(tmp_path / "elsewhere.bak")
+        manifest = manager._load_manifest()
+        old_time = (datetime.now(UTC) - timedelta(days=60)).isoformat().replace("+00:00", "Z")
+        manifest[outside_key] = {
+            "original_path": str(tmp_path / "original"),
+            "backup_path": outside_key,
+            "backup_time": old_time,
+            "file_size": 0,
+            "original_mtime": old_time,
+        }
+        manager._save_manifest(manifest)
+
+        with caplog.at_level(logging.WARNING, logger="services.deduplication.backup"):
+            removed = manager.cleanup_old_backups(max_age_days=30)
+
+        assert removed == []
+        # The corrupt entry stays so it can be inspected.
+        assert outside_key in manager._load_manifest()
+        assert any("outside the backup directory" in r.message for r in caplog.records), (
+            f"expected outside-dir WARNING, got: {[r.message for r in caplog.records]}"
+        )

--- a/tests/services/deduplication/test_dedup_backup_coverage.py
+++ b/tests/services/deduplication/test_dedup_backup_coverage.py
@@ -334,7 +334,8 @@ class TestCleanupOldBackupsExceptionHandler:
         """Lines 264-265: OSError from _backup_safe_unlink is caught per-file.
 
         cleanup_old_backups must continue processing remaining entries
-        instead of aborting the whole pass.
+        instead of aborting the whole pass.  The manifest entry is
+        preserved so the next pass can retry (issue #350 C1/C2).
         """
         backup_path = bm.create_backup(sample_file)
         self._age_backup(bm, backup_path)
@@ -346,14 +347,15 @@ class TestCleanupOldBackupsExceptionHandler:
             removed = bm.cleanup_old_backups(max_age_days=30)
 
         assert removed == []
-        # manifest entry should still be purged even though unlink failed
-        assert bm._load_manifest() == {}
+        # Entry preserved so retry can happen on the next pass.
+        assert str(backup_path.resolve()) in bm._load_manifest()
 
     def test_valueerror_in_unlink_is_skipped(self, bm: BackupManager, sample_file: Path) -> None:
         """Lines 264-265: ValueError from _backup_safe_unlink is caught per-file.
 
         A SafeDir ValueError (e.g. backslash in filename) must not abort
-        the entire cleanup pass.
+        the entire cleanup pass.  The manifest entry is preserved so the
+        next pass can retry (issue #350 C1/C2).
         """
         backup_path = bm.create_backup(sample_file)
         self._age_backup(bm, backup_path)
@@ -365,4 +367,5 @@ class TestCleanupOldBackupsExceptionHandler:
             removed = bm.cleanup_old_backups(max_age_days=30)
 
         assert removed == []
-        assert bm._load_manifest() == {}
+        # Entry preserved so retry can happen on the next pass.
+        assert str(backup_path.resolve()) in bm._load_manifest()

--- a/tests/services/deduplication/test_dedup_backup_coverage.py
+++ b/tests/services/deduplication/test_dedup_backup_coverage.py
@@ -12,7 +12,11 @@ from unittest.mock import patch
 
 import pytest
 
-from services.deduplication.backup import BackupManager, _backup_safe_unlink
+from services.deduplication.backup import (
+    BackupManager,
+    _backup_safe_unlink,
+    _is_safedir_safe_name,
+)
 
 pytestmark = [pytest.mark.ci, pytest.mark.unit]
 
@@ -369,3 +373,60 @@ class TestCleanupOldBackupsExceptionHandler:
         assert removed == []
         # Entry preserved so retry can happen on the next pass.
         assert str(backup_path.resolve()) in bm._load_manifest()
+
+
+# ---------------------------------------------------------------------------
+# _is_safedir_safe_name — line 47 (reserved names return False)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestIsSafedirSafeName:
+    """Line 47: _is_safedir_safe_name returns False for reserved path components."""
+
+    def test_empty_string_is_not_safe(self) -> None:
+        assert _is_safedir_safe_name("") is False
+
+    def test_dot_is_not_safe(self) -> None:
+        assert _is_safedir_safe_name(".") is False
+
+    def test_dotdot_is_not_safe(self) -> None:
+        assert _is_safedir_safe_name("..") is False
+
+    def test_normal_name_is_safe(self) -> None:
+        assert _is_safedir_safe_name("backup_2024.tar.gz") is True
+
+    def test_forbidden_char_is_not_safe(self) -> None:
+        assert _is_safedir_safe_name("bad\\name") is False
+
+
+# ---------------------------------------------------------------------------
+# cleanup_old_backups — path-containment guard lines 315-316, 322
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCleanupOutOfRootManifestEntry:
+    """Lines 315-316, 322: manifest entries outside backup_dir are skipped."""
+
+    def test_out_of_root_entry_is_skipped_and_preserved(
+        self, bm: BackupManager, tmp_path: Path
+    ) -> None:
+        old_time = (datetime.now(UTC) - timedelta(days=60)).isoformat().replace("+00:00", "Z")
+        outside_key = str(tmp_path / "outside_file.txt")
+        bm._save_manifest(
+            {
+                outside_key: {
+                    "original_path": "/some/original.txt",
+                    "backup_path": outside_key,
+                    "backup_time": old_time,
+                    "file_size": 0,
+                    "original_mtime": old_time,
+                }
+            }
+        )
+
+        removed = bm.cleanup_old_backups(max_age_days=30)
+
+        assert removed == []
+        assert outside_key in bm._load_manifest()

--- a/tests/services/deduplication/test_image_dedup.py
+++ b/tests/services/deduplication/test_image_dedup.py
@@ -829,10 +829,13 @@ class TestMissingImagededupDep:
         """ImportError is raised with install hint when imagededup is absent."""
         import services.deduplication.image_dedup as _mod
 
-        original = _mod._IMAGEDEDUP_AVAILABLE
+        original_avail = _mod._IMAGEDEDUP_AVAILABLE
+        original_py314 = _mod._PY314_PLUS
         try:
             _mod._IMAGEDEDUP_AVAILABLE = False
+            _mod._PY314_PLUS = False  # ensure pip-install branch, not py314 guard
             with pytest.raises(ImportError, match="pip install 'fo-core\\[dedup-image\\]'"):
                 ImageDeduplicator()
         finally:
-            _mod._IMAGEDEDUP_AVAILABLE = original
+            _mod._IMAGEDEDUP_AVAILABLE = original_avail
+            _mod._PY314_PLUS = original_py314

--- a/tests/services/deduplication/test_image_dedup.py
+++ b/tests/services/deduplication/test_image_dedup.py
@@ -832,7 +832,7 @@ class TestMissingImagededupDep:
         original = _mod._IMAGEDEDUP_AVAILABLE
         try:
             _mod._IMAGEDEDUP_AVAILABLE = False
-            with pytest.raises(ImportError, match="pip install 'fo-core\\[dedup\\]'"):
+            with pytest.raises(ImportError, match="pip install 'fo-core\\[dedup-image\\]'"):
                 ImageDeduplicator()
         finally:
             _mod._IMAGEDEDUP_AVAILABLE = original

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -493,17 +493,13 @@ class TestDatetimeCompatibility:
 
     def test_utc_aware_comparison(self) -> None:
         """UTC-aware datetimes should be comparable."""
-        from datetime import UTC
-
-        t1 = datetime.datetime(2024, 1, 1, tzinfo=UTC)
-        t2 = datetime.datetime(2024, 6, 1, tzinfo=UTC)
+        t1 = datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC)
+        t2 = datetime.datetime(2024, 6, 1, tzinfo=datetime.UTC)
         assert t1 < t2
 
     def test_utc_isoformat(self) -> None:
         """UTC datetime isoformat should include timezone info."""
-        from datetime import UTC
-
-        dt = datetime.datetime(2024, 1, 15, 14, 30, 0, tzinfo=UTC)
+        dt = datetime.datetime(2024, 1, 15, 14, 30, 0, tzinfo=datetime.UTC)
         iso = dt.isoformat()
         assert "+00:00" in iso or "Z" in iso
 

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -142,6 +142,7 @@ class TestStrEnumBackport:
 
     def test_basic_strenum_creation(self) -> None:
         """Creating a StrEnum subclass should work."""
+
         class Color(StrEnum):
             RED = "red"
             GREEN = "green"
@@ -151,6 +152,7 @@ class TestStrEnumBackport:
 
     def test_strenum_string_equality(self) -> None:
         """StrEnum members should compare equal to their string values."""
+
         class Status(StrEnum):
             ACTIVE = "active"
             INACTIVE = "inactive"
@@ -160,6 +162,7 @@ class TestStrEnumBackport:
 
     def test_strenum_str_conversion(self) -> None:
         """str() on StrEnum member should return the value, not 'Class.MEMBER'."""
+
         class Priority(StrEnum):
             HIGH = "high"
             LOW = "low"
@@ -169,6 +172,7 @@ class TestStrEnumBackport:
 
     def test_strenum_format_string(self) -> None:
         """StrEnum members should work in f-strings and format()."""
+
         class Level(StrEnum):
             INFO = "info"
             WARN = "warn"
@@ -178,6 +182,7 @@ class TestStrEnumBackport:
 
     def test_strenum_is_string_subclass(self) -> None:
         """StrEnum members should be instances of str with their string value."""
+
         class Direction(StrEnum):
             NORTH = "north"
 
@@ -185,6 +190,7 @@ class TestStrEnumBackport:
 
     def test_strenum_is_enum_subclass(self) -> None:
         """StrEnum members should be instances of Enum."""
+
         class Direction(StrEnum):
             NORTH = "north"
 
@@ -192,6 +198,7 @@ class TestStrEnumBackport:
 
     def test_strenum_value_access(self) -> None:
         """StrEnum .value should return the string value."""
+
         class Mode(StrEnum):
             READ = "read"
             WRITE = "write"
@@ -201,6 +208,7 @@ class TestStrEnumBackport:
 
     def test_strenum_iteration(self) -> None:
         """StrEnum should support iteration over members."""
+
         class Suit(StrEnum):
             HEARTS = "hearts"
             DIAMONDS = "diamonds"
@@ -212,6 +220,7 @@ class TestStrEnumBackport:
 
     def test_strenum_lookup_by_value(self) -> None:
         """StrEnum should support lookup by value."""
+
         class Season(StrEnum):
             SPRING = "spring"
             SUMMER = "summer"
@@ -221,6 +230,7 @@ class TestStrEnumBackport:
 
     def test_strenum_in_dict_key(self) -> None:
         """StrEnum members should work as dict keys and match string keys."""
+
         class Key(StrEnum):
             NAME = "name"
             AGE = "age"
@@ -231,6 +241,7 @@ class TestStrEnumBackport:
 
     def test_strenum_hashable(self) -> None:
         """StrEnum members should be hashable and usable in sets."""
+
         class Tag(StrEnum):
             A = "a"
             B = "b"
@@ -248,6 +259,7 @@ class TestStrEnumBackport:
 
     def test_strenum_repr(self) -> None:
         """StrEnum repr should include class name and member name."""
+
         class Flavor(StrEnum):
             VANILLA = "vanilla"
 
@@ -417,6 +429,7 @@ class TestIsinstanceTupleForm:
 
     def test_isinstance_with_enum(self) -> None:
         """isinstance checks with Enum types should work."""
+
         class Color(StrEnum):
             RED = "red"
 

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -17,10 +17,9 @@ Test areas:
 from __future__ import annotations
 
 import datetime
-import importlib
 import sys
 from dataclasses import dataclass, field, fields
-from enum import Enum
+from enum import Enum, StrEnum
 from pathlib import Path
 from typing import Any, get_type_hints
 
@@ -141,16 +140,8 @@ class TestFutureAnnotations:
 class TestStrEnumBackport:
     """Verify the StrEnum backport works identically to the 3.11+ stdlib version."""
 
-    def test_import_from_compat(self) -> None:
-        """StrEnum should be importable from _compat module."""
-        from _compat import StrEnum
-
-        assert StrEnum is not None
-
     def test_basic_strenum_creation(self) -> None:
         """Creating a StrEnum subclass should work."""
-        from _compat import StrEnum
-
         class Color(StrEnum):
             RED = "red"
             GREEN = "green"
@@ -160,8 +151,6 @@ class TestStrEnumBackport:
 
     def test_strenum_string_equality(self) -> None:
         """StrEnum members should compare equal to their string values."""
-        from _compat import StrEnum
-
         class Status(StrEnum):
             ACTIVE = "active"
             INACTIVE = "inactive"
@@ -171,8 +160,6 @@ class TestStrEnumBackport:
 
     def test_strenum_str_conversion(self) -> None:
         """str() on StrEnum member should return the value, not 'Class.MEMBER'."""
-        from _compat import StrEnum
-
         class Priority(StrEnum):
             HIGH = "high"
             LOW = "low"
@@ -182,8 +169,6 @@ class TestStrEnumBackport:
 
     def test_strenum_format_string(self) -> None:
         """StrEnum members should work in f-strings and format()."""
-        from _compat import StrEnum
-
         class Level(StrEnum):
             INFO = "info"
             WARN = "warn"
@@ -193,8 +178,6 @@ class TestStrEnumBackport:
 
     def test_strenum_is_string_subclass(self) -> None:
         """StrEnum members should be instances of str with their string value."""
-        from _compat import StrEnum
-
         class Direction(StrEnum):
             NORTH = "north"
 
@@ -202,8 +185,6 @@ class TestStrEnumBackport:
 
     def test_strenum_is_enum_subclass(self) -> None:
         """StrEnum members should be instances of Enum."""
-        from _compat import StrEnum
-
         class Direction(StrEnum):
             NORTH = "north"
 
@@ -211,8 +192,6 @@ class TestStrEnumBackport:
 
     def test_strenum_value_access(self) -> None:
         """StrEnum .value should return the string value."""
-        from _compat import StrEnum
-
         class Mode(StrEnum):
             READ = "read"
             WRITE = "write"
@@ -222,8 +201,6 @@ class TestStrEnumBackport:
 
     def test_strenum_iteration(self) -> None:
         """StrEnum should support iteration over members."""
-        from _compat import StrEnum
-
         class Suit(StrEnum):
             HEARTS = "hearts"
             DIAMONDS = "diamonds"
@@ -235,8 +212,6 @@ class TestStrEnumBackport:
 
     def test_strenum_lookup_by_value(self) -> None:
         """StrEnum should support lookup by value."""
-        from _compat import StrEnum
-
         class Season(StrEnum):
             SPRING = "spring"
             SUMMER = "summer"
@@ -246,8 +221,6 @@ class TestStrEnumBackport:
 
     def test_strenum_in_dict_key(self) -> None:
         """StrEnum members should work as dict keys and match string keys."""
-        from _compat import StrEnum
-
         class Key(StrEnum):
             NAME = "name"
             AGE = "age"
@@ -258,8 +231,6 @@ class TestStrEnumBackport:
 
     def test_strenum_hashable(self) -> None:
         """StrEnum members should be hashable and usable in sets."""
-        from _compat import StrEnum
-
         class Tag(StrEnum):
             A = "a"
             B = "b"
@@ -269,8 +240,6 @@ class TestStrEnumBackport:
 
     def test_strenum_type_error_on_non_string(self) -> None:
         """StrEnum should reject non-string values."""
-        from _compat import StrEnum
-
         # On Python 3.11+ the native StrEnum raises TypeError too
         with pytest.raises((TypeError, ValueError)):
 
@@ -279,8 +248,6 @@ class TestStrEnumBackport:
 
     def test_strenum_repr(self) -> None:
         """StrEnum repr should include class name and member name."""
-        from _compat import StrEnum
-
         class Flavor(StrEnum):
             VANILLA = "vanilla"
 
@@ -450,8 +417,6 @@ class TestIsinstanceTupleForm:
 
     def test_isinstance_with_enum(self) -> None:
         """isinstance checks with Enum types should work."""
-        from _compat import StrEnum
-
         class Color(StrEnum):
             RED = "red"
 
@@ -467,18 +432,6 @@ class TestIsinstanceTupleForm:
 @pytest.mark.unit
 class TestImportPaths:
     """Verify that all critical import paths resolve correctly."""
-
-    def test_import_compat_module(self) -> None:
-        """The _compat module should be importable."""
-        mod = importlib.import_module("_compat")
-        assert hasattr(mod, "StrEnum")
-        assert hasattr(mod, "UTC")
-
-    def test_import_strenum_from_compat(self) -> None:
-        """StrEnum should be importable from _compat."""
-        from _compat import StrEnum
-
-        assert issubclass(StrEnum, Enum)
 
     def test_import_para_categories(self) -> None:
         """PARACategory should be importable."""
@@ -498,13 +451,6 @@ class TestImportPaths:
         from undo.models import ConflictType
 
         assert issubclass(ConflictType, Enum)
-
-    def test_compat_all_exports(self) -> None:
-        """_compat.__all__ should list all public exports."""
-        import _compat
-
-        assert "StrEnum" in _compat.__all__
-        assert "UTC" in _compat.__all__
 
 
 # ===================================================================
@@ -526,29 +472,15 @@ class TestDatetimeCompatibility:
         utc = datetime.UTC
         assert utc.utcoffset(None) == datetime.timedelta(0)
 
-    def test_utc_from_compat(self) -> None:
-        """UTC constant from _compat should match datetime.UTC."""
-        from _compat import UTC
-
-        assert UTC is datetime.UTC
-
     def test_datetime_now_with_utc(self) -> None:
         """Creating UTC-aware datetimes should use datetime.UTC."""
         now = datetime.datetime.now(tz=datetime.UTC)
         assert now.tzinfo is not None
         assert now.tzinfo == datetime.UTC
 
-    def test_datetime_now_with_compat_utc(self) -> None:
-        """Creating UTC-aware datetimes with _compat.UTC should work."""
-        from _compat import UTC
-
-        now = datetime.datetime.now(tz=UTC)
-        assert now.tzinfo is not None
-        assert now.tzinfo == datetime.UTC
-
     def test_utc_aware_comparison(self) -> None:
         """UTC-aware datetimes should be comparable."""
-        from _compat import UTC
+        from datetime import UTC
 
         t1 = datetime.datetime(2024, 1, 1, tzinfo=UTC)
         t2 = datetime.datetime(2024, 6, 1, tzinfo=UTC)
@@ -556,7 +488,7 @@ class TestDatetimeCompatibility:
 
     def test_utc_isoformat(self) -> None:
         """UTC datetime isoformat should include timezone info."""
-        from _compat import UTC
+        from datetime import UTC
 
         dt = datetime.datetime(2024, 1, 15, 14, 30, 0, tzinfo=UTC)
         iso = dt.isoformat()

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -132,13 +132,13 @@ class TestFutureAnnotations:
 
 
 # ===================================================================
-# Section 2: StrEnum backport tests
+# Section 2: StrEnum (stdlib) tests
 # ===================================================================
 
 
 @pytest.mark.unit
-class TestStrEnumBackport:
-    """Verify the StrEnum backport works identically to the 3.11+ stdlib version."""
+class TestStrEnumStdlib:
+    """Verify that the stdlib StrEnum (Python 3.11+) works correctly."""
 
     def test_basic_strenum_creation(self) -> None:
         """Creating a StrEnum subclass should work."""


### PR DESCRIPTION
## Summary

The May-22 nightly **CI Full Matrix #57** (run `26326474801`) and the post-merge **CI #1020** (run `26322669044`) on commit `1148db6` are both failing on main. Locally reproducing the Linux full-suite command surfaced **24 deterministic test failures** across three independent root causes — none of them flakes. This PR fixes all three.

## Failure groups (root cause analysis)

| # | Failures | Symptom | Root cause |
|---|---|---|---|
| **1** | 22 in `tests/test_compatibility.py` | `ModuleNotFoundError: No module named '_compat'` | `src/_compat.py` was deleted in commit `bbcafef` ("fix _compat packaging bug") and every production import switched to stdlib `from enum import StrEnum` / `from datetime import UTC`, but `tests/test_compatibility.py` was missed during that cleanup. The tests still try to `from _compat import StrEnum`. |
| **2** | 1 in `tests/services/deduplication/test_image_dedup.py` | Regex `pip install 'fo-core\[dedup\]'` does not match actual message `pip install 'fo-core[dedup-image]'` | PR #388 (commit `1148db6`, the very tip of main) renamed the extra `fo-core[dedup]` → `fo-core[dedup-image]` in the `ImportError` text but the matching `pytest.raises(..., match=...)` regex was not updated. |
| **3** | 1 in `tests/services/deduplication/test_dedup_backup.py` | `assert bad_key in final_manifest` fails because the entry was deleted | PR #363 (commit `5bfd573`) updated `test_valueerror_on_unlink_does_not_abort_cleanup` to assert that the manifest entry is **preserved** when SafeDir rejects the name (issue #350 C1/C2), but the production `cleanup_old_backups` in `src/services/deduplication/backup.py` still unconditionally does `del manifest[backup_key]` regardless of unlink outcome. Tests and production drifted. |

## Fixes

1. **`tests/test_compatibility.py`** — replace 16 `from _compat import StrEnum` and 4 `from _compat import UTC` with the stdlib `enum.StrEnum` / `datetime.UTC` (which is what the deleted `_compat` re-exported anyway). Remove four tests that were specifically asserting the existence of the `_compat` module: `test_import_from_compat`, `test_import_compat_module`, `test_import_strenum_from_compat`, `test_compat_all_exports`, plus the now-redundant `test_utc_from_compat` and `test_datetime_now_with_compat_utc`. The remaining 47 tests still cover StrEnum / UTC behaviour end-to-end via stdlib imports.

2. **`tests/services/deduplication/test_image_dedup.py`** — update the `pytest.raises(..., match=...)` regex to the new install hint.

3. **`src/services/deduplication/backup.py` + dedup_backup tests** — bring `cleanup_old_backups` in line with PR #363's design intent: drop the manifest entry **only** when the file was actually unlinked OR when it's confirmed gone with a SafeDir-safe name; preserve it otherwise so the next cleanup pass can retry. Two older tests (`test_oserror_in_unlink_is_skipped`, `test_valueerror_in_unlink_is_skipped` in `test_dedup_backup_coverage.py`) and one integration test (`test_cleanup_old_backups_ignores_unlink_errors`) still asserted the **old** "always remove" behaviour — update them to match the new design with the rationale spelled out in their docstrings.

   Adds a small `_is_safedir_safe_name` helper that mirrors `utils.safedir._INVALID_NAME_CHARS` / `_RESERVED_NAMES` so the cleanup path can decide "stale entry safe to drop" vs "bad name worth preserving for an operator" without importing private SafeDir internals.

## Trade-offs

* The dedup_backup test updates change *test expectations* — they had been asserting the pre-PR-#363 design. I confirmed via `git log` that PR #363 explicitly introduced the "preserve on failure for retry" semantic (issue #350 C1/C2) and only updated one of the four tests it affected; the other three tests were stale. This PR does not weaken any test: each updated assertion still verifies that a specific manifest key behaves as the design dictates.
* The four `_compat` module-existence tests are deleted (not weakened). The module they tested has been removed from the codebase — keeping the tests would require restoring the deleted module.

## Verification (local)

| Run | Command | Result |
|---|---|---|
| Linux nightly full | `pytest tests/ --ignore=tests/extras/test_extras_{cad,dedup_image,media,scientific}.py -m "not benchmark and not e2e" --strict-markers -n auto --dist=loadgroup --timeout=60 --override-ini="addopts="` | **17,531 passed, 83 skipped, 1 xfailed** |
| macOS / Windows subset | same with `-m "ci or smoke" --timeout=30` | **4,903 passed, 2 skipped** |
| CI guardrails | `pytest tests/ci/ --strict-markers --override-ini="addopts="` | **705 passed, 1 skipped** |
| Ruff (changed files) | `ruff check src/services/deduplication/backup.py tests/test_compatibility.py tests/services/deduplication/test_image_dedup.py tests/services/deduplication/test_dedup_backup_coverage.py tests/integration/test_dedup_backup.py` | **All checks passed** |
| mypy on touched module | `mypy --config-file pyproject.toml src/services/deduplication/backup.py` | **Success: no issues found in 1 source file** |

## Impacted areas

* `src/services/deduplication/backup.py` — adds `_is_safedir_safe_name` helper; tightens manifest deletion logic in `cleanup_old_backups`. No public-API change.
* `tests/test_compatibility.py` — `_compat` → stdlib imports; removes 6 obsolete tests; 47 remaining tests still validate the same Python-3.11+ patterns.
* `tests/services/deduplication/test_image_dedup.py` — regex fix only.
* `tests/services/deduplication/test_dedup_backup_coverage.py`, `tests/integration/test_dedup_backup.py` — assert manifest preservation rather than deletion when unlink fails.

## Failing CI runs addressed

* CI Full Matrix #57 — https://github.com/curdriceaurora/fo-core/actions/runs/26326474801 (Linux py3.11 / py3.12 jobs)
* CI #1020 — https://github.com/curdriceaurora/fo-core/actions/runs/26322669044 (test-full py3.11 / py3.12 jobs)

The macOS job in CI Full Matrix #57 also failed, but it runs the `ci or smoke` subset which I could not reproduce a failure on locally (4,903 tests pass). The same Linux-side fixes should be neutral-or-positive for that job; if it still fails after this PR, it'll need separate investigation with the CI logs.

## Test plan

- [x] All previously-failing tests now pass locally
- [x] Full Linux suite runs clean (17,531 tests)
- [x] `ci or smoke` subset runs clean (4,903 tests)
- [x] No new ruff or mypy regressions on touched files
- [ ] CI green on this PR (verifying)

---
_Generated by [Claude Code](https://claude.ai/code/session_012tQVomve6sm3J3NG9MN8cN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backup cleanup now preserves manifest entries when removal fails or targets appear outside the backup area; stale entries are only removed when safe to do so, reducing accidental data loss.

* **Chores**
  * Minor typing and compatibility modernizations to rely on newer stdlib features.

* **Tests**
  * Expanded integration and unit tests covering backup safety checks and cleanup retry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->