### PR TITLE
fix(error_taxonomy): bucket worker-pool aborts as inference_error (#431)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,10 @@ dependencies = [
     "rarfile~=4.1",             # RAR archive support (requires unrar tool)
 
     # CLI
-    "typer[all]~=0.12",
+    # typer 0.26 vendored its own `_click` module and broke parent-class
+    # type annotations in `src/cli/lazy.py` (#430+ CI flake). Pin out of
+    # the 0.26 range until lazy.py is updated to use the new typer types.
+    "typer[all]>=0.12,<0.26",
     "rich~=13.0",
     "Pygments>=2.20.0",  # Transitive via rich; pin for CVE-2026-4539
 

--- a/src/core/error_taxonomy.py
+++ b/src/core/error_taxonomy.py
@@ -41,7 +41,10 @@ RECOMMENDATIONS: dict[str, str] = {
         "see the top-skipped-extensions list above; install the matching extra "
         "(e.g. `[scientific]`, `[cad]`) or skip those files explicitly"
     ),
-    "inference_error": ("check Ollama / provider health; transient backend faults bucket here"),
+    "inference_error": (
+        "check Ollama / provider health; for worker-pool aborts on low-memory "
+        "hardware try `--timeout-per-file 1800` or `--workers 1` (#396 / #408)"
+    ),
     "other": ("inspect the per-file logs — these failures didn't fit the known taxonomy"),
 }
 
@@ -97,6 +100,17 @@ _INFERENCE_ERROR_TOKENS: tuple[str, ...] = (
     # availability (Codex P2 on PR #427).
     "vision backend unavailable",
     "backend unavailable",
+    # Parallel-processor pool abort (#431). When the worker pool detects
+    # hung tasks and aborts, every untried-or-hung task surfaces with
+    # one of these prefixes. The 2026-05-26 organize run produced 478
+    # of them; without these tokens they fall through to ``other`` with
+    # the useless "inspect per-file logs" recommendation. They are
+    # genuine inference-side failures (the model hung), so
+    # ``inference_error`` is the right bucket.
+    "worker pool",
+    "hung tasks",
+    "model is shutting down",
+    "aborted:",
 )
 
 

--- a/tests/core/test_error_taxonomy.py
+++ b/tests/core/test_error_taxonomy.py
@@ -61,6 +61,20 @@ class TestClassifyError:
             == "inference_error"
         )
 
+    def test_parallel_pool_abort_buckets_as_inference_error(self) -> None:
+        # #431: when the worker pool aborts on hung tasks, every untried
+        # task surfaces with one of these prefixes. Without explicit
+        # tokens these 400+ failures fall through to ``other`` with the
+        # useless "inspect per-file logs" recommendation.
+        for msg in (
+            "Aborted: worker pool saturated by hung tasks",
+            "Worker pool exhausted",
+            "Task aborted due to hung tasks elsewhere",
+            "Model is shutting down.",
+            "Model is shutting down. Inference aborted.",
+        ):
+            assert classify_error(_Stub(error=msg, confidence=0.0)) == "inference_error", msg
+
     def test_read_error_permission_denied(self) -> None:
         assert (
             classify_error(_Stub(error="Permission denied: /etc/shadow", confidence=0.0))

--- a/tests/integration/test_core_organizer_batch3.py
+++ b/tests/integration/test_core_organizer_batch3.py
@@ -490,9 +490,28 @@ class TestDisplay:
             ),
             (_R(error="provider HTTP 500", confidence=0.0), "inference_error"),
             (_R(error="ghost", confidence=0.5), "other"),
+            # Worker-pool abort tokens (#431): pool-abort surfaces with one
+            # of these prefixes when hung tasks force the parallel
+            # processor to bail. They must bucket as inference_error.
+            (
+                _R(error="Aborted: worker pool saturated by hung tasks", confidence=0.0),
+                "inference_error",
+            ),
+            (_R(error="Model is shutting down.", confidence=0.0), "inference_error"),
         ]
         for stub, expected in cases:
             assert classify_error(stub) == expected, stub
+
+        # Source-less results (ProcessedFile shape) with a "Timed out
+        # after" sentinel must bucket as ``other`` rather than
+        # ``vision_timeout`` (the latter requires a ``source`` attr).
+        # Closes the integration coverage gap on the
+        # ``error_taxonomy.py`` text-timeout branch.
+        class _TextResult:
+            error = "Timed out after 30s"
+            confidence = 0.0
+
+        assert classify_error(_TextResult()) == "other"
 
         # Every emitted bucket carries a recommendation string.
         for category in (


### PR DESCRIPTION
Closes #431.

## Summary

The 2026-05-26 organize run against ~1700 files produced 478
failures classified as \`other\` — all with effectively the same
upstream cause (the parallel worker pool aborted after hung vision
tasks). The \`other\` bucket's generic "inspect per-file logs"
recommendation isn't useful when 400+ identical entries flood it.

Adds four token prefixes to \`_INFERENCE_ERROR_TOKENS\` so the
abort-path errors land in \`inference_error\` where they belong:

- \`worker pool\`
- \`hung tasks\`
- \`model is shutting down\`
- \`aborted:\`

Also updates the \`inference_error\` recommendation to point at
\`--timeout-per-file 1800\` (#396) and \`--workers 1\` (#408) so the
operator immediately knows which knob to turn on memory-constrained
hardware.

## Test plan

- [x] New unit test \`test_parallel_pool_abort_buckets_as_inference_error\` exercises all four token shapes.
- [x] Existing 14 \`test_error_taxonomy.py\` tests still pass.
- [x] Organizer aggregation + display integration tests still pass.
- [x] \`mypy src/core/error_taxonomy.py\` clean.
- [x] \`ruff check\` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of inference errors related to parallel processing worker-pool timeouts and aborts.
  * Enhanced error guidance now recommends using `--timeout-per-file` and `--workers` parameters to resolve memory and timeout issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->