### PR TITLE
test(cli): fix main-CI break from stale organize/preview FileOrganizer assertions

### DIFF
--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -142,9 +142,10 @@ def test_preview_requires_setup_completed(mock_cm):
     assert "setup" in result.stdout.lower()
 
 
+@patch("cli.organize._resolve_timeout_per_file", return_value=300.0)
 @patch("cli.organize._check_setup_completed", return_value=True)
 @patch("core.organizer.FileOrganizer")
-def test_organize_command_live(mock_organizer_cls, _mock_setup, tmp_path):
+def test_organize_command_live(mock_organizer_cls, _mock_setup, _mock_timeout, tmp_path):
     """Test organize command executes FileOrganizer correctly."""
     mock_instance = MagicMock()
     mock_result = MagicMock(processed_files=5, skipped_files=1, failed_files=0)
@@ -174,9 +175,10 @@ def test_organize_command_live(mock_organizer_cls, _mock_setup, tmp_path):
     mock_instance.organize.assert_called_once_with(in_dir, out_dir, show_skipped=False)
 
 
+@patch("cli.organize._resolve_timeout_per_file", return_value=300.0)
 @patch("cli.organize._check_setup_completed", return_value=True)
 @patch("core.organizer.FileOrganizer")
-def test_organize_command_dry_run(mock_organizer_cls, _mock_setup, tmp_path):
+def test_organize_command_dry_run(mock_organizer_cls, _mock_setup, _mock_timeout, tmp_path):
     """Test organize command processes dry-run flag."""
     mock_instance = MagicMock()
     mock_result = MagicMock(processed_files=3, skipped_files=0, failed_files=0)
@@ -228,9 +230,10 @@ def test_organize_command_error(mock_organizer_cls, _mock_setup, tmp_path):
     assert "Error: Something broke" in result.stdout
 
 
+@patch("cli.organize._resolve_timeout_per_file", return_value=300.0)
 @patch("cli.organize._check_setup_completed", return_value=True)
 @patch("core.organizer.FileOrganizer")
-def test_preview_command(mock_organizer_cls, _mock_setup, tmp_path):
+def test_preview_command(mock_organizer_cls, _mock_setup, _mock_timeout, tmp_path):
     """Test preview command runs organizer in dry_run mode."""
     mock_instance = MagicMock()
     mock_result = MagicMock(total_files=10)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
@@ -162,12 +162,13 @@ def test_organize_command_live(mock_organizer_cls, _mock_setup, tmp_path):
     assert "Organizing" in result.stdout
     mock_organizer_cls.assert_called_once_with(
         dry_run=False,
-        parallel_workers=None,
+        parallel_workers=ANY,  # auto-default min(4, cpu_count()//2) per #408
         prefetch_depth=2,
         enable_vision=True,
         no_prefetch=False,
         transcribe_audio=False,
         max_transcribe_seconds=600.0,
+        timeout_per_file=300.0,  # AppConfig/ProcessingSettings default per #396
     )
     # show_skipped kwarg is always forwarded (defaults to False) since #412.
     mock_instance.organize.assert_called_once_with(in_dir, out_dir, show_skipped=False)
@@ -193,12 +194,13 @@ def test_organize_command_dry_run(mock_organizer_cls, _mock_setup, tmp_path):
     assert "Dry run mode" in result.stdout
     mock_organizer_cls.assert_called_once_with(
         dry_run=True,
-        parallel_workers=None,
+        parallel_workers=ANY,  # auto-default min(4, cpu_count()//2) per #408
         prefetch_depth=2,
         enable_vision=True,
         no_prefetch=False,
         transcribe_audio=False,
         max_transcribe_seconds=600.0,
+        timeout_per_file=300.0,  # AppConfig/ProcessingSettings default per #396
     )
     # A.cli resolves the path args before dispatching; the service sees
     # the canonical absolute form. show_skipped=False default since #412.
@@ -243,12 +245,13 @@ def test_preview_command(mock_organizer_cls, _mock_setup, tmp_path):
     assert "Previewing" in result.stdout
     mock_organizer_cls.assert_called_once_with(
         dry_run=True,
-        parallel_workers=None,
+        parallel_workers=ANY,  # auto-default min(4, cpu_count()//2) per #408
         prefetch_depth=2,
         enable_vision=True,
         no_prefetch=False,
         transcribe_audio=False,
         max_transcribe_seconds=600.0,
+        timeout_per_file=300.0,  # AppConfig/ProcessingSettings default per #396
     )
     resolved = in_dir.resolve()
     mock_instance.organize.assert_called_once_with(resolved, resolved)


### PR DESCRIPTION
## Problem

Main CI broke at commit `5d71bf6` (`perf(cli): zero-startup fast-path for hardware-info`). The failing jobs were three tests in `tests/cli/test_main.py`:

- `test_organize_command_live`
- `test_organize_command_dry_run`
- `test_preview_command`

Each asserted the **pre-#408/#396** `FileOrganizer(...)` call signature:

```
Expected: FileOrganizer(..., parallel_workers=None, max_transcribe_seconds=600.0)
  Actual: FileOrganizer(..., parallel_workers=1, ..., timeout_per_file=300.0)
```

The CLI now:
- resolves `parallel_workers` via the cpu-count auto-default (`min(4, max(1, cpu_count()//2))`, #408) — never `None`
- always forwards `timeout_per_file` (resolved from the flag → `AppConfig.processing.timeout_per_file` → `ProcessingSettings` default of `300.0`, #396)

The assertions were never updated when those features landed.

## Why it only failed on main (not the PR)

The three tests carry **no `@pytest.mark.ci` marker**, so the PR's `-m "ci"` subset run skipped them. Only the full main-push suite exercises them — so the regression was invisible until it merged. The hardware-info commit itself is unrelated; it was simply the next push to run the full suite.

## Fix

Update the three assertion blocks to mirror the canonical pattern already used in `tests/cli/test_cli_organize.py::test_organize_basic`:

- `parallel_workers=ANY` — the auto-default is host-dependent, so a literal would be flaky across runners
- add `timeout_per_file=300.0` — the `ProcessingSettings` default on a clean (no on-disk config) CI env

Added `ANY` to the `unittest.mock` import.

## Verification

- `tests/cli/test_main.py` — 15 passed
- Fixed tests pass under randomized ordering and in isolation
- `ruff check tests/cli/test_main.py` — clean
- Swept the suite for other stale `parallel_workers=None` assertions — none remain

> Note: `tests/cli/test_cli_utilities_coverage.py::test_index_build_failure_exits_with_error` fails in a `dev`-only local venv (missing `search`/`dedup-text` extras for `hybrid_retriever`); it passes on CI where those extras are installed. Out of scope for this fix.

https://claude.ai/code/session_01NdjxsudMKfwhLy8aYn9wSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdjxsudMKfwhLy8aYn9wSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CLI command tests to verify auto-selection of parallel workers and application of file timeout settings for organize and preview commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->