### PR TITLE
Fix: Resolve Matrix CI Failures (Windows path portability in pipx detection test)

### DIFF
--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -253,9 +253,13 @@ class TestInstallMethodDetection:
 
     def test_detect_pipx_via_pipx_home_env(self):
         """Should detect pipx when executable is under PIPX_HOME/venvs/."""
+        import os
 
-        custom_home = "/custom/pipx"
-        fake_exe = "/custom/pipx/venvs/fo-core/bin/python"
+        # Build paths with the OS-native separator so the test matches what
+        # _detect_install_method() constructs via os.path.join + os.sep
+        # (forward slashes on POSIX, backslashes on Windows).
+        custom_home = os.path.join(os.sep, "custom", "pipx")
+        fake_exe = os.path.join(custom_home, "venvs", "fo-core", "bin", "python")
         with patch("cli.doctor.sys.executable", fake_exe):
             with patch.dict("os.environ", {"PIPX_HOME": custom_home}):
                 result = _detect_install_method()

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -251,7 +251,7 @@ class TestInstallMethodDetection:
             result = _detect_install_method()
             assert result == "pipx"
 
-    def test_detect_pipx_via_pipx_home_env(self):
+    def test_detect_pipx_via_pipx_home_env(self, monkeypatch: pytest.MonkeyPatch):
         """Should detect pipx when executable is under PIPX_HOME/venvs/."""
         import os
 
@@ -261,9 +261,9 @@ class TestInstallMethodDetection:
         custom_home = os.path.join(os.sep, "custom", "pipx")
         fake_exe = os.path.join(custom_home, "venvs", "fo-core", "bin", "python")
         with patch("cli.doctor.sys.executable", fake_exe):
-            with patch.dict("os.environ", {"PIPX_HOME": custom_home}):
-                result = _detect_install_method()
-                assert result == "pipx"
+            monkeypatch.setenv("PIPX_HOME", custom_home)
+            result = _detect_install_method()
+            assert result == "pipx"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary of failures detected

The `CI Full Matrix` scheduled workflow has been failing every day on the Windows runner since main settled on `dd13452`. Affected runs (all on `main`):

- [Run 27002217752 — 2026-06-05](https://github.com/curdriceaurora/fo-core/actions/runs/27002217752)
- [Run 26938361854 — 2026-06-04](https://github.com/curdriceaurora/fo-core/actions/runs/26938361854)
- [Run 26871404355 — 2026-06-03](https://github.com/curdriceaurora/fo-core/actions/runs/26871404355)
- [Run 26806177119 — 2026-06-02](https://github.com/curdriceaurora/fo-core/actions/runs/26806177119)

In every case the only failing job is `Test Windows (Python 3.12)`, and the only failing test is:

```
FAILED tests/cli/test_doctor.py::TestInstallMethodDetection::test_detect_pipx_via_pipx_home_env
  - AssertionError: assert 'pip' == 'pipx'
```

All other matrix legs (`macOS 3.12`, `Linux 3.11`, `Linux 3.12`, `Coverage gate`) pass.

## Root cause

`tests/cli/test_doctor.py:254` builds POSIX-style fixture paths:

```python
custom_home = "/custom/pipx"
fake_exe    = "/custom/pipx/venvs/fo-core/bin/python"
```

The production function `cli.doctor._detect_install_method()` then composes its match prefix as:

```python
exe_path.startswith(os.path.join(pipx_home, "venvs") + os.sep)
```

On Windows, `os.path.join("/custom/pipx", "venvs")` returns `"/custom/pipx\\venvs"` and `os.sep` is `"\\"`, so the prefix becomes `"/custom/pipx\\venvs\\"`. The forward-slash `fake_exe` never starts with that — it falls through to the `return "pip"` branch and the assertion fails.

This is purely a test-portability bug — the production code behaves correctly on each platform when given native paths.

## Fix implemented and rationale

Build the test fixture paths with `os.path.join` + `os.sep` so they use the OS-native separators on whichever platform the test runs on. The result:

- POSIX: `custom_home="/custom/pipx"`, `fake_exe="/custom/pipx/venvs/fo-core/bin/python"` (unchanged behavior).
- Windows: `custom_home="\\custom\\pipx"`, `fake_exe="\\custom\\pipx\\venvs\\fo-core\\bin\\python"` (now matches what `os.path.join + os.sep` produces, so `.startswith(...)` is True).

The production code is left untouched. The test now exercises the function the way it's actually called in production on each OS, rather than asserting an unreachable code path on Windows.

## Trade-offs

- We could alternatively normalize paths inside `_detect_install_method` (e.g. `os.path.normpath` on both sides), but the function is intentionally simple and the failing scenario (mixed POSIX/Windows separators in a single environment) cannot occur in real use — `sys.executable` and `PIPX_HOME` are populated by the OS in native form. Fixing the test keeps the change minimal and matches reality.
- Did **not** mark the test xfail or weaken the assertion — the test is provably correct on both platforms once the fixture paths are platform-native.

## Verification

- Reproduced the Windows behavior with a standalone cross-platform simulation using `ntpath` and `posixpath` and confirmed the new fixture pattern returns `"pipx"` on both, while the old POSIX-only literals returned `"pip"` on Windows (the observed CI failure).
- Local pytest invocation was blocked by an unrelated environment issue (`cryptography` rust binding panic on this container), so end-to-end verification will come from the Windows matrix leg of this PR's CI run.

## Impacted areas/modules

- `tests/cli/test_doctor.py` only.
- No production code changes; no behavior change on any platform.

## Before / after

| Platform | Before this PR | After this PR |
|---|---|---|
| Linux 3.11 / 3.12 | ✅ pass | ✅ pass |
| macOS 3.12 | ✅ pass | ✅ pass |
| Windows 3.12 | ❌ `test_detect_pipx_via_pipx_home_env` | ✅ pass |


---
_Generated by [Claude Code](https://claude.ai/code/session_01NCD76E2ojGJstwnqSHvJXp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform compatibility in test path handling by using OS-native path separators instead of hardcoded formats, ensuring tests run correctly across different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->