### PR TITLE
chore(release): bump version to 2.0.0-beta.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fo-core"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 description = "Streamlined CLI file organizer powered by local AI (Ollama)"
 authors = [
     {name = "fo-core Team", email = "noreply@example.com"}

--- a/src/version.py
+++ b/src/version.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-__version__ = "2.0.0-beta.7"
+__version__ = "2.0.0-beta.9"
 
 # Pattern for semantic versioning with optional pre-release and build metadata
 _VERSION_PATTERN = re.compile(


### PR DESCRIPTION
Rolls up the 12 issues shipped in the v2.0.0-beta.9 cycle.

## Included PRs

| Issue | PR | Summary |
|------|------|---------|
| #404 | #419 | fast-path `fo version` startup |
| #385 | #418 | restore docstring coverage to 98.6% baseline |
| #412 | #417 | unsupported extension report in summary |
| #413 | #414 | filter Office temp lock files |
| #396 | #420 | expose per-file timeout config |
| #407 | #421 | adaptive vision timeout by file size |
| #406 | #422 | vision timeout → EXIF fallback categorization |
| #408 | #423 | parallel worker auto-default + `--workers` alias |
| #410 | #424 | per-file inference timing + summary stats |
| #409 | #426 | per-decision confidence + Review-recommended summary |
| #411 | #427 | structured error summary by failure category |
| #415 | #428 | harden SVG rasterization against XXE / billion-laughs |

## Test plan

- [x] CI already validated each constituent PR (12 squashed merges to main since beta.8).
- [x] `pyproject.toml` is the only file carrying the version string.
- [x] No other files reference `beta.8` (verified with `grep -r 2.0.0-beta.8`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.0.0-beta.9

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->