### PR TITLE
fix(ci): platform-aware pipx detection test (Windows matrix)

### DIFF
--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -253,9 +253,13 @@ class TestInstallMethodDetection:
 
     def test_detect_pipx_via_pipx_home_env(self):
         """Should detect pipx when executable is under PIPX_HOME/venvs/."""
+        import os
 
-        custom_home = "/custom/pipx"
-        fake_exe = "/custom/pipx/venvs/fo-core/bin/python"
+        # Build paths with the platform's native separator so the test matches
+        # the implementation's `os.path.join(pipx_home, "venvs") + os.sep` check
+        # on both POSIX and Windows.
+        custom_home = os.sep + os.path.join("custom", "pipx")
+        fake_exe = os.path.join(custom_home, "venvs", "fo-core", "bin", "python")
         with patch("cli.doctor.sys.executable", fake_exe):
             with patch.dict("os.environ", {"PIPX_HOME": custom_home}):
                 result = _detect_install_method()


### PR DESCRIPTION
## Summary

Restores green status of the **CI Full Matrix / Test Windows (Python 3.12)** job, which has been the sole failing matrix slot on recent scheduled runs (e.g. [run 26871404355](https://github.com/curdriceaurora/fo-core/actions/runs/26871404355) on commit `dd13452`).

## Failure detected

Single deterministic test failure, only on Windows + Python 3.12:

```
FAILED tests/cli/test_doctor.py::TestInstallMethodDetection::test_detect_pipx_via_pipx_home_env
    - AssertionError: assert 'pip' == 'pipx'
```

All four other matrix jobs (Linux py3.11, Linux py3.12, macOS py3.12, coverage gate) pass on the same commit.

## Root cause

The test (lines 254–262 of `tests/cli/test_doctor.py`) hardcoded POSIX-style paths:

```python
custom_home = "/custom/pipx"
fake_exe    = "/custom/pipx/venvs/fo-core/bin/python"
```

But the production code `_detect_install_method()` in `src/cli/doctor.py:119` builds its comparison prefix with the platform's join + separator:

```python
if exe_path.startswith(os.path.join(pipx_home, "venvs") + os.sep):
```

On Windows this evaluates to `"/custom/pipx\venvs\"` (mixed separators because `pipx_home` is forward-slash but `os.sep == "\\"`). The `startswith` check against a pure forward-slash `exe_path` always fails, so the function returns `"pip"` and the assertion blows up.

This is a **test-side bug** — the production code's behaviour on real Windows installs (where both `PIPX_HOME` and `sys.executable` use `\\`) is correct. The other tests in the same class already use either platform-mocked `os.path.expanduser` or `os.path.expanduser(...)` directly, which is why they pass on Windows.

## Fix

Build the test inputs with `os.sep` + `os.path.join` so the same separator semantics are exercised on POSIX and Windows:

```python
custom_home = os.sep + os.path.join("custom", "pipx")
fake_exe    = os.path.join(custom_home, "venvs", "fo-core", "bin", "python")
```

- POSIX: `custom_home="/custom/pipx"`, prefix `"/custom/pipx/venvs/"` → matches ✓
- Windows: `custom_home="\\custom\\pipx"`, prefix `"\\custom\\pipx\\venvs\\"` → matches ✓

## Verification

Local cross-platform simulation using `posixpath` and `ntpath` modules:

| Inputs | POSIX | Windows |
|--------|-------|---------|
| New (`os.sep`-aware) | `pipx` ✓ | `pipx` ✓ |
| Old (hardcoded `/`) | `pipx` ✓ | `pip` ✗ (reproduces failure) |

Other local checks:
- `ruff check tests/cli/test_doctor.py` — passes
- `ruff format --check` — already formatted
- G1 (pre-commit-staged absolute-path) — clean
- G2 (`scripts/check_test_hardcoded_paths.py` full-suite scan) — clean

The Linux/macOS jobs of the same Matrix workflow already passed on the unchanged production code, so they will continue to pass under the new test inputs (POSIX path → same `startswith` match).

## Trade-offs

- No production code change — the implementation is correct on real Windows installs (where `PIPX_HOME` would itself use `\\`). The fix is scoped to the test simulating realistic per-platform inputs.
- No test weakening — the assertion still verifies that a `PIPX_HOME`-based pipx executable is detected as `"pipx"`; only the input construction is now platform-aware.

## Impacted areas

- `tests/cli/test_doctor.py` — single test function (`test_detect_pipx_via_pipx_home_env`), +6/-2.

## Links

- Failing run: https://github.com/curdriceaurora/fo-core/actions/runs/26871404355
- Failing job: https://github.com/curdriceaurora/fo-core/actions/runs/26871404355/job/79247377805


---
_Generated by [Claude Code](https://claude.ai/code/session_016HW7fZfLu6C6kH9zo1K8Qa)_