### PR TITLE
fix(organizer): exclude 0-duration vision samples from inference stats (#430)

### DIFF
--- a/src/core/organizer.py
+++ b/src/core/organizer.py
@@ -287,7 +287,14 @@ class FileOrganizer:
 
             for p in all_processed:
                 ms = getattr(p, "inference_ms", None)
-                if isinstance(ms, (int, float)):
+                # Skip non-positive samples (#430). The dispatcher's
+                # vision-fallback path copies ``file_result.duration_ms``
+                # into ``inference_ms``; when the parallel pool aborts
+                # BEFORE a task starts running, ``duration_ms`` is 0.0.
+                # Those zero "attempts" must not pull the mean / p95 /
+                # p99 to 0 — they represent files that never ran, not
+                # files that ran in ~0 ms.
+                if isinstance(ms, (int, float)) and ms > 0:
                     # ProcessedImage carries the `source` field (#406) so we
                     # treat the image side; ProcessedFile is the text side.
                     if hasattr(p, "source"):

--- a/tests/core/test_organizer.py
+++ b/tests/core/test_organizer.py
@@ -288,6 +288,56 @@ class TestFileOrganizer:
         assert result.error_examples["vision_timeout"] == "exif.jpg"
         assert result.error_examples["inference_error"] == "bad.png"
 
+    def test_zero_inference_ms_samples_excluded_from_summary(self, tmp_path: Path) -> None:
+        """#430: dispatcher copies file_result.duration_ms into
+        ProcessedImage.inference_ms even when the parallel pool aborts a
+        task BEFORE it runs (duration_ms=0). Those zero "attempts" must
+        not be added to the sample set — otherwise the summary's mean /
+        p95 / p99 are pulled to 0 and obscure real tail latency.
+        """
+        from services.vision_processor import ProcessedImage
+
+        results: list[ProcessedImage] = [
+            # Real successful inference — should be counted.
+            ProcessedImage(
+                file_path=tmp_path / "ok.png",
+                description="d",
+                folder_name="images",
+                filename="ok",
+                confidence=1.0,
+                inference_ms=1672294.5,
+            ),
+            # Zero-duration fallback (pool aborted before run) — must NOT
+            # contribute to the sample set.
+            ProcessedImage(
+                file_path=tmp_path / "aborted.jpg",
+                description="",
+                folder_name="errors",
+                filename="aborted",
+                source="fallback_filename",
+                confidence=0.3,
+                inference_ms=0.0,
+            ),
+        ]
+        for i, r in enumerate(results):
+            r.file_path.write_bytes(f"u-{i}".encode())
+
+        organizer = FileOrganizer(dry_run=True, enable_vision=False)
+        with (
+            patch.object(
+                organizer,
+                "_categorize_files",
+                return_value=([], [r.file_path for r in results], [], [], [], []),
+            ),
+            patch.object(organizer, "_process_all_file_types", return_value=results),
+            patch.object(organizer, "_execute_organization"),
+        ):
+            result = organizer.organize(tmp_path, tmp_path / "out")
+
+        # Only the real inference contributes — the zero-duration entry
+        # is excluded by the > 0 guard.
+        assert result.vision_inference_ms_samples == [1672294.5]
+
     def test_organizer_falls_back_to_default_threshold_on_config_error(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Closes #430.

## Summary

A 2026-05-26 organize run that triggered the worker-pool abort
produced this summary line:

\`Vision inference — mean: 0.00s, p50: 0.00s, p95: 0.00s, p99: 0.00s (n=2)\`

…despite two debug-log entries showing real samples (1672 s and 1711 s).

**Root cause**: the dispatcher's vision-fallback path copies
\`file_result.duration_ms\` into \`ProcessedImage.inference_ms\`. When
the parallel pool aborts a task BEFORE it starts (pool-saturation
abort), \`duration_ms\` is 0.0. Those zero values were the only
samples that arrived through \`process_batch_iter\`'s yield path
before the dispatcher moved on; the real completions (1672 s and
1711 s) arrived too late during the cleanup phase and never made it
into \`processed\`.

## Fix

In the organizer's pre-dedup aggregator, require \`ms > 0\` for
inclusion in the sample set. Zero is now treated as a sentinel for
"never ran" and excluded — consistent with the contract that
\`vision_inference_ms_samples\` represents real attempts.

The 1672/1711 s completions that arrived during cleanup are still
lost (that's a different issue, tracked separately under #432), but
at least the summary now reports n=0 instead of a misleading 0.00s
mean over n=2 phantom samples.

## Test plan

- [x] New unit test \`test_zero_inference_ms_samples_excluded_from_summary\`
- [x] Existing low-confidence + breakdown aggregation tests still pass.
- [x] \`mypy\`, \`ruff\` clean.