### PR TITLE
test(doctor): fix Windows pipx detection test (CI Full Matrix nightly failure)

### DIFF
--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -10,6 +10,7 @@ Tests the doctor CLI command including:
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -243,8 +244,6 @@ class TestInstallMethodDetection:
 
     def test_detect_pipx_new_share_location(self):
         """Should detect pipx when executable is in ~/.local/share/pipx/venvs/ (new default)."""
-        import os
-
         share_dir = os.path.expanduser("~/.local/share/pipx/venvs/")
         fake_exe = share_dir + "fo-core/bin/python"
         with patch("cli.doctor.sys.executable", fake_exe):
@@ -253,9 +252,12 @@ class TestInstallMethodDetection:
 
     def test_detect_pipx_via_pipx_home_env(self):
         """Should detect pipx when executable is under PIPX_HOME/venvs/."""
-
-        custom_home = "/custom/pipx"
-        fake_exe = "/custom/pipx/venvs/fo-core/bin/python"
+        # Build paths with os.path.join/os.sep so the test data matches how
+        # _detect_install_method joins PIPX_HOME with "venvs" + os.sep. Hardcoded
+        # POSIX separators broke this test on Windows, where production builds the
+        # prefix with backslashes and the forward-slash exe path never matched.
+        custom_home = os.path.join(os.sep, "custom", "pipx")
+        fake_exe = os.path.join(custom_home, "venvs", "fo-core", "bin", "python")
         with patch("cli.doctor.sys.executable", fake_exe):
             with patch.dict("os.environ", {"PIPX_HOME": custom_home}):
                 result = _detect_install_method()

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -250,7 +250,7 @@ class TestInstallMethodDetection:
             result = _detect_install_method()
             assert result == "pipx"
 
-    def test_detect_pipx_via_pipx_home_env(self):
+    def test_detect_pipx_via_pipx_home_env(self, monkeypatch: pytest.MonkeyPatch):
         """Should detect pipx when executable is under PIPX_HOME/venvs/."""
         # Build paths with os.path.join/os.sep so the test data matches how
         # _detect_install_method joins PIPX_HOME with "venvs" + os.sep. Hardcoded
@@ -258,10 +258,11 @@ class TestInstallMethodDetection:
         # prefix with backslashes and the forward-slash exe path never matched.
         custom_home = os.path.join(os.sep, "custom", "pipx")
         fake_exe = os.path.join(custom_home, "venvs", "fo-core", "bin", "python")
+        # monkeypatch.setenv keeps the PIPX_HOME mutation xdist-safe (auto-restored).
+        monkeypatch.setenv("PIPX_HOME", custom_home)
         with patch("cli.doctor.sys.executable", fake_exe):
-            with patch.dict("os.environ", {"PIPX_HOME": custom_home}):
-                result = _detect_install_method()
-                assert result == "pipx"
+            result = _detect_install_method()
+            assert result == "pipx"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What

Fixes the **sole** failing test in the nightly `CI Full Matrix` → **Test Windows (Python 3.12)** job, which has failed deterministically every run (confirmed identical on the 06-03 and 06-05 nightlies: `1 failed, 4921 passed`).

## Root cause

`tests/cli/test_doctor.py::TestInstallMethodDetection::test_detect_pipx_via_pipx_home_env` hardcoded POSIX path separators:

```python
custom_home = "/custom/pipx"
fake_exe = "/custom/pipx/venvs/fo-core/bin/python"
```

Production `src/cli/doctor.py:119` builds its match prefix with native separators:

```python
if exe_path.startswith(os.path.join(pipx_home, "venvs") + os.sep):
```

On Windows, `os.path.join("/custom/pipx", "venvs") + os.sep` → `'/custom/pipx\venvs\'` (backslash `os.sep`). The forward-slash `fake_exe` never starts with that prefix, so `_detect_install_method()` returned `"pip"` and the assertion `== "pipx"` failed:

```
AssertionError: assert 'pip' == 'pipx'
```

This is a **test-only** defect — production code is correct for real Windows pipx installs, where `sys.executable` uses native separators. The sibling detection tests pass on Windows because they build paths via `os.path.expanduser`, staying consistent with production's `os.path` semantics.

## Fix

Build the test fixtures with `os.path.join` / `os.sep` so the data matches production's path construction on every platform:

```python
custom_home = os.path.join(os.sep, "custom", "pipx")
fake_exe = os.path.join(custom_home, "venvs", "fo-core", "bin", "python")
```

Verified equivalent under both `posixpath` and `ntpath` semantics — returns `"pipx"` on both. Also hoisted a local `import os` to module level (now used by multiple tests).

## Validation

- `pytest tests/cli/test_doctor.py` → **162 passed**
- `ruff check` / `ruff format --check` on the changed file → clean
- Path logic simulated against `posixpath` **and** `ntpath` → both return `pipx`

## Note on final Windows verification

`ci-full.yml` only runs on the nightly `schedule` and `workflow_dispatch` — it does **not** run on PRs. Authoritative Windows confirmation will come from the next nightly, or from manually triggering `CI Full Matrix` via `workflow_dispatch` on `main` after merge.

Follow-up: filing an issue to extend the G2 hardcoded-paths rail to flag raw `/`-separated literals in path-comparison test data, so this class of Windows breakage is caught at PR time rather than in the nightly.

https://claude.ai/code/session_01RCkCUBfoZcYPZ6aGHJZhNy

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCkCUBfoZcYPZ6aGHJZhNy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite with improved cross-platform path handling to ensure compatibility across different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->