### PR TITLE
Fix: Resolve Matrix CI Failures (block Dependabot typer>=0.26 bump)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,12 @@ updates:
       # pyproject.toml comment on the `pytest-timeout` constraint.
       - dependency-name: "pytest-timeout"
         versions: [">=2.4.0"]
+      # typer 0.26+: vendored its own `_click` module and broke parent-class
+      # type annotations in `src/cli/lazy.py` (`LazyCommandProxy(click.Group)`).
+      # See pyproject.toml comment on the `typer[all]` constraint; matched
+      # type-check / lint / Test PR suite / Integration tests failure on PR #443.
+      - dependency-name: "typer"
+        versions: [">=0.26"]
     groups:
       dev-dependencies:
         patterns:


### PR DESCRIPTION
## Summary of Failures Detected

| Where | Job | Conclusion | Run |
|-------|-----|------------|-----|
| [PR #443](https://github.com/curdriceaurora/fo-core/pull/443) (Dependabot `typer >=0.12,<0.27`) | `Test PR suite (py3.11)` | ❌ failure | [26509514981](https://github.com/curdriceaurora/fo-core/actions/runs/26509514981/job/78070624382) |
| [PR #443](https://github.com/curdriceaurora/fo-core/pull/443) | `type-check` | ❌ failure | [26509514981](https://github.com/curdriceaurora/fo-core/actions/runs/26509514981/job/78070357415) |
| [PR #443](https://github.com/curdriceaurora/fo-core/pull/443) | `lint` | ❌ failure | [26509514981](https://github.com/curdriceaurora/fo-core/actions/runs/26509514981/job/78070357213) |
| [PR #443](https://github.com/curdriceaurora/fo-core/pull/443) | `Integration tests (PR)` | ❌ failure | [26509514879](https://github.com/curdriceaurora/fo-core/actions/runs/26509514879/job/78070356931) |

`main` (HEAD `2779738`) and the most-recently-merged PRs (#440, #441, #442) are fully green across every matrix job (`Extras [...]`, `Test full suite (py3.x)`, `Test PR suite`, `Integration tests`, `audit-dependencies-extras [ubuntu/macos]`). No other CI failures were found in the most recent failure window.

## Root Cause

Dependabot is configured with `versioning-strategy: increase-if-necessary` (`.github/dependabot.yml:8`), which **rewrites the upper bounds in `pyproject.toml`**. PR #443's only diff:

```diff
-    "typer[all]>=0.12,<0.26",
+    "typer[all]>=0.12,<0.27",
```

`pyproject.toml:53-56` documents inline why the `<0.26` upper bound was placed deliberately:

> *typer 0.26 vendored its own `_click` module and broke parent-class type annotations in `src/cli/lazy.py` (#430+ CI flake). Pin out of the 0.26 range until lazy.py is updated to use the new typer types.*

The breaking type is at `src/cli/lazy.py:30` — `class LazyCommandProxy(click.Group)`. With typer 0.26's vendored `_click`, `click.Group` resolves to `Any` and mypy strict mode rejects the subclass under several rules, producing the type-check failure observed on PR #443. The same cascade fails `lint` (pre-commit `mypy-changed` hook) and the `Test PR suite` / `Integration tests` jobs.

The `pyproject.toml` constraint is not load-bearing against Dependabot under `increase-if-necessary` — only the explicit `dependabot.yml` ignore filter is. This is the same class of issue PR #442 just fixed for `mypy` and `pytest-timeout`; `typer` was the third sibling not yet covered.

## Fix Implemented

Add a `versions: [">=0.26"]` ignore entry for `typer` in the root-level `ignore:` list, mirroring the existing entries for `mypy` and `pytest-timeout`:

```yaml
# typer 0.26+: vendored its own `_click` module and broke parent-class
# type annotations in `src/cli/lazy.py` (`LazyCommandProxy(click.Group)`).
# See pyproject.toml comment on the `typer[all]` constraint; matched
# type-check / lint / Test PR suite / Integration tests failure on PR #443.
- dependency-name: "typer"
  versions: [">=0.26"]
```

## Rationale & Trade-offs

- **One config-only file changed** — no runtime source touched. Scope strictly limited to stopping the regression-bump recurrence.
- **Not closing PR #443 in this commit** — that's the Dependabot owner's call. After this lands, `@dependabot recreate` on PR #443 (or the next weekly run) will respect the ignore filter and the PR will go away on its own.
- **No test weakening, no test removal, no broad refactor** — the failing tests/types are correctly rejecting genuinely-broken upstream behavior; the right fix is at the dependency-management layer.
- **Lower bound spelled `>=0.26` (not `0.26.x`)** — explicit semver bound makes it obvious when the constraint can be relaxed (e.g. flip to `>=0.27` if upstream restores the public `click.Group` re-export, or remove entirely once `src/cli/lazy.py` is updated to use the new vendored typer types).

## Verification Steps Performed

- [x] `.github/dependabot.yml` parses as valid YAML and the new entry resolves to `{'dependency-name': 'typer', 'versions': ['>=0.26']}` (`python3 -c "import yaml; ..."`)
- [x] Verified `src/cli/lazy.py:30` still declares `class LazyCommandProxy(click.Group)` — the exact subclass-of-`Any` that typer 0.26 breaks
- [x] Verified the inline comment in `pyproject.toml:53-56` documents the same root cause
- [x] Cross-checked the PR #442 pattern (`mypy>=2.0.0`, `pytest-timeout>=2.4.0` entries) to keep the configuration style consistent
- [x] No source code, no tests, no other config changed — `git diff --stat` shows only `.github/dependabot.yml` (+6 lines)
- [ ] Next Dependabot weekly run (Monday) skips `typer>=0.26` proposals

## Impacted Areas / Modules

- `.github/dependabot.yml` (+6 lines, ignore filter)

No code, test, or other configuration files are touched.

## Before / After Behavior

**Before**: Dependabot opens a PR (#443) weekly bumping `typer` upper bound past `<0.26`. Every such PR cascades into 4 red matrix CI jobs; reviewers must manually `@dependabot ignore this version` per occurrence.

**After**: Dependabot consults the ignore filter at PR-generation time and never opens the bumped PR in the first place. Matrix CI stays green. The pin can be removed (alongside the `pyproject.toml` comment) the day `src/cli/lazy.py` is updated to use the new typer-vendored `_click` types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TpDwMnHAnp7R2Y4Q36dDsz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints to prevent compatibility issues with transitive dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->