### PR TITLE
test(ci): add G2-sep rail for separator-sensitive POSIX path literals (#465)

### DIFF
--- a/.claude/rules/test-generation-patterns.md
+++ b/.claude/rules/test-generation-patterns.md
@@ -622,6 +622,17 @@ hardcoded paths in tests are:
   (e.g. `"/etc/passwd"` as an _input_ to a validator, never as an output target)
 - Path-validation test constants clearly marked as adversarial inputs
 
+**Related sub-rail — separator-sensitive literals (G2-sep)**: Even a path that
+is *not* `/tmp`/`/home`/`/Users` is a Windows hazard when it hardcodes `/`
+separators and is then compared against a value the code-under-test builds with
+`os.path.join(...) + os.sep` (backslashes on Windows). This was the root cause of
+the PR #464 nightly Windows failure (`fake_exe = "/custom/pipx/venvs/.../python"`).
+The `g2sep` rail (`scripts/check_test_separator_paths.py`, advisory; baseline
+pinned by `tests/ci/test_g2_separator_paths_rail.py`) flags a multi-segment
+absolute POSIX literal assigned to a path-like variable. Build such values with
+`os.path.join` / `os.sep` (or `tmp_path`); opt out with `# g2sep: ok — <reason>`
+for a genuinely Linux-only path.
+
 ---
 
 ## Pattern T14: GENERATOR_THROW_FALSE_RAISE

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,23 @@ repos:
         files: ^tests/.*\.py$
 
       # ----------------------------------------------------------------
+      # G2-sep: separator-sensitive POSIX path literals in test data.
+      # A multi-segment absolute "/a/b/c" literal assigned to a path-like
+      # variable hardcodes "/" separators and never matches
+      # os.path.join(...) + os.sep on Windows — the root cause fixed in
+      # PR #464 (test_doctor.py). The nightly-only Windows runner means
+      # this isn't caught at PR time, hence the rail. ADVISORY for now;
+      # baseline pinned at 0 via tests/ci/test_g2_separator_paths_rail.py.
+      # Honors `# g2sep: ok — <reason>` for genuine Linux-only paths.
+      # ----------------------------------------------------------------
+      - id: g2sep-separator-sensitive-test-paths
+        name: no separator-sensitive POSIX path literals in tests (G2-sep, advisory)
+        entry: python3 scripts/check_test_separator_paths.py --advisory
+        language: system
+        pass_filenames: false
+        files: ^tests/.*\.py$
+
+      # ----------------------------------------------------------------
       # G3: AST check — every CLI command that accepts a Path argument
       # must route it through resolve_cli_path() / validate_pair() /
       # validate_within_roots() (or a _validate_* helper that delegates

--- a/scripts/check_test_separator_paths.py
+++ b/scripts/check_test_separator_paths.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""G2-sep rail: flag separator-sensitive POSIX path literals in test data.
+
+Sibling to the G2 hardcoded-paths rail (``scripts/check_test_hardcoded_paths.py``).
+G2 blocks ``/tmp/``, ``/Users/``, ``/home/`` literals. This rail targets a
+different, separator-sensitive failure mode that G2 misses entirely.
+
+Background
+----------
+A *multi-segment absolute POSIX string literal* (e.g.
+``"/custom/pipx/venvs/fo-core/bin/python"``) assigned to a path-like variable
+in a test hardcodes ``/`` separators. When the code under test builds the
+comparison side with ``os.path.join(...) + os.sep`` — which yields BACKSLASH
+separators on Windows — the forward-slash literal never matches, and the test
+fails *only* on the Windows CI runner.
+
+This is the exact root cause fixed in PR #464 (``tests/cli/test_doctor.py``
+``test_detect_pipx_via_pipx_home_env``: ``fake_exe = "/custom/.../python"`` and
+``custom_home = "/custom/pipx"``). Because the Windows runner only runs in the
+nightly ``CI Full Matrix`` — not on PRs — this class of breakage isn't caught
+at PR time; it surfaces a day later in the nightly. Hence this rail.
+
+Detection (AST-based, ``tests/`` only)
+--------------------------------------
+For each ``<name> = "<literal>"`` (or annotated ``<name>: T = "<literal>"``)
+assignment where BOTH hold:
+
+1. ``<literal>`` is a separator-sensitive absolute POSIX path — it starts with
+   ``/``, has at least two non-empty ``/``-separated segments, is not a URL
+   (contains ``://``), and is not a documented adversarial input
+   (``/etc/passwd`` etc., mirrored from G2); AND
+2. ``<name>`` is path-like — one of its ``_``-split components is in
+   ``_PATHISH_WORDS`` (``exe``, ``path``, ``dir``, ``home`` …). These are the
+   variables that get fed into path comparisons.
+
+Flag the assignment. The fix is to build the value with ``os.path.join`` /
+``os.sep`` (or use the ``tmp_path`` fixture) so it matches the platform
+separators the code under test uses.
+
+Opt-out
+-------
+``# g2sep: ok — <reason>`` on the assignment line — for the rare case where a
+Linux-only absolute path is genuinely intended (e.g. an adversarial input not
+covered by the built-in list). This dedicated token (rather than reusing ruff's
+suppression namespace) matches the other advisory rails in this repo.
+
+Lifecycle
+---------
+Phase 1: advisory. The pre-commit hook passes ``--advisory`` (exits 0 even on
+violation); ``tests/ci/test_g2_separator_paths_rail.py`` pins the baseline at 0
+so any regression fails CI via the baseline test. Promote to enforcing by
+dropping ``--advisory`` once the baseline has held at 0.
+
+Exit 0 = no violations (or advisory mode).
+Exit 1 = violations and not advisory.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import re
+import sys
+import tokenize
+from pathlib import Path
+
+# Project root — the script lives at ``scripts/check_test_separator_paths.py``.
+_ROOT = Path(__file__).resolve().parent.parent
+_TESTS_DIR = _ROOT / "tests"
+
+# A separator-sensitive absolute POSIX literal: starts with ``/`` and has at
+# least two non-empty ``/``-separated segments. ``/tmp`` (single segment) does
+# not match — that bare form is G2's job; we target multi-segment paths whose
+# embedded separators are the portability hazard.
+_SEP_RE = re.compile(r"^/[^/\s]+/[^/\s]+")
+
+# Adversarial inputs that are legitimately hardcoded as path-validation test
+# inputs (T13 allowance). Mirrors ``_ADVERSARIAL_INPUTS`` in the G2 detector.
+# Substring match: any literal containing one of these is exempt.
+_ADVERSARIAL_INPUTS = (
+    "/etc/passwd",
+    "/etc/shadow",
+    "/proc/self/mem",
+    "/root/",
+    "/dev/null",
+    "/dev/zero",
+)
+
+# ``_``-split name components that mark a variable as path-like. A literal is
+# only flagged when assigned to a variable whose snake_case components include
+# one of these — keeping the rail focused on values that feed path comparisons
+# and away from URL fragments, dict keys, and other incidental ``/`` strings.
+_PATHISH_WORDS = frozenset(
+    {
+        "exe",
+        "executable",
+        "path",
+        "dir",
+        "home",
+        "venv",
+        "venvs",
+        "bin",
+        "root",
+        "file",
+    }
+)
+
+# Allow an in-line ``# g2sep: ok — <reason>`` opt-out. A dedicated token
+# (rather than reusing ruff's suppression namespace) keeps this rail independent
+# of G2 and matches the convention used by the other advisory rails in this repo.
+_OPT_OUT_RE = re.compile(r"#\s*g2sep:\s*ok\b")
+
+# Phase 1: advisory. Flip to ``True`` (and drop ``--advisory`` from the
+# pre-commit hook) to promote to globally enforcing.
+_ENFORCING = False
+
+
+def is_separator_sensitive(value: str) -> bool:
+    """True if *value* is a multi-segment absolute POSIX path literal.
+
+    Excludes URLs (``scheme://host/path``) and documented adversarial inputs.
+    """
+    if "://" in value:  # URL, not a filesystem path
+        return False
+    if not _SEP_RE.match(value):
+        return False
+    if any(marker in value for marker in _ADVERSARIAL_INPUTS):
+        return False
+    return True
+
+
+def is_pathish_name(name: str) -> bool:
+    """True if *name*'s snake_case components include a path-like word."""
+    return any(part in _PATHISH_WORDS for part in name.lower().split("_"))
+
+
+def _has_opt_out(line: str) -> bool:
+    return bool(_OPT_OUT_RE.search(line))
+
+
+def _collect_opt_out_lines(source: str) -> set[int]:
+    """Return 1-based line numbers carrying the ``# g2sep: ok`` token."""
+    marker_lines: set[int] = set()
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            if tok.type == tokenize.COMMENT and _OPT_OUT_RE.search(tok.string):
+                marker_lines.add(tok.start[0])
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        return set()
+    return marker_lines
+
+
+def _assign_targets(node: ast.AST) -> list[tuple[str, ast.expr]]:
+    """Return [(target_name, value)] for a simple Assign / AnnAssign node."""
+    out: list[tuple[str, ast.expr]] = []
+    if isinstance(node, ast.Assign):
+        if node.value is None:
+            return out
+        for tgt in node.targets:
+            if isinstance(tgt, ast.Name):
+                out.append((tgt.id, node.value))
+    elif isinstance(node, ast.AnnAssign):
+        if node.value is not None and isinstance(node.target, ast.Name):
+            out.append((node.target.id, node.value))
+    return out
+
+
+def find_violations(path: Path) -> list[tuple[int, str, str]]:
+    """Return ``[(lineno, var_name, literal)]`` for each unexempted match."""
+    violations: list[tuple[int, str, str]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return violations
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return violations
+
+    opt_out_lines = _collect_opt_out_lines(text)
+
+    for node in ast.walk(tree):
+        for name, value in _assign_targets(node):
+            if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+                continue
+            if not is_pathish_name(name):
+                continue
+            if not is_separator_sensitive(value.value):
+                continue
+            lineno = getattr(node, "lineno", value.lineno)
+            # Honour an opt-out marker anywhere across the assignment's span.
+            end = getattr(node, "end_lineno", lineno) or lineno
+            if any(ln in opt_out_lines for ln in range(lineno, end + 1)):
+                continue
+            violations.append((lineno, name, value.value))
+    return sorted(set(violations))
+
+
+def _iter_test_files() -> list[Path]:
+    return sorted(_TESTS_DIR.rglob("*.py"))
+
+
+def _scan_all() -> list[tuple[Path, int, str, str]]:
+    out: list[tuple[Path, int, str, str]] = []
+    for path in _iter_test_files():
+        for lineno, name, literal in find_violations(path):
+            out.append((path.relative_to(_ROOT), lineno, name, literal))
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    force_advisory = "--advisory" in args
+
+    all_violations = _scan_all()
+
+    if not all_violations:
+        print("[g2sep] 0 separator-sensitive path literal(s).", file=sys.stderr)
+        return 0
+
+    print(
+        f"[g2sep] {len(all_violations)} separator-sensitive path literal(s) "
+        f"across {len({v[0] for v in all_violations})} file(s).\n"
+        "A multi-segment absolute POSIX literal is assigned to a path-like "
+        "variable. Hardcoded '/' separators don't match os.path.join(...) + "
+        "os.sep on Windows, so the test fails only on the Windows CI runner "
+        "(see PR #464).\n"
+        "Build the value with os.path.join / os.sep (or use tmp_path), or mark "
+        "the line with `# g2sep: ok — <reason>` if a Linux-only path is "
+        "genuinely intended.\n"
+        "Breakdown:",
+        file=sys.stderr,
+    )
+    for path, lineno, name, literal in all_violations:
+        print(f"  {path}:{lineno}: {name} = {literal!r}", file=sys.stderr)
+
+    if force_advisory or not _ENFORCING:
+        print("\nADVISORY mode — exiting 0.", file=sys.stderr)
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_test_separator_paths.py
+++ b/scripts/check_test_separator_paths.py
@@ -28,7 +28,9 @@ assignment where BOTH hold:
 1. ``<literal>`` is a separator-sensitive absolute POSIX path — it starts with
    ``/``, has at least two non-empty ``/``-separated segments, is not a URL
    (contains ``://``), and is not a documented adversarial input
-   (``/etc/passwd`` etc., mirrored from G2); AND
+   (``/etc/passwd`` etc., mirrored from G2). f-strings are handled via their
+   static skeleton (``f"/custom/pipx/venvs/{name}/bin"`` counts), since the
+   hardcoded ``/`` prefix carries the same hazard; AND
 2. ``<name>`` is path-like — one of its ``_``-split components is in
    ``_PATHISH_WORDS`` (``exe``, ``path``, ``dir``, ``home`` …). These are the
    variables that get fed into path comparisons.
@@ -150,6 +152,34 @@ def _collect_opt_out_lines(source: str) -> set[int]:
     return marker_lines
 
 
+# Placeholder substituted for an f-string ``{...}`` interpolation when building
+# the static path skeleton — a non-slash, non-space sentinel so the interpolation
+# reads as a single path segment for separator-sensitivity matching.
+_FSTRING_PLACEHOLDER = "\x00"
+
+
+def _literal_skeleton(value: ast.expr) -> str | None:
+    """Return the static string skeleton of *value*, or None if not a str literal.
+
+    For a plain ``ast.Constant`` str this is the value itself. For an f-string
+    (``ast.JoinedStr``) the literal parts are kept verbatim and each ``{...}``
+    interpolation is replaced by a single-segment placeholder, so a hardcoded
+    absolute prefix like ``f"/custom/pipx/venvs/{name}/bin/python"`` is still
+    caught — it has the same Windows separator hazard as the plain literal.
+    """
+    if isinstance(value, ast.Constant):
+        return value.value if isinstance(value.value, str) else None
+    if isinstance(value, ast.JoinedStr):
+        parts: list[str] = []
+        for part in value.values:
+            if isinstance(part, ast.Constant) and isinstance(part.value, str):
+                parts.append(part.value)
+            else:  # FormattedValue (a `{...}` interpolation) or nested JoinedStr
+                parts.append(_FSTRING_PLACEHOLDER)
+        return "".join(parts)
+    return None
+
+
 def _assign_targets(node: ast.AST) -> list[tuple[str, ast.expr]]:
     """Return [(target_name, value)] for a simple Assign / AnnAssign node."""
     out: list[tuple[str, ast.expr]] = []
@@ -181,18 +211,20 @@ def find_violations(path: Path) -> list[tuple[int, str, str]]:
 
     for node in ast.walk(tree):
         for name, value in _assign_targets(node):
-            if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+            skeleton = _literal_skeleton(value)
+            if skeleton is None:
                 continue
             if not is_pathish_name(name):
                 continue
-            if not is_separator_sensitive(value.value):
+            if not is_separator_sensitive(skeleton):
                 continue
             lineno = getattr(node, "lineno", value.lineno)
             # Honour an opt-out marker anywhere across the assignment's span.
             end = getattr(node, "end_lineno", lineno) or lineno
             if any(ln in opt_out_lines for ln in range(lineno, end + 1)):
                 continue
-            violations.append((lineno, name, value.value))
+            # Render f-string interpolations readably in the reported literal.
+            violations.append((lineno, name, skeleton.replace(_FSTRING_PLACEHOLDER, "{...}")))
     return sorted(set(violations))
 
 

--- a/tests/ci/test_g2_separator_paths_rail.py
+++ b/tests/ci/test_g2_separator_paths_rail.py
@@ -33,6 +33,7 @@ _SCRIPT = _FO_ROOT / "scripts" / "check_test_separator_paths.py"
 sys.path.insert(0, str(_FO_ROOT / "scripts"))
 from check_test_separator_paths import (  # noqa: E402
     _ADVERSARIAL_INPUTS,
+    _scan_all,
     find_violations,
     is_pathish_name,
     is_separator_sensitive,
@@ -43,6 +44,10 @@ from check_test_separator_paths import (  # noqa: E402
 # assignment the rail would flag in this file.
 _SEP = "/custom" + "/pipx/venvs/fo-core/bin/python"
 _SEP2 = "/custom" + "/pipx"
+
+# Pinned baseline for the advisory rail. PR #464 fixed the only occurrence, so
+# the count is 0; any regression must drive this test red.
+_BASELINE_VIOLATIONS = 0
 
 
 # ---------------------------------------------------------------------------
@@ -200,27 +205,34 @@ class TestFindViolations:
 
 
 class TestBaselineEnforcement:
-    """The detector must report zero violations on the current tests/ tree.
+    """The detector must report no more than the pinned baseline on tests/.
 
-    The rail ships advisory (the pre-commit hook exits 0 even on violation),
-    so this baseline test is what actually fails CI on a regression. Promote
-    the hook to enforcing once this baseline has held at zero.
+    The rail ships advisory: the pre-commit hook (and ``main`` while
+    ``_ENFORCING`` is False) exits 0 even on violation, so the script's return
+    code is NOT the gate. This test queries the scanned violation list directly
+    so a regression fails CI regardless of advisory exit semantics. Promote the
+    hook to enforcing once this baseline has held at zero.
     """
 
-    def test_full_suite_has_zero_violations(self) -> None:
+    def test_no_regression_beyond_baseline(self) -> None:
+        actual = len(_scan_all())
+        assert actual <= _BASELINE_VIOLATIONS, (
+            f"G2-sep count rose: baseline={_BASELINE_VIOLATIONS}, actual={actual}. "
+            "A separator-sensitive absolute POSIX literal was assigned to a "
+            "path-like variable in tests/. Build it with os.path.join / os.sep "
+            "(or use tmp_path), or add `# g2sep: ok — <reason>`."
+        )
+
+    def test_script_runs_and_exits_zero_in_advisory(self) -> None:
+        # Smoke test: the script is invokable as a hook and stays advisory.
         result = subprocess.run(
-            [sys.executable, str(_SCRIPT)],
+            [sys.executable, str(_SCRIPT), "--advisory"],
             capture_output=True,
             text=True,
             cwd=_FO_ROOT,
             check=False,
         )
-        assert result.returncode == 0, (
-            "G2-sep baseline regressed: a separator-sensitive absolute POSIX "
-            "literal was assigned to a path-like variable in tests/. Build it "
-            "with os.path.join / os.sep (or use tmp_path), or add "
-            f"`# g2sep: ok — <reason>`.\n\nstderr:\n{result.stderr}"
-        )
+        assert result.returncode == 0, result.stderr
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ci/test_g2_separator_paths_rail.py
+++ b/tests/ci/test_g2_separator_paths_rail.py
@@ -1,0 +1,260 @@
+"""Tests for the G2-sep rail (``scripts/check_test_separator_paths.py``).
+
+The rail flags separator-sensitive absolute POSIX path literals assigned to
+path-like variables in test files — the class of Windows-only breakage fixed
+in PR #464 (``test_doctor.py`` ``test_detect_pipx_via_pipx_home_env``). The
+detector runs as both an advisory pre-commit hook and as the baseline CI test
+in this file.
+
+Tests cover the literal predicate, the path-like-name predicate (with T10
+negative cases for each), the opt-out exemption, the adversarial-input
+exemption, end-to-end ``find_violations`` behaviour, and the baseline assertion
+that no unexempted violations exist on ``main``.
+
+Sample separator-sensitive literals are built via concatenation and assigned to
+non-path-like names so this self-test file does not trip its own rail.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.ci
+
+_FO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _FO_ROOT / "scripts" / "check_test_separator_paths.py"
+
+# Import the detector directly so helpers can be unit-tested without spawning a
+# subprocess for every case.
+sys.path.insert(0, str(_FO_ROOT / "scripts"))
+from check_test_separator_paths import (  # noqa: E402
+    _ADVERSARIAL_INPUTS,
+    find_violations,
+    is_pathish_name,
+    is_separator_sensitive,
+    main,
+)
+
+# Built via concatenation so the line is not a raw ``<name> = "<literal>"``
+# assignment the rail would flag in this file.
+_SEP = "/custom" + "/pipx/venvs/fo-core/bin/python"
+_SEP2 = "/custom" + "/pipx"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: is_separator_sensitive
+# ---------------------------------------------------------------------------
+
+
+class TestSeparatorSensitivePredicate:
+    """Multi-segment absolute POSIX literals match; near-misses do not."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            _SEP,
+            _SEP2,
+            "/opt" + "/app/bin/python",
+            "/srv" + "/data/file.txt",
+        ],
+    )
+    def test_matches_separator_sensitive(self, value: str) -> None:
+        assert is_separator_sensitive(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "relative/path/segment",  # not absolute
+            "/single",  # only one segment
+            "/single/",  # trailing slash, second segment empty
+            "https://example.com/a/b",  # URL
+            "file://" + "/srv/x/y",  # URL scheme
+            "/etc/passwd",  # adversarial input — exempt
+            "/dev/null",  # adversarial input — exempt
+            "plain string",
+            "",
+        ],
+    )
+    def test_rejects_non_separator_sensitive(self, value: str) -> None:
+        assert is_separator_sensitive(value) is False
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: is_pathish_name (T10 — surface-similar negatives)
+# ---------------------------------------------------------------------------
+
+
+class TestPathishName:
+    """Snake_case names with a path-like component match; others do not."""
+
+    @pytest.mark.parametrize(
+        "name",
+        ["fake_exe", "custom_home", "share_dir", "exe_path", "venv_root", "config_file"],
+    )
+    def test_pathish_names_match(self, name: str) -> None:
+        assert is_pathish_name(name) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "profile",  # contains "file" but not as a component
+            "result",
+            "value",
+            "data",
+            "endpoint",
+            "url",
+            "directory_listing_count",  # "directory" != "dir" component
+        ],
+    )
+    def test_non_pathish_names_do_not_match(self, name: str) -> None:
+        assert is_pathish_name(name) is False
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: adversarial-input exemption
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarialExemption:
+    """Documented path-validation inputs are never separator-sensitive hits."""
+
+    @pytest.mark.parametrize("adv_path", _ADVERSARIAL_INPUTS)
+    def test_known_adversarial_path_is_exempt(self, adv_path: str) -> None:
+        # Even a multi-segment absolute path is exempt when it is a documented
+        # adversarial input.
+        assert is_separator_sensitive(adv_path + "/x") is False
+
+    def test_unrelated_etc_path_is_not_exempt(self) -> None:
+        # /etc/hosts is NOT in the adversarial list, so it is treated as a
+        # genuine separator-sensitive literal.
+        assert is_separator_sensitive("/etc" + "/hosts/file") is True
+
+
+# ---------------------------------------------------------------------------
+# Integration: find_violations against synthetic files
+# ---------------------------------------------------------------------------
+
+
+class TestFindViolations:
+    """End-to-end detection on per-case tmp files."""
+
+    def test_flags_pr464_shape(self, tmp_path: Path) -> None:
+        f = tmp_path / "test_bug.py"
+        f.write_text(
+            "def test_detect():\n"
+            f'    custom_home = "{_SEP2}"\n'
+            f'    fake_exe = "{_SEP}"\n'
+            "    assert custom_home and fake_exe\n"
+        )
+        violations = find_violations(f)
+        assert len(violations) == 2
+        assert violations[0] == (2, "custom_home", _SEP2)
+        assert violations[1] == (3, "fake_exe", _SEP)
+
+    def test_non_pathish_variable_is_not_flagged(self, tmp_path: Path) -> None:
+        f = tmp_path / "test_url.py"
+        f.write_text(f'def test_x():\n    endpoint = "{_SEP}"\n')
+        assert find_violations(f) == []
+
+    def test_constructed_path_is_not_flagged(self, tmp_path: Path) -> None:
+        # The recommended fix (os.path.join) assigns a Call, not a Constant —
+        # the rail must not flag it.
+        f = tmp_path / "test_fixed.py"
+        f.write_text(
+            "import os\n"
+            "def test_x():\n"
+            '    fake_exe = os.path.join(os.sep, "custom", "pipx", "bin", "python")\n'
+        )
+        assert find_violations(f) == []
+
+    def test_adversarial_input_is_not_flagged(self, tmp_path: Path) -> None:
+        f = tmp_path / "test_adv.py"
+        f.write_text('def test_x():\n    exe_path = "/etc/passwd"\n')
+        assert find_violations(f) == []
+
+    def test_url_is_not_flagged(self, tmp_path: Path) -> None:
+        f = tmp_path / "test_url2.py"
+        f.write_text('def test_x():\n    base_path = "https://example.com/a/b"\n')
+        assert find_violations(f) == []
+
+    def test_opt_out_marker_skips_line(self, tmp_path: Path) -> None:
+        f = tmp_path / "test_optout.py"
+        f.write_text(f'def test_x():\n    fake_exe = "{_SEP}"  # g2sep: ok — linux-only fixture\n')
+        assert find_violations(f) == []
+
+    def test_annotated_assignment_is_flagged(self, tmp_path: Path) -> None:
+        f = tmp_path / "test_ann.py"
+        f.write_text(f'def test_x():\n    home_dir: str = "{_SEP2}"\n')
+        violations = find_violations(f)
+        assert len(violations) == 1
+        assert violations[0] == (2, "home_dir", _SEP2)
+
+
+# ---------------------------------------------------------------------------
+# Baseline: the project's own tests/ must hold at zero violations
+# ---------------------------------------------------------------------------
+
+
+class TestBaselineEnforcement:
+    """The detector must report zero violations on the current tests/ tree.
+
+    The rail ships advisory (the pre-commit hook exits 0 even on violation),
+    so this baseline test is what actually fails CI on a regression. Promote
+    the hook to enforcing once this baseline has held at zero.
+    """
+
+    def test_full_suite_has_zero_violations(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT)],
+            capture_output=True,
+            text=True,
+            cwd=_FO_ROOT,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            "G2-sep baseline regressed: a separator-sensitive absolute POSIX "
+            "literal was assigned to a path-like variable in tests/. Build it "
+            "with os.path.join / os.sep (or use tmp_path), or add "
+            f"`# g2sep: ok — <reason>`.\n\nstderr:\n{result.stderr}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Contract: advisory vs enforcing exit codes
+# ---------------------------------------------------------------------------
+
+
+class TestMainContract:
+    """``main`` exits 0 in advisory mode even when violations are present."""
+
+    def test_advisory_returns_zero_with_violations(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        synthetic_tests = tmp_path / "tests"
+        synthetic_tests.mkdir()
+        (synthetic_tests / "test_bad.py").write_text(f'def test_x():\n    fake_exe = "{_SEP}"\n')
+
+        import check_test_separator_paths as mod
+
+        monkeypatch.setattr(mod, "_TESTS_DIR", synthetic_tests)
+        monkeypatch.setattr(mod, "_ROOT", tmp_path)
+
+        assert mod.main(["--advisory"]) == 0
+
+    def test_clean_tree_returns_zero(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        synthetic_tests = tmp_path / "tests"
+        synthetic_tests.mkdir()
+        (synthetic_tests / "test_ok.py").write_text(
+            'def test_x():\n    endpoint = "/api/v1/upload"\n'
+        )
+
+        import check_test_separator_paths as mod
+
+        monkeypatch.setattr(mod, "_TESTS_DIR", synthetic_tests)
+        monkeypatch.setattr(mod, "_ROOT", tmp_path)
+
+        assert main(["--advisory"]) == 0

--- a/tests/ci/test_g2_separator_paths_rail.py
+++ b/tests/ci/test_g2_separator_paths_rail.py
@@ -191,6 +191,27 @@ class TestFindViolations:
         f.write_text(f'def test_x():\n    fake_exe = "{_SEP}"  # g2sep: ok — linux-only fixture\n')
         assert find_violations(f) == []
 
+    def test_flags_fstring_with_hardcoded_absolute_prefix(self, tmp_path: Path) -> None:
+        # f-strings build the same hazard as plain literals: the hardcoded "/"
+        # prefix never matches os.path.join(...) + os.sep on Windows.
+        f = tmp_path / "test_fstring.py"
+        f.write_text('def test_x(name):\n    fake_exe = f"/custom/pipx/venvs/{name}/bin/python"\n')
+        violations = find_violations(f)
+        assert len(violations) == 1
+        assert violations[0] == (2, "fake_exe", "/custom/pipx/venvs/{...}/bin/python")
+
+    def test_fstring_leading_interpolation_is_not_flagged(self, tmp_path: Path) -> None:
+        # Rooted at a variable, not a hardcoded "/" — the skeleton does not start
+        # with "/", so it is correctly skipped.
+        f = tmp_path / "test_fstring_var.py"
+        f.write_text('def test_x(base):\n    home_dir = f"{base}/sub/path"\n')
+        assert find_violations(f) == []
+
+    def test_fstring_url_is_not_flagged(self, tmp_path: Path) -> None:
+        f = tmp_path / "test_fstring_url.py"
+        f.write_text('def test_x(host):\n    base_path = f"https://{host}/a/b"\n')
+        assert find_violations(f) == []
+
     def test_annotated_assignment_is_flagged(self, tmp_path: Path) -> None:
         f = tmp_path / "test_ann.py"
         f.write_text(f'def test_x():\n    home_dir: str = "{_SEP2}"\n')


### PR DESCRIPTION
Closes #465. Follow-up to #464.

> **Stacked on #464** — based on `claude/nice-bohr-lQwBC` for a clean diff. GitHub will auto-retarget this PR to `main` when #464 merges.

## Why

PR #464 fixed a deterministic nightly Windows failure whose root cause was a **separator-sensitive** path literal: `fake_exe = "/custom/pipx/venvs/fo-core/bin/python"` hardcodes `/`, but the code under test built its comparison prefix with `os.path.join(...) + os.sep` (backslashes on Windows), so it never matched. The existing **G2** rail only blocks `/tmp/` `/Users/` `/home/`, so it misses this class entirely. And because the Windows runner only runs in the nightly `CI Full Matrix` (not on PRs), this isn't caught at PR time.

## What

A new **advisory** sibling rail, `g2sep`:

- **`scripts/check_test_separator_paths.py`** — AST detector over `tests/`. Flags a *multi-segment absolute POSIX literal* assigned to a *path-like variable* (`exe`/`path`/`dir`/`home`/`venv`/`bin`/`root`/`file` components). Exempts URLs (`://`), documented adversarial inputs (`/etc/passwd`, …, mirrored from G2), and lines marked `# g2sep: ok — <reason>`. Supports `--advisory` (exits 0 on violation).
- **`tests/ci/test_g2_separator_paths_rail.py`** — predicate unit tests with T10 surface-similar negatives, `find_violations` integration cases, and a **baseline test pinning the count at 0** (the real CI gate while the hook is advisory).
- **`.pre-commit-config.yaml`** — registers the hook in `--advisory` mode next to G2.
- **`test-generation-patterns.md`** — cross-references the rail from T13.

## Detection scope (deliberately precise)

I measured candidate triggers against the live `tests/` tree:

| Trigger | Hits | Notes |
|---------|------|-------|
| Function uses `os.path.join`/`os.sep`/`expanduser` + has a sep-sensitive literal | 5 | all false positives — URL fragments (`/files/upload`, `/api/v`), a model-path config string, thread keys |
| **Sep-sensitive literal assigned to path-like variable** | **0** | precise; this is the #464 shape |

The path-like-variable trigger is at baseline **0**, so the rail lands clean and immediately ratchets — any new regression fails the baseline test. Verified the detector flags **both** lines of the original #464 bug.

## Validation

- 43 rail tests pass; full guardrail sweep (`test_g2_*`, `test_test_quality_guardrails`) → 140 passed
- `ruff check` / `ruff format` clean; `mypy` clean on the detector
- `pymarkdown -c .pymarkdown.json` clean on the edited rule
- Detector exits 0 on the current `tests/` tree (baseline 0, no self-flag)

## Lifecycle

Advisory now (hook exits 0; baseline test is the gate). Promote to enforcing by flipping `_ENFORCING = True` and dropping `--advisory` once the baseline has held at 0 — same path as the other advisory rails.

https://claude.ai/code/session_01RCkCUBfoZcYPZ6aGHJZhNy

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCkCUBfoZcYPZ6aGHJZhNy)_