### PR TITLE
chore(release): bump version to 2.0.0-beta.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fo-core"
-version = "2.0.0-beta.9"
+version = "2.0.0-beta.10"
 description = "Streamlined CLI file organizer powered by local AI (Ollama)"
 authors = [
     {name = "fo-core Team", email = "noreply@example.com"}

--- a/src/version.py
+++ b/src/version.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-__version__ = "2.0.0-beta.9"
+__version__ = "2.0.0-beta.10"
 
 # Pattern for semantic versioning with optional pre-release and build metadata
 _VERSION_PATTERN = re.compile(


### PR DESCRIPTION
Rolls up the v2.0.0-beta.10 cycle. All 4 issues shipped (one of the original 5 closed as not-a-bug after re-inspection).

## Included PRs

| Issue | PR | Summary |
|------|------|---------|
| #431 | #436 | bucket worker-pool aborts as \`inference_error\` (was \`other\`) |
| #430 | #437 | exclude 0-duration vision samples from inference stats |
| #435 | #439 | surface tuning hint in worker-pool saturation warning |
| #432 | #438 | retry pool-abort collateral via single-worker pass instead of mass-failing |

\`#434\` (top-skipped-extensions report) was closed as not-a-bug — the section was rendering correctly all along; the original report was a log-window truncation artifact.

Plus the \`typer<0.26\` dependency pin (bundled in #436) which unblocked CI after upstream typer 0.26 vendored \`_click\` and broke \`src/cli/lazy.py\` type annotations.

## Test plan

- [x] Each constituent PR cleared CI independently.
- [x] All 4 merges landed cleanly with the 30-min hold + Codex/CodeRabbit review cycle.
- [x] \`pyproject.toml\` and \`src/version.py\` are the only files carrying the version string (synced this time to avoid a repeat of the #429 drift that CodeRabbit caught).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 2.0.0-beta.10

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->