### PR TITLE
fix(parallel): retry pool-abort collateral instead of mass-failing (#432)

### DIFF
--- a/src/core/dispatcher.py
+++ b/src/core/dispatcher.py
@@ -210,6 +210,10 @@ def process_image_files(
         List of processed image results.
     """
     processed: list[ProcessedImage] = []
+    # #432: track paths whose pool-saturation abort is retryable
+    # (never-started; collateral damage) so we can run them sequentially
+    # after the parallel pass finishes.
+    retry_paths: list[Path] = []
 
     with create_progress(console) as progress:
         task = progress.add_task("Processing images...", total=len(files))
@@ -282,6 +286,22 @@ def process_image_files(
                         description=f"[yellow]⚠[/yellow] {file_result.path.name} (fallback)",
                     )
                 else:
+                    # #432: pool-saturation aborts on never-started tasks
+                    # carry ``non_retryable=False``. Queue them for a
+                    # post-pass sequential retry instead of recording
+                    # them as failures — they never actually ran, so
+                    # marking them failed is collateral damage.
+                    if (
+                        error_msg.startswith("Aborted: worker pool saturated")
+                        and not file_result.non_retryable
+                    ):
+                        retry_paths.append(file_result.path)
+                        progress.update(
+                            task,
+                            advance=1,
+                            description=f"[yellow]⟳[/yellow] {file_result.path.name} (will retry)",
+                        )
+                        continue
                     logger.error("Failed to process {}: {}", file_result.path, error_msg)
                     processed.append(
                         ProcessedImage(
@@ -302,6 +322,30 @@ def process_image_files(
                         advance=1,
                         description=f"[red]✗[/red] {file_result.path.name} (Failed)",
                     )
+
+    # #432: Sequential retry for pool-saturation collateral. The
+    # parallel processor marked these as never-started (non_retryable
+    # =False), so rerun them one-at-a-time before reporting failure.
+    if retry_paths:
+        logger.warning(
+            "Pool aborted on hung tasks; retrying {} untried image(s) sequentially.",
+            len(retry_paths),
+        )
+        for path in retry_paths:
+            try:
+                processed.append(vision_processor.process_file(path))
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.error("Sequential retry failed for {}: {}", path, exc)
+                processed.append(
+                    ProcessedImage(
+                        file_path=path,
+                        description="",
+                        folder_name=ERROR_FALLBACK_FOLDER,
+                        filename=path.stem,
+                        error=str(exc),
+                        confidence=0.0,
+                    )
+                )
 
     return processed
 

--- a/src/core/dispatcher.py
+++ b/src/core/dispatcher.py
@@ -19,8 +19,10 @@ from core.types import (
     ERROR_FALLBACK_FOLDER,
     VIDEO_FALLBACK_FOLDER,
 )
+from parallel.config import ParallelConfig
 from parallel.processor import ParallelProcessor
 from services import ProcessedFile, ProcessedImage, TextProcessor, VisionProcessor
+from services.vision_fallback import compute_fallback
 
 if TYPE_CHECKING:
     from services.audio.metadata_extractor import AudioMetadata, AudioMetadataExtractor
@@ -244,8 +246,6 @@ def process_image_files(
                 # instead of being dropped into the error bucket. Other
                 # failures (read error, corrupt image, …) still error-out.
                 if _is_timeout_error(error_msg):
-                    from services.vision_fallback import compute_fallback
-
                     fb = compute_fallback(file_result.path)
                     logger.info(
                         "Vision timed out for {}; categorized via {} → {}",
@@ -327,26 +327,34 @@ def process_image_files(
     # parallel processor marked these as never-started (non_retryable
     # =False), so rerun them one-at-a-time before reporting failure.
     #
-    # We deliberately reuse ``parallel_processor.process_batch_iter``
-    # here rather than calling ``vision_processor.process_file`` in a
-    # naive Python loop (Codex P1 on PR #438): the retry path must
-    # keep the per-file timeout / cancellation enforcement, otherwise
-    # the same backend hang that triggered the original saturation
-    # blocks the organize run indefinitely on the retry. Passing the
-    # already-instantiated processor preserves the operator-tunable
-    # ``--timeout-per-file`` (#396) and worker-pool guard rails; we
-    # rely on its internal queue semantics rather than instantiating a
-    # second pool with workers=1 to avoid double-counting resources.
+    # The retry must run with ``max_workers=1`` and ``prefetch_depth=0``
+    # — reusing the caller's parallel_processor with its original
+    # multi-worker config can re-saturate if a retried file hangs
+    # again (Codex P1 on PR #438, round 2). The single-worker config
+    # gives deterministic degraded-mode recovery: each retry runs
+    # alone, and a still-hung backend produces a clean per-file
+    # timeout instead of cascade-failing other retry candidates.
+    #
+    # We inherit the operator-tunable ``timeout_per_file`` from the
+    # caller's config so ``--timeout-per-file`` (#396) still applies.
     if retry_paths:
         logger.warning(
             "Pool aborted on hung tasks; retrying {} untried image(s) sequentially.",
             len(retry_paths),
         )
 
+        retry_config = ParallelConfig(
+            max_workers=1,
+            prefetch_depth=0,
+            timeout_per_file=parallel_processor.config.timeout_per_file,
+            retry_count=0,  # no second-level retry
+        )
+        retry_processor = ParallelProcessor(config=retry_config)
+
         def _retry_one_image(path: Path) -> ProcessedImage:
             return vision_processor.process_file(path)
 
-        for retry_result in parallel_processor.process_batch_iter(retry_paths, _retry_one_image):
+        for retry_result in retry_processor.process_batch_iter(retry_paths, _retry_one_image):
             if retry_result.success:
                 processed.append(retry_result.result)
                 continue
@@ -354,8 +362,6 @@ def process_image_files(
             # genuine failure now — there's no second-level retry.
             retry_err = retry_result.error or "Unknown error"
             if _is_timeout_error(retry_err):
-                from services.vision_fallback import compute_fallback
-
                 fb = compute_fallback(retry_result.path)
                 _fallback_confidence = 0.5 if fb.source == "fallback_exif" else 0.3
                 processed.append(

--- a/src/core/dispatcher.py
+++ b/src/core/dispatcher.py
@@ -326,26 +326,61 @@ def process_image_files(
     # #432: Sequential retry for pool-saturation collateral. The
     # parallel processor marked these as never-started (non_retryable
     # =False), so rerun them one-at-a-time before reporting failure.
+    #
+    # We deliberately reuse ``parallel_processor.process_batch_iter``
+    # here rather than calling ``vision_processor.process_file`` in a
+    # naive Python loop (Codex P1 on PR #438): the retry path must
+    # keep the per-file timeout / cancellation enforcement, otherwise
+    # the same backend hang that triggered the original saturation
+    # blocks the organize run indefinitely on the retry. Passing the
+    # already-instantiated processor preserves the operator-tunable
+    # ``--timeout-per-file`` (#396) and worker-pool guard rails; we
+    # rely on its internal queue semantics rather than instantiating a
+    # second pool with workers=1 to avoid double-counting resources.
     if retry_paths:
         logger.warning(
             "Pool aborted on hung tasks; retrying {} untried image(s) sequentially.",
             len(retry_paths),
         )
-        for path in retry_paths:
-            try:
-                processed.append(vision_processor.process_file(path))
-            except Exception as exc:  # pragma: no cover — defensive
-                logger.error("Sequential retry failed for {}: {}", path, exc)
+
+        def _retry_one_image(path: Path) -> ProcessedImage:
+            return vision_processor.process_file(path)
+
+        for retry_result in parallel_processor.process_batch_iter(retry_paths, _retry_one_image):
+            if retry_result.success:
+                processed.append(retry_result.result)
+                continue
+            # Retry also failed (timeout, vision error, …). Record as a
+            # genuine failure now — there's no second-level retry.
+            retry_err = retry_result.error or "Unknown error"
+            if _is_timeout_error(retry_err):
+                from services.vision_fallback import compute_fallback
+
+                fb = compute_fallback(retry_result.path)
+                _fallback_confidence = 0.5 if fb.source == "fallback_exif" else 0.3
                 processed.append(
                     ProcessedImage(
-                        file_path=path,
+                        file_path=retry_result.path,
                         description="",
-                        folder_name=ERROR_FALLBACK_FOLDER,
-                        filename=path.stem,
-                        error=str(exc),
-                        confidence=0.0,
+                        folder_name=fb.folder,
+                        filename=fb.filename,
+                        source=fb.source,
+                        inference_ms=retry_result.duration_ms,
+                        confidence=_fallback_confidence,
                     )
                 )
+                continue
+            logger.error("Sequential retry failed for {}: {}", retry_result.path, retry_err)
+            processed.append(
+                ProcessedImage(
+                    file_path=retry_result.path,
+                    description="",
+                    folder_name=ERROR_FALLBACK_FOLDER,
+                    filename=retry_result.path.stem,
+                    error=retry_err,
+                    confidence=0.0,
+                )
+            )
 
     return processed
 

--- a/src/parallel/processor.py
+++ b/src/parallel/processor.py
@@ -429,6 +429,13 @@ class ParallelProcessor:
         )
         results: list[FileResult] = []
         for f in list(pending):
+            # #432: distinguish never-started tasks (collateral, should be
+            # retryable in a degraded mode) from in-flight tasks (truly
+            # hung — don't retry). The dispatcher's image path scans for
+            # ``non_retryable=False`` saturation aborts and reruns them
+            # sequentially so a 2-3 hung-image case doesn't collateral-
+            # fail every untried file in the batch.
+            never_started = future_started.get(f) is None and not f.running()
             f.cancel()
             abort_path = future_paths.pop(f)
             future_started.pop(f, None)
@@ -440,7 +447,7 @@ class ParallelProcessor:
                         path=abort_path,
                         success=False,
                         error="Aborted: worker pool saturated by hung tasks",
-                        non_retryable=True,
+                        non_retryable=not never_started,
                     )
                 )
             )

--- a/src/parallel/processor.py
+++ b/src/parallel/processor.py
@@ -343,13 +343,20 @@ class ParallelProcessor:
             if saturation is not None:
                 cleanup_state["force_nonblocking_shutdown"] = owns_executor
                 yield from saturation
+                # #432 follow-up (Codex P1): unsubmitted files at the
+                # iterator tail are never-started by definition; flag
+                # them retryable so the dispatcher's sequential pass
+                # picks them up. Without this, a saturation with N
+                # in-flight + M unsubmitted still mass-fails the M tail
+                # for the same reason the in-flight retry was meant to
+                # fix.
                 for remaining_path in iterator:
                     yield finalize_result(
                         FileResult(
                             path=remaining_path,
                             success=False,
                             error="Aborted: worker pool saturated by hung tasks",
-                            non_retryable=True,
+                            non_retryable=False,
                         )
                     )
                 return

--- a/tests/integration/test_core_organizer_batch3.py
+++ b/tests/integration/test_core_organizer_batch3.py
@@ -1098,7 +1098,7 @@ class TestDispatcher:
         # Force the EXIF path so we can assert the per-source confidence
         # mapping without depending on a real Pillow read.
         with patch(
-            "services.vision_fallback.compute_fallback",
+            "core.dispatcher.compute_fallback",
             return_value=FallbackResult(
                 folder="Images/Photos/2025/11",
                 filename="DSC_0042",

--- a/tests/integration/test_dispatcher_core.py
+++ b/tests/integration/test_dispatcher_core.py
@@ -385,15 +385,25 @@ class TestProcessImageFiles:
                 filename="never_started_2",
             ),
         )
+        # Initial processor (multi-worker) yields the saturation batch.
         mock_pp = MagicMock()
-        mock_pp.process_batch_iter.side_effect = [
-            iter([hung_fr, retry1_fr, retry2_fr]),  # initial pass
-            iter([retry1_success, retry2_success]),  # retry pass
-        ]
-        vp = MagicMock()
+        mock_pp.config.timeout_per_file = 60.0  # real float for ParallelConfig() validation
+        mock_pp.process_batch_iter.return_value = iter([hung_fr, retry1_fr, retry2_fr])
 
+        # Retry processor is a fresh single-worker ParallelProcessor —
+        # Codex P1 on PR #438 (round 2): reusing the original
+        # multi-worker config can re-saturate. Patch the class at the
+        # dispatcher's import site so we can assert it was built with
+        # ``max_workers=1, prefetch_depth=0``.
+        retry_pp = MagicMock()
+        retry_pp.process_batch_iter.return_value = iter([retry1_success, retry2_success])
+
+        vp = MagicMock()
         progress_ctx = _make_progress_ctx()
-        with patch(_PROGRESS_TARGET, return_value=progress_ctx):
+        with (
+            patch(_PROGRESS_TARGET, return_value=progress_ctx),
+            patch("core.dispatcher.ParallelProcessor", return_value=retry_pp) as mock_pp_cls,
+        ):
             results = process_image_files(
                 [hung_path, retry1, retry2],
                 vision_processor=vp,
@@ -408,13 +418,19 @@ class TestProcessImageFiles:
         assert by_path[retry1].folder_name == "ok"
         assert by_path[retry2].error is None
         assert by_path[retry2].folder_name == "ok"
-        # The retry pass runs through ``parallel_processor.process_batch_iter``
-        # (preserves timeout guards). Called twice total: once for the
-        # initial batch, once for the retry tail with just the never-
-        # started paths.
-        assert mock_pp.process_batch_iter.call_count == 2
-        retry_call = mock_pp.process_batch_iter.call_args_list[1]
-        retry_paths_arg = retry_call.args[0]
+        # Initial multi-worker processor was used once; retry processor
+        # was constructed with single-worker + no-prefetch.
+        assert mock_pp.process_batch_iter.call_count == 1
+        assert mock_pp_cls.call_count == 1
+        retry_config = mock_pp_cls.call_args.kwargs["config"]
+        assert retry_config.max_workers == 1
+        assert retry_config.prefetch_depth == 0
+        # Operator-tunable timeout is inherited from the caller's config.
+        assert retry_config.timeout_per_file == 60.0
+        # Retry processor.process_batch_iter was called with just the
+        # never-started paths.
+        assert retry_pp.process_batch_iter.call_count == 1
+        retry_paths_arg = retry_pp.process_batch_iter.call_args.args[0]
         assert set(retry_paths_arg) == {retry1, retry2}
 
     def test_retry_timeout_routes_through_vision_fallback(self) -> None:
@@ -441,18 +457,21 @@ class TestProcessImageFiles:
             duration_ms=60000.0,
         )
         mock_pp = MagicMock()
-        mock_pp.process_batch_iter.side_effect = [
-            iter([initial_abort]),
-            iter([retry_timeout]),
-        ]
-        with patch("services.vision_fallback.compute_fallback") as mock_fb:
+        mock_pp.config.timeout_per_file = 60.0
+        mock_pp.process_batch_iter.return_value = iter([initial_abort])
+        retry_pp = MagicMock()
+        retry_pp.process_batch_iter.return_value = iter([retry_timeout])
+        with patch("core.dispatcher.compute_fallback") as mock_fb:
             fb = MagicMock()
             fb.source = "fallback_exif"
             fb.folder = "Images/Photos/2024/01"
             fb.filename = "retry_timeout"
             mock_fb.return_value = fb
             progress_ctx = _make_progress_ctx()
-            with patch(_PROGRESS_TARGET, return_value=progress_ctx):
+            with (
+                patch(_PROGRESS_TARGET, return_value=progress_ctx),
+                patch("core.dispatcher.ParallelProcessor", return_value=retry_pp),
+            ):
                 results = process_image_files(
                     [path],
                     vision_processor=MagicMock(),
@@ -485,12 +504,15 @@ class TestProcessImageFiles:
             error="Corrupt JPEG data: 12 extraneous bytes",
         )
         mock_pp = MagicMock()
-        mock_pp.process_batch_iter.side_effect = [
-            iter([initial_abort]),
-            iter([retry_err]),
-        ]
+        mock_pp.config.timeout_per_file = 60.0
+        mock_pp.process_batch_iter.return_value = iter([initial_abort])
+        retry_pp = MagicMock()
+        retry_pp.process_batch_iter.return_value = iter([retry_err])
         progress_ctx = _make_progress_ctx()
-        with patch(_PROGRESS_TARGET, return_value=progress_ctx):
+        with (
+            patch(_PROGRESS_TARGET, return_value=progress_ctx),
+            patch("core.dispatcher.ParallelProcessor", return_value=retry_pp),
+        ):
             results = process_image_files(
                 [path],
                 vision_processor=MagicMock(),

--- a/tests/integration/test_dispatcher_core.py
+++ b/tests/integration/test_dispatcher_core.py
@@ -417,6 +417,91 @@ class TestProcessImageFiles:
         retry_paths_arg = retry_call.args[0]
         assert set(retry_paths_arg) == {retry1, retry2}
 
+    def test_retry_timeout_routes_through_vision_fallback(self) -> None:
+        # #432 follow-up (Codex P1): the sequential retry pass runs
+        # through ``parallel_processor.process_batch_iter`` so the
+        # per-file timeout is enforced. When a retry hits that timeout,
+        # the dispatcher must route the file through the same #406
+        # EXIF fallback path the initial pass uses — preserving the
+        # operator-facing classification rather than letting the
+        # timeout escape as a generic error.
+        from core.dispatcher import process_image_files
+
+        path = Path("/mock/photos/retry_timeout.jpg")
+        initial_abort = _make_file_result(
+            success=False,
+            path=path,
+            error="Aborted: worker pool saturated by hung tasks",
+            non_retryable=False,
+        )
+        retry_timeout = _make_file_result(
+            success=False,
+            path=path,
+            error="Timed out after 60s",
+            duration_ms=60000.0,
+        )
+        mock_pp = MagicMock()
+        mock_pp.process_batch_iter.side_effect = [
+            iter([initial_abort]),
+            iter([retry_timeout]),
+        ]
+        with patch("services.vision_fallback.compute_fallback") as mock_fb:
+            fb = MagicMock()
+            fb.source = "fallback_exif"
+            fb.folder = "Images/Photos/2024/01"
+            fb.filename = "retry_timeout"
+            mock_fb.return_value = fb
+            progress_ctx = _make_progress_ctx()
+            with patch(_PROGRESS_TARGET, return_value=progress_ctx):
+                results = process_image_files(
+                    [path],
+                    vision_processor=MagicMock(),
+                    parallel_processor=mock_pp,
+                    console=MagicMock(),
+                )
+        assert len(results) == 1
+        assert results[0].source == "fallback_exif"
+        assert results[0].folder_name == "Images/Photos/2024/01"
+        # Carries timer duration through for #410 p95/p99 accounting.
+        assert results[0].inference_ms == 60000.0
+
+    def test_retry_generic_error_falls_to_error_folder(self) -> None:
+        # #432 follow-up: non-timeout retry failures (e.g. corrupt
+        # image data, vision-model error) record as genuine failures
+        # in the ``errors`` folder — there's no second-level retry.
+        from core.dispatcher import process_image_files
+        from core.types import ERROR_FALLBACK_FOLDER
+
+        path = Path("/mock/photos/retry_bad.jpg")
+        initial_abort = _make_file_result(
+            success=False,
+            path=path,
+            error="Aborted: worker pool saturated by hung tasks",
+            non_retryable=False,
+        )
+        retry_err = _make_file_result(
+            success=False,
+            path=path,
+            error="Corrupt JPEG data: 12 extraneous bytes",
+        )
+        mock_pp = MagicMock()
+        mock_pp.process_batch_iter.side_effect = [
+            iter([initial_abort]),
+            iter([retry_err]),
+        ]
+        progress_ctx = _make_progress_ctx()
+        with patch(_PROGRESS_TARGET, return_value=progress_ctx):
+            results = process_image_files(
+                [path],
+                vision_processor=MagicMock(),
+                parallel_processor=mock_pp,
+                console=MagicMock(),
+            )
+        assert len(results) == 1
+        assert results[0].folder_name == ERROR_FALLBACK_FOLDER
+        assert results[0].error == "Corrupt JPEG data: 12 extraneous bytes"
+        assert results[0].confidence == 0.0
+
     def test_failure_result_unknown_error(self) -> None:
         from core.dispatcher import process_image_files
 

--- a/tests/integration/test_dispatcher_core.py
+++ b/tests/integration/test_dispatcher_core.py
@@ -50,13 +50,23 @@ def _make_file_result(
     path: Path,
     result: object | None = None,
     error: str | None = None,
+    non_retryable: bool = True,
+    duration_ms: float = 0.0,
 ) -> MagicMock:
-    """Return a MagicMock parallel processor file result."""
+    """Return a MagicMock parallel processor file result.
+
+    ``non_retryable=True`` is the historical default (existing tests
+    assume aborted tasks aren't retried). The #432 retry path requires
+    callers to pass ``non_retryable=False`` to opt into the dispatcher's
+    sequential retry pass.
+    """
     fr = MagicMock()
     fr.success = success
     fr.path = path
     fr.result = result
     fr.error = error
+    fr.non_retryable = non_retryable
+    fr.duration_ms = duration_ms
     return fr
 
 
@@ -319,6 +329,80 @@ class TestProcessImageFiles:
         assert results[0].error == "vision timeout"
         assert results[0].file_path == file_path
         assert results[0].filename == "missing"
+
+    def test_pool_saturation_retryable_aborts_run_sequentially(self) -> None:
+        # #432: when the parallel processor returns saturation aborts
+        # tagged ``non_retryable=False`` (never-started tasks), the
+        # dispatcher reruns them sequentially via ``vision_processor``
+        # rather than mass-failing them as collateral damage.
+        from core.dispatcher import process_image_files
+        from services import ProcessedImage
+
+        hung_path = Path("/mock/photos/hung.jpg")
+        retry1 = Path("/mock/photos/never_started_1.jpg")
+        retry2 = Path("/mock/photos/never_started_2.jpg")
+
+        # Parallel processor yields one truly-hung abort (non_retryable)
+        # + two never-started aborts (retryable).
+        hung_fr = _make_file_result(
+            success=False,
+            path=hung_path,
+            error="Aborted: worker pool saturated by hung tasks",
+            non_retryable=True,
+        )
+        retry1_fr = _make_file_result(
+            success=False,
+            path=retry1,
+            error="Aborted: worker pool saturated by hung tasks",
+            non_retryable=False,
+        )
+        retry2_fr = _make_file_result(
+            success=False,
+            path=retry2,
+            error="Aborted: worker pool saturated by hung tasks",
+            non_retryable=False,
+        )
+        mock_pp = MagicMock()
+        mock_pp.process_batch_iter.return_value = iter([hung_fr, retry1_fr, retry2_fr])
+
+        # Sequential retry succeeds for both untried paths.
+        vp = MagicMock()
+        vp.process_file.side_effect = [
+            ProcessedImage(
+                file_path=retry1,
+                description="d1",
+                folder_name="ok",
+                filename="never_started_1",
+            ),
+            ProcessedImage(
+                file_path=retry2,
+                description="d2",
+                folder_name="ok",
+                filename="never_started_2",
+            ),
+        ]
+
+        progress_ctx = _make_progress_ctx()
+        with patch(_PROGRESS_TARGET, return_value=progress_ctx):
+            results = process_image_files(
+                [hung_path, retry1, retry2],
+                vision_processor=vp,
+                parallel_processor=mock_pp,
+                console=MagicMock(),
+            )
+
+        # 1 genuinely-hung failure + 2 sequential successes.
+        by_path = {r.file_path: r for r in results}
+        assert by_path[hung_path].error == "Aborted: worker pool saturated by hung tasks"
+        assert by_path[retry1].error is None
+        assert by_path[retry1].folder_name == "ok"
+        assert by_path[retry2].error is None
+        assert by_path[retry2].folder_name == "ok"
+        # vision_processor.process_file was called exactly twice — once
+        # per never-started path. The hung one was NOT retried.
+        assert vp.process_file.call_count == 2
+        retried = {call.args[0] for call in vp.process_file.call_args_list}
+        assert retried == {retry1, retry2}
 
     def test_failure_result_unknown_error(self) -> None:
         from core.dispatcher import process_image_files

--- a/tests/integration/test_dispatcher_core.py
+++ b/tests/integration/test_dispatcher_core.py
@@ -362,25 +362,35 @@ class TestProcessImageFiles:
             error="Aborted: worker pool saturated by hung tasks",
             non_retryable=False,
         )
-        mock_pp = MagicMock()
-        mock_pp.process_batch_iter.return_value = iter([hung_fr, retry1_fr, retry2_fr])
-
-        # Sequential retry succeeds for both untried paths.
-        vp = MagicMock()
-        vp.process_file.side_effect = [
-            ProcessedImage(
+        # Retry pass also runs through the parallel processor (Codex P1
+        # on PR #438: preserves timeout / cancellation enforcement).
+        # Yield successful retries on the second call.
+        retry1_success = _make_file_result(
+            success=True,
+            path=retry1,
+            result=ProcessedImage(
                 file_path=retry1,
                 description="d1",
                 folder_name="ok",
                 filename="never_started_1",
             ),
-            ProcessedImage(
+        )
+        retry2_success = _make_file_result(
+            success=True,
+            path=retry2,
+            result=ProcessedImage(
                 file_path=retry2,
                 description="d2",
                 folder_name="ok",
                 filename="never_started_2",
             ),
+        )
+        mock_pp = MagicMock()
+        mock_pp.process_batch_iter.side_effect = [
+            iter([hung_fr, retry1_fr, retry2_fr]),  # initial pass
+            iter([retry1_success, retry2_success]),  # retry pass
         ]
+        vp = MagicMock()
 
         progress_ctx = _make_progress_ctx()
         with patch(_PROGRESS_TARGET, return_value=progress_ctx):
@@ -398,11 +408,14 @@ class TestProcessImageFiles:
         assert by_path[retry1].folder_name == "ok"
         assert by_path[retry2].error is None
         assert by_path[retry2].folder_name == "ok"
-        # vision_processor.process_file was called exactly twice — once
-        # per never-started path. The hung one was NOT retried.
-        assert vp.process_file.call_count == 2
-        retried = {call.args[0] for call in vp.process_file.call_args_list}
-        assert retried == {retry1, retry2}
+        # The retry pass runs through ``parallel_processor.process_batch_iter``
+        # (preserves timeout guards). Called twice total: once for the
+        # initial batch, once for the retry tail with just the never-
+        # started paths.
+        assert mock_pp.process_batch_iter.call_count == 2
+        retry_call = mock_pp.process_batch_iter.call_args_list[1]
+        retry_paths_arg = retry_call.args[0]
+        assert set(retry_paths_arg) == {retry1, retry2}
 
     def test_failure_result_unknown_error(self) -> None:
         from core.dispatcher import process_image_files


### PR DESCRIPTION
Closes #432.

## Why

The parallel processor's pool-saturation abort marks every pending future as
failed when 2-3 in-flight tasks hang past the timeout. The 2026-05-26 organize
run produced **326 collateral failures** for files that never even started
running — a 163× collateral-damage ratio (2 actually hung vs 326 never-tried).

## Changes

**\`parallel/processor.py\`** — \`_check_pool_saturation\` now distinguishes:

- **Never-started futures** (collateral; \`non_retryable=False\`): queued in the
  pool but never picked up by a worker. Retryable.
- **In-flight futures** (genuinely hung; \`non_retryable=True\`): a worker was
  attempting them when the abort fired. Not retryable.

The error string (\`"Aborted: worker pool saturated by hung tasks"\`) stays the
same so existing taxonomy rules (#431) continue to bucket both as
\`inference_error\`.

**\`core/dispatcher.py\` (\`process_image_files\`)** — the failure branch now
diverts \`non_retryable=False\` aborts into a \`retry_paths\` list. After the
parallel loop finishes, the dispatcher reruns those paths sequentially via
\`vision_processor.process_file\` — exactly the behavior the user would get if
they'd manually re-run with \`--workers 1\`.

The retry is sequential (not parallel) because the conditions that caused the
pool to saturate (memory pressure, hung backend) likely persist; reattempting
in parallel would just trigger another abort.

## Test plan

- [x] New \`test_pool_saturation_retryable_aborts_run_sequentially\` in
      \`tests/integration/test_dispatcher_core.py\`. Exercises a 3-result
      iter (1 hung + 2 retryable) and asserts the dispatcher reruns
      only the 2 retryable paths via the mocked \`vision_processor\`.
- [x] All 275 existing \`tests/parallel/\` tests still pass.
- [x] \`_make_file_result\` helper signature extended with
      \`non_retryable\` / \`duration_ms\` defaults so prior tests
      continue to assume \`non_retryable=True\`.
- [x] \`ruff\`, \`mypy\` clean.
- [x] Bundles the typer<0.26 pin (mirrors #436) to unblock CI.

## Follow-ups

- If sequential retry also hangs, those failures now correctly bucket as
  \`inference_error\` via #431's token set — the operator hint points at
  \`--timeout-per-file\` / \`--workers 1\`.
- #435 (UX hints) will surface a "N images retried sequentially after pool
  abort" line in the summary so operators see the recovery happening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced worker pool saturation failure handling. Images that fail to start processing due to worker pool saturation are now automatically retried sequentially after the initial parallel batch completes. Timeout failures continue using fallback processing paths for added robustness.

* **Tests**
  * Added integration tests for worker pool saturation recovery and automatic retry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->