### PR TITLE
fix: address unresolved review findings from PRs #400 and #417

### DIFF
--- a/.github/workflows/parallel-macos-matrix.yml
+++ b/.github/workflows/parallel-macos-matrix.yml
@@ -26,10 +26,11 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@v6
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -57,10 +58,11 @@ jobs:
     env:
       PYTHONUTF8: "1"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@v6
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
           cache: pip
@@ -88,10 +90,11 @@ jobs:
     env:
       PYTHONUTF8: "1"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@v6
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
           cache: pip
@@ -106,8 +109,13 @@ jobs:
         # -n auto omitted: xdist on Windows propagates CTRL_C_EVENT as
         # KeyboardInterrupt causing exit code 1 when all tests pass.
         # --timeout omitted: pytest-timeout thread-mode fires during teardown on Windows.
+        # ``shell: bash`` (Git Bash on windows-latest) so the standard `\`
+        # line continuation works — the prior `^` form was CMD syntax and
+        # silently broke under the default PowerShell shell (CodeRabbit
+        # P1 on PR #400).
+        shell: bash
         run: |
-          pytest tests/parallel/ ^
-            --strict-markers ^
-            --override-ini="addopts=" ^
+          pytest tests/parallel/ \
+            --strict-markers \
+            --override-ini="addopts=" \
             -v

--- a/src/core/types.py
+++ b/src/core/types.py
@@ -54,7 +54,7 @@ class OrganizationResult:
     processing_time: float = 0.0
     organized_structure: dict[str, list[str]] = field(default_factory=dict)
     errors: list[tuple[str, str]] = field(default_factory=list)  # (file, error)
-    skipped_by_extension: Counter[str] = field(default_factory=Counter)
+    skipped_by_extension: Counter[str] = field(default_factory=Counter)  # pyre-ignore[35]
     fallback_files: int = 0  # pyre-ignore[35]: Pyre 0.9.25 mis-flags dataclass field annotations under `from __future__ import annotations`. Same pre-existing pattern as the other counters above (alerts #39-46 on main).
     # Per-file inference durations in milliseconds (#410). Populated by
     # the organizer from ProcessedFile.inference_ms / ProcessedImage.inference_ms.

--- a/src/parallel/processor.py
+++ b/src/parallel/processor.py
@@ -535,24 +535,30 @@ class ParallelProcessor:
                 if future.done():
                     # Task completed in the narrow window between cancel() and
                     # done() — a race that only occurs on some OS schedulers
-                    # (commonly macOS).  The processor had already decided this
-                    # task exceeded the timeout; discard the result and report a
-                    # consistent timeout so callers see uniform behaviour across
-                    # platforms.  Mark non_retryable: the task was too slow once
-                    # and will be too slow again.
+                    # (commonly macOS).  Preserve the actual result rather
+                    # than reporting a phantom timeout: the backdated
+                    # ``future_started[future] = now - poll_interval``
+                    # (above) can trip the elapsed-time check up to
+                    # ``poll_interval`` seconds early, so a task that
+                    # genuinely finished within the configured timeout was
+                    # otherwise being reported as ``non_retryable=True``
+                    # and discarding its actual return value — Codex P1 on
+                    # PR #400.
                     pending.remove(future)
                     del future_paths[future]
                     del future_started[future]
                     future_queued_at.pop(future, None)
-                    race_timeout_result = finalize_result(
-                        FileResult(
-                            path=path,
-                            success=False,
-                            error=f"Timed out after {timeout}s",
-                            non_retryable=True,
+                    try:
+                        race_result = future.result()
+                    except Exception as exc:
+                        # The task completed but raised — surface the
+                        # real exception text rather than a timeout.
+                        race_result = finalize_result(
+                            FileResult(path=path, success=False, error=str(exc))
                         )
-                    )
-                    return (False, False, [race_timeout_result])
+                    else:
+                        race_result = finalize_result(race_result)
+                    return (False, False, [race_result])
 
                 # Task is running and cannot be cancelled.  Abandon it —
                 # remove from tracking so other files continue normally.

--- a/tests/parallel/test_processor.py
+++ b/tests/parallel/test_processor.py
@@ -7,6 +7,7 @@ callbacks, error handling, and graceful shutdown.
 """
 
 import threading
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -424,6 +425,90 @@ class TestProcessBatchIter(unittest.TestCase):
         files = [Path("a.txt"), Path("b.txt")]
         list(processor.process_batch_iter(files, _identity))
         self.assertEqual(callback.call_count, 2)
+
+
+class TestTimeoutRacePreservesResult(unittest.TestCase):
+    """Codex P1 on PR #400: when ``cancel()`` returns False and
+    ``future.done()`` returns True, the task actually completed in the
+    race window — preserve its real result instead of reporting a
+    phantom timeout.
+    """
+
+    def test_race_window_preserves_successful_result(self) -> None:
+        from concurrent.futures import Future
+        from unittest.mock import MagicMock
+
+        from parallel.processor import ParallelProcessor
+        from parallel.result import FileResult
+
+        processor = ParallelProcessor(config=ParallelConfig(timeout_per_file=0.1))
+        # Construct a future that:
+        # 1. cancel() returns False (couldn't cancel — task already running)
+        # 2. done() returns True (the task ACTUALLY finished in the race window)
+        # 3. result() returns a real successful FileResult
+        finished_result = FileResult(path=Path("ok.txt"), success=True, result="real-output")
+        future: Future[FileResult] = MagicMock(spec=Future)
+        future.cancel.return_value = False
+        future.done.return_value = True
+        future.result.return_value = finished_result
+
+        pending = {future}
+        future_paths = {future: Path("ok.txt")}
+        # Backdate start so the timeout elapsed check fires.
+        future_started = {future: time.monotonic() - 1.0}
+        future_queued_at = {future: time.monotonic() - 1.0}
+
+        out = processor._handle_timeouts(
+            pending=pending,
+            future_paths=future_paths,
+            future_started=future_started,
+            future_queued_at=future_queued_at,
+            timeout=0.1,
+            poll_interval=0.05,
+            finalize_result=lambda r: r,
+        )
+        self.assertIsNotNone(out)
+        should_abort, needs_shutdown, results = out  # type: ignore[misc]
+        self.assertFalse(should_abort)
+        self.assertEqual(len(results), 1)
+        # The real successful result is preserved — NOT a timeout phantom.
+        self.assertTrue(results[0].success)
+        self.assertEqual(results[0].result, "real-output")
+
+    def test_race_window_preserves_exception(self) -> None:
+        from concurrent.futures import Future
+        from unittest.mock import MagicMock
+
+        from parallel.processor import ParallelProcessor
+        from parallel.result import FileResult
+
+        processor = ParallelProcessor(config=ParallelConfig(timeout_per_file=0.1))
+        future: Future[FileResult] = MagicMock(spec=Future)
+        future.cancel.return_value = False
+        future.done.return_value = True
+        # Task finished in the race window but raised — surface the
+        # actual exception text rather than a timeout phantom.
+        future.result.side_effect = RuntimeError("ollama 500")
+
+        pending = {future}
+        future_paths = {future: Path("boom.txt")}
+        future_started = {future: time.monotonic() - 1.0}
+        future_queued_at = {future: time.monotonic() - 1.0}
+
+        out = processor._handle_timeouts(
+            pending=pending,
+            future_paths=future_paths,
+            future_started=future_started,
+            future_queued_at=future_queued_at,
+            timeout=0.1,
+            poll_interval=0.05,
+            finalize_result=lambda r: r,
+        )
+        self.assertIsNotNone(out)
+        _, _, results = out  # type: ignore[misc]
+        self.assertEqual(len(results), 1)
+        self.assertFalse(results[0].success)
+        self.assertIn("ollama 500", results[0].error or "")
 
 
 class TestExecutorFallback(unittest.TestCase):


### PR DESCRIPTION
Three cleanup items found during a 2-day audit of unaddressed review threads.

## What's fixed

### Pyre — \`src/core/types.py\` (was unresolved on PR #417)

\`OrganizationResult.skipped_by_extension\` was missing the inline \`# pyre-ignore[35]\` pragma that every other counter/list/dict field in the dataclass carries. github-advanced-security kept flagging it on every PR that touched the file. One-line fix.

### Workflow hardening — \`.github/workflows/parallel-macos-matrix.yml\` (was unresolved on PR #400, CodeRabbit)

- Pin \`actions/checkout@de0fac2e...\` (v6.0.2) and \`actions/setup-python@a309ff8b...\` (v6.2.0) — matches \`ci.yml\`'s pattern.
- Add \`persist-credentials: false\` to the checkout step.
- Switch the Windows \`run:\` step to \`shell: bash\` so the \`\\\` line continuation works (the previous \`^\` form was CMD syntax and silently broke under PowerShell, the default \`windows-latest\` shell).

### Race-window result preservation — \`src/parallel/processor.py\` (was unresolved Codex P1 on PR #400)

When \`future.cancel()\` returned \`False\` and \`future.done()\` returned \`True\` (a real race only seen on some macOS schedulers), the branch ALWAYS reported a phantom \`Timed out after Xs, non_retryable=True\` result and discarded the task's actual return value.

Because \`future_started\` is deliberately backdated by \`poll_interval\` for drift compensation, the elapsed-time check can fire up to \`poll_interval\` seconds early — so a task that actually finished within the configured timeout could land in this branch and be misreported as a non-retryable timeout.

The branch now calls \`future.result()\` and forwards the real outcome (or wraps the exception text when the task raised). Two new regression tests
exercise both shapes via \`MagicMock(spec=Future)\`.

## Test plan

- [x] 278 \`tests/parallel/\` tests pass (276 existing + 2 new regression tests).
- [x] \`mypy\`, \`ruff\` clean.
- [x] Pyre alert resolves on \`OrganizationResult.skipped_by_extension\` (same pattern as the rest of the file).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a race condition in parallel task processing where results from jobs completing near the timeout boundary were incorrectly reported as timeouts instead of their actual outcomes.

* **Tests**
  * Added new test cases validating proper result preservation during timeout race windows.

* **Chores**
  * Updated CI/CD workflow configurations and type annotations for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->