### PR TITLE
chore(release): bump version to 2.0.0-beta.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fo-core"
-version = "2.0.0-beta.7"
+version = "2.0.0-beta.8"
 description = "Streamlined CLI file organizer powered by local AI (Ollama)"
 authors = [
     {name = "fo-core Team", email = "noreply@example.com"}


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` version from `2.0.0-beta.7` → `2.0.0-beta.8`

## What's new since beta.7

### Features
- **Per-run session log** — each CLI invocation writes a full DEBUG NDJSON log to `~/.local/state/fo/logs/sessions/`. View with `fo logs --session`, list with `fo logs --list`. (#394)
- **Vision image downscaling** — large images are downscaled before sending to vision model to reduce latency and token cost. (#398)
- **Doctor improvements** — install method detection, corrected extra mapping, package-level diagnostics. (#395)

### Fixed
- **Parallel macOS race** — `cancel()→False/done()→True` race treated correctly as timeout. (#400)
- **PackageNotFoundError in updater** — PEP 440 version parsing hardened. (#392)
- **Dedup-image Python 3.14+** — actionable ImportError with correct extra name. (#386)
- **Loguru sink teardown** — guard against double-remove; expose `file_log_sink_id`. (#390)
- **Scientific reader fallback** — narrow except to `(ImportError, OSError)`. (#388)
- **CI matrix fixes** — compat, dedup-image, cloud extras on Python 3.14. (#387)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.0.0-beta.8

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->