### PR TITLE
Fix: Resolve Matrix CI failure (Windows pipx detection)

### DIFF
--- a/src/cli/doctor.py
+++ b/src/cli/doctor.py
@@ -112,15 +112,21 @@ def _detect_install_method() -> str:
     Returns:
         "pipx" if running in a pipx venv, "pip" otherwise
     """
-    exe_path = sys.executable
+    # Normalize paths so prefix comparison works regardless of slash style.
+    # On Windows, PIPX_HOME or sys.executable can carry forward slashes
+    # (env files copied from POSIX, WSL setups), while os.path.join uses os.sep,
+    # producing a mixed-separator pattern that never matches.
+    exe_path = os.path.normpath(sys.executable)
     # Check PIPX_HOME env var first (user-configured or set by pipx itself)
     pipx_home = os.environ.get("PIPX_HOME")
     if pipx_home:
-        if exe_path.startswith(os.path.join(pipx_home, "venvs") + os.sep):
+        pattern = os.path.normpath(os.path.join(pipx_home, "venvs")) + os.sep
+        if exe_path.startswith(pattern):
             return "pipx"
     # Check both the old (~/.local/pipx) and new (~/.local/share/pipx) default locations
     for base in ("~/.local/pipx/venvs/", "~/.local/share/pipx/venvs/"):
-        if exe_path.startswith(os.path.expanduser(base)):
+        pattern = os.path.normpath(os.path.expanduser(base)) + os.sep
+        if exe_path.startswith(pattern):
             return "pipx"
     return "pip"
 


### PR DESCRIPTION
## Summary

The scheduled `CI Full Matrix` workflow has been failing daily on `main` since at least 2026-06-02 — the **Test Windows (Python 3.12)** job fails one test while all other matrix variants (Linux 3.11, Linux 3.12, macOS 3.12) pass.

| Run | Conclusion | Failing job |
|-----|-----------|-------------|
| [#26938361854](https://github.com/curdriceaurora/fo-core/actions/runs/26938361854) (2026-06-04) | failure | Test Windows (py3.12) |
| [#26871404355](https://github.com/curdriceaurora/fo-core/actions/runs/26871404355) (2026-06-03) | failure | Test Windows (py3.12) |
| [#26806177119](https://github.com/curdriceaurora/fo-core/actions/runs/26806177119) (2026-06-02) | failure | Test Windows (py3.12) |

Failing test (1 of 4922 total):
```
FAILED tests/cli/test_doctor.py::TestInstallMethodDetection::test_detect_pipx_via_pipx_home_env
  AssertionError: assert 'pip' == 'pipx'
```

## Root Cause Analysis

The test sets `PIPX_HOME=/custom/pipx` and `sys.executable=/custom/pipx/venvs/fo-core/bin/python`, then expects `_detect_install_method()` to return `"pipx"`.

`cli/doctor.py:117-120` builds the match pattern via:

```python
exe_path.startswith(os.path.join(pipx_home, "venvs") + os.sep)
```

On Windows:
- `os.path.join("/custom/pipx", "venvs")` → `"/custom/pipx\venvs"` (mixed separators; `join` doesn't rewrite the input's existing forward slashes but uses `os.sep` to attach the new segment)
- `os.sep` → `"\\"`
- Pattern → `"/custom/pipx\venvs\"`
- `"/custom/pipx/venvs/fo-core/bin/python".startswith("/custom/pipx\venvs\")` → **False** → falls through to `"pip"`.

This is a **real correctness bug**, not just a test issue: any Windows user whose `PIPX_HOME` carries forward slashes (env files copied from a POSIX machine, WSL setups, scripted exports) would have pipx misdetected. The other tests in this class happened to pass on Windows only because they used forward-slash paths on both sides of the comparison and didn't go through the `os.path.join` branch.

**Classification:** Deterministic code regression (Windows path handling). Not flaky, not infrastructure.

## Fix

Normalize both the executable path and each candidate pattern with `os.path.normpath()` before the prefix check. The same treatment is applied to the `~/.local/pipx/...` fallback branch for consistency.

```python
exe_path = os.path.normpath(sys.executable)
...
pattern = os.path.normpath(os.path.join(pipx_home, "venvs")) + os.sep
if exe_path.startswith(pattern):
    return "pipx"
```

This keeps the production logic minimal and platform-agnostic; the test was already exercising a realistic input shape and didn't need to change.

## Verification

- ✅ 162 tests in `tests/cli/test_doctor.py` pass on Linux.
- ✅ Direct simulation under `ntpath` (Windows path semantics) confirms:
  - `test_detect_pipx_via_pipx_home_env` now returns `"pipx"` (was `"pip"`).
  - All other 4 `TestInstallMethodDetection` cases still behave correctly.
- ✅ `ruff check` clean.
- ✅ Other matrix variants (Linux py3.11/3.12, macOS) were already green; no behavior change for forward-slash-on-both-sides cases.

## Impact

- `src/cli/doctor.py` — `_detect_install_method()` only (used in 4 call sites within the same file for install/upgrade flows).
- No public API change.
- No test changes.

## Trade-offs considered

- **Fix in test instead** (use platform-appropriate paths): rejected — the test input represents a realistic env-var shape and the production code should handle it. Project rule: "code correction over test weakening."
- **Use `pathlib.Path`**: rejected — `os.path.startswith`-style prefix matching is more straightforward than pathlib's `is_relative_to`, which would require try/except and adds an import.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XsuKQuqGdbUZsJx4hDHohQ)_