### PR TITLE
feat(observability): per-file inference timing + summary stats (#410)

### DIFF
--- a/src/core/dispatcher.py
+++ b/src/core/dispatcher.py
@@ -253,6 +253,14 @@ def process_image_files(
                             folder_name=fb.folder,
                             filename=fb.filename,
                             source=fb.source,
+                            # Carry the timeout's wall-clock through so the
+                            # #410 summary's p95/p99 reflect this image's
+                            # real worst-case latency. Without this, the
+                            # slowest attempts in a run are silently
+                            # excluded from the percentile sample set and
+                            # the observability output understates tail
+                            # latency (CodeRabbit P2 on PR #424).
+                            inference_ms=file_result.duration_ms,
                             # NB: no `error` field — the file is not a failure
                         )
                     )

--- a/src/core/display.py
+++ b/src/core/display.py
@@ -94,6 +94,13 @@ def show_summary(
             console.print(f"    ... and {len(result.errors) - 10} more")
     console.print(f"  Processing time: {result.processing_time:.2f}s")
 
+    # Inference duration stats (#410). Vision and text are aggregated
+    # separately so operators can spot a slow modality even when the
+    # other is fine. Lines only render when the corresponding sample
+    # list is non-empty (i.e. the run actually invoked that modality).
+    _render_inference_stats(console, "Vision", result.vision_inference_ms_samples)
+    _render_inference_stats(console, "Text", result.text_inference_ms_samples)
+
     # Skipped-extension breakdown (#412). Render whenever anything was
     # skipped; --show-skipped expands past TOP_SKIPPED_EXTENSIONS.
     if result.skipped_by_extension:
@@ -158,4 +165,52 @@ def create_progress(console: Console) -> Progress:
         TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
         TimeElapsedColumn(),
         console=console,
+    )
+
+
+def _percentile(samples: list[float], p: float) -> float:
+    """Return the *p*-th percentile (0 <= p <= 100) of *samples*.
+
+    Uses linear interpolation between the closest ranks — equivalent to
+    NumPy's default ``method="linear"`` but kept dependency-free so the
+    summary renderer never needs to import NumPy. Returns 0.0 for an
+    empty sample list so callers don't have to special-case it.
+    """
+    if not samples:
+        return 0.0
+    if len(samples) == 1:
+        return samples[0]
+    ordered = sorted(samples)
+    # Clamp p into [0, 100] then translate to a fractional index in
+    # [0, len-1]. Linear interpolation between neighbours yields the
+    # same percentile NumPy / pandas produce for the same data.
+    p_clamped = max(0.0, min(100.0, p))
+    rank = (p_clamped / 100.0) * (len(ordered) - 1)
+    lo = int(rank)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = rank - lo
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * frac
+
+
+def _render_inference_stats(console: Console, label: str, samples: list[float]) -> None:
+    """Render mean/p50/p95/p99 for an inference-time sample list (#410).
+
+    Args:
+        console: Rich console to print to.
+        label: ``"Vision"`` or ``"Text"`` — used as the section header.
+        samples: List of per-file inference durations in milliseconds.
+            An empty list short-circuits — the section is omitted from
+            the summary so runs that didn't invoke that modality stay
+            uncluttered.
+    """
+    if not samples:
+        return
+    mean_ms = sum(samples) / len(samples)
+    p50 = _percentile(samples, 50)
+    p95 = _percentile(samples, 95)
+    p99 = _percentile(samples, 99)
+    console.print(
+        f"  [dim]{label} inference — mean: {mean_ms / 1000:.2f}s, "
+        f"p50: {p50 / 1000:.2f}s, p95: {p95 / 1000:.2f}s, "
+        f"p99: {p99 / 1000:.2f}s (n={len(samples)})[/dim]"
     )

--- a/src/core/organizer.py
+++ b/src/core/organizer.py
@@ -262,6 +262,25 @@ class FileOrganizer:
         )
 
         if all_processed:
+            # Per-file inference duration samples (#410). Collect BEFORE
+            # dedup so the summary's `n` matches the per-file
+            # text/vision_inference_ms log stream — `_deduplicate_processed`
+            # drops content-duplicate entries from `all_processed`, but
+            # those inferences already ran and were logged, so they must
+            # contribute to mean/p50/p95/p99 (CodeRabbit P2 catch on PR #424).
+            # Skip entries that never went through process_file (e.g.
+            # dispatcher-built fallbacks) which carry inference_ms == None.
+            for p in all_processed:
+                ms = getattr(p, "inference_ms", None)
+                if not isinstance(ms, (int, float)):
+                    continue
+                # ProcessedImage carries the `source` field (#406) so we
+                # treat the image side; ProcessedFile is the text side.
+                if hasattr(p, "source"):
+                    result.vision_inference_ms_samples.append(float(ms))
+                else:
+                    result.text_inference_ms_samples.append(float(ms))
+
             all_processed = self._deduplicate_processed(all_processed, result)
             failed_cnt = sum(1 for p in all_processed if p.error)
             # Vision-timeout fallbacks (#406) count as processed (they
@@ -276,21 +295,6 @@ class FileOrganizer:
             result.processed_files = len(all_processed) - failed_cnt
             result.failed_files = failed_cnt
             result.fallback_files = fallback_cnt
-            # Per-file inference duration samples (#410). Partitioned by
-            # the result-class so the summary renderer can produce
-            # separate p50/p95/p99 for vision vs text. Skip entries that
-            # never went through process_file (e.g. dispatcher-built
-            # fallbacks) which carry inference_ms == None.
-            for p in all_processed:
-                ms = getattr(p, "inference_ms", None)
-                if not isinstance(ms, (int, float)):
-                    continue
-                # ProcessedImage carries the `source` field (#406) so we
-                # treat the image side; ProcessedFile is the text side.
-                if hasattr(p, "source"):
-                    result.vision_inference_ms_samples.append(float(ms))
-                else:
-                    result.text_inference_ms_samples.append(float(ms))
             self._execute_organization(
                 all_processed, input_path, output_path, skip_existing, result
             )

--- a/src/core/organizer.py
+++ b/src/core/organizer.py
@@ -276,6 +276,21 @@ class FileOrganizer:
             result.processed_files = len(all_processed) - failed_cnt
             result.failed_files = failed_cnt
             result.fallback_files = fallback_cnt
+            # Per-file inference duration samples (#410). Partitioned by
+            # the result-class so the summary renderer can produce
+            # separate p50/p95/p99 for vision vs text. Skip entries that
+            # never went through process_file (e.g. dispatcher-built
+            # fallbacks) which carry inference_ms == None.
+            for p in all_processed:
+                ms = getattr(p, "inference_ms", None)
+                if not isinstance(ms, (int, float)):
+                    continue
+                # ProcessedImage carries the `source` field (#406) so we
+                # treat the image side; ProcessedFile is the text side.
+                if hasattr(p, "source"):
+                    result.vision_inference_ms_samples.append(float(ms))
+                else:
+                    result.text_inference_ms_samples.append(float(ms))
             self._execute_organization(
                 all_processed, input_path, output_path, skip_existing, result
             )

--- a/src/core/types.py
+++ b/src/core/types.py
@@ -56,6 +56,14 @@ class OrganizationResult:
     errors: list[tuple[str, str]] = field(default_factory=list)  # (file, error)
     skipped_by_extension: Counter[str] = field(default_factory=Counter)
     fallback_files: int = 0  # pyre-ignore[35]: Pyre 0.9.25 mis-flags dataclass field annotations under `from __future__ import annotations`. Same pre-existing pattern as the other counters above (alerts #39-46 on main).
+    # Per-file inference durations in milliseconds (#410). Populated by
+    # the organizer from ProcessedFile.inference_ms / ProcessedImage.inference_ms.
+    # The summary renderer derives mean / p50 / p95 / p99 from these samples;
+    # storing the raw list keeps stats decoupled from the dataclass and
+    # lets future code compute additional percentiles without a schema
+    # change.
+    vision_inference_ms_samples: list[float] = field(default_factory=list)  # pyre-ignore[35]
+    text_inference_ms_samples: list[float] = field(default_factory=list)  # pyre-ignore[35]
 
 
 # ---------------------------------------------------------------------------

--- a/src/services/inference_timer.py
+++ b/src/services/inference_timer.py
@@ -1,0 +1,97 @@
+"""Shared per-inference timer for the text + vision processors (#410).
+
+A small context-manager wrapping ``time.perf_counter`` so the two
+processors don't redefine timing logic, and so operators get a
+consistent ``{kind}_inference_ms=<N>`` log line for every call —
+including the failure branches that previously silently swallowed
+timing data.
+
+Usage:
+
+    from services.inference_timer import time_inference
+
+    with time_inference("vision", file_path) as t:
+        ...  # model.generate / process_file body
+    # t.elapsed_ms now carries the duration; the helper has already
+    # emitted the structured log.
+
+The context manager fires the log in ``__exit__`` regardless of
+whether the body raised, so timeout / OSError / model-backend failure
+paths still produce a measurement that downstream summary code
+(``core/display.py``) can aggregate into p50 / p95 / p99 (#410
+acceptance criteria).
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from types import TracebackType
+from typing import Literal
+
+from loguru import logger
+
+InferenceKind = Literal["vision", "text"]
+
+
+class _InferenceTimer:
+    """Context-manager handle returned from :func:`time_inference`.
+
+    Exposes ``elapsed_ms`` (a float, always >= 0) so callers can attach
+    the timing to a result object as well as relying on the log line.
+    """
+
+    __slots__ = ("_kind", "_path", "_t0", "elapsed_ms")
+
+    def __init__(self, kind: InferenceKind, file_path: Path | str) -> None:
+        self._kind = kind
+        self._path = Path(file_path) if not isinstance(file_path, Path) else file_path
+        self._t0: float = 0.0
+        self.elapsed_ms: float = 0.0
+
+    def __enter__(self) -> _InferenceTimer:
+        self._t0 = time.perf_counter()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        # Always record + log, even on the exception path.
+        self.elapsed_ms = max(0.0, (time.perf_counter() - self._t0) * 1000.0)
+        # Structured single-line log so log-grep / NDJSON consumers can
+        # extract `{kind}_inference_ms=` deterministically.
+        if exc is None:
+            logger.debug(
+                "{}_inference_ms={:.1f} file={}",
+                self._kind,
+                self.elapsed_ms,
+                self._path.name,
+            )
+        else:
+            logger.debug(
+                "{}_inference_ms={:.1f} file={} error={}",
+                self._kind,
+                self.elapsed_ms,
+                self._path.name,
+                exc_type.__name__ if exc_type is not None else "unknown",
+            )
+
+
+def time_inference(kind: InferenceKind, file_path: Path | str) -> _InferenceTimer:
+    """Open a per-inference timing scope.
+
+    Args:
+        kind: ``"vision"`` or ``"text"`` — used as the log-field prefix
+            and to keep p50/p95/p99 stats partitioned per-modality in
+            the run summary.
+        file_path: The file being processed (used as the log's ``file``
+            field; the timer never opens or stats the path itself).
+
+    Returns:
+        A context-manager whose ``.elapsed_ms`` attribute holds the
+        measured duration in milliseconds after ``__exit__``.
+    """
+    return _InferenceTimer(kind, file_path)

--- a/src/services/inference_timer.py
+++ b/src/services/inference_timer.py
@@ -2,24 +2,27 @@
 
 A small context-manager wrapping ``time.perf_counter`` so the two
 processors don't redefine timing logic, and so operators get a
-consistent ``{kind}_inference_ms=<N>`` log line for every call —
-including the failure branches that previously silently swallowed
-timing data.
+consistent ``{kind}_inference_ms=<N>`` log line for every call that
+actually invoked the model — including the failure branches that
+previously silently swallowed timing data.
 
 Usage:
 
     from services.inference_timer import time_inference
 
     with time_inference("vision", file_path) as t:
-        ...  # model.generate / process_file body
-    # t.elapsed_ms now carries the duration; the helper has already
-    # emitted the structured log.
+        ...  # body that MAY or MAY NOT invoke the model
+        if about_to_call_model:
+            t.mark_invoked()
+        ...  # the model call itself
+    # t.elapsed_ms carries the duration regardless. The structured log
+    # line fires on __exit__ only when mark_invoked() was called or
+    # the body raised (failures during a started inference count).
 
-The context manager fires the log in ``__exit__`` regardless of
-whether the body raised, so timeout / OSError / model-backend failure
-paths still produce a measurement that downstream summary code
-(``core/display.py``) can aggregate into p50 / p95 / p99 (#410
-acceptance criteria).
+Pre-inference early returns that never call ``mark_invoked()`` are
+silently excluded — both from the log stream AND from the in-process
+samples — so log-based dashboards don't get biased downward by
+near-zero non-events (CodeRabbit P2 round-trip on PR #424).
 """
 
 from __future__ import annotations
@@ -39,15 +42,30 @@ class _InferenceTimer:
 
     Exposes ``elapsed_ms`` (a float, always >= 0) so callers can attach
     the timing to a result object as well as relying on the log line.
+    Callers must call :meth:`mark_invoked` before exit to opt into the
+    structured log; an exception during the body counts as an invoked-
+    but-failed inference and also triggers the log automatically.
     """
 
-    __slots__ = ("_kind", "_path", "_t0", "elapsed_ms")
+    __slots__ = ("_kind", "_path", "_t0", "_invoked", "elapsed_ms")
 
     def __init__(self, kind: InferenceKind, file_path: Path | str) -> None:
         self._kind = kind
         self._path = Path(file_path) if not isinstance(file_path, Path) else file_path
         self._t0: float = 0.0
+        self._invoked: bool = False
         self.elapsed_ms: float = 0.0
+
+    def mark_invoked(self) -> None:
+        """Signal that the body actually invoked the model.
+
+        Without this call, a clean exit from the context manager
+        produces no log line — ``elapsed_ms`` is still measured so
+        callers can read it directly. With it, the log fires on
+        ``__exit__`` and observability pipelines see a sample for
+        this file.
+        """
+        self._invoked = True
 
     def __enter__(self) -> _InferenceTimer:
         self._t0 = time.perf_counter()
@@ -59,8 +77,14 @@ class _InferenceTimer:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        # Always record + log, even on the exception path.
+        # Always record the elapsed time, even on the exception path.
         self.elapsed_ms = max(0.0, (time.perf_counter() - self._t0) * 1000.0)
+        # Log only when the model was actually invoked. An exception
+        # mid-body is treated as an invoked-but-failed inference: those
+        # samples are exactly what operators need during degraded-
+        # backend periods, so they fire the log.
+        if not self._invoked and exc is None:
+            return
         # Structured single-line log so log-grep / NDJSON consumers can
         # extract `{kind}_inference_ms=` deterministically.
         if exc is None:
@@ -92,6 +116,9 @@ def time_inference(kind: InferenceKind, file_path: Path | str) -> _InferenceTime
 
     Returns:
         A context-manager whose ``.elapsed_ms`` attribute holds the
-        measured duration in milliseconds after ``__exit__``.
+        measured duration in milliseconds after ``__exit__``. The
+        structured log line is emitted only when
+        :meth:`_InferenceTimer.mark_invoked` was called or the body
+        raised an exception.
     """
     return _InferenceTimer(kind, file_path)

--- a/src/services/text_processor.py
+++ b/src/services/text_processor.py
@@ -177,9 +177,11 @@ class TextProcessor:
         generate_filename: bool,
         scan_root: str | Path | None,
     ) -> ProcessedFile:
-        """Inner body of process_file — extracted so :meth:`process_file`
-        can wrap it uniformly with the per-call timer regardless of
-        which return / exception branch fires.
+        """Inner body of :meth:`process_file`.
+
+        Extracted so the outer ``process_file`` can wrap this with the
+        per-call timer (#410) regardless of which return / exception
+        branch fires.
         """
         import time
 

--- a/src/services/text_processor.py
+++ b/src/services/text_processor.py
@@ -165,7 +165,14 @@ class TextProcessor:
                 generate_filename=generate_filename,
                 scan_root=scan_root,
             )
-        result.inference_ms = _timer.elapsed_ms
+        # Only attach the timer to results where the model was actually
+        # invoked. Non-inference branches (symlink rejection, unsupported
+        # content, read-path failures) set `result.error` before any
+        # text_model.generate() call; folding those near-zero samples
+        # into mean/p95/p99 would understate real text latency
+        # (CodeRabbit P2 catch on PR #424).
+        if not result.error:
+            result.inference_ms = _timer.elapsed_ms
         return result
 
     def _process_file_inner(

--- a/src/services/text_processor.py
+++ b/src/services/text_processor.py
@@ -194,6 +194,12 @@ class TextProcessor:
 
         scan_root_path = Path(scan_root) if scan_root is not None else None
         start_time = time.time()
+        # Flips to True once we cross the read/setup phase and are about
+        # to issue a model call. Used by the exception handlers below so
+        # pre-inference OSError subclasses (e.g. FileTooLargeError from
+        # read_file) aren't misclassified as inference attempts
+        # (CodeRabbit P2 catch on PR #424).
+        model_invoked = False
 
         try:
             # Read file content via SafeDir for the migrated extensions
@@ -263,7 +269,6 @@ class TextProcessor:
 
             # Generate description (summary)
             description = ""
-            model_invoked = False
             if generate_description:
                 model_invoked = True  # _generate_description issues the model call
                 description = self._generate_description(content)
@@ -338,9 +343,11 @@ class TextProcessor:
                 type(e).__name__,
                 e,
             )
-            # These exception types fire only after the read succeeded,
-            # i.e. during _generate_description / folder / filename —
-            # all of which are model calls. Count as an inference attempt.
+            # Only count as an inference attempt when we'd already
+            # flipped `model_invoked` above. OSError subclasses raised
+            # from read_file / SafeDir (e.g. FileTooLargeError) hit this
+            # handler too, and those are pre-inference — including them
+            # in samples would understate real text-model latency.
             return (
                 ProcessedFile(
                     file_path=file_path,
@@ -349,7 +356,7 @@ class TextProcessor:
                     filename=file_path.stem,
                     error=str(e),
                 ),
-                True,  # the failing call counts as an inference attempt
+                model_invoked,
             )
 
     def _clean_ai_generated_name(self, name: str, max_words: int = 3) -> str:

--- a/src/services/text_processor.py
+++ b/src/services/text_processor.py
@@ -167,6 +167,10 @@ class TextProcessor:
                 generate_filename=generate_filename,
                 scan_root=scan_root,
             )
+            if model_invoked:
+                # Both gates the log line emission AND signals "include
+                # in samples" for the in-process aggregator below.
+                _timer.mark_invoked()
         if model_invoked:
             result.inference_ms = _timer.elapsed_ms
         return result

--- a/src/services/text_processor.py
+++ b/src/services/text_processor.py
@@ -154,24 +154,20 @@ class TextProcessor:
         """
         file_path = Path(file_path)
         # Per-file inference timer (#410). Emits `text_inference_ms=<N>`
-        # on exit for both success and exception branches; the duration
-        # is attached to the returned ProcessedFile so the summary
-        # renderer can aggregate p50/p95/p99 across the run.
+        # on exit for both success and exception branches; the inner
+        # method returns (result, model_invoked) so we can record the
+        # sample for failed-but-attempted inferences (which DO need to
+        # show up in p95/p99 during degraded-backend periods) while
+        # excluding non-inference paths (CodeRabbit P2 round-trip).
         with time_inference("text", file_path) as _timer:
-            result = self._process_file_inner(
+            result, model_invoked = self._process_file_inner(
                 file_path,
                 generate_description=generate_description,
                 generate_folder=generate_folder,
                 generate_filename=generate_filename,
                 scan_root=scan_root,
             )
-        # Only attach the timer to results where the model was actually
-        # invoked. Non-inference branches (symlink rejection, unsupported
-        # content, read-path failures) set `result.error` before any
-        # text_model.generate() call; folding those near-zero samples
-        # into mean/p95/p99 would understate real text latency
-        # (CodeRabbit P2 catch on PR #424).
-        if not result.error:
+        if model_invoked:
             result.inference_ms = _timer.elapsed_ms
         return result
 
@@ -183,7 +179,7 @@ class TextProcessor:
         generate_folder: bool,
         generate_filename: bool,
         scan_root: str | Path | None,
-    ) -> ProcessedFile:
+    ) -> tuple[ProcessedFile, bool]:
         """Inner body of :meth:`process_file`.
 
         Extracted so the outer ``process_file`` can wrap this with the
@@ -216,12 +212,15 @@ class TextProcessor:
                         content = read_file_via_safedir(safe_dir, file_path.name)
             except SymlinkRejected as exc:
                 logger.warning("Refused to read symlinked file {}: {}", file_path, exc)
-                return ProcessedFile(
-                    file_path=file_path,
-                    description="",
-                    folder_name="errors",
-                    filename=file_path.stem,
-                    error=f"Refused to read symlink: {file_path.name}",
+                return (
+                    ProcessedFile(
+                        file_path=file_path,
+                        description="",
+                        folder_name="errors",
+                        filename=file_path.stem,
+                        error=f"Refused to read symlink: {file_path.name}",
+                    ),
+                    False,  # no model call attempted
                 )
             except NotImplementedError:
                 # SafeDir requires POSIX dir_fd / O_NOFOLLOW; on Windows
@@ -244,12 +243,15 @@ class TextProcessor:
                 content = read_file(file_path)
 
             if content is None:
-                return ProcessedFile(
-                    file_path=file_path,
-                    description="",
-                    folder_name="unsupported",
-                    filename=file_path.stem,
-                    error="Unsupported file type",
+                return (
+                    ProcessedFile(
+                        file_path=file_path,
+                        description="",
+                        folder_name="unsupported",
+                        filename=file_path.stem,
+                        error="Unsupported file type",
+                    ),
+                    False,  # no model call attempted
                 )
 
             # Truncate if too long
@@ -257,13 +259,16 @@ class TextProcessor:
 
             # Generate description (summary)
             description = ""
+            model_invoked = False
             if generate_description:
+                model_invoked = True  # _generate_description issues the model call
                 description = self._generate_description(content)
                 logger.debug("Generated description ({} chars)", len(description))
 
             # Generate folder name
             folder_name = ""
             if generate_folder:
+                model_invoked = True  # _generate_folder_name issues the model call
                 folder_name = self._generate_folder_name(
                     description or content, original_stem=file_path.stem
                 )
@@ -272,6 +277,7 @@ class TextProcessor:
             # Generate filename
             filename = ""
             if generate_filename:
+                model_invoked = True  # _generate_filename issues the model call
                 filename = self._generate_filename(
                     description or content, original_stem=file_path.stem
                 )
@@ -279,13 +285,16 @@ class TextProcessor:
 
             processing_time = time.time() - start_time
 
-            return ProcessedFile(
-                file_path=file_path,
-                description=description,
-                folder_name=folder_name,
-                filename=filename,
-                original_content=content[:500],  # Keep first 500 chars for reference
-                processing_time=processing_time,
+            return (
+                ProcessedFile(
+                    file_path=file_path,
+                    description=description,
+                    folder_name=folder_name,
+                    filename=filename,
+                    original_content=content[:500],  # Keep first 500 chars for reference
+                    processing_time=processing_time,
+                ),
+                model_invoked,
             )
 
         except FileReadError as e:
@@ -299,15 +308,20 @@ class TextProcessor:
                 type(e).__name__,
                 e,
             )
-            return ProcessedFile(
-                file_path=file_path,
-                description="",
-                folder_name="errors",
-                filename=file_path.stem,
-                # Preserve the existing ``error=str(e)`` contract — B2
-                # scope is log-message categorisation, not the public
-                # ``ProcessedFile.error`` field.
-                error=str(e),
+            # FileReadError fires from the SafeDir / read_file path
+            # BEFORE any model call — pre-inference.
+            return (
+                ProcessedFile(
+                    file_path=file_path,
+                    description="",
+                    folder_name="errors",
+                    filename=file_path.stem,
+                    # Preserve the existing ``error=str(e)`` contract — B2
+                    # scope is log-message categorisation, not the public
+                    # ``ProcessedFile.error`` field.
+                    error=str(e),
+                ),
+                False,  # read failure → no model call attempted
             )
         except (RuntimeError, ValueError, OSError, AttributeError) as e:
             # B2: typed tuple already narrows to "model / inference"
@@ -320,12 +334,18 @@ class TextProcessor:
                 type(e).__name__,
                 e,
             )
-            return ProcessedFile(
-                file_path=file_path,
-                description="",
-                folder_name="errors",
-                filename=file_path.stem,
-                error=str(e),
+            # These exception types fire only after the read succeeded,
+            # i.e. during _generate_description / folder / filename —
+            # all of which are model calls. Count as an inference attempt.
+            return (
+                ProcessedFile(
+                    file_path=file_path,
+                    description="",
+                    folder_name="errors",
+                    filename=file_path.stem,
+                    error=str(e),
+                ),
+                True,  # the failing call counts as an inference attempt
             )
 
     def _clean_ai_generated_name(self, name: str, max_words: int = 3) -> str:

--- a/src/services/text_processor.py
+++ b/src/services/text_processor.py
@@ -12,6 +12,7 @@ from loguru import logger
 from models import TextModel
 from models.base import BaseModel, ModelConfig, ModelType
 from models.provider_factory import get_text_model
+from services.inference_timer import time_inference
 from utils.file_readers import FileReadError, read_file
 from utils.readers import read_file_via_safedir, read_file_via_safedir_anchored
 from utils.safedir import SafeDir, SymlinkRejected
@@ -33,6 +34,10 @@ class ProcessedFile:
     processing_time: float = 0.0
     error: str | None = None
     transcript: str | None = None
+    # Wall-clock duration of the inference path measured in milliseconds
+    # (#410). Populated even on failure paths so summary aggregation
+    # (p50/p95/p99) reflects every per-file attempt.
+    inference_ms: float | None = None
 
 
 # Stop-words and noise words filtered from AI-generated names.
@@ -147,9 +152,37 @@ class TextProcessor:
         Returns:
             ProcessedFile with metadata
         """
+        file_path = Path(file_path)
+        # Per-file inference timer (#410). Emits `text_inference_ms=<N>`
+        # on exit for both success and exception branches; the duration
+        # is attached to the returned ProcessedFile so the summary
+        # renderer can aggregate p50/p95/p99 across the run.
+        with time_inference("text", file_path) as _timer:
+            result = self._process_file_inner(
+                file_path,
+                generate_description=generate_description,
+                generate_folder=generate_folder,
+                generate_filename=generate_filename,
+                scan_root=scan_root,
+            )
+        result.inference_ms = _timer.elapsed_ms
+        return result
+
+    def _process_file_inner(
+        self,
+        file_path: Path,
+        *,
+        generate_description: bool,
+        generate_folder: bool,
+        generate_filename: bool,
+        scan_root: str | Path | None,
+    ) -> ProcessedFile:
+        """Inner body of process_file — extracted so :meth:`process_file`
+        can wrap it uniformly with the per-call timer regardless of
+        which return / exception branch fires.
+        """
         import time
 
-        file_path = Path(file_path)
         scan_root_path = Path(scan_root) if scan_root is not None else None
         start_time = time.time()
 

--- a/src/services/vision_processor.py
+++ b/src/services/vision_processor.py
@@ -204,11 +204,15 @@ class VisionProcessor:
 
         # Per-file inference timer (#410). The context manager logs
         # `vision_inference_ms=<N>` on exit — success and exception
-        # paths both fire — and exposes the duration on `_timer.elapsed_ms`
-        # so we can attach it to every returned ProcessedImage for the
-        # summary aggregator.
+        # paths both fire — and exposes the duration on `_timer.elapsed_ms`.
+        # The inner method returns a (result, model_invoked) tuple so we
+        # can attribute the timer correctly even on mid-flight failures:
+        # an attempted-but-failed inference DOES contribute to p95/p99
+        # (operators need accurate tail latency during degraded backend
+        # periods), while pre-inference early returns (circuit-open,
+        # file-not-found) DO NOT (CodeRabbit P2 round-trip on PR #424).
         with time_inference("vision", file_path) as _timer:
-            result = self._process_file_inner(
+            result, model_invoked = self._process_file_inner(
                 file_path,
                 start_time=start_time,
                 generate_description=generate_description,
@@ -216,12 +220,7 @@ class VisionProcessor:
                 generate_filename=generate_filename,
                 perform_ocr=perform_ocr,
             )
-        # Only attach the timer to results where the model was actually
-        # invoked. Early-return paths (circuit-open, file-not-found,
-        # ...) set `result.error` before any inference happens; folding
-        # those near-zero samples into mean/p95/p99 would understate
-        # real vision latency (CodeRabbit P2 catch on PR #424).
-        if not result.error:
+        if model_invoked:
             result.inference_ms = _timer.elapsed_ms
         return result
 
@@ -234,11 +233,16 @@ class VisionProcessor:
         generate_folder: bool,
         generate_filename: bool,
         perform_ocr: bool,
-    ) -> ProcessedImage:
+    ) -> tuple[ProcessedImage, bool]:
         """Inner body of :meth:`process_file`.
 
-        Extracted so the outer timing wrapper (#410) can run uniformly
-        regardless of which early-return branch fires.
+        Returns ``(result, model_invoked)``. ``model_invoked`` is True
+        iff at least one model call (description / OCR / folder /
+        filename) was attempted — regardless of whether it succeeded
+        or raised. Failed-but-attempted inferences must contribute to
+        the #410 p95/p99 summary so operators see real tail latency
+        during degraded-backend periods; pre-inference early returns
+        (circuit-open before any call, file-not-found) must not.
         """
         try:
             if self._is_circuit_open():
@@ -252,44 +256,56 @@ class VisionProcessor:
                     file_path.name,
                     error_message,
                 )
-                return ProcessedImage(
-                    file_path=file_path,
-                    description=f"Image from {file_path.name}",
-                    folder_name="images",
-                    filename=file_path.stem,
-                    error=error_message,
+                return (
+                    ProcessedImage(
+                        file_path=file_path,
+                        description=f"Image from {file_path.name}",
+                        folder_name="images",
+                        filename=file_path.stem,
+                        error=error_message,
+                    ),
+                    False,  # no model call attempted
                 )
 
             # Validate file exists
             if not file_path.exists():
-                return ProcessedImage(
-                    file_path=file_path,
-                    description="",
-                    folder_name="errors",
-                    filename=file_path.stem,
-                    error="File not found",
+                return (
+                    ProcessedImage(
+                        file_path=file_path,
+                        description="",
+                        folder_name="errors",
+                        filename=file_path.stem,
+                        error="File not found",
+                    ),
+                    False,  # no model call attempted
                 )
 
             # Generate description
             description = ""
+            model_invoked = False
             if generate_description:
                 logger.debug(f"Analyzing image: {file_path.name}")
+                model_invoked = True  # _generate_description issues the model call
                 description = self._generate_description(file_path)
                 logger.debug(f"Generated description ({len(description)} chars)")
                 if self._is_circuit_open():
                     error_message = self._circuit_open_error()
-                    return ProcessedImage(
-                        file_path=file_path,
-                        description=description or f"Image from {file_path.name}",
-                        folder_name="images",
-                        filename=file_path.stem,
-                        error=error_message,
+                    return (
+                        ProcessedImage(
+                            file_path=file_path,
+                            description=description or f"Image from {file_path.name}",
+                            folder_name="images",
+                            filename=file_path.stem,
+                            error=error_message,
+                        ),
+                        True,  # the call that tripped the circuit DID happen
                     )
 
             # Extract text if needed
             extracted_text = None
             has_text = False
             if perform_ocr:
+                model_invoked = True  # _extract_text issues the model call
                 extracted_text = self._extract_text(file_path)
                 has_text = bool(extracted_text and len(extracted_text.strip()) > 10)
                 if has_text and extracted_text is not None:
@@ -298,6 +314,7 @@ class VisionProcessor:
             # Generate folder name
             folder_name = ""
             if generate_folder:
+                model_invoked = True  # _generate_folder_name issues the model call
                 # Use extracted text if available, otherwise use description
                 context: str = (extracted_text or description) if has_text else description
                 folder_name = self._generate_folder_name(file_path, context)
@@ -306,6 +323,7 @@ class VisionProcessor:
             # Generate filename
             filename = ""
             if generate_filename:
+                model_invoked = True  # _generate_filename issues the model call
                 # Use extracted text if available, otherwise use description
                 context = (extracted_text or description) if has_text else description
                 filename = self._generate_filename(file_path, context)
@@ -313,14 +331,17 @@ class VisionProcessor:
 
             processing_time = time.time() - start_time
 
-            return ProcessedImage(
-                file_path=file_path,
-                description=description,
-                folder_name=folder_name,
-                filename=filename,
-                has_text=has_text,
-                extracted_text=extracted_text[:500] if extracted_text else None,
-                processing_time=processing_time,
+            return (
+                ProcessedImage(
+                    file_path=file_path,
+                    description=description,
+                    folder_name=folder_name,
+                    filename=filename,
+                    has_text=has_text,
+                    extracted_text=extracted_text[:500] if extracted_text else None,
+                    processing_time=processing_time,
+                ),
+                model_invoked,
             )
 
         except Exception as e:
@@ -336,15 +357,23 @@ class VisionProcessor:
                 type(e).__name__,
                 e,
             )
-            return ProcessedImage(
-                file_path=file_path,
-                description="",
-                folder_name="errors",
-                filename=file_path.stem,
-                # Preserve the existing ``error=str(e)`` contract — B2
-                # scope is log-message categorisation, not the public
-                # ``ProcessedImage.error`` field.
-                error=str(e),
+            # Conservative: assume the exception came from a model call
+            # unless we know otherwise. The pre-inference branches all
+            # return cleanly above (they don't raise), so anything that
+            # raises has already passed the model-call point or is a
+            # filesystem error caught further down the inner body.
+            return (
+                ProcessedImage(
+                    file_path=file_path,
+                    description="",
+                    folder_name="errors",
+                    filename=file_path.stem,
+                    # Preserve the existing ``error=str(e)`` contract — B2
+                    # scope is log-message categorisation, not the public
+                    # ``ProcessedImage.error`` field.
+                    error=str(e),
+                ),
+                True,  # the failing call counts as an inference attempt
             )
 
     def _clean_ai_generated_name(self, name: str, max_words: int = 3) -> str:

--- a/src/services/vision_processor.py
+++ b/src/services/vision_processor.py
@@ -181,8 +181,6 @@ class VisionProcessor:
         Returns:
             ProcessedImage with metadata
         """
-        import time
-
         file_path = Path(file_path)
         start_time = time.time()
 
@@ -234,8 +232,6 @@ class VisionProcessor:
         """Original process_file body, extracted so the timing wrapper above
         can run uniformly regardless of which early-return branch fires.
         """
-        import time
-
         try:
             if self._is_circuit_open():
                 logger.warning(

--- a/src/services/vision_processor.py
+++ b/src/services/vision_processor.py
@@ -248,6 +248,10 @@ class VisionProcessor:
         during degraded-backend periods; pre-inference early returns
         (circuit-open before any call, file-not-found) must not.
         """
+        # Tracked across the try block so the broad except below can
+        # tell apart pre-inference exceptions (filesystem / decode)
+        # from in-flight inference failures.
+        model_invoked = False
         try:
             if self._is_circuit_open():
                 logger.warning(
@@ -286,7 +290,6 @@ class VisionProcessor:
 
             # Generate description
             description = ""
-            model_invoked = False
             if generate_description:
                 logger.debug(f"Analyzing image: {file_path.name}")
                 model_invoked = True  # _generate_description issues the model call
@@ -361,11 +364,10 @@ class VisionProcessor:
                 type(e).__name__,
                 e,
             )
-            # Conservative: assume the exception came from a model call
-            # unless we know otherwise. The pre-inference branches all
-            # return cleanly above (they don't raise), so anything that
-            # raises has already passed the model-call point or is a
-            # filesystem error caught further down the inner body.
+            # Forward `model_invoked` so a pre-inference exception
+            # (filesystem error, image-decode failure) is reported as
+            # NOT an inference attempt, while an in-flight inference
+            # failure (after we'd flipped the flag above) still counts.
             return (
                 ProcessedImage(
                     file_path=file_path,
@@ -377,7 +379,7 @@ class VisionProcessor:
                     # ``ProcessedImage.error`` field.
                     error=str(e),
                 ),
-                True,  # the failing call counts as an inference attempt
+                model_invoked,
             )
 
     def _clean_ai_generated_name(self, name: str, max_words: int = 3) -> str:

--- a/src/services/vision_processor.py
+++ b/src/services/vision_processor.py
@@ -220,6 +220,10 @@ class VisionProcessor:
                 generate_filename=generate_filename,
                 perform_ocr=perform_ocr,
             )
+            if model_invoked:
+                # Both gates the log line emission AND signals "include
+                # in samples" for the in-process aggregator below.
+                _timer.mark_invoked()
         if model_invoked:
             result.inference_ms = _timer.elapsed_ms
         return result

--- a/src/services/vision_processor.py
+++ b/src/services/vision_processor.py
@@ -16,6 +16,7 @@ from config.schema import ProcessingSettings
 from models import VisionModel
 from models.base import BaseModel, ModelConfig, ModelType
 from models.provider_factory import get_vision_model
+from services.inference_timer import time_inference
 
 _BYTES_PER_MB = 1024 * 1024
 
@@ -74,6 +75,13 @@ class ProcessedImage:
     processing_time: float = 0.0
     error: str | None = None
     source: str = "vision"
+    # Wall-clock duration of the inference path measured in milliseconds
+    # (#410). Populated even on the error / fallback paths so summary
+    # aggregation (p50/p95/p99) reflects every per-file attempt, not just
+    # the happy path. None on results assembled without going through
+    # process_file (e.g. metadata-only fallback constructed by the
+    # dispatcher).
+    inference_ms: float | None = None
 
 
 class VisionProcessor:
@@ -195,6 +203,38 @@ class VisionProcessor:
             # stat() can fail on permission-denied / disappeared files;
             # don't let the informational log break the real work below.
             pass
+
+        # Per-file inference timer (#410). The context manager logs
+        # `vision_inference_ms=<N>` on exit — success and exception
+        # paths both fire — and exposes the duration on `_timer.elapsed_ms`
+        # so we can attach it to every returned ProcessedImage for the
+        # summary aggregator.
+        with time_inference("vision", file_path) as _timer:
+            result = self._process_file_inner(
+                file_path,
+                start_time=start_time,
+                generate_description=generate_description,
+                generate_folder=generate_folder,
+                generate_filename=generate_filename,
+                perform_ocr=perform_ocr,
+            )
+        result.inference_ms = _timer.elapsed_ms
+        return result
+
+    def _process_file_inner(
+        self,
+        file_path: Path,
+        *,
+        start_time: float,
+        generate_description: bool,
+        generate_folder: bool,
+        generate_filename: bool,
+        perform_ocr: bool,
+    ) -> ProcessedImage:
+        """Original process_file body, extracted so the timing wrapper above
+        can run uniformly regardless of which early-return branch fires.
+        """
+        import time
 
         try:
             if self._is_circuit_open():

--- a/src/services/vision_processor.py
+++ b/src/services/vision_processor.py
@@ -229,8 +229,10 @@ class VisionProcessor:
         generate_filename: bool,
         perform_ocr: bool,
     ) -> ProcessedImage:
-        """Original process_file body, extracted so the timing wrapper above
-        can run uniformly regardless of which early-return branch fires.
+        """Inner body of :meth:`process_file`.
+
+        Extracted so the outer timing wrapper (#410) can run uniformly
+        regardless of which early-return branch fires.
         """
         try:
             if self._is_circuit_open():

--- a/src/services/vision_processor.py
+++ b/src/services/vision_processor.py
@@ -216,7 +216,13 @@ class VisionProcessor:
                 generate_filename=generate_filename,
                 perform_ocr=perform_ocr,
             )
-        result.inference_ms = _timer.elapsed_ms
+        # Only attach the timer to results where the model was actually
+        # invoked. Early-return paths (circuit-open, file-not-found,
+        # ...) set `result.error` before any inference happens; folding
+        # those near-zero samples into mean/p95/p99 would understate
+        # real vision latency (CodeRabbit P2 catch on PR #424).
+        if not result.error:
+            result.inference_ms = _timer.elapsed_ms
         return result
 
     def _process_file_inner(

--- a/tests/integration/test_core_organizer_batch3.py
+++ b/tests/integration/test_core_organizer_batch3.py
@@ -886,6 +886,36 @@ class TestDispatcher:
         assert result.error is None or result.error == ""
         assert result.folder_name == "Images/Screenshots/2026"
         assert result.source == "fallback_filename"
+        # #410: timeout's wall-clock duration is preserved on the
+        # fallback result so it lands in the p95/p99 inference sample.
+        # `_make_file_result_failure` defaults duration_ms to 1.0.
+        assert result.inference_ms == 1.0
+
+    def test_process_image_files_timeout_fallback_carries_long_duration(
+        self, tmp_path: Path
+    ) -> None:
+        """Long timeout durations land on the fallback's inference_ms (#410)."""
+        from rich.console import Console
+
+        from core import dispatcher
+        from parallel.result import FileResult
+
+        img = tmp_path / "IMG_20260522_140307.jpg"
+        img.write_bytes(b"")
+
+        # Simulate a 5-minute timeout (the dispatcher default).
+        file_result = FileResult(
+            path=img,
+            success=False,
+            error="Timed out after 300.0s",
+            duration_ms=300_000.0,
+        )
+        mock_pp = self._make_mock_parallel_processor([file_result])
+        results = dispatcher.process_image_files([img], MagicMock(), mock_pp, Console(quiet=True))
+
+        assert results[0].inference_ms == 300_000.0
+        # The timeout sample is now part of the p95/p99 inputs, where
+        # before this fix it was silently dropped.
 
     def test_process_image_files_non_timeout_failure_is_not_fallback(self, tmp_path: Path) -> None:
         """Read errors / corrupt-image failures still take the regular error path."""

--- a/tests/integration/test_core_organizer_batch3.py
+++ b/tests/integration/test_core_organizer_batch3.py
@@ -607,6 +607,82 @@ class TestDisplay:
         out = console.export_text()
         assert "Categorized via fallback" not in out
 
+    def test_show_summary_renders_vision_inference_stats(self, tmp_path: Path) -> None:
+        """Per-file vision inference samples produce a mean/p50/p95/p99 line (#410)."""
+        from rich.console import Console
+
+        from core.display import show_summary
+        from core.types import OrganizationResult
+
+        console = Console(record=True, width=160)
+        result = OrganizationResult(
+            total_files=5,
+            processed_files=5,
+            vision_inference_ms_samples=[100.0, 200.0, 300.0, 400.0, 500.0],
+        )
+        show_summary(console, result, tmp_path, dry_run=True)
+        out = console.export_text()
+        assert "Vision inference" in out
+        assert "mean:" in out
+        assert "p50:" in out
+        assert "p95:" in out
+        assert "p99:" in out
+        assert "(n=5)" in out
+
+    def test_show_summary_renders_text_inference_stats_independently(self, tmp_path: Path) -> None:
+        """Text and vision stats render independently (#410)."""
+        from rich.console import Console
+
+        from core.display import show_summary
+        from core.types import OrganizationResult
+
+        console = Console(record=True, width=160)
+        result = OrganizationResult(
+            total_files=3,
+            processed_files=3,
+            text_inference_ms_samples=[50.0, 75.0, 100.0],
+        )
+        show_summary(console, result, tmp_path, dry_run=True)
+        out = console.export_text()
+        assert "Text inference" in out
+        assert "(n=3)" in out
+        assert "Vision inference" not in out
+
+    def test_show_summary_omits_inference_stats_when_no_samples(self, tmp_path: Path) -> None:
+        """Empty sample lists short-circuit — no inference line rendered (#410)."""
+        from rich.console import Console
+
+        from core.display import show_summary
+        from core.types import OrganizationResult
+
+        console = Console(record=True, width=160)
+        result = OrganizationResult(total_files=2, processed_files=2)
+        show_summary(console, result, tmp_path, dry_run=True)
+        out = console.export_text()
+        assert "Vision inference" not in out
+        assert "Text inference" not in out
+
+    def test_percentile_helper_matches_simple_cases(self) -> None:
+        """_percentile reproduces standard linear-interp results (#410)."""
+        from core.display import _percentile
+
+        # Empty → 0 (no special-casing in callers)
+        assert _percentile([], 50) == 0.0
+        # Single sample → returns it for any percentile
+        assert _percentile([42.0], 50) == 42.0
+        assert _percentile([42.0], 99) == 42.0
+        # Ten evenly-spaced samples; linear interp matches NumPy default
+        samples = [float(x) for x in range(1, 11)]  # 1..10
+        # p50: rank = 0.5 * 9 = 4.5 → 5.5
+        assert _percentile(samples, 50) == pytest.approx(5.5)
+        # p95: rank = 0.95 * 9 = 8.55 → 9.55
+        assert _percentile(samples, 95) == pytest.approx(9.55)
+        # Clamping
+        assert _percentile([1.0, 2.0, 3.0], 0) == 1.0
+        assert _percentile([1.0, 2.0, 3.0], 100) == 3.0
+        assert _percentile([1.0, 2.0, 3.0], 200) == 3.0
+        assert _percentile([1.0, 2.0, 3.0], -50) == 1.0
+
     def test_show_summary_show_skipped_expands_full_list(self, tmp_path: Path) -> None:
         """show_skipped=True bypasses the Top-N cap regardless of distinct count."""
         from collections import Counter

--- a/tests/services/test_inference_timer.py
+++ b/tests/services/test_inference_timer.py
@@ -1,9 +1,9 @@
 """Tests for ``services.inference_timer`` (#410).
 
 Verifies that:
-- the context manager records a non-negative ``elapsed_ms`` for both
-  success and exception paths,
-- the structured log line is emitted on both paths,
+- elapsed_ms is recorded on both success and exception paths,
+- the log line fires only when ``mark_invoked()`` was called or the
+  body raised (no log for purely pre-inference scopes),
 - the ``kind`` argument lands in the log prefix verbatim.
 """
 
@@ -24,12 +24,10 @@ def test_records_elapsed_on_success(tmp_path: Path) -> None:
     f.write_text("hi")
 
     with time_inference("text", f) as t:
-        pass
+        t.mark_invoked()
 
-    # A no-op body must measure as a finite, small duration. Use a
-    # generous upper bound (1 second) so the bound is meaningful but
-    # not so tight it flakes on slow CI runners. Lower bound is
-    # already implicit via _InferenceTimer's `max(0.0, ...)`.
+    # Sanity bound — a no-op body should measure as a finite, small
+    # duration. Lower bound is already implicit via `max(0.0, ...)`.
     assert isinstance(t.elapsed_ms, float)
     assert t.elapsed_ms < 1000.0
 
@@ -40,28 +38,48 @@ def test_records_elapsed_on_exception(tmp_path: Path) -> None:
 
     with pytest.raises(RuntimeError, match="boom"):
         with time_inference("vision", f) as t:
+            # An exception mid-body counts as an invoked-but-failed
+            # inference; mark_invoked() is unnecessary in that case.
             raise RuntimeError("boom")
 
-    # __exit__ still updated elapsed_ms despite the exception. The
-    # synchronous raise body is essentially instantaneous, so the
-    # measurement should be a small finite float.
     assert isinstance(t.elapsed_ms, float)
     assert t.elapsed_ms < 1000.0
 
 
-def test_logs_kind_and_filename_on_success(tmp_path: Path) -> None:
+def test_log_emitted_when_marked_invoked(tmp_path: Path) -> None:
     f = tmp_path / "shot.png"
     f.write_bytes(b"")
 
     with patch("services.inference_timer.logger") as mock_logger:
-        with time_inference("vision", f):
-            pass
+        with time_inference("vision", f) as t:
+            t.mark_invoked()
 
     mock_logger.debug.assert_called_once()
     fmt, kind, _ms, file_name = mock_logger.debug.call_args.args
     assert "{}_inference_ms=" in fmt
     assert kind == "vision"
     assert file_name == "shot.png"
+
+
+def test_log_suppressed_when_not_marked_invoked(tmp_path: Path) -> None:
+    """Pre-inference early-return paths must not emit a timing log line.
+
+    CodeRabbit P2 round-trip on PR #424: log-based observability
+    pipelines would aggregate near-zero non-inference events under the
+    ``inference_ms`` key and bias real latency dashboards downward.
+    """
+    f = tmp_path / "noop.txt"
+    f.write_text("x")
+
+    with patch("services.inference_timer.logger") as mock_logger:
+        with time_inference("text", f) as t:
+            # mark_invoked() not called — simulates a pre-inference
+            # early return (file-not-found, circuit-open, …).
+            pass
+
+    mock_logger.debug.assert_not_called()
+    # elapsed_ms is still measured (callers may inspect it directly).
+    assert t.elapsed_ms < 1000.0
 
 
 def test_logs_error_field_on_exception(tmp_path: Path) -> None:
@@ -71,6 +89,9 @@ def test_logs_error_field_on_exception(tmp_path: Path) -> None:
     with patch("services.inference_timer.logger") as mock_logger:
         with pytest.raises(ValueError):
             with time_inference("vision", f):
+                # No mark_invoked() — but the exception still triggers
+                # the log because it's interpreted as a started-then-
+                # failed inference.
                 raise ValueError("bad input")
 
     mock_logger.debug.assert_called_once()
@@ -84,8 +105,8 @@ def test_logs_error_field_on_exception(tmp_path: Path) -> None:
 def test_accepts_string_path(tmp_path: Path) -> None:
     """Path-or-str is accepted; internal logging uses the basename."""
     with patch("services.inference_timer.logger") as mock_logger:
-        with time_inference("text", str(tmp_path / "report.md")):
-            pass
+        with time_inference("text", str(tmp_path / "report.md")) as t:
+            t.mark_invoked()
 
     _fmt, _kind, _ms, file_name = mock_logger.debug.call_args.args
     assert file_name == "report.md"
@@ -94,8 +115,6 @@ def test_accepts_string_path(tmp_path: Path) -> None:
 def test_zero_duration_is_not_negative(tmp_path: Path) -> None:
     """A no-op body still produces a finite, small reading."""
     with time_inference("text", tmp_path / "x") as t:
-        pass
-    # _InferenceTimer clamps to max(0.0, …) so a no-op body must be
-    # a sane small positive float (well under 1s on any platform).
+        t.mark_invoked()
     assert isinstance(t.elapsed_ms, float)
     assert t.elapsed_ms < 1000.0

--- a/tests/services/test_inference_timer.py
+++ b/tests/services/test_inference_timer.py
@@ -1,0 +1,90 @@
+"""Tests for ``services.inference_timer`` (#410).
+
+Verifies that:
+- the context manager records a non-negative ``elapsed_ms`` for both
+  success and exception paths,
+- the structured log line is emitted on both paths,
+- the ``kind`` argument lands in the log prefix verbatim.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from services.inference_timer import time_inference
+
+pytestmark = [pytest.mark.unit, pytest.mark.ci]
+
+
+def test_records_elapsed_on_success(tmp_path: Path) -> None:
+    f = tmp_path / "doc.txt"
+    f.write_text("hi")
+
+    with time_inference("text", f) as t:
+        pass
+
+    assert t.elapsed_ms >= 0.0
+
+
+def test_records_elapsed_on_exception(tmp_path: Path) -> None:
+    f = tmp_path / "doc.txt"
+    f.write_text("hi")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with time_inference("vision", f) as t:
+            raise RuntimeError("boom")
+
+    # __exit__ still updated elapsed_ms despite the exception.
+    assert t.elapsed_ms >= 0.0
+
+
+def test_logs_kind_and_filename_on_success(tmp_path: Path) -> None:
+    f = tmp_path / "shot.png"
+    f.write_bytes(b"")
+
+    with patch("services.inference_timer.logger") as mock_logger:
+        with time_inference("vision", f):
+            pass
+
+    mock_logger.debug.assert_called_once()
+    fmt, kind, _ms, file_name = mock_logger.debug.call_args.args
+    assert "{}_inference_ms=" in fmt
+    assert kind == "vision"
+    assert file_name == "shot.png"
+
+
+def test_logs_error_field_on_exception(tmp_path: Path) -> None:
+    f = tmp_path / "shot.png"
+    f.write_bytes(b"")
+
+    with patch("services.inference_timer.logger") as mock_logger:
+        with pytest.raises(ValueError):
+            with time_inference("vision", f):
+                raise ValueError("bad input")
+
+    mock_logger.debug.assert_called_once()
+    fmt, kind, _ms, file_name, error = mock_logger.debug.call_args.args
+    assert "error={}" in fmt
+    assert kind == "vision"
+    assert file_name == "shot.png"
+    assert error == "ValueError"
+
+
+def test_accepts_string_path(tmp_path: Path) -> None:
+    """Path-or-str is accepted; internal logging uses the basename."""
+    with patch("services.inference_timer.logger") as mock_logger:
+        with time_inference("text", str(tmp_path / "report.md")):
+            pass
+
+    _fmt, _kind, _ms, file_name = mock_logger.debug.call_args.args
+    assert file_name == "report.md"
+
+
+def test_zero_duration_is_not_negative() -> None:
+    """A no-op body still produces a non-negative reading."""
+    with time_inference("text", "/tmp/x") as t:
+        pass
+    assert t.elapsed_ms >= 0.0

--- a/tests/services/test_inference_timer.py
+++ b/tests/services/test_inference_timer.py
@@ -26,7 +26,12 @@ def test_records_elapsed_on_success(tmp_path: Path) -> None:
     with time_inference("text", f) as t:
         pass
 
-    assert t.elapsed_ms >= 0.0
+    # A no-op body must measure as a finite, small duration. Use a
+    # generous upper bound (1 second) so the bound is meaningful but
+    # not so tight it flakes on slow CI runners. Lower bound is
+    # already implicit via _InferenceTimer's `max(0.0, ...)`.
+    assert isinstance(t.elapsed_ms, float)
+    assert t.elapsed_ms < 1000.0
 
 
 def test_records_elapsed_on_exception(tmp_path: Path) -> None:
@@ -37,8 +42,11 @@ def test_records_elapsed_on_exception(tmp_path: Path) -> None:
         with time_inference("vision", f) as t:
             raise RuntimeError("boom")
 
-    # __exit__ still updated elapsed_ms despite the exception.
-    assert t.elapsed_ms >= 0.0
+    # __exit__ still updated elapsed_ms despite the exception. The
+    # synchronous raise body is essentially instantaneous, so the
+    # measurement should be a small finite float.
+    assert isinstance(t.elapsed_ms, float)
+    assert t.elapsed_ms < 1000.0
 
 
 def test_logs_kind_and_filename_on_success(tmp_path: Path) -> None:
@@ -83,8 +91,11 @@ def test_accepts_string_path(tmp_path: Path) -> None:
     assert file_name == "report.md"
 
 
-def test_zero_duration_is_not_negative() -> None:
-    """A no-op body still produces a non-negative reading."""
-    with time_inference("text", "/tmp/x") as t:
+def test_zero_duration_is_not_negative(tmp_path: Path) -> None:
+    """A no-op body still produces a finite, small reading."""
+    with time_inference("text", tmp_path / "x") as t:
         pass
-    assert t.elapsed_ms >= 0.0
+    # _InferenceTimer clamps to max(0.0, …) so a no-op body must be
+    # a sane small positive float (well under 1s on any platform).
+    assert isinstance(t.elapsed_ms, float)
+    assert t.elapsed_ms < 1000.0

--- a/tests/services/test_text_processor.py
+++ b/tests/services/test_text_processor.py
@@ -272,6 +272,30 @@ class TestTextProcessorFileProcessing:
         assert result.folder_name == "errors"
 
     @patch("services.text_processor.read_file_via_safedir")
+    def test_process_file_read_oserror_does_not_record_inference_ms(
+        self, mock_read: MagicMock, text_processor: TextProcessor
+    ) -> None:
+        """OSError raised pre-inference (e.g. FileTooLargeError) must NOT
+        be counted as an inference attempt (#410 / CodeRabbit P2).
+
+        Before this fix the broad `except (..., OSError, ...)` handler
+        treated every OSError as a model-call failure, so oversized
+        files (FileTooLargeError) were emitted as text_inference_ms
+        samples and biased mean/p95/p99 downward.
+        """
+        # Simulate FileTooLargeError (an OSError subclass) raised
+        # during the read phase, before any model call would happen.
+        mock_read.side_effect = OSError("File exceeds MAX_FILE_SIZE_BYTES")
+
+        result = text_processor.process_file("oversize.txt")
+
+        assert result.error is not None
+        assert "exceeds" in result.error.lower()
+        # The key assertion: pre-inference OSError leaves inference_ms
+        # at None so the run summary doesn't see a fake sample.
+        assert result.inference_ms is None
+
+    @patch("services.text_processor.read_file_via_safedir")
     def test_process_file_toggle_flags(
         self, mock_read: MagicMock, text_processor: TextProcessor, mock_text_model: MagicMock
     ) -> None:

--- a/tests/services/test_vision_processor.py
+++ b/tests/services/test_vision_processor.py
@@ -144,6 +144,33 @@ class TestVisionProcessorProcessFile:
         assert result.error == "File not found"
         assert result.folder_name == "errors"
 
+    def test_process_file_not_found_does_not_record_inference_ms(
+        self, vision_processor: VisionProcessor
+    ) -> None:
+        """Early-return paths skip the inference-ms sample (#410 / CodeRabbit P2)."""
+        result = vision_processor.process_file("/nonexistent/img.jpg")
+        # Non-inference path → inference_ms stays None so the run summary
+        # doesn't get a 0ms sample that would skew p95/p99 low.
+        assert result.error == "File not found"
+        assert result.inference_ms is None
+
+    def test_process_file_success_records_inference_ms(
+        self, vision_processor: VisionProcessor, mock_vision_model: MagicMock, tmp_path: Path
+    ) -> None:
+        """Happy-path inferences populate inference_ms (#410)."""
+        img = tmp_path / "ok.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0")
+        mock_vision_model.generate.side_effect = [
+            "A sunset",
+            "",  # OCR empty
+            "nature",
+            "sunset",
+        ]
+        result = vision_processor.process_file(img)
+        assert result.error is None
+        assert isinstance(result.inference_ms, float)
+        assert result.inference_ms < 5000.0
+
     def test_process_file_model_errors_graceful(
         self, vision_processor: VisionProcessor, mock_vision_model: MagicMock, tmp_path: Path
     ) -> None:

--- a/tests/services/test_vision_processor.py
+++ b/tests/services/test_vision_processor.py
@@ -342,6 +342,44 @@ class TestVisionProcessorProcessFile:
         assert result.error is None
         assert processor._is_circuit_open() is False
 
+    def test_failed_mid_flight_inference_still_records_inference_ms(
+        self, mock_vision_model: MagicMock, tmp_path: Path
+    ) -> None:
+        """A model call that raises mid-flight DOES record inference_ms (#410).
+
+        CodeRabbit P2 round-trip on PR #424: failed-but-attempted
+        inferences must contribute to p95/p99 so operators see real
+        tail latency during degraded-backend periods. Only purely
+        pre-inference paths (circuit-open at the very start,
+        file-not-found) should be excluded.
+        """
+        img1 = tmp_path / "trip.jpg"
+        img2 = tmp_path / "after.jpg"
+        img1.write_bytes(b"\xff\xd8")
+        img2.write_bytes(b"\xff\xd8")
+
+        # Fatal error trips the circuit on the first call; the second
+        # invocation then short-circuits BEFORE any model call.
+        mock_vision_model.generate.side_effect = RuntimeError(
+            "model runner has unexpectedly stopped"
+        )
+        processor = VisionProcessor(
+            vision_model=mock_vision_model,
+            backend_cooldown_seconds=120.0,
+        )
+
+        first = processor.process_file(img1)
+        # First call: model WAS invoked (and failed) → inference_ms set
+        assert first.error is not None
+        assert isinstance(first.inference_ms, float)
+        assert first.inference_ms < 5000.0
+
+        # Second call: circuit-open short-circuit → inference_ms None
+        second = processor.process_file(img2)
+        assert second.error is not None
+        assert "Vision backend unavailable" in second.error
+        assert second.inference_ms is None
+
 
 @pytest.mark.unit
 class TestVisionProcessorCleanName:


### PR DESCRIPTION
## Summary
Resolves #410 (Phase 3 piece 1 of 3 in the observability chain). Every per-file inference now emits a structured \`{kind}_inference_ms=<N>\` log line on both success and failure paths, and the run summary aggregates them into mean / p50 / p95 / p99 per modality.

## Changes
- new \`src/services/inference_timer.py\` — \`time_inference(kind, path)\` context-manager. Fires the log on \`__exit__\` regardless of whether the body raised.
- \`ProcessedImage\` + \`ProcessedFile\` gain \`inference_ms: float | None = None\`.
- Both \`process_file\` methods now wrap their body in \`with time_inference(...)\`. Single shared timer — no per-modality duplication.
- \`OrganizationResult\` gains raw sample lists for vision + text.
- \`core/organizer.py\` populates samples from each result's \`inference_ms\`.
- \`core/display.show_summary\` renders \`<Modality> inference — mean / p50 / p95 / p99 (n=N)\` per modality. Empty samples short-circuit.
- Dependency-free \`_percentile()\` helper does linear interpolation matching NumPy's default.

## Acceptance (from #410)
- [x] Every per-file inference logs \`{vision,text}_inference_ms=\`
- [x] Summary shows mean/p50/p95 per modality (also p99 + n)
- [x] Timer implemented in one shared wrapper
- [x] Unit test covers success and exception paths

## Test plan
- 6 new \`test_inference_timer.py\` tests
- 4 new \`TestDisplay\` tests (rendering, partition, short-circuit, percentile)
- 199 tests pass across services + core + integration sweeps
- mypy clean

## Sequence
Phase 3 piece 1 of 3: **#410** (this PR) → #409 (confidence scores) → #411 (structured error summary consuming both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inference timing statistics now displayed in summary reports for vision and text processing, including mean, p50, p95, and p99 percentile metrics.

* **Tests**
  * Added comprehensive test coverage for inference timing and summary statistics functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->