### PR TITLE
test+docs: green the main full-suite (logs docs + audio import-stub fix)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -403,6 +403,47 @@ fo analytics ~/Documents
 
 ---
 
+### `logs`
+
+View or tail fo log files.
+
+By default, shows the last 50 lines of the main `fo.log` file. Use `--session`
+to view the most recent session log instead, or `--list` to see all available
+session logs.
+
+**Usage:**
+
+```bash
+fo logs [OPTIONS]
+```
+
+**Options:**
+- `--follow, -f` — Follow log output (like `tail -f`)
+- `--lines, -n INTEGER` — Number of lines to show (default: 50)
+- `--session` — Show the latest session log instead of the main `fo.log`
+- `--list, -l` — List all available session logs
+
+**Examples:**
+
+```bash
+# Show the last 50 lines of fo.log
+fo logs
+
+# Tail fo.log (like tail -f)
+fo logs --follow
+
+# Show the latest session log
+fo logs --session
+
+# List all session logs
+fo logs --list
+
+# Show the last 100 lines of the latest session log
+fo logs --session --lines 100
+```
+
+---
+
 ## Sub-Commands
 
 ### `benchmark` — Performance Benchmarking

--- a/tests/services/audio/test_audio_preprocessor.py
+++ b/tests/services/audio/test_audio_preprocessor.py
@@ -7,6 +7,7 @@ External dependencies (ffmpeg, pydub) are mocked.
 
 from __future__ import annotations
 
+import builtins
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,6 +17,12 @@ from services.audio.preprocessor import (
     AudioFormat,
     AudioPreprocessor,
 )
+
+# Real ``__import__`` captured before any test patches ``builtins.__import__``.
+# ``fake_import`` helpers delegate non-target imports here so legitimate stdlib
+# imports (e.g. ``ntpath`` lazily imported by ``Path(...)`` on Python 3.12)
+# still succeed instead of being rejected by an over-broad stub.
+_ORIG_IMPORT = builtins.__import__
 
 pytestmark = [pytest.mark.unit]
 
@@ -230,7 +237,7 @@ class TestConvertWithPydub:
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError("no pydub")
-            raise ImportError(f"no {name}")
+            return _ORIG_IMPORT(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             with pytest.raises(ImportError, match="Neither ffmpeg nor pydub"):
@@ -269,7 +276,7 @@ class TestNormalizeAudio:
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError
-            raise ImportError
+            return _ORIG_IMPORT(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             result = preprocessor.normalize_audio(audio_file)
@@ -321,7 +328,7 @@ class TestRemoveSilence:
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError
-            raise ImportError
+            return _ORIG_IMPORT(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             result = preprocessor.remove_silence(audio_file)
@@ -420,7 +427,7 @@ class TestGetAudioInfo:
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError
-            raise ImportError
+            return _ORIG_IMPORT(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             info = AudioPreprocessor.get_audio_info(audio_file)

--- a/tests/services/audio/test_audio_utils.py
+++ b/tests/services/audio/test_audio_utils.py
@@ -7,6 +7,7 @@ All external dependencies (pydub, tinytag) are mocked.
 
 from __future__ import annotations
 
+import builtins
 import hashlib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -28,6 +29,13 @@ from services.audio.utils import (
 )
 
 pytestmark = [pytest.mark.unit]
+
+# Real ``__import__`` captured at module-import time (before any test patches
+# ``builtins.__import__``). The ``fake_import`` helpers below delegate every
+# non-target import to it so that legitimate stdlib imports triggered by
+# production code still succeed — e.g. ``Path(...)`` lazily imports ``ntpath``
+# on Python 3.12, which an over-broad "raise for everything" stub would break.
+_ORIG_IMPORT = builtins.__import__
 
 
 # ---------------------------------------------------------------------------
@@ -88,7 +96,7 @@ class TestGetAudioDuration:
                 raise ImportError("no pydub")
             if name == "tinytag":
                 return mock_tinytag
-            raise ImportError(f"no {name}")
+            return _ORIG_IMPORT(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             duration = get_audio_duration(audio_file)
@@ -101,7 +109,7 @@ class TestGetAudioDuration:
         def fake_import(name, *args, **kwargs):
             if name in ("pydub", "tinytag"):
                 raise ImportError(f"no {name}")
-            raise ImportError(f"no {name}")
+            return _ORIG_IMPORT(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             duration = get_audio_duration(audio_file)
@@ -151,7 +159,7 @@ class TestNormalizeAudio:
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError("no pydub")
-            raise ImportError(f"no {name}")
+            return _ORIG_IMPORT(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             result = normalize_audio(audio_file)
@@ -186,7 +194,7 @@ class TestSplitAudio:
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError("no pydub")
-            raise ImportError(f"no {name}")
+            return _ORIG_IMPORT(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             result = split_audio(audio_file)
@@ -235,7 +243,7 @@ class TestConvertAudioFormat:
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError("no pydub")
-            raise ImportError(f"no {name}")
+            return _ORIG_IMPORT(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             result = convert_audio_format(audio_file, "wav")
@@ -316,7 +324,7 @@ class TestDetectSilenceSegments:
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError("no pydub")
-            raise ImportError(f"no {name}")
+            return _ORIG_IMPORT(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             result = detect_silence_segments(audio_file)
@@ -359,7 +367,7 @@ class TestTrimAudio:
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError
-            raise ImportError
+            return _ORIG_IMPORT(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             result = trim_audio(audio_file)
@@ -400,7 +408,7 @@ class TestMergeAudioFiles:
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError
-            raise ImportError
+            return _ORIG_IMPORT(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             with pytest.raises(ImportError):
@@ -456,7 +464,7 @@ class TestGetAudioPeakAmplitude:
         def fake_import(name, *args, **kwargs):
             if "pydub" in name:
                 raise ImportError
-            raise ImportError
+            return _ORIG_IMPORT(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             result = get_audio_peak_amplitude(audio_file)

--- a/tests/services/audio/test_utils_branches.py
+++ b/tests/services/audio/test_utils_branches.py
@@ -7,6 +7,7 @@ src/services/audio/utils.py.  Every test class carries
 
 from __future__ import annotations
 
+import builtins
 import hashlib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -26,6 +27,12 @@ from services.audio.utils import (
     trim_audio,
     validate_audio_file,
 )
+
+# Real ``__import__`` captured before any test patches ``builtins.__import__``.
+# ``fake_import`` helpers delegate non-target imports here so legitimate stdlib
+# imports (e.g. ``ntpath`` lazily imported by ``Path(...)`` on Python 3.12)
+# still succeed instead of being rejected by an over-broad stub.
+_ORIG_IMPORT = builtins.__import__
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -58,7 +65,7 @@ class TestGetAudioDurationBranches:
                 raise ImportError("no pydub")
             if name == "tinytag":
                 return mock_tinytag
-            raise ImportError(f"no {name}")
+            return _ORIG_IMPORT(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=fake_import):
             duration = get_audio_duration(audio)
@@ -571,7 +578,7 @@ class TestDetectSilenceSegmentsBranches:
             """Substitute __import__ that raises ImportError for any pydub import."""
             if "pydub" in name:
                 raise ImportError("no pydub")
-            raise ImportError(f"no {name}")
+            return _ORIG_IMPORT(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=_no_pydub):
             result = detect_silence_segments(audio_file)


### PR DESCRIPTION
## Context

After PR #453 merged, the main-push **"Test full suite"** job ([run 26688819538](https://github.com/curdriceaurora/fo-core/actions/runs/26688819538)) still failed on **both py3.11 and py3.12**. #453 correctly fixed the three `test_main.py` assertions, but the full suite had two *separate, pre-existing* failures unrelated to that change (or to the hardware-info commit). This PR fixes both.

## Failure 1 — `test_commands_exist` (py3.11 **and** py3.12)

`tests/docs/test_cli_docs_accuracy.py::TestAllCommandsDocumented::test_commands_exist` asserts every registered CLI command is documented in `docs/cli-reference.md`. The `logs` command (`cli.logs.logs_command`, wired into `main.py`, added in #372/#394) was never documented — the docs file hadn't been touched since before `logs` landed.

**Fix:** add a `### \`logs\`` section under *Top-Level Commands*, documenting `--follow/-f`, `--lines/-n`, `--session`, and `--list/-l`, mirroring the existing command-section format (usage / options / examples). Verified clean against `.pymarkdown.json` and the docs-accuracy test.

## Failure 2 — audio `test_no_pydub` family (py3.12 only, ~10 tests)

Each test used a `fake_import` stub that raised `ImportError` for **every** non-pydub import:

```python
def fake_import(name, *args, **kwargs):
    if "pydub" in name:
        raise ImportError("no pydub")
    raise ImportError(f"no {name}")   # ← rejects ALL other imports
```

On Python 3.12, `Path(audio_path)` inside the production code lazily does `import ntpath`, which the over-broad stub rejected with `ImportError: no ntpath` — failing the test for an unrelated reason. (Python 3.11's pathlib doesn't lazy-import `ntpath` per call, so these passed there.)

**Fix:** capture the real `__import__` at module-import time (`_ORIG_IMPORT = builtins.__import__`) and delegate every non-target import to it, so only the genuinely-simulated-missing module (`pydub`/`tinytag`/`torch`) raises. Applied across `test_audio_utils.py`, `test_audio_preprocessor.py`, and `test_utils_branches.py`. (`test_audio_transcriber_service.py` already delegated correctly.)

## Not real CI failures (ruled out)

- `test_cli_logs.py` tests — flaky xdist cross-file pollution (different ones fail each run; all pass in isolation and within their own file).
- `test_version_flag_installed_wheel` — only failed in my local `uv` venv (no `pip` for the `pip wheel` subprocess); CI uses setup-python + pip.

## Verification

- py3.11: `tests/docs/...` + `tests/services/audio/` → 329 passed, 1 xfailed
- py3.12: `tests/services/audio/` → 325 passed; docs-accuracy → passed
- `ruff check` clean on all changed files
- `pymarkdown -c .pymarkdown.json scan docs/cli-reference.md` → 0 violations
- Full-suite run (py3.12) re-run locally to confirm no remaining deterministic failures

https://claude.ai/code/session_01NdjxsudMKfwhLy8aYn9wSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdjxsudMKfwhLy8aYn9wSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the new `fo logs` CLI sub-command, including usage syntax, supported option flags (`--follow`, `--lines`, `--session`, `--list`), and detailed examples for viewing and managing application logs.

* **Tests**
  * Improved test reliability and robustness for audio processing service tests to ensure stable execution across various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->