### PR TITLE
fix(ci): normalize paths in pipx detection for Windows compat

### DIFF
--- a/src/cli/doctor.py
+++ b/src/cli/doctor.py
@@ -112,15 +112,19 @@ def _detect_install_method() -> str:
     Returns:
         "pipx" if running in a pipx venv, "pip" otherwise
     """
-    exe_path = sys.executable
+    # Normalize sys.executable so forward/backslash mixes (legal on Windows) compare
+    # consistently against the expected pipx-venv prefixes.
+    exe_path = os.path.normpath(sys.executable)
     # Check PIPX_HOME env var first (user-configured or set by pipx itself)
     pipx_home = os.environ.get("PIPX_HOME")
     if pipx_home:
-        if exe_path.startswith(os.path.join(pipx_home, "venvs") + os.sep):
+        prefix = os.path.normpath(os.path.join(pipx_home, "venvs")) + os.sep
+        if exe_path.startswith(prefix):
             return "pipx"
     # Check both the old (~/.local/pipx) and new (~/.local/share/pipx) default locations
     for base in ("~/.local/pipx/venvs/", "~/.local/share/pipx/venvs/"):
-        if exe_path.startswith(os.path.expanduser(base)):
+        prefix = os.path.normpath(os.path.expanduser(base)) + os.sep
+        if exe_path.startswith(prefix):
             return "pipx"
     return "pip"
 


### PR DESCRIPTION
## Summary

Fixes the only failure in the latest **CI Full Matrix** run on `main`
([run 26806177119](https://github.com/curdriceaurora/fo-core/actions/runs/26806177119)):
the **Test Windows (Python 3.12)** job
([job 79024126283](https://github.com/curdriceaurora/fo-core/actions/runs/26806177119/job/79024126283))
failed on a single test, Linux and macOS were green.

- Failing test: `tests/cli/test_doctor.py::TestInstallMethodDetection::test_detect_pipx_via_pipx_home_env`
- Assertion: `assert 'pip' == 'pipx'`

## Root cause

`src/cli/doctor.py::_detect_install_method()` compared `sys.executable`
against `os.path.join(PIPX_HOME, "venvs") + os.sep`. On Windows:

- `os.path.join("/custom/pipx", "venvs")` → `/custom/pipx\venvs`
- `+ os.sep` → `/custom/pipx\venvs\`
- The test mocks `sys.executable = "/custom/pipx/venvs/fo-core/bin/python"` (forward slashes)
- `startswith` mismatches → returns `"pip"` instead of `"pipx"`

This is not just a test-isolation quirk: any real Windows user who sets
`PIPX_HOME=C:/Users/me/pipx` (forward slashes — legal on Windows) hits
the same mismatch and gets `pip` install hints instead of `pipx`
hints for the entire `fo doctor` flow.

## Fix

Wrap both sides of the comparison in `os.path.normpath()` so they
agree on separator style on every platform:

- `exe_path` is normalized once at the top of the function
- Each candidate prefix is normalized before `+ os.sep`

No behavior change on Linux/macOS where `os.sep` is already `/`.

## Verification

- Local: `pytest tests/cli/test_doctor.py` → **162/162 passing**, including
  the 5 detection cases (the previously failing one now passes on Linux too).
- Cross-platform: an `ntpath`-based simulation exercising the failing
  scenario plus three real-Windows variants (backslash, forward-slash,
  and mixed `PIPX_HOME` + `sys.executable` combinations) all return the
  expected `"pipx"` / `"pip"` values.
- `ruff check`, `ruff format --check`, `mypy` on `src/cli/doctor.py` all pass.

## Trade-offs

None — `os.path.normpath` is the standard cross-platform normalizer and
adds two function calls in a startup path that runs once per `fo doctor`
invocation. No tests weakened, no test inputs changed.

## Impacted areas

- `src/cli/doctor.py` (only `_detect_install_method`)
- All downstream `install_method == "pipx"` branches in `fo doctor`,
  `fo doctor install`, and `fo doctor install-all` benefit from
  correct detection on Windows.

https://claude.ai/code/session_017Knn5owgK2GsKLz4sruCQ1

---
_Generated by [Claude Code](https://claude.ai/code/session_017Knn5owgK2GsKLz4sruCQ1)_