### PR TITLE
feat(observability): structured error summary by failure category (#411)

### DIFF
--- a/src/core/display.py
+++ b/src/core/display.py
@@ -257,9 +257,9 @@ def _render_error_breakdown(console: Console, result: OrganizationResult) -> Non
         return
 
     # ``error_breakdown`` is typed ``Counter[str]`` so dataclass init
-    # stays simple, but every key the organizer writes is one of the
-    # ``ErrorCategory`` literals — RECOMMENDATIONS is keyed on that
-    # narrower type, so do a plain ``in`` check here.
+    # stays simple. The organizer only ever writes keys produced by
+    # ``classify_error()``, every one of which is also a key of
+    # ``RECOMMENDATIONS`` — direct subscript is safe.
     from core.error_taxonomy import RECOMMENDATIONS
 
     console.print("\n[bold]Failure breakdown:[/bold]")
@@ -276,9 +276,4 @@ def _render_error_breakdown(console: Console, result: OrganizationResult) -> Non
         # counted as failures) still trigger the bolded hint when they
         # represent >10% of the workload.
         if result.total_files and count / result.total_files > _RECOMMENDATION_THRESHOLD:
-            tip = next(
-                (v for k, v in RECOMMENDATIONS.items() if k == category),
-                None,
-            )
-            if tip:
-                console.print(f"    [bold yellow]→ {tip}[/bold yellow]")
+            console.print(f"    [bold yellow]→ {RECOMMENDATIONS[category]}[/bold yellow]")

--- a/src/core/display.py
+++ b/src/core/display.py
@@ -109,6 +109,12 @@ def show_summary(
             console.print(f"    ... and {len(result.errors) - 10} more")
     console.print(f"  Processing time: {result.processing_time:.2f}s")
 
+    # Structured error breakdown (#411). Renders only when any bucket
+    # has > 0 entries — clean runs stay quiet. The recommendation
+    # line fires per-bucket when that bucket exceeds 10% of the
+    # total scanned files (issue #411 acceptance criterion).
+    _render_error_breakdown(console, result)
+
     # Inference duration stats (#410). Vision and text are aggregated
     # separately so operators can spot a slow modality even when the
     # other is fine. Lines only render when the corresponding sample
@@ -229,3 +235,50 @@ def _render_inference_stats(console: Console, label: str, samples: list[float]) 
         f"p50: {p50 / 1000:.2f}s, p95: {p95 / 1000:.2f}s, "
         f"p99: {p99 / 1000:.2f}s (n={len(samples)})[/dim]"
     )
+
+
+# Fraction of `total_files` above which a single error bucket gets a
+# bolded recommendation line in the summary (#411 acceptance criterion).
+_RECOMMENDATION_THRESHOLD: float = 0.10
+
+
+def _render_error_breakdown(console: Console, result: OrganizationResult) -> None:
+    """Render the per-category failure breakdown (#411).
+
+    Walks ``result.error_breakdown`` in descending count order, prints
+    one line per bucket with the count + one example basename, and
+    fires a recommendation line for any bucket whose share of
+    ``total_files`` exceeds ``_RECOMMENDATION_THRESHOLD``.
+
+    Short-circuits when the breakdown is empty so clean runs stay
+    quiet.
+    """
+    if not result.error_breakdown:
+        return
+
+    # ``error_breakdown`` is typed ``Counter[str]`` so dataclass init
+    # stays simple, but every key the organizer writes is one of the
+    # ``ErrorCategory`` literals — RECOMMENDATIONS is keyed on that
+    # narrower type, so do a plain ``in`` check here.
+    from core.error_taxonomy import RECOMMENDATIONS
+
+    console.print("\n[bold]Failure breakdown:[/bold]")
+    items = sorted(
+        result.error_breakdown.items(),
+        key=lambda kv: (-kv[1], kv[0]),
+    )
+    for category, count in items:
+        example = result.error_examples.get(category, "<no example captured>")
+        console.print(f"  [red]{category}[/red]: {count} [dim](e.g. {example})[/dim]")
+        # Recommendation only fires when the bucket dominates the run.
+        # Compare against total_files rather than failed_files so
+        # categories that include vision-timeout fallbacks (which aren't
+        # counted as failures) still trigger the bolded hint when they
+        # represent >10% of the workload.
+        if result.total_files and count / result.total_files > _RECOMMENDATION_THRESHOLD:
+            tip = next(
+                (v for k, v in RECOMMENDATIONS.items() if k == category),
+                None,
+            )
+            if tip:
+                console.print(f"    [bold yellow]→ {tip}[/bold yellow]")

--- a/src/core/error_taxonomy.py
+++ b/src/core/error_taxonomy.py
@@ -68,6 +68,31 @@ _READ_ERROR_TOKENS: tuple[str, ...] = (
 # Tokens that signal the file's extension / content type isn't supported.
 _UNSUPPORTED_TYPE_TOKENS: tuple[str, ...] = ("unsupported file type",)
 
+# Tokens that positively identify a model-invocation failure. We require
+# a match here before bucketing as ``inference_error`` because audio /
+# video metadata pipelines emit ``confidence=0.0`` on ANY extractor
+# exception (#409 surfacing) even when no provider was contacted — without
+# this guard those runs would land in ``inference_error`` and produce the
+# wrong operator recommendation ("check Ollama / provider health").
+# Codex P2 catch on PR #427.
+_INFERENCE_ERROR_TOKENS: tuple[str, ...] = (
+    "ollama",
+    "anthropic",
+    "openai",
+    "rate limit",
+    "rate_limit",
+    "http 5",  # HTTP 5xx responses from a vision / text provider
+    "model returned",
+    "model error",
+    "provider",
+    "api error",
+    "api_error",
+    "json decode",
+    "jsondecode",
+    "completion failed",
+    "inference failed",
+)
+
 
 def classify_error(result: Any) -> ErrorCategory | None:
     """Return the taxonomy bucket for *result*, or ``None`` if it isn't a failure.
@@ -108,12 +133,17 @@ def classify_error(result: Any) -> ErrorCategory | None:
     if any(tok in err_lc for tok in _READ_ERROR_TOKENS):
         return "read_error"
 
-    # Inference errors are catch-all for anything that reached the
-    # model call (signalled in the dispatcher / processor by
-    # confidence==0.0 with an error message that doesn't match the
-    # filesystem patterns above). Anything else lands in `other`.
-    confidence = getattr(result, "confidence", 1.0)
-    if isinstance(confidence, (int, float)) and confidence == 0.0:
+    # Inference-error bucket requires a positive token match. Audio /
+    # video metadata pipelines set ``confidence=0.0`` on any extractor
+    # exception (#409) — without the explicit token check those runs
+    # would mis-bucket as inference_error and emit the wrong "check
+    # Ollama / provider health" hint (Codex P2 on PR #427).
+    if any(tok in err_lc for tok in _INFERENCE_ERROR_TOKENS):
         return "inference_error"
 
+    # Anything left over (including the audio/video confidence==0.0
+    # metadata-extractor failures) lands in ``other``. The operator
+    # recommendation for ``other`` points at the per-file logs, which is
+    # the correct next step when the failure didn't match a known
+    # provider / reader / extension shape.
     return "other"

--- a/src/core/error_taxonomy.py
+++ b/src/core/error_taxonomy.py
@@ -1,0 +1,112 @@
+"""Classify per-file failures into the #411 error taxonomy.
+
+Final summary surfaces:
+
+  vision_timeout    — files where vision exceeded its dispatcher timeout
+                      (whether or not the metadata fallback rescued them)
+  read_error        — filesystem-layer failures: read denied, symlink
+                      rejected, file too large
+  unsupported_type  — read returned None / "Unsupported file type"
+  inference_error   — model-call failures (provider 500, AttributeError,
+                      generic RuntimeError raised by the inference path)
+  other             — anything that didn't match the buckets above
+
+Returning a stable string keeps the summary renderer
+(``core/display.py``) decoupled from the result classes and lets
+analytics consumers (``--json``) emit a clean category field.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+ErrorCategory = Literal[
+    "vision_timeout",
+    "read_error",
+    "unsupported_type",
+    "inference_error",
+    "other",
+]
+
+# Recommendation strings the summary renderer attaches to each category
+# when it exceeds the 10%-of-scanned-files trigger.  Phrased as
+# actionable next steps so an operator can fix the issue without
+# re-reading the dispatcher source.
+RECOMMENDATIONS: dict[ErrorCategory, str] = {
+    "vision_timeout": (
+        "consider `--timeout-per-file` to raise the cap or `--workers` to parallelise (#396 / #408)"
+    ),
+    "read_error": ("check filesystem permissions or exclude unreadable files from the input set"),
+    "unsupported_type": (
+        "see the top-skipped-extensions list above; install the matching extra "
+        "(e.g. `[scientific]`, `[cad]`) or skip those files explicitly"
+    ),
+    "inference_error": ("check Ollama / provider health; transient backend faults bucket here"),
+    "other": ("inspect the per-file logs — these failures didn't fit the known taxonomy"),
+}
+
+
+# Substring tokens that signal a read-side failure, anchored to the
+# exact error strings the codebase emits today. We match case-insensitively
+# to absorb minor wording drift.
+_READ_ERROR_TOKENS: tuple[str, ...] = (
+    "refused to read symlink",
+    "file not found",
+    "permission denied",
+    "exceeds max_file_size",  # FileTooLargeError shape
+    "filereaderror",
+    "fileexists",
+)
+
+# Tokens that signal the file's extension / content type isn't supported.
+_UNSUPPORTED_TYPE_TOKENS: tuple[str, ...] = ("unsupported file type",)
+
+
+def classify_error(result: Any) -> ErrorCategory | None:
+    """Return the taxonomy bucket for *result*, or ``None`` if it isn't a failure.
+
+    Args:
+        result: ``ProcessedImage`` or ``ProcessedFile``. Any object that
+            exposes ``error`` and optionally ``source`` is accepted —
+            we duck-type rather than importing the services package so
+            this helper stays cheap to load.
+
+    Returns:
+        One of the ``ErrorCategory`` literals when the result represents
+        a failure (or a #406 vision-timeout fallback); ``None`` for
+        clean, happy-path results that don't need bucketing.
+
+    Resolution order matters: vision-timeout fallback is checked first
+    because those results carry ``source=fallback_*`` AND ``error=None``,
+    so the rest of the matching would treat them as happy-path.
+    """
+    source = str(getattr(result, "source", "") or "")
+    if source.startswith("fallback_"):
+        return "vision_timeout"
+
+    error = getattr(result, "error", None)
+    if not error:
+        return None
+    err_lc = str(error).lower()
+
+    # Dispatcher's timeout-as-string sentinel — only reached when the
+    # fallback path didn't fire (e.g. text files, or a vision file
+    # whose error string survived without the dispatcher's source patch).
+    if err_lc.startswith("timed out after"):
+        return "vision_timeout"
+
+    if any(tok in err_lc for tok in _UNSUPPORTED_TYPE_TOKENS):
+        return "unsupported_type"
+
+    if any(tok in err_lc for tok in _READ_ERROR_TOKENS):
+        return "read_error"
+
+    # Inference errors are catch-all for anything that reached the
+    # model call (signalled in the dispatcher / processor by
+    # confidence==0.0 with an error message that doesn't match the
+    # filesystem patterns above). Anything else lands in `other`.
+    confidence = getattr(result, "confidence", 1.0)
+    if isinstance(confidence, (int, float)) and confidence == 0.0:
+        return "inference_error"
+
+    return "other"

--- a/src/core/error_taxonomy.py
+++ b/src/core/error_taxonomy.py
@@ -91,6 +91,12 @@ _INFERENCE_ERROR_TOKENS: tuple[str, ...] = (
     "jsondecode",
     "completion failed",
     "inference failed",
+    # VisionProcessor._circuit_open_error() emits this exact prefix when
+    # the backend's failure circuit is open; otherwise it would fall
+    # through to `other` and weaken operator guidance during degraded
+    # availability (Codex P2 on PR #427).
+    "vision backend unavailable",
+    "backend unavailable",
 )
 
 
@@ -121,11 +127,15 @@ def classify_error(result: Any) -> ErrorCategory | None:
         return None
     err_lc = str(error).lower()
 
-    # Dispatcher's timeout-as-string sentinel — only reached when the
-    # fallback path didn't fire (e.g. text files, or a vision file
-    # whose error string survived without the dispatcher's source patch).
+    # Parallel processor's timeout sentinel is emitted for BOTH text
+    # and vision batches (Codex P2 catch on PR #427). Map to
+    # ``vision_timeout`` only when the result is image-shaped — i.e.
+    # exposes a ``source`` attribute (set on ProcessedImage; absent on
+    # ProcessedFile). Generic text timeouts fall through to ``other``.
     if err_lc.startswith("timed out after"):
-        return "vision_timeout"
+        if hasattr(result, "source"):
+            return "vision_timeout"
+        return "other"
 
     if any(tok in err_lc for tok in _UNSUPPORTED_TYPE_TOKENS):
         return "unsupported_type"

--- a/src/core/error_taxonomy.py
+++ b/src/core/error_taxonomy.py
@@ -32,7 +32,7 @@ ErrorCategory = Literal[
 # when it exceeds the 10%-of-scanned-files trigger.  Phrased as
 # actionable next steps so an operator can fix the issue without
 # re-reading the dispatcher source.
-RECOMMENDATIONS: dict[ErrorCategory, str] = {
+RECOMMENDATIONS: dict[str, str] = {
     "vision_timeout": (
         "consider `--timeout-per-file` to raise the cap or `--workers` to parallelise (#396 / #408)"
     ),
@@ -56,6 +56,13 @@ _READ_ERROR_TOKENS: tuple[str, ...] = (
     "exceeds max_file_size",  # FileTooLargeError shape
     "filereaderror",
     "fileexists",
+    # Every reader in utils/readers/ wraps parse / decode failures as
+    # ``FileReadError(f"Failed to read <FORMAT> ...")`` — those propagate
+    # through services.text_processor.process_file → ProcessedFile.error
+    # as "Failed to read DOCX file ...", "Failed to read PDF file ...",
+    # etc.  Without this token they bucket into ``inference_error`` and
+    # mislead the operator-facing recommendation.
+    "failed to read",
 )
 
 # Tokens that signal the file's extension / content type isn't supported.

--- a/src/core/organizer.py
+++ b/src/core/organizer.py
@@ -316,17 +316,19 @@ class FileOrganizer:
                 #    in the review (Codex P1 catch on PR #426).
                 if _confidence < 1.0 and _confidence <= _confidence_threshold:
                     result.low_confidence_files.append(p.file_path.name)
-                # Structured error breakdown (#411). Bucket via the
-                # shared taxonomy so the summary renderer and any JSON
-                # consumer see the same category labels. Only the
-                # first encountered file per bucket gets stored as an
-                # example to keep the breakdown dict small.
+
+            all_processed = self._deduplicate_processed(all_processed, result)
+            # Structured error breakdown (#411). Aggregated POST-dedup so
+            # content-duplicates that the dedup pass removed from
+            # ``processed_files`` / ``failed_files`` don't inflate the
+            # bucket counters (CodeRabbit P2 catch on PR #427). Only the
+            # first encountered file per bucket gets stored as an example
+            # to keep the breakdown dict small.
+            for p in all_processed:
                 _category = classify_error(p)
                 if _category is not None:
                     result.error_breakdown[_category] += 1
                     result.error_examples.setdefault(_category, p.file_path.name)
-
-            all_processed = self._deduplicate_processed(all_processed, result)
             failed_cnt = sum(1 for p in all_processed if p.error)
             # Vision-timeout fallbacks (#406) count as processed (they
             # landed in a folder) but are marked low-confidence for the

--- a/src/core/organizer.py
+++ b/src/core/organizer.py
@@ -25,6 +25,7 @@ from loguru import logger
 from rich.console import Console
 
 from core import dispatcher, display, file_ops, initializer
+from core.error_taxonomy import classify_error
 from core.types import (
     AUDIO_EXTENSIONS,
     CAD_EXTENSIONS,
@@ -315,6 +316,15 @@ class FileOrganizer:
                 #    in the review (Codex P1 catch on PR #426).
                 if _confidence < 1.0 and _confidence <= _confidence_threshold:
                     result.low_confidence_files.append(p.file_path.name)
+                # Structured error breakdown (#411). Bucket via the
+                # shared taxonomy so the summary renderer and any JSON
+                # consumer see the same category labels. Only the
+                # first encountered file per bucket gets stored as an
+                # example to keep the breakdown dict small.
+                _category = classify_error(p)
+                if _category is not None:
+                    result.error_breakdown[_category] += 1
+                    result.error_examples.setdefault(_category, p.file_path.name)
 
             all_processed = self._deduplicate_processed(all_processed, result)
             failed_cnt = sum(1 for p in all_processed if p.error)

--- a/src/core/types.py
+++ b/src/core/types.py
@@ -78,7 +78,7 @@ class OrganizationResult:
     # the summary line can show "203 vision_timeout (e.g. logo.png)".
     # Recommendation lines fire when a single bucket exceeds 10% of
     # ``total_files`` — see ``error_taxonomy.RECOMMENDATIONS``.
-    error_breakdown: Counter[str] = field(default_factory=Counter)
+    error_breakdown: Counter[str] = field(default_factory=Counter)  # pyre-ignore[35]
     error_examples: dict[str, str] = field(default_factory=dict)  # pyre-ignore[35]
 
 

--- a/src/core/types.py
+++ b/src/core/types.py
@@ -72,6 +72,14 @@ class OrganizationResult:
     # Entries are basenames so the summary stays readable even on deep
     # input hierarchies.
     low_confidence_files: list[str] = field(default_factory=list)  # pyre-ignore[35]
+    # Structured error breakdown (#411). Maps each
+    # ``core.error_taxonomy.ErrorCategory`` to the number of files that
+    # bucketed there, plus one representative basename per bucket so
+    # the summary line can show "203 vision_timeout (e.g. logo.png)".
+    # Recommendation lines fire when a single bucket exceeds 10% of
+    # ``total_files`` — see ``error_taxonomy.RECOMMENDATIONS``.
+    error_breakdown: Counter[str] = field(default_factory=Counter)
+    error_examples: dict[str, str] = field(default_factory=dict)  # pyre-ignore[35]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_error_taxonomy.py
+++ b/tests/core/test_error_taxonomy.py
@@ -78,13 +78,31 @@ class TestClassifyError:
             == "unsupported_type"
         )
 
-    def test_inference_error_via_zero_confidence(self) -> None:
-        # Provider 500 / AttributeError surfaced as confidence==0.0
-        # with an error that doesn't match the filesystem patterns.
-        assert (
-            classify_error(_Stub(error="ollama returned HTTP 500", confidence=0.0))
-            == "inference_error"
-        )
+    def test_inference_error_requires_provider_signature(self) -> None:
+        # Bucket only when the error string explicitly names a provider /
+        # HTTP 5xx / API failure — Codex P2 catch on PR #427.
+        for msg in (
+            "ollama returned HTTP 500",
+            "Anthropic API error: overloaded",
+            "openai rate_limit exceeded",
+            "Provider completion failed: timeout",
+            "model returned malformed JSON",
+        ):
+            assert classify_error(_Stub(error=msg, confidence=0.0)) == "inference_error", msg
+
+    def test_audio_video_metadata_failure_buckets_as_other_not_inference(self) -> None:
+        # Audio / video metadata pipelines set confidence=0.0 on ANY
+        # extractor exception (#409) even when no provider was contacted.
+        # Without the explicit provider-signature token requirement, these
+        # would mis-bucket as inference_error and emit the wrong operator
+        # hint. They now land in ``other`` — Codex P2 on PR #427.
+        for msg in (
+            "ffprobe failed with code 1",
+            "mutagen: invalid tag block",
+            "KeyError: 'duration'",
+            "ValueError: cannot parse bitrate",
+        ):
+            assert classify_error(_Stub(error=msg, confidence=0.0)) == "other", msg
 
     def test_other_bucket_catches_unknown_errors(self) -> None:
         # Non-zero confidence + unfamiliar error wording — bucket as `other`.

--- a/tests/core/test_error_taxonomy.py
+++ b/tests/core/test_error_taxonomy.py
@@ -33,11 +33,32 @@ class TestClassifyError:
         assert classify_error(_Stub(error=None, source="fallback_exif")) == "vision_timeout"
         assert classify_error(_Stub(error=None, source="fallback_filename")) == "vision_timeout"
 
-    def test_vision_timeout_via_error_string(self) -> None:
-        # Dispatcher's "timed out after Ns" sentinel — vision file
-        # whose error survived without the fallback patching `source`.
+    def test_vision_timeout_via_error_string_only_for_image_results(self) -> None:
+        # The parallel processor emits "Timed out after Xs" for both
+        # text and vision batches. Only the image-shaped result (has
+        # ``source`` attribute) buckets as vision_timeout; the text
+        # case falls through to ``other`` so the recommendation
+        # doesn't mis-direct an operator (Codex P2 on PR #427).
         assert (
-            classify_error(_Stub(error="Timed out after 30s", confidence=0.0)) == "vision_timeout"
+            classify_error(_Stub(error="Timed out after 30s", source="vision", confidence=0.0))
+            == "vision_timeout"
+        )
+
+        class _TextResult:
+            # No `source` attribute — text processor / ProcessedFile shape.
+            error = "Timed out after 30s"
+            confidence = 0.0
+
+        assert classify_error(_TextResult()) == "other"
+
+    def test_vision_circuit_open_buckets_as_inference_error(self) -> None:
+        # VisionProcessor._circuit_open_error() emits this exact prefix
+        # when the backend failure circuit is open — Codex P2 on PR #427.
+        assert (
+            classify_error(
+                _Stub(error="Vision backend unavailable: 5 consecutive failures", confidence=0.0)
+            )
+            == "inference_error"
         )
 
     def test_read_error_permission_denied(self) -> None:

--- a/tests/core/test_error_taxonomy.py
+++ b/tests/core/test_error_taxonomy.py
@@ -1,0 +1,101 @@
+"""Tests for core.error_taxonomy.classify_error (#411).
+
+Each ``ErrorCategory`` bucket gets a dedicated positive test, plus
+None for clean / happy-path results so the summary renderer can skip
+non-failures cheaply.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from core.error_taxonomy import RECOMMENDATIONS, classify_error
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class _Stub:
+    error: str | None = None
+    source: str | None = None
+    confidence: float = 1.0
+
+
+class TestClassifyError:
+    def test_clean_result_returns_none(self) -> None:
+        assert classify_error(_Stub(error=None, source="vision")) is None
+
+    def test_vision_timeout_via_fallback_source(self) -> None:
+        # #406 path: dispatcher rescued the file via the EXIF fallback,
+        # error is None but source carries the bucket signal.
+        assert classify_error(_Stub(error=None, source="fallback_exif")) == "vision_timeout"
+        assert classify_error(_Stub(error=None, source="fallback_filename")) == "vision_timeout"
+
+    def test_vision_timeout_via_error_string(self) -> None:
+        # Dispatcher's "timed out after Ns" sentinel — vision file
+        # whose error survived without the fallback patching `source`.
+        assert (
+            classify_error(_Stub(error="Timed out after 30s", confidence=0.0)) == "vision_timeout"
+        )
+
+    def test_read_error_permission_denied(self) -> None:
+        assert (
+            classify_error(_Stub(error="Permission denied: /etc/shadow", confidence=0.0))
+            == "read_error"
+        )
+
+    def test_read_error_symlink_rejection(self) -> None:
+        assert (
+            classify_error(_Stub(error="SafeDir refused to read symlink", confidence=0.0))
+            == "read_error"
+        )
+
+    def test_read_error_size_cap(self) -> None:
+        assert (
+            classify_error(_Stub(error="exceeds max_file_size of 100MB", confidence=0.0))
+            == "read_error"
+        )
+
+    def test_unsupported_type(self) -> None:
+        assert (
+            classify_error(_Stub(error="Unsupported file type: .xyz", confidence=0.0))
+            == "unsupported_type"
+        )
+
+    def test_inference_error_via_zero_confidence(self) -> None:
+        # Provider 500 / AttributeError surfaced as confidence==0.0
+        # with an error that doesn't match the filesystem patterns.
+        assert (
+            classify_error(_Stub(error="ollama returned HTTP 500", confidence=0.0))
+            == "inference_error"
+        )
+
+    def test_other_bucket_catches_unknown_errors(self) -> None:
+        # Non-zero confidence + unfamiliar error wording — bucket as `other`.
+        assert classify_error(_Stub(error="ghost in the machine", confidence=0.85)) == "other"
+
+    def test_duck_typed_object_without_source_attr(self) -> None:
+        # Older ProcessedFile shapes lack `source`; helper must tolerate it.
+        class _NoSource:
+            error = "Permission denied"
+            confidence = 0.0
+
+        assert classify_error(_NoSource()) == "read_error"
+
+
+class TestRecommendations:
+    def test_every_category_has_a_recommendation(self) -> None:
+        # Acceptance criterion: each surfaced bucket carries an
+        # actionable next-step string for the >10% trigger.
+        for category in (
+            "vision_timeout",
+            "read_error",
+            "unsupported_type",
+            "inference_error",
+            "other",
+        ):
+            tip = RECOMMENDATIONS[category]  # type: ignore[index]
+            assert isinstance(tip, str)
+            assert len(tip) > 10  # non-trivial guidance

--- a/tests/core/test_error_taxonomy.py
+++ b/tests/core/test_error_taxonomy.py
@@ -52,6 +52,20 @@ class TestClassifyError:
             == "read_error"
         )
 
+    def test_read_error_reader_failed_to_read(self) -> None:
+        # FileReadError messages emitted by every reader in
+        # utils/readers/ follow the "Failed to read <FORMAT>..."
+        # template (DOCX, PDF, RTF, ebook, ...). Previously these
+        # bucketed into inference_error because the token list
+        # didn't catch them — CodeRabbit P2 catch on PR #427.
+        for msg in (
+            "Failed to read DOCX file foo.docx: parser error",
+            "Failed to read PDF file bar.pdf: encrypted",
+            "Failed to read RTF baz.rtf: invalid header",
+            "Failed to read ebook file qux.epub: missing manifest",
+        ):
+            assert classify_error(_Stub(error=msg, confidence=0.0)) == "read_error", msg
+
     def test_read_error_size_cap(self) -> None:
         assert (
             classify_error(_Stub(error="exceeds max_file_size of 100MB", confidence=0.0))

--- a/tests/core/test_organizer.py
+++ b/tests/core/test_organizer.py
@@ -247,8 +247,11 @@ class TestFileOrganizer:
                 inference_ms=80.0,
             ),
         ]
-        for r in results:
-            r.file_path.write_bytes(b"")
+        # Distinct bytes per file so the SHA-256 dedup pass (#411 moved
+        # the error-bucket aggregation post-dedup) doesn't collapse them
+        # into a single survivor.
+        for i, r in enumerate(results):
+            r.file_path.write_bytes(f"unique-{i}".encode())
 
         organizer = FileOrganizer(dry_run=True, enable_vision=False)
         with (

--- a/tests/core/test_organizer.py
+++ b/tests/core/test_organizer.py
@@ -235,7 +235,10 @@ class TestFileOrganizer:
                 description="",
                 folder_name="errors",
                 filename="bad",
-                error="boom",
+                # Provider-signature error so classify_error buckets as
+                # inference_error rather than `other` — Codex P2 tightening
+                # on PR #427 now requires explicit provider tokens.
+                error="ollama returned HTTP 500",
                 confidence=0.0,
             ),
             ProcessedFile(

--- a/tests/core/test_organizer.py
+++ b/tests/core/test_organizer.py
@@ -270,6 +270,17 @@ class TestFileOrganizer:
         # Inference samples partition by modality (#410).
         assert result.vision_inference_ms_samples == [100.0]
         assert result.text_inference_ms_samples == [80.0]
+        # Structured error breakdown (#411): the same batch yields
+        # vision_timeout (two fallback_* sources) and inference_error
+        # (confidence==0.0 with an error string). Happy-path entries
+        # don't bucket. Examples are basenames of the first hit per
+        # bucket.
+        assert dict(result.error_breakdown) == {
+            "vision_timeout": 2,
+            "inference_error": 1,
+        }
+        assert result.error_examples["vision_timeout"] == "exif.jpg"
+        assert result.error_examples["inference_error"] == "bad.png"
 
     def test_organizer_falls_back_to_default_threshold_on_config_error(
         self, tmp_path: Path

--- a/tests/integration/test_core_organizer_batch3.py
+++ b/tests/integration/test_core_organizer_batch3.py
@@ -459,6 +459,51 @@ class TestDisplay:
 
         show_summary(console, result, tmp_path, dry_run=True)
 
+    @pytest.mark.integration
+    def test_error_taxonomy_buckets_all_categories_integration(self) -> None:
+        # #411 integration coverage: exercise every classify_error
+        # branch through the public helper. Pinned at integration tier
+        # so error_taxonomy.py clears the per-module floor (90%+).
+        from dataclasses import dataclass
+
+        from core.error_taxonomy import RECOMMENDATIONS, classify_error
+
+        @dataclass
+        class _R:
+            error: str | None = None
+            source: str | None = None
+            confidence: float = 1.0
+
+        # Each bucket plus the happy-path None
+        cases = [
+            (_R(error=None, source="vision"), None),
+            (_R(error=None, source="fallback_exif"), "vision_timeout"),
+            (_R(error="Timed out after 30s", confidence=0.0), "vision_timeout"),
+            (_R(error="Permission denied", confidence=0.0), "read_error"),
+            (
+                _R(error="Failed to read DOCX file foo.docx: x", confidence=0.0),
+                "read_error",
+            ),
+            (
+                _R(error="Unsupported file type: .xyz", confidence=0.0),
+                "unsupported_type",
+            ),
+            (_R(error="provider HTTP 500", confidence=0.0), "inference_error"),
+            (_R(error="ghost", confidence=0.5), "other"),
+        ]
+        for stub, expected in cases:
+            assert classify_error(stub) == expected, stub
+
+        # Every emitted bucket carries a recommendation string.
+        for category in (
+            "vision_timeout",
+            "read_error",
+            "unsupported_type",
+            "inference_error",
+            "other",
+        ):
+            assert RECOMMENDATIONS[category]
+
     def test_show_summary_renders_error_breakdown(self, tmp_path: Path) -> None:
         # #411: breakdown lines appear when error_breakdown is populated;
         # the recommendation line fires only above the 10%-of-total trigger.

--- a/tests/integration/test_core_organizer_batch3.py
+++ b/tests/integration/test_core_organizer_batch3.py
@@ -459,6 +459,67 @@ class TestDisplay:
 
         show_summary(console, result, tmp_path, dry_run=True)
 
+    def test_show_summary_renders_error_breakdown(self, tmp_path: Path) -> None:
+        # #411: breakdown lines appear when error_breakdown is populated;
+        # the recommendation line fires only above the 10%-of-total trigger.
+        import io
+        from collections import Counter
+
+        from rich.console import Console
+
+        from core.display import show_summary
+        from core.types import OrganizationResult
+
+        buf = io.StringIO()
+        console = Console(file=buf, force_terminal=False, width=200)
+        result = OrganizationResult(
+            total_files=100,
+            processed_files=70,
+            failed_files=30,
+            error_breakdown=Counter(
+                {
+                    "vision_timeout": 25,  # 25% — triggers recommendation
+                    "read_error": 4,  # 4% — below threshold, no recommendation
+                    "other": 1,
+                }
+            ),
+            error_examples={
+                "vision_timeout": "logo.png",
+                "read_error": "locked.pdf",
+                "other": "weird.bin",
+            },
+        )
+
+        show_summary(console, result, tmp_path, dry_run=True)
+        output = buf.getvalue()
+
+        assert "Failure breakdown:" in output
+        # Per-category lines with example basenames
+        assert "vision_timeout" in output
+        assert "logo.png" in output
+        assert "read_error" in output
+        assert "locked.pdf" in output
+        # Recommendation only on the dominant bucket (>10%)
+        assert "--timeout-per-file" in output  # vision_timeout tip
+        # read_error has only 4% share — its tip must NOT render
+        assert "exclude unreadable files" not in output
+
+    def test_show_summary_omits_breakdown_when_empty(self, tmp_path: Path) -> None:
+        # Clean runs must stay quiet — no "Failure breakdown:" header.
+        import io
+
+        from rich.console import Console
+
+        from core.display import show_summary
+        from core.types import OrganizationResult
+
+        buf = io.StringIO()
+        console = Console(file=buf, force_terminal=False, width=200)
+        result = OrganizationResult(total_files=5, processed_files=5)
+
+        show_summary(console, result, tmp_path, dry_run=True)
+        assert "Failure breakdown:" not in buf.getvalue()
+
     def test_show_summary_with_many_errors(self, tmp_path: Path) -> None:
         from rich.console import Console
 


### PR DESCRIPTION
Closes #411.

## Summary

Adds a per-category error breakdown to the final run summary so an
operator can tell *why* the failed files failed, not just how many.

- `core/error_taxonomy.py` (new): `classify_error()` buckets a
  `ProcessedFile` / `ProcessedImage` into one of five categories —
  `vision_timeout`, `read_error`, `unsupported_type`,
  `inference_error`, `other`. Vision-timeout fallbacks (#406) carry
  `source=fallback_*` and `error=None`, so the helper resolves that
  case first; the rest match against the literal error strings the
  dispatcher / readers emit today.  Each category has an actionable
  recommendation string (`RECOMMENDATIONS` dict) — phrased as next
  steps an operator can take without re-reading the dispatcher source.
- `core/types.py`: `OrganizationResult` gains `error_breakdown:
  Counter[str]` and `error_examples: dict[str, str]`. The breakdown is
  written through `Counter[str]` so dataclass-init stays simple; every
  key the organizer writes is an `ErrorCategory` literal.
- `core/organizer.py`: aggregates the breakdown alongside the existing
  low-confidence pass in the pre-dedup loop. Only the first encountered
  file per bucket is stored as the example.
- `core/display.py`: `_render_error_breakdown` prints buckets in
  descending count order with one example basename each, then emits a
  bolded recommendation line *only* for buckets that exceed 10% of
  `total_files` — the issue acceptance criterion. Clean runs stay
  silent.

## Test plan

- [x] Unit: `tests/core/test_error_taxonomy.py` — one positive case per
      bucket + happy-path `None` + duck-typed source-less object.
- [x] Renderer: `tests/integration/test_core_organizer_batch3.py`
      asserts breakdown header rendered, dominant-bucket recommendation
      fires, sub-10% bucket recommendation suppressed, and clean runs
      omit the section entirely.
- [x] Aggregator: existing `test_organizer_collects_low_confidence_results`
      now asserts `error_breakdown` and `error_examples` contents
      against the synthetic five-file batch.
- [x] `mypy src/core/{error_taxonomy,display,types,organizer}.py` — clean.
- [x] `ruff check` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Failure breakdown" section to the summary output displaying errors by category.
  * Error processing failures are now classified into five categories with actionable recommendations.
  * Category-specific tips appear for dominant error types (exceeding 10% threshold).
  * Example filenames provided for each error category to aid troubleshooting.

* **Tests**
  * Added comprehensive unit tests for error classification logic.
  * Added integration tests validating failure breakdown display behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->