### PR TITLE
ci(deps): block Dependabot from proposing known-broken mypy 2.x / pytest-timeout 2.4.x bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,17 @@ updates:
       - dependency-name: "rich"
       - dependency-name: "tinytag"
       - dependency-name: "watchdog"
+      # mypy 2.x: pre-commit `mypy-changed` hook fails on subclasses of
+      # Any-typed bases (FileSystemEventHandler, click.Group, TyperGroup),
+      # producing 8 new errors not present in 1.x. See pyproject.toml
+      # comment on the `mypy` constraint; matched lint failure on PR #425.
+      - dependency-name: "mypy"
+        versions: [">=2.0.0"]
+      # pytest-timeout 2.4.0: timer thread not cancelled on Windows, crashes
+      # during teardown (AssertionError in read_global_capture). See
+      # pyproject.toml comment on the `pytest-timeout` constraint.
+      - dependency-name: "pytest-timeout"
+        versions: [">=2.4.0"]
     groups:
       dev-dependencies:
         patterns:


### PR DESCRIPTION
## Summary

Stops Dependabot from regenerating PRs that bump `mypy` to 2.x or `pytest-timeout` to 2.4.x — both of which are already documented inline in `pyproject.toml` as regressions that break CI.

## Failure Detected

| Where | Job | Conclusion |
|-------|-----|------------|
| [PR #425](https://github.com/curdriceaurora/fo-core/pull/425) (Dependabot dev-dependencies bump) | `lint` | ❌ failure |

Other recent merged PRs (#438, #440, #441) and the latest commit on `main` (`8625c7d`) are fully green — including all matrix jobs (`Extras [...]`, `Test full suite (py3.x)`, `Test PR suite`, `Integration tests`). No other CI failures were found in the most recent failure window.

## Root Cause

Dependabot is configured with `versioning-strategy: increase-if-necessary`, which **rewrites the upper bounds in `pyproject.toml`** to allow newer versions of grouped dev dependencies. PR #425's diff:

```diff
-    "pytest-timeout>=2.2.0,<2.4.0",
+    "pytest-timeout>=2.2.0,<2.5.0",
-    "mypy!=1.20.2,~=1.8",
+    "mypy~=2.1",
```

Both upper bounds were placed deliberately:

- **`mypy<2.0`** — Reproduced locally with `mypy 2.1.0`: 8 new strict-mode errors not present in 1.x:
  - `src/watcher/handler.py:57` — Class cannot subclass `FileSystemEventHandler` (has type `Any`)
  - `src/cli/lazy.py:30,115` — Same for `click.Group`, `TyperGroup`
  - `src/cli/lazy.py:78,86,96,146` — Returning Any from typed function
  - `src/services/deduplication/quality.py:23` — Unused `type: ignore`
  The inline `pyproject.toml` comment already says: *"2.1.0 crash: INTERNAL ERROR exit-code-2 on CI"*.

- **`pytest-timeout<2.4.0`** — The inline comment says: *"2.4.0 regression: timer thread not cancelled on Windows; crashes during teardown (AssertionError in read_global_capture). PR #126 originally pinned `<2.4.0`; PR #227 inadvertently re-introduced `~=2.4.0` which resolves to the buggy 2.4.0."*

The `pyproject.toml` constraint is not load-bearing against Dependabot under `increase-if-necessary` — only the explicit dependabot `ignore` filter is.

## Fix

Add `versions:` filters to the existing root-level `ignore:` list in `.github/dependabot.yml`:

```yaml
- dependency-name: "mypy"
  versions: [">=2.0.0"]
- dependency-name: "pytest-timeout"
  versions: [">=2.4.0"]
```

Each entry mirrors the rationale already documented in `pyproject.toml`. When the upstream regressions are resolved, removing the inline comment and the ignore filter together restores Dependabot bumps.

## Trade-offs

- **Not closing PR #425 here** — closing/reopening is the Dependabot owner's call; this PR just stops the issue from recurring.
- **Not touching the source code** to make it pass with mypy 2.x — mypy 2.x is genuinely stricter on subclassing `Any`-typed third-party bases; that's a separate, much larger workstream that needs to be done deliberately, not driven by a Dependabot bump.
- **Versions filter uses `>=2.0.0`** rather than `2.x` — explicit lower bound makes it obvious when the constraint can be relaxed (e.g. flip to `>=3.0.0` once mypy 2.x is supported).

## Verification

- [x] `.github/dependabot.yml` parses as valid YAML (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Reproduced the mypy 2.1.0 failure locally (8 errors, listed above)
- [x] No runtime code changes — scope limited to one config file
- [ ] Next Dependabot weekly run (Monday) skips `mypy>=2.0.0` and `pytest-timeout>=2.4.0` proposals

## Affected Files

- `.github/dependabot.yml` (+11 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016FA3vYoSbPCyBUGs2w7yBc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to better handle version constraints for development tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->