### PR TITLE
perf(cli): zero-startup fast-path for hardware-info (#451)

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -81,7 +81,7 @@ _SETUP_GATE_ALLOWLIST: frozenset[str] = frozenset(
 relaxes the first-run gate for it — verify the command doesn't write
 or organize files first."""
 
-_ZERO_STARTUP_COMMANDS: frozenset[str] = frozenset({"version"})
+_ZERO_STARTUP_COMMANDS: frozenset[str] = frozenset({"version", "hardware-info"})
 """Commands whose contract is pure metadata output.
 
 These commands should not pay for log sinks, setup checks, durable-move
@@ -159,7 +159,7 @@ def main_callback(
 ) -> None:
     """Initialize global CLI state and perform startup bookkeeping.
 
-    Sets ctx.obj to a CLIState containing the provided flags (with CLIState.no_interactive set to the inverse of `interactive`), generates a unique session ID for this invocation, installs the credential-redacting log filter on the root logger, sets up per-run session logging, and runs a durable-move recovery sweep on the default journal to clean up interrupted operations. The startup sweep is skipped when the invoked subcommand is "recover"; if the sweep raises an exception it is logged at WARNING and execution continues.
+    Sets ctx.obj to a CLIState containing the provided flags (with CLIState.no_interactive set to the inverse of `interactive`), generates a unique session ID for this invocation, installs the credential-redacting log filter on the root logger, sets up per-run session logging, and runs a durable-move recovery sweep on the default journal to clean up interrupted operations. The startup sweep is skipped when the invoked subcommand is "recover"; if the sweep raises an exception it is logged at WARNING and execution continues. Zero-startup commands (those in _ZERO_STARTUP_COMMANDS, e.g. "version" and "hardware-info") skip all I/O bookkeeping — log sinks and the recovery sweep — unless --debug is passed, which forces the full startup path.
 
     Parameters:
         ctx (typer.Context): Typer invocation context used to store CLIState.
@@ -167,9 +167,6 @@ def main_callback(
         version_flag (bool): Eager version callback value (accepted and ignored here).
     """
     _ = version_flag
-
-    if ctx.invoked_subcommand in _ZERO_STARTUP_COMMANDS:
-        return
 
     # Generate unique session ID for this CLI invocation
     # Format: YYYY-MM-DDTHH-MM-SS-{short_uuid}
@@ -186,6 +183,14 @@ def main_callback(
         debug=debug,
         session_id=session_id,
     )
+
+    # Zero-startup commands (pure metadata / read-only diagnostics) skip the I/O
+    # bookkeeping below — log sinks, session-log cleanup, durable-move recovery
+    # sweep. CLIState is built first (above) so global flags like --json still
+    # flow through to these commands. --debug opts back into the full path so
+    # loguru DEBUG output and recovery still run when explicitly requested.
+    if not debug and ctx.invoked_subcommand in _ZERO_STARTUP_COMMANDS:
+        return
 
     if debug:
         # Install a loguru DEBUG-level stderr handler so every

--- a/tests/cli/test_debug_flag.py
+++ b/tests/cli/test_debug_flag.py
@@ -190,7 +190,9 @@ def test_rotating_log_file_created(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     monkeypatch.setattr("loguru.logger.remove", lambda _id: None)
 
     runner = CliRunner()
-    result = runner.invoke(app, ["hardware-info"])
+    # `logs --list` runs full startup bookkeeping; `hardware-info` is now a
+    # zero-startup command (#451) that skips sink setup, so it can't carry this.
+    result = runner.invoke(app, ["logs", "--list"])
     assert result.exit_code == 0
     assert log_dir.exists(), "log directory should be created"
     log_files = list(log_dir.glob("fo.log*"))
@@ -234,8 +236,11 @@ def test_unwritable_log_dir_degrades_gracefully(
         raise OSError("permission denied")
 
     monkeypatch.setattr("config.path_manager.get_canonical_paths", _raise_oserror)
+    monkeypatch.setattr("loguru.logger.add", lambda *_a, **_k: None)
     monkeypatch.setattr("loguru.logger.remove", lambda _id: None)
 
     runner = CliRunner()
-    result = runner.invoke(app, ["hardware-info"])
+    # `--debug` forces the full startup path; `hardware-info` alone is now a
+    # zero-startup command (#451) and would skip the log-sink block under test.
+    result = runner.invoke(app, ["--debug", "hardware-info"])
     assert result.exit_code == 0

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from importlib.metadata import PackageNotFoundError
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -52,6 +54,63 @@ def test_version_command_skips_startup_bookkeeping(monkeypatch: pytest.MonkeyPat
     assert "fo 1.2.3" in result.stdout
     assert log_sink_calls == []
     assert sweep_calls == []
+
+
+@pytest.mark.ci
+def test_hardware_info_command_skips_startup_bookkeeping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`fo hardware-info` should print its profile without log sinks or recovery sweeps."""
+    log_sink_calls: list[object] = []
+    sweep_calls: list[object] = []
+
+    monkeypatch.setattr("loguru.logger.add", lambda sink, **_kwargs: log_sink_calls.append(sink))
+    monkeypatch.setattr("cli.main._durable_move_sweep", lambda journal: sweep_calls.append(journal))
+    monkeypatch.setattr("core.hardware_profile.detect_hardware", lambda: MagicMock())
+
+    result = runner.invoke(app, ["hardware-info"])
+
+    assert result.exit_code == 0
+    assert log_sink_calls == []
+    assert sweep_calls == []
+    assert "Hardware Profile" in result.stdout
+
+
+@pytest.mark.ci
+def test_hardware_info_honors_global_json_flag() -> None:
+    """`fo --json hardware-info` must emit JSON (global flag flows through after reorder)."""
+    fake_profile = MagicMock()
+    fake_profile.to_dict.return_value = {"gpu_type": "none", "ram_gb": 16}
+
+    with patch("core.hardware_profile.detect_hardware", return_value=fake_profile):
+        result = runner.invoke(app, ["--json", "hardware-info"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload == {"gpu_type": "none", "ram_gb": 16}
+
+
+@pytest.mark.ci
+def test_hardware_info_debug_forces_full_startup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`fo --debug hardware-info` opts back into the full startup path (sinks + sweep)."""
+    log_sink_calls: list[object] = []
+    sweep_calls: list[object] = []
+
+    monkeypatch.setattr("loguru.logger.add", lambda sink, **_kwargs: log_sink_calls.append(sink))
+    # call_on_close fires logger.remove() on the (mocked) sink ids; loguru's
+    # remove(None) wipes ALL handlers, so noop it to avoid polluting global state.
+    monkeypatch.setattr("loguru.logger.remove", lambda _id: None)
+    monkeypatch.setattr("cli.main._durable_move_sweep", lambda journal: sweep_calls.append(journal))
+    monkeypatch.setattr("config.path_manager.get_canonical_paths", lambda: {"logs": tmp_path})
+    monkeypatch.setattr("core.hardware_profile.detect_hardware", lambda: MagicMock())
+
+    result = runner.invoke(app, ["--debug", "hardware-info"])
+
+    assert result.exit_code == 0
+    assert len(log_sink_calls) >= 3  # debug stderr + rotating-file + session sinks installed
+    assert len(sweep_calls) == 1  # durable-move recovery sweep ran exactly once
 
 
 @pytest.mark.ci

--- a/tests/cli/test_session_logging.py
+++ b/tests/cli/test_session_logging.py
@@ -215,10 +215,13 @@ def test_unwritable_session_log_dir_degrades_gracefully(
         original_mkdir(self, *args, **kwargs)
 
     monkeypatch.setattr(Path, "mkdir", _patched_mkdir)
+    monkeypatch.setattr("loguru.logger.add", lambda *_a, **_k: None)
     monkeypatch.setattr("loguru.logger.remove", lambda _id: None)
 
     runner = CliRunner()
-    result = runner.invoke(app, ["hardware-info"])
+    # `--debug` forces the full startup path; `hardware-info` alone is now a
+    # zero-startup command (#451) and would skip the session-log block under test.
+    result = runner.invoke(app, ["--debug", "hardware-info"])
     # Should degrade gracefully and still exit 0
     assert result.exit_code == 0
 


### PR DESCRIPTION
## Summary

`fo hardware-info` paid the full `main_callback` startup bookkeeping (loguru file/session sinks, session-log cleanup, durable-move recovery sweep) on every run — ~0.9s of overhead for a read-only diagnostic whose real work (`detect_hardware()`) is ~0.15s. This adds it to the existing zero-startup fast-path that `fo version` already uses.

- Build `CLIState` **before** the `_ZERO_STARTUP_COMMANDS` early-return so global flags like `--json` still flow through to fast-path commands (a naive add-to-set would have silently broken `fo --json hardware-info`).
- Guard the early-return with `not debug` so `--debug` opts back into the full startup path (DEBUG logging + recovery still run when explicitly requested).
- Add `hardware-info` to `_ZERO_STARTUP_COMMANDS`.
- Update the `main_callback` docstring to match the new control flow (F10).

Skipping the sweep is safe because `hardware-info` is read-only — it never moves files, so recovery still runs on the next file-mutating command.

## Test plan

New regression tests in `tests/cli/test_main.py`:
- [x] `test_hardware_info_command_skips_startup_bookkeeping` — no log sinks, no recovery sweep
- [x] `test_hardware_info_honors_global_json_flag` — `fo --json hardware-info` still emits JSON (proves the reorder)
- [x] `test_hardware_info_debug_forces_full_startup` — `--debug` installs sinks + runs sweep

Repointed three pre-existing tests that used `fo hardware-info` as a carrier for asserting full startup bookkeeping (now skipped):
- [x] `test_rotating_log_file_created` → `logs --list`
- [x] `test_unwritable_log_dir_degrades_gracefully` → `--debug hardware-info`
- [x] `test_unwritable_session_log_dir_degrades_gracefully` → `--debug hardware-info`

No wall-clock latency assertion (project C1 FLAKY_GATE rule). Local `pre-commit-validation.sh` passes; affected `tests/cli/` files green.

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `hardware-info` command to retrieve detailed system hardware information.
  * Certain CLI commands now skip non-critical initialization overhead for faster startup by default. Full startup sequence can be enabled with the `--debug` flag.
  * `hardware-info` command supports the `--json` flag to output results in JSON format.

* **Documentation**
  * Updated command documentation to reflect conditional startup behavior and `--debug` flag usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->