### PR TITLE
test: eliminate xdist global-state pollution in integration suite (#455)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,25 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+
+# Eagerly import the lazily-loaded `fo logs` command module at collection time.
+#
+# `cli/logs.py` binds ``get_canonical_paths`` via ``from config.path_manager
+# import get_canonical_paths`` at module scope, and `cli.main` imports
+# `cli.logs` lazily (only on the first ``fo logs`` invocation). If that first
+# import happens *inside* a test that has monkeypatched
+# ``config.path_manager.get_canonical_paths`` to a temp path, `cli.logs` binds
+# its module-level name to the test's lambda — and ``monkeypatch`` restores the
+# `config.path_manager` attribute but not `cli.logs`'s separate binding. The
+# stale lambda then makes every later ``fo logs`` resolve a deleted temp dir,
+# corrupting unrelated tests under xdist (issue #455). Importing here, before
+# any test runs, pins the binding to the real function.
+import cli.logs  # noqa: F401  (intentional import-for-side-effect)
 
 collect_ignore_glob = [
     # Playwright browser tests require `playwright install chromium` and
@@ -23,6 +37,53 @@ collect_ignore_glob = [
     # Run explicitly: pytest tests/playwright/ --browser chromium --override-ini='addopts='
     "playwright/**",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Global test isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _restore_loguru_handlers() -> Iterator[None]:
+    """Drop loguru handlers leaked by a test so they cannot pollute later tests.
+
+    ``cli.main.main_callback`` installs per-run rotating-file and session-log
+    sinks on loguru's *global* logger and relies on Typer ``call_on_close``
+    callbacks to remove them. Several tests exercise that callback while
+    monkeypatching ``loguru.logger.remove`` to a no-op (to keep loguru's global
+    state out of their own assertions); the no-op suppresses the cleanup, so the
+    sinks leak into the global logger. Because those sinks use ``serialize=True``
+    and ``enqueue=True``, a leaked handler keeps writing NDJSON log records to
+    whatever stream is active — and under Typer's ``CliRunner`` (which mixes
+    stderr into the captured stdout) that corrupts the output of a *different*
+    test sharing the same xdist worker, intermittently breaking JSON-output and
+    log-content assertions (issue #455).
+
+    Snapshot the handler ids before the test and remove any added during it,
+    restoring loguru to its pre-test handler set. ``logger._core.handlers`` is
+    loguru's internal handler registry; loguru exposes no public list-handlers
+    API, but this attribute has been stable across releases.
+
+    ``logger.remove`` is captured at setup and called directly at teardown:
+    the very tests that leak handlers do so by monkeypatching
+    ``loguru.logger.remove`` to a no-op, and fixture-teardown order relative to
+    ``monkeypatch`` is not guaranteed — binding the real callable up front makes
+    the cleanup work regardless.
+    """
+    from loguru import logger
+
+    real_remove = logger.remove  # bind before a test can monkeypatch it to a no-op
+    before = set(logger._core.handlers)
+    try:
+        yield
+    finally:
+        for handler_id in set(logger._core.handlers) - before:
+            try:
+                real_remove(handler_id)
+            except ValueError:
+                pass  # already removed (e.g. by the command's own call_on_close)
+
 
 # ---------------------------------------------------------------------------
 # Version-aware fixtures

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ Requires Python 3.11+.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import sys
 from collections.abc import Callable, Iterator
 from pathlib import Path
@@ -60,16 +61,30 @@ def _restore_loguru_handlers() -> Iterator[None]:
     test sharing the same xdist worker, intermittently breaking JSON-output and
     log-content assertions (issue #455).
 
-    Snapshot the handler ids before the test and remove any added during it,
-    restoring loguru to its pre-test handler set. ``logger._core.handlers`` is
-    loguru's internal handler registry; loguru exposes no public list-handlers
-    API, but this attribute has been stable across releases.
+    Snapshot the handler ids before the test and restore loguru to its pre-test
+    handler set. ``logger._core.handlers`` is loguru's internal handler registry;
+    loguru exposes no public list-handlers API, but this attribute has been
+    stable across releases.
 
     ``logger.remove`` is captured at setup and called directly at teardown:
     the very tests that leak handlers do so by monkeypatching
     ``loguru.logger.remove`` to a no-op, and fixture-teardown order relative to
     ``monkeypatch`` is not guaranteed — binding the real callable up front makes
     the cleanup work regardless.
+
+    Two teardown cases:
+
+    * **Baseline intact** (common): every pre-test handler id is still present,
+      so only the handlers the test added are dropped.
+    * **Baseline disturbed**: the test called bare ``logger.remove()`` — e.g.
+      ``cli.analytics.analytics_command`` does this before installing its own
+      stderr sink — which removes pre-existing handlers. ``logger.remove()``
+      *stops* sinks irreversibly (enqueue workers terminated) and leaves loguru's
+      cached ``min_level`` stale, so re-inserting the original handler objects
+      would revive dead sinks. Reset to loguru's default stderr sink via the
+      public ``add`` API instead (which rebuilds ``min_level`` correctly), so
+      later tests start from a functional baseline rather than with logging
+      silently disabled.
     """
     from loguru import logger
 
@@ -78,11 +93,17 @@ def _restore_loguru_handlers() -> Iterator[None]:
     try:
         yield
     finally:
-        for handler_id in set(logger._core.handlers) - before:
-            try:
-                real_remove(handler_id)
-            except ValueError:
-                pass  # already removed (e.g. by the command's own call_on_close)
+        after = set(logger._core.handlers)
+        if before <= after:
+            # Baseline survived — only drop what the test added (stops their workers).
+            for handler_id in after - before:
+                with contextlib.suppress(ValueError):
+                    real_remove(handler_id)  # ValueError: already removed via call_on_close
+        elif after != before:
+            # A pre-test handler was removed; the originals are unrecoverable, so
+            # restore a functional default instead of leaving logging disabled.
+            real_remove()
+            logger.add(sys.stderr)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #455.

## Problem

The `Test full suite (py3.11 / py3.12)` CI job (push to `main`) was intermittently red: a *different random subset* of integration CLI tests (`test_cli_logs`, `test_cli_benchmark_analytics_undo_display_utils`, …) failed on each run, while every failing test passed in isolation. Two independent cross-test global-state leaks, both surfacing only under `pytest-xdist` when a polluting test shares a worker with a victim.

## Root cause 1 — leaked loguru handlers (serialized-record pollution)

`cli.main.main_callback` installs per-run rotating-file and session-log sinks (`serialize=True, enqueue=True`) on loguru's **global** logger, cleaned up via Typer `call_on_close`. Several tests exercise that path while monkeypatching `loguru.logger.remove` to a **no-op** (to keep loguru state out of their assertions) — so the sinks leak. Once the owning tmp dir is deleted, the leaked sink writes NDJSON records to the active stream; under Typer's `CliRunner` (stderr mixed into stdout) that corrupts a *later* test's captured output, breaking `json.loads(...)` / content assertions.

**Fix:** an autouse fixture that snapshots loguru handler ids before each test and removes any added during it. It binds the real `logger.remove` up front, so cleanup works even for tests that no-op it mid-test (fixture-teardown order vs `monkeypatch` isn't guaranteed).

## Root cause 2 — stale `get_canonical_paths` binding (wrong-path pollution)

`cli/logs.py` binds the function via `from config.path_manager import get_canonical_paths` at module scope, and `cli.main` imports `cli.logs` **lazily** on first `fo logs` use. When that first import lands *inside* a test that monkeypatched `config.path_manager.get_canonical_paths` to a tmp path, `cli.logs` binds its name to the test's lambda. `monkeypatch` restores the origin-module attribute but **not** `cli.logs`'s separate binding — so every later `fo logs` resolves a deleted tmp dir (empty output / wrong session listing). Heisenbug: depends on which test first imports `cli.logs`.

**Fix:** eagerly `import cli.logs` at conftest load, pinning the binding to the real function before any test can monkeypatch.

## Validation

3 consecutive full-suite runs (`-n auto --dist=loadgroup`, `[dev,search]`) → **zero flaky failures**, down from 3–4 per run. The two leak channels were each reproduced deterministically and confirmed fixed (the loguru leak via a snapshot diff; the path leak traced to `cli.logs.get_canonical_paths` resolving the leaker's tmp dir inside the victim's invoke). Both fixes are test-only (`tests/conftest.py`); no production change.

> The only residual local failure is `test_version_flag_installed_wheel`, which shells out to `pip wheel` and fails in a `pip`-less `uv` venv — it passes on CI. Not related to this change.

https://claude.ai/code/session_01NdjxsudMKfwhLy8aYn9wSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdjxsudMKfwhLy8aYn9wSo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by preventing logging handler leaks between tests.
  * Enhanced test reliability across parallel test execution environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curdriceaurora/fo-core/pull/456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->