### PR TITLE
docs(rules): auto un-draft a watched PR once its CI is green

### DIFF
--- a/.claude/rules/pr-monitoring-protocol.md
+++ b/.claude/rules/pr-monitoring-protocol.md
@@ -92,6 +92,17 @@ Based on checklist results, decide on action:
 
 **Action**: Continue monitoring, check again in 5-10 minutes
 
+### Scenario A2: Draft PR with Green CI ✅ → Un-draft
+
+- PR is in **draft** state
+- All required CI checks have completed green (skipped main-only jobs don't count against this)
+
+**Action**: Automatically switch the PR from draft to ready-for-review (un-draft).
+Do **not** wait to be asked, and do **not** auto-merge — un-drafting only. Marking
+ready triggers reviewers (e.g. CodeRabbit) and surfaces the PR for approval. If a
+later commit sends the PR back through draft and its CI is green again, re-apply
+this rule.
+
 ### Scenario B: Issue Detected ⚠️
 - CI failing (related to your changes)
 - OR new comments requiring fixes

--- a/.claude/rules/pr-workflow-master.md
+++ b/.claude/rules/pr-workflow-master.md
@@ -86,6 +86,7 @@
 
 **What Triggers State Changes**:
 - Issue detected (CI fail, new comments, merge conflict) → PAUSED
+- Draft PR + all required CI green → auto un-draft (mark ready; never auto-merge). See Scenario A2 in `pr-monitoring-protocol.md`.
 - Merge conditions met → READY TO MERGE
 - Unresolvable issue (waiting for clarification, unresponsive reviewer) → BLOCKED
 


### PR DESCRIPTION
## What

Adds a standing PR-monitoring rule: **when a watched PR is in draft state and all required CI checks have completed green, automatically switch it to ready-for-review (un-draft)** — never auto-merge, un-drafting only.

## Why

Requested workflow preference: a green draft PR should surface for review (triggering CodeRabbit and the approval gate) without waiting to be asked. Un-drafting is safe and reversible; merging stays a separate, explicit step.

## Changes

- `pr-monitoring-protocol.md` — new **Scenario A2: Draft PR with Green CI → Un-draft** in the "Assess Findings" decision section. Notes that `skipped` main-only jobs don't count against "green", and that the rule re-applies if a later commit sends the PR back through draft.
- `pr-workflow-master.md` — cross-reference line in the MONITORING state's "What Triggers State Changes".

Docs-only; both files pass `pymarkdown -c .pymarkdown.json` with 0 violations.

https://claude.ai/code/session_01NdjxsudMKfwhLy8aYn9wSo

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdjxsudMKfwhLy8aYn9wSo)_