### PR TITLE
feat(ux): surface tuning hint in worker-pool saturation warning (#435)

### DIFF
--- a/src/parallel/processor.py
+++ b/src/parallel/processor.py
@@ -423,7 +423,11 @@ class ParallelProcessor:
             return None
         logger.warning(
             "Worker pool saturated: %d queued tasks waited > %.0fs without "
-            "starting. Aborting remaining work.",
+            "starting. Aborting remaining work. "
+            "Hint: raise `--timeout-per-file` (#396) or lower `--workers` "
+            "(#408) — on low-memory hardware running large vision models, "
+            "concurrent slots often exhaust unified memory and trigger this "
+            "saturation path.",
             len(stalled),
             timeout * 2,
         )

--- a/tests/parallel/test_concurrency_fixes.py
+++ b/tests/parallel/test_concurrency_fixes.py
@@ -276,6 +276,50 @@ class TestConcurrencyFixes(unittest.TestCase):
             f"queued_2 must report pool saturation, got: {by_path.get(Path('queued_2'))}",
         )
 
+    def test_saturated_pool_warning_includes_tuning_hint(self) -> None:
+        """#435: the saturation warning surfaces the tuning hint inline.
+
+        Operators don't discover ``--timeout-per-file`` / ``--workers``
+        until something breaks badly; the warning that fires when the
+        pool aborts must point at those knobs so the next run can be
+        tuned without a maintainer round-trip.
+        """
+        stop_event = threading.Event()
+        config = ParallelConfig(max_workers=1, timeout_per_file=0.1, retry_count=0)
+        processor = ParallelProcessor(config=config)
+
+        def hung_task(_path: Path) -> str:
+            stop_event.wait()
+            return "done"
+
+        captured: list[str] = []
+
+        def fake_warning(msg: str, *args: object, **_kw: object) -> None:
+            # Loguru-style: msg is a format string with %d / %s substitutions
+            try:
+                captured.append(msg % args)
+            except TypeError:
+                captured.append(msg)
+
+        from parallel import processor as processor_mod
+
+        with patch.object(processor_mod.logger, "warning", side_effect=fake_warning):
+            try:
+                processor.process_batch([Path("hung_1"), Path("queued_2")], hung_task)
+            finally:
+                stop_event.set()
+
+        saturated = [line for line in captured if "saturated" in line.lower()]
+        self.assertTrue(saturated, f"expected a saturation warning, got: {captured}")
+        self.assertTrue(
+            any("--timeout-per-file" in line for line in saturated),
+            f"saturation warning should mention --timeout-per-file: {saturated}",
+        )
+        self.assertTrue(
+            any("--workers" in line for line in saturated),
+            f"saturation warning should mention --workers: {saturated}",
+        )
+
     def test_error_message_does_not_control_retry_policy(self) -> None:
         """Regular failures containing the abort phrase should still be retried."""
         config = ParallelConfig(


### PR DESCRIPTION
Closes #435.

## Why

Operators don't discover \`--timeout-per-file\` (#396) and \`--workers\` (#408)
until something breaks badly. The 2026-05-26 organize run was the canonical
case: 478 files failed with the saturation abort and the user had no signal
pointing at the right knob.

The post-run summary now covers this via #411 + #431 (recommendation line on
the \`inference_error\` bucket points at both flags), but the in-batch warning
was a generic "Aborting remaining work" that didn't help.

## Change

Extends \`parallel/processor.py::_check_pool_saturation\`'s warning to:

\`\`\`text
Worker pool saturated: N queued tasks waited > Xs without starting.
Aborting remaining work. Hint: raise \`--timeout-per-file\` (#396) or lower
\`--workers\` (#408) — on low-memory hardware running large vision models,
concurrent slots often exhaust unified memory and trigger this saturation path.
\`\`\`

The warning fires once per pool-abort event (not per-file), so log spam stays
bounded.

## Test plan

- [x] New \`test_saturated_pool_warning_includes_tuning_hint\` patches
      \`processor.logger.warning\` and asserts the captured warning text
      contains both \`--timeout-per-file\` and \`--workers\`.
- [x] 276 existing \`tests/parallel/\` tests still pass.
- [x] \`ruff\`, \`mypy\` clean.
- [x] Bundles the typer<0.26 pin (mirrors #436) to unblock CI.