### PR TITLE
feat(organize): unsupported extension report in summary (#412)

### DIFF
--- a/src/cli/organize.py
+++ b/src/cli/organize.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import Any
 
 import typer
 from rich.console import Console
@@ -10,8 +12,37 @@ from rich.panel import Panel
 
 from cli.path_validation import resolve_cli_path, validate_pair
 from cli.state import _get_state
+from core.types import OrganizationResult
 
 console = Console()
+
+
+def _organize_result_to_json(result: OrganizationResult) -> dict[str, Any]:
+    """Serialize an ``OrganizationResult`` for ``fo organize --json`` (#412).
+
+    The ``skipped_by_extension`` Counter is rendered as a plain dict for
+    JSON consumers; key order follows ``Counter.most_common()`` so the
+    payload itself reflects the breakdown ranking.
+    """
+    return {
+        "total_files": result.total_files,
+        "processed_files": result.processed_files,
+        "skipped_files": result.skipped_files,
+        "failed_files": result.failed_files,
+        "deduplicated_files": result.deduplicated_files,
+        "processing_time": result.processing_time,
+        "skipped_by_extension": dict(result.skipped_by_extension.most_common()),
+        "errors": [{"file": file_str, "error": err} for file_str, err in result.errors],
+    }
+
+
+def _emit_organize_json(result: OrganizationResult) -> None:
+    """Emit the JSON payload for ``fo organize --json``.
+
+    Printed via the stdlib ``print`` so the output stays parseable; Rich
+    markup tags would otherwise leak escape codes into the JSON payload.
+    """
+    print(json.dumps(_organize_result_to_json(result), indent=2))
 
 
 def _check_setup_completed() -> bool:
@@ -127,6 +158,24 @@ def organize(
             "Default: 600 (10 min). Set to 0 to disable the cap entirely."
         ),
     ),
+    show_skipped: bool = typer.Option(
+        False,
+        "--show-skipped",
+        help=(
+            "Print the full breakdown of skipped extensions instead of the "
+            "default top-10 preview. Useful when triaging which formats to "
+            "support next."
+        ),
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help=(
+            "Emit the run summary as JSON on stdout (includes "
+            "`skipped_by_extension`). Suppresses the interactive Rich "
+            "summary so the payload stays machine-parseable."
+        ),
+    ),
 ) -> None:
     """Organize files in a directory using AI models."""
     # First-run setup gate now lives in `cli.main.main_callback` and runs
@@ -140,9 +189,10 @@ def organize(
     output_dir = resolve_cli_path(output_dir, must_exist=False, must_be_dir=True)
     validate_pair(input_dir, output_dir)
 
-    console.print(f"[bold]Organizing[/bold] {input_dir} -> {output_dir}")
-    if dry_run or _get_state().dry_run:
-        console.print("[yellow]Dry run mode — no files will be moved.[/yellow]")
+    if not json_output:
+        console.print(f"[bold]Organizing[/bold] {input_dir} -> {output_dir}")
+        if dry_run or _get_state().dry_run:
+            console.print("[yellow]Dry run mode — no files will be moved.[/yellow]")
     resolved_workers, resolved_prefetch_depth = _resolve_parallel_settings(
         sequential, max_workers, prefetch_depth, no_prefetch
     )
@@ -161,11 +211,18 @@ def organize(
             # value; convert to None for the organizer (None means uncapped).
             max_transcribe_seconds=max_transcribe_seconds if max_transcribe_seconds > 0 else None,
         )
-        result = organizer.organize(input_dir, output_dir)
-        console.print(
-            f"[green]Done:[/green] {result.processed_files} processed, "
-            f"{result.skipped_files} skipped, {result.failed_files} failed"
-        )
+        if json_output:
+            # Silence the Rich progress + summary by swapping in a no-op
+            # console; the JSON payload is the only thing on stdout.
+            organizer.console = Console(quiet=True)
+        result = organizer.organize(input_dir, output_dir, show_skipped=show_skipped)
+        if json_output:
+            _emit_organize_json(result)
+        else:
+            console.print(
+                f"[green]Done:[/green] {result.processed_files} processed, "
+                f"{result.skipped_files} skipped, {result.failed_files} failed"
+            )
     except Exception as exc:
         console.print(f"[red]Error: {exc}[/red]")
         # Step 3: surface the full Rich traceback when --debug is set so

--- a/src/core/display.py
+++ b/src/core/display.py
@@ -16,6 +16,11 @@ from rich.table import Table
 
 from core.types import OrganizationResult
 
+# Top-N cap for the unsupported-extension breakdown rendered in the
+# summary. Beyond N entries the remaining tail is summarized in a hint
+# line that points users at ``--show-skipped`` for the full list.
+TOP_SKIPPED_EXTENSIONS: int = 10
+
 
 def show_file_breakdown(
     console: Console,
@@ -49,8 +54,19 @@ def show_summary(
     output_path: Path,
     *,
     dry_run: bool,
+    show_skipped: bool = False,
 ) -> None:
-    """Show final organization summary."""
+    """Show final organization summary.
+
+    Args:
+        console: Rich console to print to.
+        result: Aggregate organize result.
+        output_path: Destination directory (printed in the structure section).
+        dry_run: When True, append the dry-run reminder banner.
+        show_skipped: When True, print every entry of
+            ``result.skipped_by_extension`` instead of the top-N preview.
+            Wired to ``--show-skipped`` on the ``fo organize`` command.
+    """
     console.print("\n" + "=" * 70)
     console.print("[bold green]Organization Complete![/bold green]")
     console.print("=" * 70)
@@ -70,6 +86,11 @@ def show_summary(
             console.print(f"    ... and {len(result.errors) - 10} more")
     console.print(f"  Processing time: {result.processing_time:.2f}s")
 
+    # Skipped-extension breakdown (#412). Render whenever anything was
+    # skipped; --show-skipped expands past TOP_SKIPPED_EXTENSIONS.
+    if result.skipped_by_extension:
+        _render_skipped_extensions(console, result, show_skipped=show_skipped)
+
     if result.organized_structure:
         console.print("\n[bold]Organized Structure:[/bold]")
         console.print(f"[cyan]{output_path}/[/cyan]")
@@ -85,6 +106,39 @@ def show_summary(
         console.print("[dim]Run without --dry-run to perform actual organization[/dim]")
     else:
         console.print(f"\n[green]✓ Files organized in: {output_path}[/green]")
+
+
+def _render_skipped_extensions(
+    console: Console,
+    result: OrganizationResult,
+    *,
+    show_skipped: bool,
+) -> None:
+    """Render the top-N (or full) breakdown of skipped extensions.
+
+    Sorted by count descending, then by extension name ascending so the
+    output is stable when several extensions share a count.
+    """
+    items = sorted(
+        result.skipped_by_extension.items(),
+        key=lambda kv: (-kv[1], kv[0]),
+    )
+    total_distinct = len(items)
+
+    if show_skipped or total_distinct <= TOP_SKIPPED_EXTENSIONS:
+        header = "Skipped by extension"
+        visible = items
+        tail = 0
+    else:
+        header = f"Top {TOP_SKIPPED_EXTENSIONS} skipped extensions"
+        visible = items[:TOP_SKIPPED_EXTENSIONS]
+        tail = total_distinct - TOP_SKIPPED_EXTENSIONS
+
+    console.print(f"\n[bold yellow]{header}:[/bold yellow]")
+    for ext, count in visible:
+        console.print(f"  [yellow]{ext}[/yellow]: {count}")
+    if tail:
+        console.print(f"  [dim]({tail} more — use --show-skipped for the full list)[/dim]")
 
 
 def create_progress(console: Console) -> Progress:

--- a/src/core/organizer.py
+++ b/src/core/organizer.py
@@ -197,6 +197,8 @@ class FileOrganizer:
         input_path: str | Path,
         output_path: str | Path,
         skip_existing: bool = True,
+        *,
+        show_skipped: bool = False,
     ) -> OrganizationResult:
         """Organize files from input directory to output directory.
 
@@ -204,6 +206,9 @@ class FileOrganizer:
             input_path: Path to directory with files to organize
             output_path: Path to output directory
             skip_existing: Skip files that already exist in output
+            show_skipped: When True, the summary renderer prints every
+                skipped-extension entry instead of capping at the top-N
+                preview. Wired to ``--show-skipped`` on ``fo organize``.
 
         Returns:
             OrganizationResult with statistics and structure
@@ -264,7 +269,13 @@ class FileOrganizer:
                 result.skipped_by_extension[self._skipped_extension_key(f)] += 1
 
         result.processing_time = time.time() - start_time
-        display.show_summary(self.console, result, output_path, dry_run=self.dry_run)
+        display.show_summary(
+            self.console,
+            result,
+            output_path,
+            dry_run=self.dry_run,
+            show_skipped=show_skipped,
+        )
 
         return result
 

--- a/src/core/organizer.py
+++ b/src/core/organizer.py
@@ -29,6 +29,8 @@ from core.types import (
     AUDIO_EXTENSIONS,
     CAD_EXTENSIONS,
     IMAGE_EXTENSIONS,
+    NO_EXTENSION_SENTINEL,
+    OFFICE_TEMP_SENTINEL,
     TEXT_EXTENSIONS,
     TEXT_FALLBACK_MAP,
     VIDEO_EXTENSIONS,
@@ -254,10 +256,12 @@ class FileOrganizer:
         # Skipped files
         if other_files:
             result.skipped_files = len(other_files)
-            self.console.print("\n[bold yellow]Skipped Files:[/bold yellow]")
+            # Tally the breakdown by extension (issue #412). Stored on the
+            # result so the summary renderer and --json output can surface
+            # actionable signal about which formats would reduce the skip
+            # rate the most.
             for f in other_files:
-                self.console.print(f"  [yellow]•[/yellow] {f.name} (unsupported type)")
-            self.console.print("\n  [dim]These file types are not yet supported[/dim]")
+                result.skipped_by_extension[self._skipped_extension_key(f)] += 1
 
         result.processing_time = time.time() - start_time
         display.show_summary(self.console, result, output_path, dry_run=self.dry_run)
@@ -303,6 +307,26 @@ class FileOrganizer:
                 other_files.append(f)
 
         return text_files, image_files, video_files, audio_files, cad_files, other_files
+
+    @staticmethod
+    def _skipped_extension_key(f: Path) -> str:
+        """Compute the skipped-extension bucket key for *f*.
+
+        Returns:
+            - ``OFFICE_TEMP_SENTINEL`` for Office lock files (``~$*``); the
+              .docx/.xlsx suffix would otherwise misleadingly suggest a
+              supported type was being skipped.
+            - ``NO_EXTENSION_SENTINEL`` for files with no suffix (``README``,
+              ``LICENSE``, …) so they don't collapse to ``""`` in the
+              breakdown.
+            - The lower-cased ``Path.suffix`` (e.g. ``.nib``) otherwise.
+        """
+        if f.name.startswith("~$"):
+            return OFFICE_TEMP_SENTINEL
+        ext = f.suffix.lower()
+        if not ext:
+            return NO_EXTENSION_SENTINEL
+        return ext
 
     def _process_image_type(self, image_files: list[Path]) -> list[ProcessedFile | ProcessedImage]:
         """Process image files, using vision model if available and enabled."""

--- a/src/core/types.py
+++ b/src/core/types.py
@@ -8,7 +8,16 @@ used across core modules.
 # annotations when `from __future__ import annotations` is in use.
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass, field
+
+# Sentinel keys for the skipped-extension tally when the file's suffix
+# either doesn't map cleanly to an extension or would be misleading.
+# Bucketing under these stable strings keeps the breakdown actionable
+# (users see "<office-temp>: 12" instead of ".docx: 12" — the latter would
+# suggest .docx is unsupported, which is the opposite of the truth).
+OFFICE_TEMP_SENTINEL: str = "<office-temp>"
+NO_EXTENSION_SENTINEL: str = "<no-extension>"
 
 
 @dataclass
@@ -24,6 +33,10 @@ class OrganizationResult:
         processing_time: Total time taken in seconds
         organized_structure: Dictionary mapping folder names to file lists
         errors: List of (file_path, error_message) tuples
+        skipped_by_extension: Counter mapping lower-cased extension (e.g.
+            ``.nib``) to the number of skipped files with that suffix. Office
+            temp lock files (``~$*``) and extensionless files use the
+            ``<office-temp>`` and ``<no-extension>`` sentinel keys.
 
     Invariant:
         processed_files + skipped_files + failed_files + deduplicated_files == total_files
@@ -37,6 +50,7 @@ class OrganizationResult:
     processing_time: float = 0.0
     organized_structure: dict[str, list[str]] = field(default_factory=dict)
     errors: list[tuple[str, str]] = field(default_factory=list)  # (file, error)
+    skipped_by_extension: Counter[str] = field(default_factory=Counter)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_cli_organize.py
+++ b/tests/cli/test_cli_organize.py
@@ -365,6 +365,80 @@ class TestOrganize:
         assert result.exit_code == 1
         assert "Ollama not running" in result.output
 
+    @patch("core.organizer.FileOrganizer")
+    def test_organize_show_skipped_flag_forwarded(
+        self, mock_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """--show-skipped is forwarded to organizer.organize via kwarg (#412)."""
+        from collections import Counter
+
+        from core.types import OrganizationResult
+
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        mock_org = MagicMock()
+        mock_cls.return_value = mock_org
+        # Real OrganizationResult so the JSON helper / CLI summary can read fields.
+        mock_org.organize.return_value = OrganizationResult(
+            total_files=15,
+            processed_files=12,
+            skipped_files=3,
+            skipped_by_extension=Counter({".nib": 2, ".stl": 1}),
+        )
+
+        result = runner.invoke(
+            app,
+            ["organize", str(input_dir), str(output_dir), "--show-skipped"],
+        )
+        assert result.exit_code == 0
+        # The kwarg was forwarded so the underlying summary renderer would
+        # print the full breakdown.
+        mock_org.organize.assert_called_once()
+        kwargs = mock_org.organize.call_args.kwargs
+        assert kwargs.get("show_skipped") is True
+
+    @patch("core.organizer.FileOrganizer")
+    def test_organize_json_output_includes_skipped_by_extension(
+        self, mock_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """--json output includes skipped_by_extension as a dict (#412)."""
+        import json
+        from collections import Counter
+
+        from core.types import OrganizationResult
+
+        input_dir = tmp_path / "input"
+        output_dir = tmp_path / "output"
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        mock_org = MagicMock()
+        mock_cls.return_value = mock_org
+        mock_org.organize.return_value = OrganizationResult(
+            total_files=10,
+            processed_files=7,
+            skipped_files=3,
+            skipped_by_extension=Counter({".nib": 2, ".stl": 1}),
+        )
+
+        result = runner.invoke(
+            app,
+            ["organize", str(input_dir), str(output_dir), "--json"],
+        )
+        assert result.exit_code == 0
+        # Locate the JSON object in the output (skip any Rich-styled lines).
+        json_start = result.output.find("{")
+        json_end = result.output.rfind("}") + 1
+        assert json_start != -1 and json_end > json_start
+        payload = json.loads(result.output[json_start:json_end])
+        assert payload["skipped_by_extension"] == {".nib": 2, ".stl": 1}
+        assert payload["skipped_files"] == 3
+        assert payload["processed_files"] == 7
+        assert payload["total_files"] == 10
+
 
 # ---------------------------------------------------------------------------
 # preview

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -110,7 +110,8 @@ def test_organize_command_live(mock_organizer_cls, _mock_setup, tmp_path):
         transcribe_audio=False,
         max_transcribe_seconds=600.0,
     )
-    mock_instance.organize.assert_called_once_with(in_dir, out_dir)
+    # show_skipped kwarg is always forwarded (defaults to False) since #412.
+    mock_instance.organize.assert_called_once_with(in_dir, out_dir, show_skipped=False)
 
 
 @patch("cli.organize._check_setup_completed", return_value=True)
@@ -141,8 +142,10 @@ def test_organize_command_dry_run(mock_organizer_cls, _mock_setup, tmp_path):
         max_transcribe_seconds=600.0,
     )
     # A.cli resolves the path args before dispatching; the service sees
-    # the canonical absolute form.
-    mock_instance.organize.assert_called_once_with(in_dir.resolve(), out_dir.resolve())
+    # the canonical absolute form. show_skipped=False default since #412.
+    mock_instance.organize.assert_called_once_with(
+        in_dir.resolve(), out_dir.resolve(), show_skipped=False
+    )
 
 
 @patch("cli.organize._check_setup_completed", return_value=True)

--- a/tests/core/test_organizer.py
+++ b/tests/core/test_organizer.py
@@ -478,6 +478,196 @@ class TestCategorizeFiles:
 
 
 # ---------------------------------------------------------------------------
+# skipped_by_extension reporting (#412)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestSkippedByExtensionReport:
+    """Unit tests for the skipped-extension breakdown on OrganizationResult."""
+
+    def test_organization_result_default_skipped_by_extension_is_empty(self) -> None:
+        """OrganizationResult initializes skipped_by_extension to an empty Counter."""
+        from collections import Counter
+
+        result = OrganizationResult()
+        assert isinstance(result.skipped_by_extension, Counter)
+        assert result.skipped_by_extension == Counter()
+
+    def test_skipped_extension_key_for_normal_extension(self, tmp_path: Path) -> None:
+        """A normal unsupported extension is lower-cased and returned as-is."""
+        assert FileOrganizer._skipped_extension_key(tmp_path / "a.NIB") == ".nib"
+        assert FileOrganizer._skipped_extension_key(tmp_path / "b.stl") == ".stl"
+
+    def test_skipped_extension_key_for_office_temp(self, tmp_path: Path) -> None:
+        """Office temp lock files bucket under the <office-temp> sentinel."""
+        assert FileOrganizer._skipped_extension_key(tmp_path / "~$doc.docx") == "<office-temp>"
+
+    def test_skipped_extension_key_for_extensionless(self, tmp_path: Path) -> None:
+        """Files without a suffix bucket under the <no-extension> sentinel."""
+        assert FileOrganizer._skipped_extension_key(tmp_path / "README") == "<no-extension>"
+
+    def test_organize_populates_skipped_by_extension(self, tmp_path: Path) -> None:
+        """After organize(), skipped_by_extension counts unsupported extensions."""
+        from collections import Counter
+
+        src = tmp_path / "src"
+        src.mkdir()
+        # Three unsupported extensions with varying counts.
+        for i in range(3):
+            (src / f"a{i}.nib").write_bytes(b"x")
+        for i in range(2):
+            (src / f"b{i}.stl").write_bytes(b"x")
+        (src / "c.xyz").write_bytes(b"x")
+
+        out = tmp_path / "out"
+        organizer = FileOrganizer(dry_run=True, enable_vision=False)
+        result = organizer.organize(src, out)
+
+        assert isinstance(result.skipped_by_extension, Counter)
+        assert result.skipped_by_extension[".nib"] == 3
+        assert result.skipped_by_extension[".stl"] == 2
+        assert result.skipped_by_extension[".xyz"] == 1
+        # Aggregate skipped_files still matches.
+        assert result.skipped_files == 6
+
+    def test_extensions_are_case_insensitive(self, tmp_path: Path) -> None:
+        """Uppercase/lowercase variants of an unsupported extension merge."""
+        from collections import Counter
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "a.NIB").write_bytes(b"x")
+        (src / "b.nib").write_bytes(b"x")
+        (src / "c.Nib").write_bytes(b"x")
+
+        out = tmp_path / "out"
+        organizer = FileOrganizer(dry_run=True, enable_vision=False)
+        result = organizer.organize(src, out)
+
+        assert isinstance(result.skipped_by_extension, Counter)
+        assert result.skipped_by_extension[".nib"] == 3
+
+    def test_office_temp_lock_files_use_sentinel_extension(self, tmp_path: Path) -> None:
+        """Office temp lock files (~$*) bucket under <office-temp>, not .docx."""
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "~$doc.docx").write_bytes(b"x")
+        (src / "~$sheet.xlsx").write_bytes(b"x")
+
+        out = tmp_path / "out"
+        organizer = FileOrganizer(dry_run=True, enable_vision=False)
+        result = organizer.organize(src, out)
+
+        # Office temp files share a sentinel category, not their suffix —
+        # using their suffix would route them to .docx/.xlsx which are
+        # *supported*, giving misleading actionable signal.
+        assert result.skipped_by_extension["<office-temp>"] == 2
+        assert result.skipped_by_extension[".docx"] == 0
+        assert result.skipped_files == 2
+
+    def test_extensionless_files_use_sentinel(self, tmp_path: Path) -> None:
+        """Files without an extension bucket under <no-extension>."""
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "README").write_bytes(b"x")
+        (src / "LICENSE").write_bytes(b"x")
+
+        out = tmp_path / "out"
+        organizer = FileOrganizer(dry_run=True, enable_vision=False)
+        result = organizer.organize(src, out)
+
+        assert result.skipped_by_extension["<no-extension>"] == 2
+
+
+# ---------------------------------------------------------------------------
+# show_summary skipped-extension display (#412)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.ci
+class TestSummarySkippedExtensions:
+    """Tests for top-10 / --show-skipped rendering in show_summary."""
+
+    def test_summary_shows_extensions_with_counts(self, tmp_path: Path) -> None:
+        """show_summary prints each tallied extension with its count."""
+        from collections import Counter
+
+        from core.display import show_summary
+
+        console = MagicMock()
+        res = OrganizationResult(
+            total_files=10,
+            skipped_files=10,
+            skipped_by_extension=Counter({".nib": 5, ".stl": 3, ".xyz": 2}),
+        )
+        show_summary(console, res, tmp_path, dry_run=True)
+
+        printed = " ".join(str(c) for c in console.print.call_args_list)
+        assert ".nib" in printed and "5" in printed
+        assert ".stl" in printed and "3" in printed
+        assert ".xyz" in printed and "2" in printed
+
+    def test_summary_caps_at_top_10_with_hint(self, tmp_path: Path) -> None:
+        """With >10 distinct extensions, show top 10 and a hint about the rest."""
+        from collections import Counter
+
+        from core.display import show_summary
+
+        console = MagicMock()
+        # 12 distinct extensions
+        counts = Counter({f".ext{i:02d}": (20 - i) for i in range(12)})
+        res = OrganizationResult(
+            total_files=sum(counts.values()),
+            skipped_files=sum(counts.values()),
+            skipped_by_extension=counts,
+        )
+        show_summary(console, res, tmp_path, dry_run=True)
+
+        printed = " ".join(str(c) for c in console.print.call_args_list)
+        # Top-1 .ext00 (count 20) appears; tail .ext11 (count 9) does NOT.
+        assert ".ext00" in printed
+        assert ".ext11" not in printed
+        # Hint message about more.
+        assert "--show-skipped" in printed
+
+    def test_summary_show_skipped_lists_all(self, tmp_path: Path) -> None:
+        """show_summary(show_skipped=True) prints the full grouped list."""
+        from collections import Counter
+
+        from core.display import show_summary
+
+        console = MagicMock()
+        counts = Counter({f".ext{i:02d}": (20 - i) for i in range(12)})
+        res = OrganizationResult(
+            total_files=sum(counts.values()),
+            skipped_files=sum(counts.values()),
+            skipped_by_extension=counts,
+        )
+        show_summary(console, res, tmp_path, dry_run=True, show_skipped=True)
+
+        printed = " ".join(str(c) for c in console.print.call_args_list)
+        # Every extension must appear.
+        for i in range(12):
+            assert f".ext{i:02d}" in printed
+
+    def test_summary_omits_breakdown_when_no_skipped_files(self, tmp_path: Path) -> None:
+        """No top-extensions block printed when nothing was skipped."""
+        from core.display import show_summary
+
+        console = MagicMock()
+        res = OrganizationResult(total_files=3, processed_files=3)
+        show_summary(console, res, tmp_path, dry_run=True)
+
+        printed = " ".join(str(c) for c in console.print.call_args_list)
+        # The breakdown header is only shown when there are skipped entries.
+        assert "Top 10 skipped extensions" not in printed
+        assert "Skipped by extension" not in printed
+
+
+# ---------------------------------------------------------------------------
 # _deduplicate_processed tests
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/test_core_organizer_batch3.py
+++ b/tests/integration/test_core_organizer_batch3.py
@@ -533,6 +533,63 @@ class TestDisplay:
             other_files=[Path("x.xyz")],
         )
 
+    def test_show_summary_skipped_extensions_under_top_n(self, tmp_path: Path) -> None:
+        """Few unsupported extensions render the full list with the Skipped-by-extension header."""
+        from collections import Counter
+
+        from rich.console import Console
+
+        from core.display import show_summary
+        from core.types import OrganizationResult
+
+        console = Console(quiet=True)
+        result = OrganizationResult(
+            total_files=4,
+            skipped_files=4,
+            skipped_by_extension=Counter({".nib": 2, ".stl": 1, ".html": 1}),
+        )
+
+        show_summary(console, result, tmp_path, dry_run=True)
+
+    def test_show_summary_skipped_extensions_over_top_n_truncates(self, tmp_path: Path) -> None:
+        """More than 10 distinct extensions truncates to Top 10 and prints the tail hint."""
+        from collections import Counter
+
+        from rich.console import Console
+
+        from core.display import TOP_SKIPPED_EXTENSIONS, show_summary
+        from core.types import OrganizationResult
+
+        console = Console(quiet=True)
+        # 12 distinct extensions → 2 truncated, hint line exercised
+        counts = {f".ext{i:02d}": (TOP_SKIPPED_EXTENSIONS + 2 - i) for i in range(12)}
+        result = OrganizationResult(
+            total_files=sum(counts.values()),
+            skipped_files=sum(counts.values()),
+            skipped_by_extension=Counter(counts),
+        )
+
+        show_summary(console, result, tmp_path, dry_run=False)
+
+    def test_show_summary_show_skipped_expands_full_list(self, tmp_path: Path) -> None:
+        """show_skipped=True bypasses the Top-N cap regardless of distinct count."""
+        from collections import Counter
+
+        from rich.console import Console
+
+        from core.display import TOP_SKIPPED_EXTENSIONS, show_summary
+        from core.types import OrganizationResult
+
+        console = Console(quiet=True)
+        counts = {f".ext{i:02d}": (TOP_SKIPPED_EXTENSIONS + 2 - i) for i in range(15)}
+        result = OrganizationResult(
+            total_files=sum(counts.values()),
+            skipped_files=sum(counts.values()),
+            skipped_by_extension=Counter(counts),
+        )
+
+        show_summary(console, result, tmp_path, dry_run=True, show_skipped=True)
+
 
 # ---------------------------------------------------------------------------
 # TestDispatcher


### PR DESCRIPTION
## Summary
Resolves #412. Adds actionable skip-extension breakdown to `fo organize` summary so users can see which file formats would meaningfully reduce their skip rate.

## Changes
- New `skipped_by_extension: Counter[str]` field on `OrganizationResult`, populated during scan-time categorization
- Top-10 skipped extensions with counts rendered in the run summary; tail shows hint pointing at `--show-skipped`
- New `--show-skipped` flag prints the full grouped list
- New `--json` flag emits the entire run summary (including `skipped_by_extension` as a dict) on stdout for machine consumers
- Sentinel keys `<office-temp>` and `<no-extension>` keep the breakdown actionable (office lock files would otherwise mislabel as `.docx`/`.xlsx`)

## Test plan
- [x] Unit tests in `tests/core/test_organizer.py` (12 new): default Counter, sentinel keying, case-insensitivity, office-temp/extensionless bucketing, top-10 cap with hint, `--show-skipped` full list, no-skip empty case
- [x] CLI tests in `tests/cli/test_cli_organize.py` (2 new): `--show-skipped` kwarg forwarded; `--json` payload includes `skipped_by_extension` plus the rest of the run summary
- [x] Updated `tests/cli/test_main.py` assertions to account for the new `show_skipped` kwarg always being forwarded
- [x] `python -m pytest tests/core/ tests/cli/` — 1184 passed
- [x] `python -m pytest tests/integration/test_core_organizer_batch3.py` — 127 passed (no regression on existing skipped_files behavior)
- [x] `ruff check`, `ruff format --check`, `mypy` all clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)