### PR TITLE
feat(pipeline): add .svg and .tif to image processing pipeline

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -488,7 +488,7 @@ fo update install --dry-run
 | Category | Formats |
 |----------|---------|
 | Documents | `.txt`, `.md`, `.pdf`, `.docx`, `.doc`*, `.csv`, `.xlsx`, `.xls`*, `.pptx` |
-| Images | `.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.tiff`, `.tif`, `.webp`, `.heic`, `.heif` |
+| Images | `.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.tiff`, `.tif`, `.webp`, `.heic`, `.heif`, `.svg` |
 | Video | `.mp4`, `.avi`, `.mkv`, `.mov`, `.wmv` |
 | Audio | `.mp3`, `.wav`, `.flac`, `.m4a`, `.ogg` |
 | Archives | `.zip`, `.7z`, `.tar`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.rar` |

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -10,7 +10,7 @@
 | Scientific | `.hdf5`, `.h5`, `.hdf`, `.nc`, `.nc4`, `.netcdf`, `.mat` | 7 |
 | CAD | `.dxf`, `.dwg`, `.step`, `.stp`, `.iges`, `.igs` | 6 |
 
-**Total**: 49+ file types supported
+**Total**: 52 file types supported
 
 ## Optional Dependencies
 

--- a/docs/reference/file-formats.md
+++ b/docs/reference/file-formats.md
@@ -3,14 +3,14 @@
 | Category | Formats | Count |
 |----------|---------|-------|
 | Documents | `.txt`, `.md`, `.pdf`, `.docx`, `.doc`, `.csv`, `.xlsx`, `.xls`, `.ppt`, `.pptx`, `.epub` | 11 |
-| Images | `.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.tiff`, `.tif`, `.webp`, `.heic`, `.heif` | 10 |
+| Images | `.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.tiff`, `.tif`, `.webp`, `.heic`, `.heif`, `.svg` | 11 |
 | Video | `.mp4`, `.avi`, `.mkv`, `.mov`, `.wmv` | 5 |
 | Audio | `.mp3`, `.wav`, `.flac`, `.m4a`, `.ogg` | 5 |
 | Archives | `.zip`, `.7z`, `.tar`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.rar` | 7 |
 | Scientific | `.hdf5`, `.h5`, `.hdf`, `.nc`, `.nc4`, `.netcdf`, `.mat` | 7 |
 | CAD | `.dxf`, `.dwg`, `.step`, `.stp`, `.iges`, `.igs` | 6 |
 
-**Total**: 48+ file types supported
+**Total**: 49+ file types supported
 
 ## Optional Dependencies
 
@@ -23,7 +23,7 @@ Each format group maps to an install extra:
 | Archives | `.zip`, `.7z`, `.tar`, `.tar.gz`, `.tgz`, `.tar.bz2`, `.tbz2`, `.tar.xz`, `.rar` | py7zr, rarfile | Core (default) |
 | Scientific | `.hdf5`, `.h5`, `.hdf`, `.nc`, `.nc4`, `.netcdf`, `.mat` | h5py, netCDF4, scipy | `[scientific]` |
 | CAD | `.dxf`, `.dwg`, `.step`, `.stp`, `.iges`, `.igs` | ezdxf | `[cad]` |
-| Images | `.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.tiff`, `.tif`, `.webp`, `.heic`, `.heif` | None (VisionProcessor) | Core |
+| Images | `.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`, `.tiff`, `.tif`, `.webp`, `.heic`, `.heif`, `.svg` | None (VisionProcessor); `.svg` rasterized via PyMuPDF | Core |
 | Audio | `.mp3`, `.wav`, `.flac`, `.m4a`, `.ogg` | faster-whisper, torch | `[media]` |
 | Video | `.mp4`, `.avi`, `.mkv`, `.mov`, `.wmv` | opencv-python, scenedetect | `[media]` |
 

--- a/src/core/types.py
+++ b/src/core/types.py
@@ -66,9 +66,11 @@ IMAGE_EXTENSIONS: frozenset[str] = frozenset(
         ".gif",
         ".bmp",
         ".tiff",
+        ".tif",
         ".webp",
         ".heic",
         ".heif",
+        ".svg",
     }
 )
 VIDEO_EXTENSIONS: frozenset[str] = frozenset(

--- a/src/models/_vision_helpers.py
+++ b/src/models/_vision_helpers.py
@@ -21,6 +21,10 @@ from loguru import logger
 # Fallback MIME type when extension is not recognised
 _DEFAULT_IMAGE_MIME = "image/jpeg"
 
+# Maximum pixel dimension for SVG rasterization — guards against OOM from
+# SVGs with very large intrinsic width/height before downscaling is applied.
+_SVG_MAX_RENDER_EDGE = 4096
+
 # Hardcoded map for common image extensions — more portable than mimetypes.guess_type
 # on Windows, where the registry may not have entries for modern formats (e.g. webp)
 # and mimetypes.init() calls can clobber mimetypes.add_type registrations.
@@ -40,11 +44,19 @@ _EXTENSION_MIME: dict[str, str] = {
 
 
 def _rasterize_svg_bytes_to_png(svg_data: bytes) -> bytes:
-    """Rasterize SVG bytes to PNG bytes via PyMuPDF, without touching the filesystem."""
+    """Rasterize SVG bytes to PNG bytes via PyMuPDF, without touching the filesystem.
+
+    Render size is capped at _SVG_MAX_RENDER_EDGE on the longest side so that
+    an SVG with an enormous intrinsic width/height cannot exhaust memory before
+    the caller's downscale step runs.
+    """
     doc = fitz.open(stream=svg_data, filetype="svg")
     try:
         page = doc[0]
-        pix = page.get_pixmap()
+        w, h = page.rect.width, page.rect.height
+        scale = min(1.0, _SVG_MAX_RENDER_EDGE / max(w, h, 1))
+        mat = fitz.Matrix(scale, scale) if scale < 1.0 else fitz.Identity
+        pix = page.get_pixmap(matrix=mat)
         return bytes(pix.tobytes("png"))
     finally:
         doc.close()

--- a/src/models/_vision_helpers.py
+++ b/src/models/_vision_helpers.py
@@ -15,6 +15,7 @@ import os
 import sys
 from pathlib import Path
 
+import fitz  # PyMuPDF — core dep; also handles SVG rasterization
 from loguru import logger
 
 # Fallback MIME type when extension is not recognised
@@ -38,11 +39,55 @@ _EXTENSION_MIME: dict[str, str] = {
 }
 
 
+def _rasterize_svg_bytes_to_png(svg_data: bytes) -> bytes:
+    """Rasterize SVG bytes to PNG bytes via PyMuPDF, without touching the filesystem."""
+    doc = fitz.open(stream=svg_data, filetype="svg")
+    try:
+        page = doc[0]
+        pix = page.get_pixmap()
+        return bytes(pix.tobytes("png"))
+    finally:
+        doc.close()
+
+
+def _read_image_bytes_safedir(image_path: Path) -> bytes:
+    """Read image file bytes via SafeDir on POSIX, direct open on Windows.
+
+    Refuses symlinks on POSIX (issue #352 S3).
+    """
+    if sys.platform != "win32":
+        try:
+            from utils.safedir import SafeDir, SymlinkRejected
+
+            with SafeDir.open_root(image_path.parent) as sd:
+                fd = sd.open_for_reader(image_path.name)
+                try:
+                    fh = os.fdopen(fd, "rb", closefd=True)
+                except OSError:
+                    os.close(fd)
+                    raise
+                with fh:
+                    return fh.read()
+        except (NotImplementedError, ImportError):
+            with open(
+                image_path, "rb"
+            ) as fh_direct:  # safedir: ok — Windows / NotImplementedError fallback
+                return fh_direct.read()
+        except (SymlinkRejected, ValueError) as exc:
+            raise OSError(f"Refused to read symlinked image {image_path}: {exc}") from exc
+    else:  # pragma: no cover — Windows-only branch, not reachable on POSIX CI
+        with open(
+            image_path, "rb"
+        ) as fh_win:  # safedir: ok — Windows / NotImplementedError fallback
+            return fh_win.read()
+
+
 def rasterize_svg_to_png_bytes(svg_path: Path) -> bytes:
     """Rasterize an SVG file to PNG bytes using PyMuPDF (fitz).
 
     PyMuPDF is a core dependency (used for PDF extraction), so no additional
-    packages are required.
+    packages are required.  The file is read via SafeDir on POSIX to prevent
+    symlink attacks (issue #352 S3).
 
     Args:
         svg_path: Path to the .svg file.
@@ -51,17 +96,11 @@ def rasterize_svg_to_png_bytes(svg_path: Path) -> bytes:
         PNG image as raw bytes.
 
     Raises:
-        OSError: If the SVG cannot be opened or rendered.
+        OSError: If the SVG cannot be opened or rendered, or if *svg_path*
+            is a symlink (POSIX only).
     """
-    import fitz  # PyMuPDF — core dep
-
-    doc = fitz.open(str(svg_path))
-    try:
-        page = doc[0]
-        pix = page.get_pixmap()
-        return bytes(pix.tobytes("png"))
-    finally:
-        doc.close()
+    svg_data = _read_image_bytes_safedir(svg_path)
+    return _rasterize_svg_bytes_to_png(svg_data)
 
 
 def downscale_image_if_needed(
@@ -80,10 +119,12 @@ def downscale_image_if_needed(
             Images with either dimension exceeding this are downscaled.
 
     Returns:
-        A tuple of (image_data, was_downscaled) where:
-        - image_data is either the original Path (if no downscaling) or
-          bytes of the downscaled image
-        - was_downscaled is True if the image was resized
+        A tuple of (image_data, was_converted) where:
+        - image_data is either the original Path (if no conversion) or
+          bytes of the processed image
+        - was_converted is True if the image was resized **or** converted
+          to PNG (SVG files are always rasterized to PNG bytes, even when
+          no downscaling is needed)
 
     Raises:
         ImportError: If PIL/Pillow is not available.
@@ -202,7 +243,7 @@ def image_to_data_url(image_path: Path) -> str:
     """
     ext = image_path.suffix.lower()
 
-    # SVG: rasterize to PNG via fitz — SafeDir and base64 encoding expect raster bytes
+    # SVG: read via SafeDir then rasterize to PNG via fitz
     if ext == ".svg":
         png_bytes = rasterize_svg_to_png_bytes(image_path)
         return bytes_to_data_url(png_bytes, "image/png")
@@ -213,34 +254,7 @@ def image_to_data_url(image_path: Path) -> str:
     if not mime_type:
         mime_type = _DEFAULT_IMAGE_MIME
 
-    raw: bytes
-    if sys.platform != "win32":
-        try:
-            from utils.safedir import SafeDir, SymlinkRejected
-
-            with SafeDir.open_root(image_path.parent) as sd:
-                fd = sd.open_for_reader(image_path.name)
-                try:
-                    fh = os.fdopen(fd, "rb", closefd=True)
-                except OSError:
-                    os.close(fd)
-                    raise
-                with fh:
-                    raw = fh.read()
-        except (NotImplementedError, ImportError):
-            # SafeDir primitives unavailable — fall through to direct open.
-            with open(
-                image_path, "rb"
-            ) as fh_direct:  # safedir: ok — Windows / NotImplementedError fallback
-                raw = fh_direct.read()
-        except (SymlinkRejected, ValueError) as exc:
-            raise OSError(f"Refused to read symlinked image {image_path}: {exc}") from exc
-    else:  # pragma: no cover — Windows-only branch, not reachable on POSIX CI
-        with open(
-            image_path, "rb"
-        ) as fh_win:  # safedir: ok — Windows / NotImplementedError fallback
-            raw = fh_win.read()
-
+    raw = _read_image_bytes_safedir(image_path)
     encoded = base64.b64encode(raw).decode("utf-8")
     return f"data:{mime_type};base64,{encoded}"
 

--- a/src/models/_vision_helpers.py
+++ b/src/models/_vision_helpers.py
@@ -34,7 +34,34 @@ _EXTENSION_MIME: dict[str, str] = {
     ".tif": "image/tiff",
     ".heic": "image/heic",
     ".heif": "image/heif",
+    ".svg": "image/svg+xml",
 }
+
+
+def rasterize_svg_to_png_bytes(svg_path: Path) -> bytes:
+    """Rasterize an SVG file to PNG bytes using PyMuPDF (fitz).
+
+    PyMuPDF is a core dependency (used for PDF extraction), so no additional
+    packages are required.
+
+    Args:
+        svg_path: Path to the .svg file.
+
+    Returns:
+        PNG image as raw bytes.
+
+    Raises:
+        OSError: If the SVG cannot be opened or rendered.
+    """
+    import fitz  # PyMuPDF — core dep
+
+    doc = fitz.open(str(svg_path))
+    try:
+        page = doc[0]
+        pix = page.get_pixmap()
+        return bytes(pix.tobytes("png"))
+    finally:
+        doc.close()
 
 
 def downscale_image_if_needed(
@@ -62,6 +89,43 @@ def downscale_image_if_needed(
         ImportError: If PIL/Pillow is not available.
         OSError: If the image cannot be opened or processed.
     """
+    # SVG cannot be opened by Pillow — rasterize via fitz first, then downscale the PNG
+    if image_path.suffix.lower() == ".svg":
+        png_bytes = rasterize_svg_to_png_bytes(image_path)
+        try:
+            from PIL import Image
+
+            with Image.open(io.BytesIO(png_bytes)) as img:
+                width, height = img.size
+                if max(width, height) <= max_long_edge:
+                    return png_bytes, True
+                if width > height:
+                    new_width = max_long_edge
+                    new_height = int(height * (max_long_edge / width))
+                else:
+                    new_height = max_long_edge
+                    new_width = int(width * (max_long_edge / height))
+                logger.debug(
+                    "Downscaling rasterized SVG {} from {}×{} → {}×{} before vision inference",
+                    image_path.name,
+                    width,
+                    height,
+                    new_width,
+                    new_height,
+                )
+                resized = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
+                buf = io.BytesIO()
+                resized.save(buf, format="PNG")
+                buf.seek(0)
+                return buf.getvalue(), True
+        except Exception as exc:
+            logger.warning(
+                "Failed to downscale rasterized SVG {}: {}; using rasterized PNG",
+                image_path.name,
+                exc,
+            )
+            return png_bytes, True
+
     try:
         from PIL import Image
     except ImportError as exc:
@@ -137,6 +201,12 @@ def image_to_data_url(image_path: Path) -> str:
             symlink (POSIX only).
     """
     ext = image_path.suffix.lower()
+
+    # SVG: rasterize to PNG via fitz — SafeDir and base64 encoding expect raster bytes
+    if ext == ".svg":
+        png_bytes = rasterize_svg_to_png_bytes(image_path)
+        return bytes_to_data_url(png_bytes, "image/png")
+
     mime_type = _EXTENSION_MIME.get(ext)
     if not mime_type:
         mime_type, _ = mimetypes.guess_type(str(image_path))

--- a/src/pipeline/config.py
+++ b/src/pipeline/config.py
@@ -38,9 +38,11 @@ DEFAULT_SUPPORTED_EXTENSIONS: frozenset[str] = frozenset(
         ".gif",
         ".bmp",
         ".tiff",
+        ".tif",
         ".webp",
         ".heic",
         ".heif",
+        ".svg",
         # Video
         ".mp4",
         ".avi",

--- a/src/pipeline/router.py
+++ b/src/pipeline/router.py
@@ -55,9 +55,11 @@ _DEFAULT_IMAGE_EXTENSIONS: frozenset[str] = frozenset(
         ".gif",
         ".bmp",
         ".tiff",
+        ".tif",
         ".webp",
         ".heic",
         ".heif",
+        ".svg",
     }
 )
 

--- a/tests/integration/test_models_claude_openai_audio.py
+++ b/tests/integration/test_models_claude_openai_audio.py
@@ -205,6 +205,94 @@ class TestVisionHelpers:
         assert mime == "image/jpeg"
         assert b64 == "abc"
 
+    # ------------------------------------------------------------------
+    # SVG rasterization (requires fitz / PyMuPDF — core dep)
+    # ------------------------------------------------------------------
+
+    _MINIMAL_SVG = (
+        b'<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">'
+        b'<rect width="100" height="100" fill="red"/></svg>'
+    )
+    # Wide SVG (width > height) for branch coverage of the if width > height path
+    _WIDE_SVG = (
+        b'<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">'
+        b'<rect width="200" height="100" fill="blue"/></svg>'
+    )
+
+    def test_rasterize_svg_to_png_bytes_returns_png(self, tmp_path: Path) -> None:
+        pytest.importorskip("fitz")
+        from models._vision_helpers import rasterize_svg_to_png_bytes
+
+        svg_file = tmp_path / "shape.svg"
+        svg_file.write_bytes(self._MINIMAL_SVG)
+        result = rasterize_svg_to_png_bytes(svg_file)
+        assert isinstance(result, bytes)
+        assert result[:8] == b"\x89PNG\r\n\x1a\n"
+        assert len(result) > 100
+
+    def test_downscale_image_if_needed_svg_returns_bytes(self, tmp_path: Path) -> None:
+        pytest.importorskip("fitz")
+        pytest.importorskip("PIL")
+        from models._vision_helpers import downscale_image_if_needed
+
+        svg_file = tmp_path / "shape.svg"
+        svg_file.write_bytes(self._MINIMAL_SVG)
+        result, was_converted = downscale_image_if_needed(svg_file)
+        assert isinstance(result, bytes)
+        assert was_converted is True
+        assert result[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_downscale_image_if_needed_svg_wide_triggers_width_branch(self, tmp_path: Path) -> None:
+        pytest.importorskip("fitz")
+        pytest.importorskip("PIL")
+        from models._vision_helpers import downscale_image_if_needed
+
+        svg_file = tmp_path / "wide.svg"
+        svg_file.write_bytes(self._WIDE_SVG)
+        # max_long_edge=50 forces downscale; width(~200) > height(~100) takes if branch
+        result, was_converted = downscale_image_if_needed(svg_file, max_long_edge=50)
+        assert isinstance(result, bytes)
+        assert was_converted is True
+        assert result[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_downscale_image_if_needed_svg_square_triggers_else_branch(
+        self, tmp_path: Path
+    ) -> None:
+        pytest.importorskip("fitz")
+        pytest.importorskip("PIL")
+        from models._vision_helpers import downscale_image_if_needed
+
+        svg_file = tmp_path / "square.svg"
+        svg_file.write_bytes(self._MINIMAL_SVG)
+        # max_long_edge=50 forces downscale; width(~100) == height(~100) takes else branch
+        result, was_converted = downscale_image_if_needed(svg_file, max_long_edge=50)
+        assert isinstance(result, bytes)
+        assert was_converted is True
+        assert result[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_downscale_image_if_needed_svg_pil_failure_returns_raw_png(
+        self, tmp_path: Path
+    ) -> None:
+        pytest.importorskip("fitz")
+        from models._vision_helpers import downscale_image_if_needed
+
+        svg_file = tmp_path / "shape.svg"
+        svg_file.write_bytes(self._MINIMAL_SVG)
+        with patch("PIL.Image.open", side_effect=OSError("simulated PIL failure")):
+            result, was_converted = downscale_image_if_needed(svg_file)
+        assert isinstance(result, bytes)
+        assert was_converted is True
+
+    def test_image_to_data_url_svg_returns_png_data_url(self, tmp_path: Path) -> None:
+        pytest.importorskip("fitz")
+        from models._vision_helpers import image_to_data_url
+
+        svg_file = tmp_path / "shape.svg"
+        svg_file.write_bytes(self._MINIMAL_SVG)
+        url = image_to_data_url(svg_file)
+        assert url.startswith("data:image/png;base64,")
+        assert len(url) > len("data:image/png;base64,")
+
 
 # ===========================================================================
 # _claude_client.py

--- a/tests/integration/test_models_claude_openai_audio.py
+++ b/tests/integration/test_models_claude_openai_audio.py
@@ -274,6 +274,7 @@ class TestVisionHelpers:
         self, tmp_path: Path
     ) -> None:
         pytest.importorskip("fitz")
+        pytest.importorskip("PIL")
         from models._vision_helpers import downscale_image_if_needed
 
         svg_file = tmp_path / "shape.svg"

--- a/tests/models/test_svg_tif_support.py
+++ b/tests/models/test_svg_tif_support.py
@@ -18,6 +18,7 @@ import pytest
 pytestmark = [pytest.mark.unit, pytest.mark.ci]
 
 _MINIMAL_SVG = b'<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100" height="100" fill="red"/></svg>'
+_WIDE_SVG = b'<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100"><rect width="200" height="100" fill="blue"/></svg>'
 
 
 class TestExtensionRegistration:
@@ -124,6 +125,36 @@ class TestDownscaleHandlesSvg:
         result, _ = downscale_image_if_needed(svg_file)
 
         assert isinstance(result, bytes)
+        assert result[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_svg_downscales_wide_image(self, tmp_path: Path) -> None:
+        """Wide SVG (width > height) exercises the if-branch in the downscale path."""
+        pytest.importorskip("fitz")
+        pytest.importorskip("PIL")
+        from models._vision_helpers import downscale_image_if_needed
+
+        svg_file = tmp_path / "wide.svg"
+        svg_file.write_bytes(_WIDE_SVG)
+        # max_long_edge=50 forces downscale since SVG rasterizes to ~200x100
+        result, was_converted = downscale_image_if_needed(svg_file, max_long_edge=50)
+
+        assert isinstance(result, bytes)
+        assert was_converted is True
+        assert result[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_svg_downscales_square_image(self, tmp_path: Path) -> None:
+        """Square SVG (width == height) exercises the else-branch in the downscale path."""
+        pytest.importorskip("fitz")
+        pytest.importorskip("PIL")
+        from models._vision_helpers import downscale_image_if_needed
+
+        svg_file = tmp_path / "square.svg"
+        svg_file.write_bytes(_MINIMAL_SVG)
+        # max_long_edge=50 forces downscale since SVG rasterizes to 100x100
+        result, was_converted = downscale_image_if_needed(svg_file, max_long_edge=50)
+
+        assert isinstance(result, bytes)
+        assert was_converted is True
         assert result[:8] == b"\x89PNG\r\n\x1a\n"
 
     def test_svg_fallback_on_pil_failure(self, tmp_path: Path) -> None:

--- a/tests/models/test_svg_tif_support.py
+++ b/tests/models/test_svg_tif_support.py
@@ -160,6 +160,7 @@ class TestDownscaleHandlesSvg:
     def test_svg_fallback_on_pil_failure(self, tmp_path: Path) -> None:
         """If Pillow downscale step fails, raw rasterized PNG is still returned."""
         pytest.importorskip("fitz")
+        pytest.importorskip("PIL")
         from models._vision_helpers import downscale_image_if_needed
 
         svg_file = tmp_path / "shape.svg"
@@ -200,16 +201,14 @@ class TestImageToDataUrlHandlesSvg:
 
         assert len(result) > len("data:image/png;base64,")
 
-    def test_svg_bypasses_safedir(self, tmp_path: Path) -> None:
-        """SVG path takes the fitz rasterization branch, not the SafeDir read path."""
+    def test_svg_uses_safedir_for_file_read(self, tmp_path: Path) -> None:
+        """SVG file read routes through SafeDir before rasterization (issue #402 S3 fix)."""
         pytest.importorskip("fitz")
         from models._vision_helpers import image_to_data_url
 
         svg_file = tmp_path / "shape.svg"
         svg_file.write_bytes(_MINIMAL_SVG)
 
-        with patch("utils.safedir.SafeDir.open_root") as mock_safedir:
-            result = image_to_data_url(svg_file)
+        result = image_to_data_url(svg_file)
 
-        mock_safedir.assert_not_called()
         assert result.startswith("data:image/png;base64,")

--- a/tests/models/test_svg_tif_support.py
+++ b/tests/models/test_svg_tif_support.py
@@ -97,6 +97,28 @@ class TestRasterizeSvgToPngBytes:
 
         assert len(result) > 100
 
+    def test_oversized_svg_clamped_to_max_render_edge(self, tmp_path: Path) -> None:
+        """SVGs with huge intrinsic dimensions are clamped before rasterization."""
+        pytest.importorskip("fitz")
+        import struct
+
+        from models._vision_helpers import _SVG_MAX_RENDER_EDGE, rasterize_svg_to_png_bytes
+
+        oversized_svg = (
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="10000" height="5000">'
+            b'<rect width="10000" height="5000" fill="green"/></svg>'
+        )
+        svg_file = tmp_path / "oversized.svg"
+        svg_file.write_bytes(oversized_svg)
+
+        result = rasterize_svg_to_png_bytes(svg_file)
+
+        assert result[:8] == b"\x89PNG\r\n\x1a\n"
+        # PNG IHDR chunk starts at byte 16: 4-byte width then 4-byte height
+        width = struct.unpack(">I", result[16:20])[0]
+        height = struct.unpack(">I", result[20:24])[0]
+        assert max(width, height) <= _SVG_MAX_RENDER_EDGE
+
 
 class TestDownscaleHandlesSvg:
     """downscale_image_if_needed must rasterize SVG and return bytes."""

--- a/tests/models/test_svg_tif_support.py
+++ b/tests/models/test_svg_tif_support.py
@@ -1,0 +1,184 @@
+"""Tests for .svg and .tif image format support (issue #402).
+
+Covers:
+- Extension registration in IMAGE_EXTENSIONS and pipeline frozensets
+- SVG rasterization via fitz
+- downscale_image_if_needed handling of SVG
+- image_to_data_url handling of SVG
+- .tif routed as IMAGE by the pipeline router
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+_MINIMAL_SVG = b'<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100" height="100" fill="red"/></svg>'
+
+
+class TestExtensionRegistration:
+    """Both .tif and .svg must appear in every canonical extension set."""
+
+    def test_tif_in_image_extensions(self) -> None:
+        from core.types import IMAGE_EXTENSIONS
+
+        assert ".tif" in IMAGE_EXTENSIONS
+
+    def test_svg_in_image_extensions(self) -> None:
+        from core.types import IMAGE_EXTENSIONS
+
+        assert ".svg" in IMAGE_EXTENSIONS
+
+    def test_tif_in_pipeline_default_extensions(self) -> None:
+        from pipeline.config import DEFAULT_SUPPORTED_EXTENSIONS
+
+        assert ".tif" in DEFAULT_SUPPORTED_EXTENSIONS
+
+    def test_svg_in_pipeline_default_extensions(self) -> None:
+        from pipeline.config import DEFAULT_SUPPORTED_EXTENSIONS
+
+        assert ".svg" in DEFAULT_SUPPORTED_EXTENSIONS
+
+    def test_tif_routes_to_image_processor(self) -> None:
+        from pipeline.router import FileRouter, ProcessorType
+
+        router = FileRouter()
+        assert router.route(Path("scan.tif")) == ProcessorType.IMAGE
+
+    def test_svg_routes_to_image_processor(self) -> None:
+        from pipeline.router import FileRouter, ProcessorType
+
+        router = FileRouter()
+        assert router.route(Path("diagram.svg")) == ProcessorType.IMAGE
+
+
+class TestSvgMimeEntry:
+    """SVG must have the correct MIME type in the extension map."""
+
+    def test_svg_mime_type(self) -> None:
+        from models._vision_helpers import _EXTENSION_MIME
+
+        assert _EXTENSION_MIME[".svg"] == "image/svg+xml"
+
+    def test_tif_mime_type(self) -> None:
+        from models._vision_helpers import _EXTENSION_MIME
+
+        assert _EXTENSION_MIME[".tif"] == "image/tiff"
+
+
+class TestRasterizeSvgToPngBytes:
+    """rasterize_svg_to_png_bytes produces valid PNG bytes from an SVG file."""
+
+    def test_rasterizes_svg_to_png(self, tmp_path: Path) -> None:
+        pytest.importorskip("fitz")
+        from models._vision_helpers import rasterize_svg_to_png_bytes
+
+        svg_file = tmp_path / "shape.svg"
+        svg_file.write_bytes(_MINIMAL_SVG)
+
+        result = rasterize_svg_to_png_bytes(svg_file)
+
+        assert isinstance(result, bytes)
+        assert result[:8] == b"\x89PNG\r\n\x1a\n"  # PNG magic header
+
+    def test_result_is_non_empty(self, tmp_path: Path) -> None:
+        pytest.importorskip("fitz")
+        from models._vision_helpers import rasterize_svg_to_png_bytes
+
+        svg_file = tmp_path / "shape.svg"
+        svg_file.write_bytes(_MINIMAL_SVG)
+
+        result = rasterize_svg_to_png_bytes(svg_file)
+
+        assert len(result) > 100
+
+
+class TestDownscaleHandlesSvg:
+    """downscale_image_if_needed must rasterize SVG and return bytes."""
+
+    def test_svg_returns_bytes_not_path(self, tmp_path: Path) -> None:
+        pytest.importorskip("fitz")
+        pytest.importorskip("PIL")
+        from models._vision_helpers import downscale_image_if_needed
+
+        svg_file = tmp_path / "shape.svg"
+        svg_file.write_bytes(_MINIMAL_SVG)
+
+        result, was_converted = downscale_image_if_needed(svg_file)
+
+        assert isinstance(result, bytes)
+        assert was_converted is True
+
+    def test_svg_result_is_png(self, tmp_path: Path) -> None:
+        pytest.importorskip("fitz")
+        pytest.importorskip("PIL")
+        from models._vision_helpers import downscale_image_if_needed
+
+        svg_file = tmp_path / "shape.svg"
+        svg_file.write_bytes(_MINIMAL_SVG)
+
+        result, _ = downscale_image_if_needed(svg_file)
+
+        assert isinstance(result, bytes)
+        assert result[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_svg_fallback_on_pil_failure(self, tmp_path: Path) -> None:
+        """If Pillow downscale step fails, raw rasterized PNG is still returned."""
+        pytest.importorskip("fitz")
+        from models._vision_helpers import downscale_image_if_needed
+
+        svg_file = tmp_path / "shape.svg"
+        svg_file.write_bytes(_MINIMAL_SVG)
+
+        with patch("models._vision_helpers.rasterize_svg_to_png_bytes") as mock_rast:
+            fake_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 50
+            mock_rast.return_value = fake_png
+            with patch("PIL.Image.open", side_effect=OSError("simulated PIL failure")):
+                result, was_converted = downscale_image_if_needed(svg_file)
+
+        assert result == fake_png
+        assert was_converted is True
+
+
+class TestImageToDataUrlHandlesSvg:
+    """image_to_data_url must return a PNG data URL for .svg inputs."""
+
+    def test_svg_produces_png_data_url(self, tmp_path: Path) -> None:
+        pytest.importorskip("fitz")
+        from models._vision_helpers import image_to_data_url
+
+        svg_file = tmp_path / "shape.svg"
+        svg_file.write_bytes(_MINIMAL_SVG)
+
+        result = image_to_data_url(svg_file)
+
+        assert result.startswith("data:image/png;base64,")
+
+    def test_svg_data_url_is_non_empty(self, tmp_path: Path) -> None:
+        pytest.importorskip("fitz")
+        from models._vision_helpers import image_to_data_url
+
+        svg_file = tmp_path / "shape.svg"
+        svg_file.write_bytes(_MINIMAL_SVG)
+
+        result = image_to_data_url(svg_file)
+
+        assert len(result) > len("data:image/png;base64,")
+
+    def test_svg_bypasses_safedir(self, tmp_path: Path) -> None:
+        """SVG path takes the fitz rasterization branch, not the SafeDir read path."""
+        pytest.importorskip("fitz")
+        from models._vision_helpers import image_to_data_url
+
+        svg_file = tmp_path / "shape.svg"
+        svg_file.write_bytes(_MINIMAL_SVG)
+
+        with patch("utils.safedir.SafeDir.open_root") as mock_safedir:
+            result = image_to_data_url(svg_file)
+
+        mock_safedir.assert_not_called()
+        assert result.startswith("data:image/png;base64,")


### PR DESCRIPTION
Closes #402

## Summary

Two image extensions found in real user libraries were silently skipped during `fo organize`. This PR adds full pipeline support for both with **zero new dependencies**.

| Format | Count in ~/Downloads | Approach |
|--------|---------------------|----------|
| `.tif` | 2 | Pillow already supports TIFF natively — pure extension-list addition |
| `.svg` | 27 | PyMuPDF (`fitz`, core dep used for PDF extraction) rasterizes to PNG before vision inference |

## Changes

- **`src/core/types.py`** — add `.tif`, `.svg` to `IMAGE_EXTENSIONS`
- **`src/pipeline/config.py`** — add `.tif`, `.svg` to `DEFAULT_SUPPORTED_EXTENSIONS`
- **`src/pipeline/router.py`** — add `.tif`, `.svg` to `_DEFAULT_IMAGE_EXTENSIONS`
- **`src/models/_vision_helpers.py`** — add `.svg` MIME entry (`image/svg+xml`); add `rasterize_svg_to_png_bytes()` using fitz; wire SVG rasterization into both `downscale_image_if_needed` and `image_to_data_url`
- **`tests/models/test_svg_tif_support.py`** — 16 new tests covering extension registration, MIME map, rasterization, downscale, and data URL encoding
- **`docs/reference/file-formats.md`**, **`docs/USER_GUIDE.md`** — format tables updated to include `.svg`, count updated to 49+

## Test plan

- [x] 16 new tests — all passed locally
- [x] `ruff check` — clean
- [x] `mypy` — clean
- [x] Pre-commit validation script — passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for SVG image files with automatic rasterization to PNG format
  * Added support for TIFF image files

* **Documentation**
  * Updated user guide and file formats reference to reflect SVG and TIFF support
  * Updated supported file type count from 48+ to 49+ formats

* **Tests**
  * Added comprehensive test coverage for SVG and TIFF image processing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->