### PR TITLE
feat(observability): per-decision confidence + Review-recommended summary (#409)

### DIFF
--- a/src/config/manager.py
+++ b/src/config/manager.py
@@ -496,6 +496,12 @@ class ConfigManager:
             "setup_completed": config.setup_completed,
             "models": asdict(config.models),
             "updates": asdict(config.updates),
+            # #407 / #409: serialize nested settings sections so user-set
+            # values (e.g. `processing.low_confidence_threshold`,
+            # `vision.max_long_edge`) round-trip through YAML. Missing
+            # these was a pre-existing bug — Codex P1 catch on PR #426.
+            "vision": asdict(config.vision),
+            "processing": asdict(config.processing),
         }
 
         # Only include module overrides that are set
@@ -518,6 +524,8 @@ class ConfigManager:
     @staticmethod
     def _dict_to_config(data: dict[str, Any], profile: str) -> AppConfig:
         """Deserialize a dict (from YAML) into an AppConfig."""
+        from config.schema import ProcessingSettings, VisionSettings
+
         models_data = data.get("models", {})
         if isinstance(models_data, dict):
             # Only pass keys that ModelPreset accepts
@@ -535,6 +543,28 @@ class ConfigManager:
         else:
             updates = UpdateSettings()
 
+        # #407 / #409: round-trip the nested settings sections. Missing
+        # these was a pre-existing bug — without it, `fo config set
+        # processing.low_confidence_threshold 0.7` would save but
+        # silently fail to load on the next run.
+        vision_data = data.get("vision", {})
+        if isinstance(vision_data, dict):
+            valid_vision_keys = {f.name for f in fields(VisionSettings)}
+            vision_data = {k: v for k, v in vision_data.items() if k in valid_vision_keys}
+            vision = VisionSettings(**vision_data)
+        else:
+            vision = VisionSettings()
+
+        processing_data = data.get("processing", {})
+        if isinstance(processing_data, dict):
+            valid_processing_keys = {f.name for f in fields(ProcessingSettings)}
+            processing_data = {
+                k: v for k, v in processing_data.items() if k in valid_processing_keys
+            }
+            processing = ProcessingSettings(**processing_data)
+        else:
+            processing = ProcessingSettings()
+
         return AppConfig(
             profile_name=profile,
             version=data.get("version", CURRENT_SCHEMA_VERSION),
@@ -542,6 +572,8 @@ class ConfigManager:
             setup_completed=data.get("setup_completed", False),
             models=models,
             updates=updates,
+            vision=vision,
+            processing=processing,
             watcher=data.get("watcher"),
             daemon=data.get("daemon"),
             parallel=data.get("parallel"),

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -121,12 +121,21 @@ class ProcessingSettings:
             Should not exceed ``timeout_per_file`` (the dispatcher's hard
             kill-switch). Default 300s — same as ``timeout_per_file`` so
             the adaptive value never silently outlives the dispatcher.
+        low_confidence_threshold: Files whose categorization confidence
+            falls below this score appear in the summary's "Review
+            recommended" section and in the per-file ``confidence=``
+            log line as low-confidence placements (#409). Range
+            ``(0.0, 1.0]``; default 0.5 — half the maximum so EXIF
+            fallbacks (0.5) and filename-only fallbacks (0.3, from
+            #406) are surfaced for review while happy-path vision /
+            text inferences (1.0) are not.
     """
 
     timeout_per_file: float = 300.0
     vision_base_timeout_s: float = 30.0
     vision_per_mb_factor_s: float = 15.0
     vision_max_timeout_s: float = 300.0
+    low_confidence_threshold: float = 0.5
 
     def __post_init__(self) -> None:
         """Reject invalid timeout values at construction time (#396, #407)."""
@@ -150,6 +159,11 @@ class ProcessingSettings:
             raise ValueError(
                 f"processing.vision_base_timeout_s ({self.vision_base_timeout_s}) "
                 f"must be <= vision_max_timeout_s ({self.vision_max_timeout_s})"
+            )
+        if not (0.0 < self.low_confidence_threshold <= 1.0):
+            raise ValueError(
+                "processing.low_confidence_threshold must be in (0.0, 1.0], "
+                f"got {self.low_confidence_threshold}"
             )
 
 

--- a/src/core/dispatcher.py
+++ b/src/core/dispatcher.py
@@ -397,6 +397,7 @@ def process_audio_files(
                     folder_name=AUDIO_FALLBACK_FOLDER,
                     filename=audio_path.stem,
                     error=str(exc),
+                    confidence=0.0,  # #409: surface in review list
                 )
             )
 
@@ -452,6 +453,7 @@ def process_video_files(
                     folder_name=VIDEO_FALLBACK_FOLDER,
                     filename=video_path.stem,
                     error=str(exc),
+                    confidence=0.0,  # #409: surface in review list
                 )
             )
         except (OSError, ValueError, KeyError, RuntimeError) as exc:
@@ -463,6 +465,7 @@ def process_video_files(
                     folder_name=VIDEO_FALLBACK_FOLDER,
                     filename=video_path.stem,
                     error=str(exc),
+                    confidence=0.0,  # #409: surface in review list
                 )
             )
 

--- a/src/core/dispatcher.py
+++ b/src/core/dispatcher.py
@@ -246,6 +246,14 @@ def process_image_files(
                         fb.source,
                         fb.folder,
                     )
+                    # Per-source confidence (#409). The vision model
+                    # never actually classified this file; we're going
+                    # off metadata. EXIF dates are more trustworthy
+                    # than pure filename heuristics, so they earn a
+                    # slightly higher score. Both land below the
+                    # default 0.5 threshold and so surface in the
+                    # summary's "Review recommended" section.
+                    _fallback_confidence = 0.5 if fb.source == "fallback_exif" else 0.3
                     processed.append(
                         ProcessedImage(
                             file_path=file_result.path,
@@ -261,6 +269,7 @@ def process_image_files(
                             # the observability output understates tail
                             # latency (CodeRabbit P2 on PR #424).
                             inference_ms=file_result.duration_ms,
+                            confidence=_fallback_confidence,
                             # NB: no `error` field — the file is not a failure
                         )
                     )

--- a/src/core/dispatcher.py
+++ b/src/core/dispatcher.py
@@ -167,6 +167,9 @@ def process_text_files(
                         folder_name=ERROR_FALLBACK_FOLDER,
                         filename=file_result.path.stem,
                         error=error_msg,
+                        # #409: dispatcher-built failures must surface
+                        # in the "Review recommended" section.
+                        confidence=0.0,
                     )
                 )
                 progress.update(
@@ -287,6 +290,11 @@ def process_image_files(
                             folder_name=ERROR_FALLBACK_FOLDER,
                             filename=file_result.path.stem,
                             error=error_msg,
+                            # #409: dispatcher-built failures must
+                            # surface in the "Review recommended"
+                            # section. Default confidence=1.0 would
+                            # hide them.
+                            confidence=0.0,
                         )
                     )
                     progress.update(

--- a/src/core/display.py
+++ b/src/core/display.py
@@ -84,6 +84,21 @@ def show_summary(
             f"  [yellow]Categorized via fallback "
             f"(review recommended): {result.fallback_files}[/yellow]"
         )
+    if result.low_confidence_files:
+        # #409: every file whose confidence score fell below the
+        # configured threshold. Distinct from `fallback_files` —
+        # fallbacks are one source of low confidence; vision /text
+        # error returns (confidence=0.0) are another. Show a small
+        # preview to keep the summary scannable; users can grep the
+        # session log for `confidence=` to see the full audit trail.
+        _preview = ", ".join(result.low_confidence_files[:5])
+        if len(result.low_confidence_files) > 5:
+            _preview += f", … (+{len(result.low_confidence_files) - 5} more)"
+        console.print(
+            f"  [yellow]Review recommended: "
+            f"{len(result.low_confidence_files)} files[/yellow] "
+            f"[dim]({_preview})[/dim]"
+        )
     if result.deduplicated_files:
         console.print(f"  [dim]Duplicates removed: {result.deduplicated_files}[/dim]")
     if result.errors:

--- a/src/core/organizer.py
+++ b/src/core/organizer.py
@@ -270,16 +270,41 @@ class FileOrganizer:
             # contribute to mean/p50/p95/p99 (CodeRabbit P2 catch on PR #424).
             # Skip entries that never went through process_file (e.g.
             # dispatcher-built fallbacks) which carry inference_ms == None.
+            #
+            # Per-file confidence (#409) is emitted in the same pass so
+            # the audit log and the "Review recommended" summary list
+            # stay synchronised. Threshold comes from ProcessingSettings,
+            # loaded once outside the loop.
+            try:
+                from config.manager import ConfigManager
+
+                _confidence_threshold = ConfigManager().load().processing.low_confidence_threshold
+            except Exception:
+                from config.schema import ProcessingSettings
+
+                _confidence_threshold = ProcessingSettings().low_confidence_threshold
+
             for p in all_processed:
                 ms = getattr(p, "inference_ms", None)
-                if not isinstance(ms, (int, float)):
-                    continue
-                # ProcessedImage carries the `source` field (#406) so we
-                # treat the image side; ProcessedFile is the text side.
-                if hasattr(p, "source"):
-                    result.vision_inference_ms_samples.append(float(ms))
-                else:
-                    result.text_inference_ms_samples.append(float(ms))
+                if isinstance(ms, (int, float)):
+                    # ProcessedImage carries the `source` field (#406) so we
+                    # treat the image side; ProcessedFile is the text side.
+                    if hasattr(p, "source"):
+                        result.vision_inference_ms_samples.append(float(ms))
+                    else:
+                        result.text_inference_ms_samples.append(float(ms))
+                # Confidence sample for the audit trail + summary list
+                # (#409). Confidence is always populated (defaults to
+                # 1.0 on the result dataclasses), so no None guard.
+                _confidence = float(getattr(p, "confidence", 1.0))
+                logger.debug(
+                    "confidence={:.2f} file={} source={}",
+                    _confidence,
+                    p.file_path.name,
+                    getattr(p, "source", "text"),
+                )
+                if _confidence < _confidence_threshold:
+                    result.low_confidence_files.append(p.file_path.name)
 
             all_processed = self._deduplicate_processed(all_processed, result)
             failed_cnt = sum(1 for p in all_processed if p.error)

--- a/src/core/organizer.py
+++ b/src/core/organizer.py
@@ -303,14 +303,17 @@ class FileOrganizer:
                     p.file_path.name,
                     getattr(p, "source", "text"),
                 )
-                if _confidence <= _confidence_threshold:
-                    # Inclusive on the upper bound so threshold-equal
-                    # placements (e.g. EXIF fallback at 0.5 with the
-                    # default 0.5 threshold) DO appear in "Review
-                    # recommended". Codex P1 catch on PR #426: a
-                    # strict `<` excluded those entries from the
-                    # review even though they're the canonical
-                    # borderline case the feature targets.
+                # Two conditions:
+                # 1. confidence < 1.0  — happy-path inferences (score
+                #    1.0) are NEVER flagged regardless of threshold,
+                #    so setting `low_confidence_threshold=1.0` doesn't
+                #    flood the review list with every file (Codex P2
+                #    catch on PR #426).
+                # 2. confidence <= threshold — inclusive on the
+                #    threshold so the canonical borderline case (EXIF
+                #    fallback at 0.5 against the 0.5 default) lands
+                #    in the review (Codex P1 catch on PR #426).
+                if _confidence < 1.0 and _confidence <= _confidence_threshold:
                     result.low_confidence_files.append(p.file_path.name)
 
             all_processed = self._deduplicate_processed(all_processed, result)

--- a/src/core/organizer.py
+++ b/src/core/organizer.py
@@ -303,7 +303,14 @@ class FileOrganizer:
                     p.file_path.name,
                     getattr(p, "source", "text"),
                 )
-                if _confidence < _confidence_threshold:
+                if _confidence <= _confidence_threshold:
+                    # Inclusive on the upper bound so threshold-equal
+                    # placements (e.g. EXIF fallback at 0.5 with the
+                    # default 0.5 threshold) DO appear in "Review
+                    # recommended". Codex P1 catch on PR #426: a
+                    # strict `<` excluded those entries from the
+                    # review even though they're the canonical
+                    # borderline case the feature targets.
                     result.low_confidence_files.append(p.file_path.name)
 
             all_processed = self._deduplicate_processed(all_processed, result)

--- a/src/core/types.py
+++ b/src/core/types.py
@@ -64,6 +64,14 @@ class OrganizationResult:
     # change.
     vision_inference_ms_samples: list[float] = field(default_factory=list)  # pyre-ignore[35]
     text_inference_ms_samples: list[float] = field(default_factory=list)  # pyre-ignore[35]
+    # Files placed at confidence below
+    # ``AppConfig.processing.low_confidence_threshold`` (#409). Surfaced
+    # in the summary's "Review recommended" section so operators can
+    # audit borderline categorizations (EXIF fallbacks, filename-only
+    # placements, error-bucket landings) before any destructive moves.
+    # Entries are basenames so the summary stays readable even on deep
+    # input hierarchies.
+    low_confidence_files: list[str] = field(default_factory=list)  # pyre-ignore[35]
 
 
 # ---------------------------------------------------------------------------

--- a/src/services/text_processor.py
+++ b/src/services/text_processor.py
@@ -38,6 +38,10 @@ class ProcessedFile:
     # (#410). Populated even on failure paths so summary aggregation
     # (p50/p95/p99) reflects every per-file attempt.
     inference_ms: float | None = None
+    # Categorization confidence in [0.0, 1.0] (#409). 1.0 = happy-path
+    # text inference, 0.0 = error / no usable result. Audio transcripts
+    # may attach a lower value when transcription quality is unclear.
+    confidence: float = 1.0
 
 
 # Stop-words and noise words filtered from AI-generated names.
@@ -229,6 +233,7 @@ class TextProcessor:
                         folder_name="errors",
                         filename=file_path.stem,
                         error=f"Refused to read symlink: {file_path.name}",
+                        confidence=0.0,
                     ),
                     False,  # no model call attempted
                 )
@@ -260,6 +265,7 @@ class TextProcessor:
                         folder_name="unsupported",
                         filename=file_path.stem,
                         error="Unsupported file type",
+                        confidence=0.0,
                     ),
                     False,  # no model call attempted
                 )
@@ -329,6 +335,7 @@ class TextProcessor:
                     # scope is log-message categorisation, not the public
                     # ``ProcessedFile.error`` field.
                     error=str(e),
+                    confidence=0.0,
                 ),
                 False,  # read failure → no model call attempted
             )
@@ -355,6 +362,7 @@ class TextProcessor:
                     folder_name="errors",
                     filename=file_path.stem,
                     error=str(e),
+                    confidence=0.0,
                 ),
                 model_invoked,
             )

--- a/src/services/vision_processor.py
+++ b/src/services/vision_processor.py
@@ -82,6 +82,12 @@ class ProcessedImage:
     # process_file (e.g. metadata-only fallback constructed by the
     # dispatcher).
     inference_ms: float | None = None
+    # Categorization confidence in [0.0, 1.0] (#409). 1.0 = happy-path
+    # vision inference, 0.5 = EXIF-based fallback, 0.3 = filename-only
+    # fallback (#406 metadata path), 0.0 = error / no usable result.
+    # Files below `AppConfig.processing.low_confidence_threshold` are
+    # surfaced in the summary's "Review recommended" section.
+    confidence: float = 1.0
 
 
 class VisionProcessor:
@@ -271,6 +277,7 @@ class VisionProcessor:
                         folder_name="images",
                         filename=file_path.stem,
                         error=error_message,
+                        confidence=0.0,
                     ),
                     False,  # no model call attempted
                 )
@@ -284,6 +291,7 @@ class VisionProcessor:
                         folder_name="errors",
                         filename=file_path.stem,
                         error="File not found",
+                        confidence=0.0,
                     ),
                     False,  # no model call attempted
                 )
@@ -304,6 +312,7 @@ class VisionProcessor:
                             folder_name="images",
                             filename=file_path.stem,
                             error=error_message,
+                            confidence=0.0,
                         ),
                         True,  # the call that tripped the circuit DID happen
                     )
@@ -378,6 +387,7 @@ class VisionProcessor:
                     # scope is log-message categorisation, not the public
                     # ``ProcessedImage.error`` field.
                     error=str(e),
+                    confidence=0.0,
                 ),
                 model_invoked,
             )

--- a/tests/config/test_config_manager_coverage.py
+++ b/tests/config/test_config_manager_coverage.py
@@ -124,6 +124,46 @@ class TestConfigManagerSave:
         loaded = mgr.load("test")
         assert loaded.profile_name == "test"
 
+    def test_processing_settings_round_trip(self, tmp_path: Path) -> None:
+        """ProcessingSettings persists through save/load (#409 / Codex P1 on #426).
+
+        Before this fix, `_config_to_dict` / `_dict_to_config` omitted
+        the `processing` section entirely. Users running
+        `fo config set processing.low_confidence_threshold 0.7` would
+        save the file but reload to the default 0.5 on the next run.
+        """
+        from config.schema import ProcessingSettings
+
+        mgr = ConfigManager(config_dir=tmp_path)
+        cfg = AppConfig(
+            profile_name="custom-thresh",
+            processing=ProcessingSettings(
+                timeout_per_file=600.0,
+                low_confidence_threshold=0.7,
+                vision_base_timeout_s=45.0,
+            ),
+        )
+        mgr.save(cfg)
+
+        loaded = mgr.load("custom-thresh")
+        assert loaded.processing.timeout_per_file == 600.0
+        assert loaded.processing.low_confidence_threshold == 0.7
+        assert loaded.processing.vision_base_timeout_s == 45.0
+
+    def test_vision_settings_round_trip(self, tmp_path: Path) -> None:
+        """VisionSettings persists through save/load (#407 / same Codex P1)."""
+        from config.schema import VisionSettings
+
+        mgr = ConfigManager(config_dir=tmp_path)
+        cfg = AppConfig(
+            profile_name="custom-vision",
+            vision=VisionSettings(max_long_edge=2048),
+        )
+        mgr.save(cfg)
+
+        loaded = mgr.load("custom-vision")
+        assert loaded.vision.max_long_edge == 2048
+
 
 class TestConfigManagerListProfiles:
     def test_empty_when_no_file(self, tmp_path):

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -236,6 +236,11 @@ class TestProcessingSettings:
         s = ProcessingSettings(low_confidence_threshold=0.8)
         assert s.low_confidence_threshold == 0.8
 
+    def test_low_confidence_threshold_accepts_one(self) -> None:
+        """Upper bound is inclusive — 1.0 means 'review everything not happy-path'."""
+        s = ProcessingSettings(low_confidence_threshold=1.0)
+        assert s.low_confidence_threshold == 1.0
+
     def test_low_confidence_threshold_rejects_zero(self) -> None:
         """0.0 makes the threshold useless (nothing would ever fall below it)."""
         with pytest.raises(ValueError, match="low_confidence_threshold"):

--- a/tests/config/test_schema.py
+++ b/tests/config/test_schema.py
@@ -226,3 +226,27 @@ class TestProcessingSettings:
         """Base above max is nonsensical (clamp would always trigger)."""
         with pytest.raises(ValueError, match="must be <= vision_max_timeout_s"):
             ProcessingSettings(vision_base_timeout_s=400.0, vision_max_timeout_s=300.0)
+
+    def test_low_confidence_threshold_default(self) -> None:
+        """Default threshold matches the EXIF-fallback score (#409)."""
+        assert ProcessingSettings().low_confidence_threshold == 0.5
+
+    def test_low_confidence_threshold_custom(self) -> None:
+        """Threshold is tunable inside the (0, 1] range."""
+        s = ProcessingSettings(low_confidence_threshold=0.8)
+        assert s.low_confidence_threshold == 0.8
+
+    def test_low_confidence_threshold_rejects_zero(self) -> None:
+        """0.0 makes the threshold useless (nothing would ever fall below it)."""
+        with pytest.raises(ValueError, match="low_confidence_threshold"):
+            ProcessingSettings(low_confidence_threshold=0.0)
+
+    def test_low_confidence_threshold_rejects_above_one(self) -> None:
+        """Values > 1.0 are nonsensical (confidences cap at 1.0)."""
+        with pytest.raises(ValueError, match="low_confidence_threshold"):
+            ProcessingSettings(low_confidence_threshold=1.5)
+
+    def test_low_confidence_threshold_rejects_negative(self) -> None:
+        """Negative threshold is rejected."""
+        with pytest.raises(ValueError, match="low_confidence_threshold"):
+            ProcessingSettings(low_confidence_threshold=-0.1)

--- a/tests/core/test_organizer.py
+++ b/tests/core/test_organizer.py
@@ -186,25 +186,33 @@ class TestFileOrganizer:
 
     def test_organizer_collects_low_confidence_results(self, tmp_path: Path) -> None:
         """#409 end-to-end: organizer aggregation routes low-confidence
-        results into ``OrganizationResult.low_confidence_files``.
+        results into ``OrganizationResult.low_confidence_files`` and
+        partitions inference_ms samples by modality (#410).
 
-        Drives ``organize`` with a synthetic four-file batch (one
-        happy-path, one EXIF fallback @ 0.5, one filename fallback @
-        0.3, one error @ 0.0) and asserts the three non-happy-path
-        files land in the review list. Pinned to the default 0.5
-        threshold so the comparator's inclusive-but-not-1.0 semantics
-        are exercised. ci-marked so PR diff-coverage counts the
-        organizer aggregation lines.
+        Drives ``organize`` with a synthetic five-file batch:
+        - happy-path vision (confidence=1.0, vision sample)
+        - EXIF fallback @ 0.5 (low-conf, no inference_ms — fallback
+          built by dispatcher)
+        - filename fallback @ 0.3 (low-conf)
+        - error @ 0.0 (low-conf)
+        - happy-path text (confidence=1.0, TEXT sample so the else
+          branch in the aggregator runs)
+
+        Asserts: three non-happy entries land in low_confidence_files;
+        vision/text inference_ms partition correctly. ci-marked so PR
+        diff-coverage counts the organizer aggregation lines.
         """
+        from services.text_processor import ProcessedFile
         from services.vision_processor import ProcessedImage
 
-        results: list[ProcessedImage] = [
+        results: list[ProcessedImage | ProcessedFile] = [
             ProcessedImage(
                 file_path=tmp_path / "ok.png",
                 description="d",
                 folder_name="images",
                 filename="ok",
                 confidence=1.0,
+                inference_ms=100.0,
             ),
             ProcessedImage(
                 file_path=tmp_path / "exif.jpg",
@@ -230,6 +238,14 @@ class TestFileOrganizer:
                 error="boom",
                 confidence=0.0,
             ),
+            ProcessedFile(
+                file_path=tmp_path / "doc.txt",
+                description="d",
+                folder_name="docs",
+                filename="doc",
+                confidence=1.0,
+                inference_ms=80.0,
+            ),
         ]
         for r in results:
             r.file_path.write_bytes(b"")
@@ -250,6 +266,49 @@ class TestFileOrganizer:
         assert set(result.low_confidence_files) == {"exif.jpg", "name.png", "bad.png"}
         # Happy-path file is never flagged.
         assert "ok.png" not in result.low_confidence_files
+        assert "doc.txt" not in result.low_confidence_files
+        # Inference samples partition by modality (#410).
+        assert result.vision_inference_ms_samples == [100.0]
+        assert result.text_inference_ms_samples == [80.0]
+
+    def test_organizer_falls_back_to_default_threshold_on_config_error(
+        self, tmp_path: Path
+    ) -> None:
+        """#409: ConfigManager.load failure degrades to ProcessingSettings()
+        default rather than crashing the aggregation loop."""
+        from services.vision_processor import ProcessedImage
+
+        img = ProcessedImage(
+            file_path=tmp_path / "exif.jpg",
+            description="",
+            folder_name="Images/Photos/2025/11",
+            filename="exif",
+            source="fallback_exif",
+            confidence=0.5,
+        )
+        img.file_path.write_bytes(b"")
+
+        organizer = FileOrganizer(dry_run=True, enable_vision=False)
+        # Make ConfigManager raise to exercise the except branch.
+        with (
+            patch.object(
+                organizer,
+                "_categorize_files",
+                return_value=([], [img.file_path], [], [], [], []),
+            ),
+            patch.object(organizer, "_process_all_file_types", return_value=[img]),
+            patch.object(organizer, "_execute_organization"),
+            patch(
+                "config.manager.ConfigManager",
+                side_effect=RuntimeError("config broken"),
+            ),
+        ):
+            result = organizer.organize(tmp_path, tmp_path / "out")
+
+        # Fallback to ProcessingSettings() default (0.5); the 0.5
+        # confidence still lands in review under the inclusive
+        # comparator.
+        assert "exif.jpg" in result.low_confidence_files
 
     def test_threshold_one_does_not_flag_happy_path(self, tmp_path: Path) -> None:
         """#409 / Codex P2: threshold=1.0 must not flood the review list.

--- a/tests/core/test_organizer.py
+++ b/tests/core/test_organizer.py
@@ -184,6 +184,114 @@ class TestFileOrganizer:
         mock_fallback.assert_called_once()
         assert mock_fallback.call_args.args[0] == [image]
 
+    def test_organizer_collects_low_confidence_results(self, tmp_path: Path) -> None:
+        """#409 end-to-end: organizer aggregation routes low-confidence
+        results into ``OrganizationResult.low_confidence_files``.
+
+        Drives ``organize`` with a synthetic four-file batch (one
+        happy-path, one EXIF fallback @ 0.5, one filename fallback @
+        0.3, one error @ 0.0) and asserts the three non-happy-path
+        files land in the review list. Pinned to the default 0.5
+        threshold so the comparator's inclusive-but-not-1.0 semantics
+        are exercised. ci-marked so PR diff-coverage counts the
+        organizer aggregation lines.
+        """
+        from services.vision_processor import ProcessedImage
+
+        results: list[ProcessedImage] = [
+            ProcessedImage(
+                file_path=tmp_path / "ok.png",
+                description="d",
+                folder_name="images",
+                filename="ok",
+                confidence=1.0,
+            ),
+            ProcessedImage(
+                file_path=tmp_path / "exif.jpg",
+                description="",
+                folder_name="Images/Photos/2025/11",
+                filename="exif",
+                source="fallback_exif",
+                confidence=0.5,
+            ),
+            ProcessedImage(
+                file_path=tmp_path / "name.png",
+                description="",
+                folder_name="Images/Screenshots/2026",
+                filename="name",
+                source="fallback_filename",
+                confidence=0.3,
+            ),
+            ProcessedImage(
+                file_path=tmp_path / "bad.png",
+                description="",
+                folder_name="errors",
+                filename="bad",
+                error="boom",
+                confidence=0.0,
+            ),
+        ]
+        for r in results:
+            r.file_path.write_bytes(b"")
+
+        organizer = FileOrganizer(dry_run=True, enable_vision=False)
+        with (
+            patch.object(
+                organizer,
+                "_categorize_files",
+                return_value=([], [r.file_path for r in results], [], [], [], []),
+            ),
+            patch.object(organizer, "_process_all_file_types", return_value=results),
+            patch.object(organizer, "_execute_organization"),
+        ):
+            result = organizer.organize(tmp_path, tmp_path / "out")
+
+        # Default threshold (0.5), inclusive-but-not-1.0 → EXIF + name + bad.
+        assert set(result.low_confidence_files) == {"exif.jpg", "name.png", "bad.png"}
+        # Happy-path file is never flagged.
+        assert "ok.png" not in result.low_confidence_files
+
+    def test_threshold_one_does_not_flag_happy_path(self, tmp_path: Path) -> None:
+        """#409 / Codex P2: threshold=1.0 must not flood the review list.
+
+        Confidence==1.0 is the happy path and should never be flagged,
+        regardless of threshold. Verifies the
+        ``confidence < 1.0`` cap in the comparator.
+        """
+        from unittest.mock import MagicMock
+
+        from services.vision_processor import ProcessedImage
+
+        happy = ProcessedImage(
+            file_path=tmp_path / "ok.png",
+            description="d",
+            folder_name="images",
+            filename="ok",
+            confidence=1.0,
+        )
+        happy.file_path.write_bytes(b"")
+
+        organizer = FileOrganizer(dry_run=True, enable_vision=False)
+
+        # Patch the threshold loader to return 1.0 (the inclusive max).
+        mock_manager = MagicMock()
+        mock_app_cfg = MagicMock()
+        mock_app_cfg.processing.low_confidence_threshold = 1.0
+        mock_manager.load.return_value = mock_app_cfg
+        with (
+            patch.object(
+                organizer,
+                "_categorize_files",
+                return_value=([], [happy.file_path], [], [], [], []),
+            ),
+            patch.object(organizer, "_process_all_file_types", return_value=[happy]),
+            patch.object(organizer, "_execute_organization"),
+            patch("config.manager.ConfigManager", return_value=mock_manager),
+        ):
+            result = organizer.organize(tmp_path, tmp_path / "out")
+
+        assert result.low_confidence_files == []
+
 
 # ---------------------------------------------------------------------------
 # file_ops module tests

--- a/tests/integration/test_config_to_runtime.py
+++ b/tests/integration/test_config_to_runtime.py
@@ -259,3 +259,90 @@ class TestProcessingSettingsToOrganizer:
         assert compute_vision_timeout(10 * 1024 * 1024, app_cfg.processing) == 110.0
         # 30MB → raw=210, clamped to 120
         assert compute_vision_timeout(30 * 1024 * 1024, app_cfg.processing) == 120.0
+
+    def test_low_confidence_threshold_default_and_validation(self) -> None:
+        """#409: default + (0,1] validation surface in integration coverage."""
+        assert AppConfig().processing.low_confidence_threshold == 0.5
+
+        # Inclusive upper bound is accepted.
+        assert ProcessingSettings(low_confidence_threshold=1.0).low_confidence_threshold == 1.0
+
+        # All three out-of-range cases fire the same validator.
+        with pytest.raises(ValueError, match="low_confidence_threshold"):
+            ProcessingSettings(low_confidence_threshold=0.0)
+        with pytest.raises(ValueError, match="low_confidence_threshold"):
+            ProcessingSettings(low_confidence_threshold=-0.1)
+        with pytest.raises(ValueError, match="low_confidence_threshold"):
+            ProcessingSettings(low_confidence_threshold=1.5)
+
+    def test_organizer_populates_low_confidence_files(self, tmp_path: Path) -> None:
+        """#409: organizer aggregation routes low-confidence results into the review list."""
+        from unittest.mock import patch
+
+        from core.organizer import FileOrganizer
+        from core.types import OrganizationResult
+        from services.vision_processor import ProcessedImage
+
+        # Build a mixed batch: one happy-path, one EXIF fallback (= 0.5),
+        # one filename fallback (= 0.3), one error (= 0.0). At the
+        # default threshold 0.5, the inclusive `<=` puts the EXIF
+        # entry into the review list alongside the two clearly-low
+        # ones.
+        results: list[ProcessedImage] = [
+            ProcessedImage(
+                file_path=tmp_path / "ok.png",
+                description="d",
+                folder_name="images",
+                filename="ok",
+                confidence=1.0,
+            ),
+            ProcessedImage(
+                file_path=tmp_path / "exif.jpg",
+                description="",
+                folder_name="Images/Photos/2025/11",
+                filename="exif",
+                source="fallback_exif",
+                confidence=0.5,
+            ),
+            ProcessedImage(
+                file_path=tmp_path / "name.png",
+                description="",
+                folder_name="Images/Screenshots/2026",
+                filename="name",
+                source="fallback_filename",
+                confidence=0.3,
+            ),
+            ProcessedImage(
+                file_path=tmp_path / "bad.png",
+                description="",
+                folder_name="errors",
+                filename="bad",
+                error="something broke",
+                confidence=0.0,
+            ),
+        ]
+        for r in results:
+            r.file_path.write_bytes(b"")
+
+        org = FileOrganizer(
+            text_model_config=make_text_config(),
+            vision_model_config=make_vision_config(),
+            dry_run=True,
+        )
+
+        with (
+            patch.object(
+                org,
+                "_categorize_files",
+                return_value=([], [r.file_path for r in results], [], [], [], []),
+            ),
+            patch.object(org, "_process_all_file_types", return_value=results),
+            patch.object(org, "_execute_organization"),
+        ):
+            out: OrganizationResult = org.organize(tmp_path, tmp_path / "out")
+
+        assert set(out.low_confidence_files) == {
+            "exif.jpg",
+            "name.png",
+            "bad.png",
+        }

--- a/tests/integration/test_core_organizer_batch3.py
+++ b/tests/integration/test_core_organizer_batch3.py
@@ -662,6 +662,59 @@ class TestDisplay:
         assert "Vision inference" not in out
         assert "Text inference" not in out
 
+    def test_show_summary_renders_low_confidence_files(self, tmp_path: Path) -> None:
+        """low_confidence_files produces the 'Review recommended' line (#409)."""
+        from rich.console import Console
+
+        from core.display import show_summary
+        from core.types import OrganizationResult
+
+        console = Console(record=True, width=160)
+        result = OrganizationResult(
+            total_files=4,
+            processed_files=4,
+            low_confidence_files=["doc1.txt", "img2.png", "img3.png"],
+        )
+        show_summary(console, result, tmp_path, dry_run=True)
+        out = console.export_text()
+        assert "Review recommended" in out
+        assert "3 files" in out
+        # Preview lists the first entries verbatim
+        assert "doc1.txt" in out
+        assert "img2.png" in out
+
+    def test_show_summary_low_confidence_truncates_preview(self, tmp_path: Path) -> None:
+        """A long list is truncated to 5 entries with a +N more hint (#409)."""
+        from rich.console import Console
+
+        from core.display import show_summary
+        from core.types import OrganizationResult
+
+        console = Console(record=True, width=200)
+        files = [f"f{i:02d}.png" for i in range(8)]
+        result = OrganizationResult(total_files=8, processed_files=8, low_confidence_files=files)
+        show_summary(console, result, tmp_path, dry_run=True)
+        out = console.export_text()
+        assert "8 files" in out
+        # First 5 shown
+        for f in files[:5]:
+            assert f in out
+        # Tail summary
+        assert "+3 more" in out
+
+    def test_show_summary_omits_low_confidence_line_when_empty(self, tmp_path: Path) -> None:
+        """Empty low_confidence_files list short-circuits the section (#409)."""
+        from rich.console import Console
+
+        from core.display import show_summary
+        from core.types import OrganizationResult
+
+        console = Console(record=True, width=160)
+        result = OrganizationResult(total_files=2, processed_files=2)
+        show_summary(console, result, tmp_path, dry_run=True)
+        out = console.export_text()
+        assert "Review recommended" not in out
+
     def test_percentile_helper_matches_simple_cases(self) -> None:
         """_percentile reproduces standard linear-interp results (#410)."""
         from core.display import _percentile
@@ -890,6 +943,49 @@ class TestDispatcher:
         # fallback result so it lands in the p95/p99 inference sample.
         # `_make_file_result_failure` defaults duration_ms to 1.0.
         assert result.inference_ms == 1.0
+        # #409: filename-only fallback yields the lowest fallback
+        # confidence (0.3) so it surfaces in "Review recommended".
+        assert result.confidence == 0.3
+
+    def test_process_image_files_timeout_exif_fallback_higher_confidence(
+        self, tmp_path: Path
+    ) -> None:
+        """EXIF-driven fallback earns a higher confidence than filename-only (#409)."""
+        from unittest.mock import patch
+
+        from rich.console import Console
+
+        from core import dispatcher
+        from parallel.result import FileResult
+        from services.vision_fallback import FallbackResult
+
+        img = tmp_path / "DSC_0042.jpg"
+        img.write_bytes(b"")
+
+        file_result = FileResult(
+            path=img,
+            success=False,
+            error="Timed out after 300.0s",
+            duration_ms=42_000.0,
+        )
+        mock_pp = self._make_mock_parallel_processor([file_result])
+
+        # Force the EXIF path so we can assert the per-source confidence
+        # mapping without depending on a real Pillow read.
+        with patch(
+            "services.vision_fallback.compute_fallback",
+            return_value=FallbackResult(
+                folder="Images/Photos/2025/11",
+                filename="DSC_0042",
+                source="fallback_exif",
+            ),
+        ):
+            results = dispatcher.process_image_files(
+                [img], MagicMock(), mock_pp, Console(quiet=True)
+            )
+
+        assert results[0].source == "fallback_exif"
+        assert results[0].confidence == 0.5
 
     def test_process_image_files_timeout_fallback_carries_long_duration(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary
Resolves #409. Adds a per-result confidence score and a "Review recommended" summary section so operators can audit borderline categorizations before destructive moves.

## Confidence scale
| Source | Confidence | Surfaces in summary? |
|---|---|---|
| Happy-path vision / text inference | 1.0 | no |
| EXIF-driven #406 fallback | 0.5 | yes (at default threshold) |
| Filename-only #406 fallback | 0.3 | yes |
| Error returns (circuit-open, file-not-found, …) | 0.0 | yes |

Default threshold: \`AppConfig.processing.low_confidence_threshold = 0.5\` (configurable).

## Changes
- new \`ProcessingSettings.low_confidence_threshold: float\` with \`(0, 1]\` validation
- \`ProcessedImage\` / \`ProcessedFile\` gain \`confidence: float = 1.0\`
- vision + text processors set \`confidence=0.0\` on every error return
- dispatcher's #406 fallback sets \`confidence=0.3\` (filename) / \`0.5\` (EXIF)
- \`OrganizationResult.low_confidence_files: list[str]\`, populated pre-dedup
- \`core/display.show_summary\` renders "Review recommended: N files (preview…)"
- per-file \`confidence=X.XX file=… source=…\` log line at DEBUG

## Acceptance (from #409)
- [x] every processed file logs \`confidence=X.XX\`
- [x] files below threshold appear in summary's "Review recommended"
- [x] \`AppConfig.processing.low_confidence_threshold\` configurable
- [x] unit test mocks vision timeout → file lands in low-confidence list

## Test plan
- 5 new \`TestProcessingSettings\` tests for the threshold field
- 3 new \`TestDisplay\` tests for the rendering / truncation / short-circuit
- 2 new \`TestDispatcher\` confidence assertions (filename + EXIF)
- 304 tests pass across services + core + integration + config sweeps
- mypy clean

## Sequence
Phase 3 piece 2 of 3 in the observability chain: #410 (done) → **#409** (this PR) → #411 (structured error summary, consumes #410's inference timing + #409's confidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable low-confidence threshold (default 0.5) for identifying files requiring operator review
  * System now computes and tracks confidence scores during text and image processing
  * Summary output displays a "Review recommended" section listing files below the threshold

* **Tests**
  * Added unit tests validating confidence threshold configuration constraints
  * Added integration tests verifying review recommendation reporting accuracy

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->