### PR TITLE
Fix: Resolve Matrix CI Failures (Security `audit-dependencies-extras` allowlist drift)

### DIFF
--- a/.github/accepted-risks-extras.yml
+++ b/.github/accepted-risks-extras.yml
@@ -30,15 +30,28 @@ allowlist:
       patched release as of 2026-04-23; re-evaluate when diskcache ships
       a 5.6.x+ that addresses the advisory.
     expires_on: 2026-10-23
-  - advisory_id: PYSEC-2022-42969
-    package: py
-    version_spec: "<=1.11.0"
+  # PYSEC-2022-42969 (py <=1.11.0) was previously listed here. As of
+  # 2026-06-12 pip-audit's vulnerability database no longer reports the
+  # advisory for the installed ``py`` version, so the gate's
+  # "advisory not reported" rule flags the entry as unused (#475/#474
+  # Security workflow runs). Removed; re-add only if the advisory
+  # resurfaces.
+  - advisory_id: CVE-2025-3000
+    package: torch
+    version_spec: ">=0"
     reason: >-
-      Transitive via pytest (``[dev]`` / ``[all]`` test extras). The
-      advisory is a ReDoS in ``py.path.svnwc`` — SVN working-copy handling
-      that fo-core never invokes. Our pytest usage is limited to the core
-      test runner; no SVN-adjacent helpers are imported. The ``py``
-      package is effectively unmaintained (last release 2022-11) so no
-      upstream fix is expected. Re-evaluate when pytest drops the ``py``
-      dependency entirely (upstream tracking issue pytest-dev/pytest#10462).
-    expires_on: 2026-10-23
+      Direct via ``[media]`` (faster-whisper) and ``[dedup-image]``
+      (imagededup) extras. The advisory (alias PYSEC-2025-194) is a
+      memory corruption in ``torch.jit.script`` — TorchScript JIT
+      compilation that fo-core never invokes. Our torch usage is limited
+      to faster-whisper's inference call path and imagededup's CNN
+      feature extraction; neither exercises ``torch.jit.script``
+      (verified by grep across ``src/`` — no ``jit.script`` /
+      ``torch.jit`` references in the codebase). OSV publishes the
+      affected range as ``introduced=0`` / ``last_affected=2.6.0-NA``
+      with no fixed version, so pip-audit conservatively flags every
+      torch >=0 installed in the extras environment (currently 2.12.0).
+      No upstream patched version is available as of 2026-06-13;
+      re-evaluate when a torch release ships a fix for CVE-2025-3000
+      and the OSV record gets a ``fixed`` event.
+    expires_on: 2026-12-13

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,8 +60,10 @@ updates:
     labels:
       - "ci"
 
-  # The "docker" ecosystem was removed: fo-core ships no Dockerfile or
-  # Kubernetes YAML, so the weekly Dependabot run reliably exited with
-  # "No Dockerfiles nor Kubernetes YAML found in /" (e.g. job 1410440561,
-  # run 27441929109 on 2026-06-12). Re-add this entry if a Dockerfile is
-  # ever introduced.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,10 +60,8 @@ updates:
     labels:
       - "ci"
 
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    labels:
-      - "dependencies"
+  # The "docker" ecosystem was removed: fo-core ships no Dockerfile or
+  # Kubernetes YAML, so the weekly Dependabot run reliably exited with
+  # "No Dockerfiles nor Kubernetes YAML found in /" (e.g. job 1410440561,
+  # run 27441929109 on 2026-06-12). Re-add this entry if a Dockerfile is
+  # ever introduced.


### PR DESCRIPTION
## Summary of failures detected

The `Security / audit-dependencies-extras` matrix job has been failing on every recent PR (and will fail on `main` the next time the weekly cron fires) on both `ubuntu-latest` **and** `macos-latest`:

| Run | Branch | Failing matrix legs |
|-----|--------|---------------------|
| [27441966467](https://github.com/curdriceaurora/fo-core/actions/runs/27441966467) | `dependabot/github_actions/anthropics/claude-code-action-1.0.146` | ubuntu, macos |
| [27441955753](https://github.com/curdriceaurora/fo-core/actions/runs/27441955753) | `dependabot/github_actions/codecov/codecov-action-7.0.0` | ubuntu, macos |
| [27389978444](https://github.com/curdriceaurora/fo-core/actions/runs/27389978444) | `dependabot/uv/uv-ee15119a60` (torch 2.10.0→2.12.0) | ubuntu, macos |

In every case the gate emitted:

```
pip-audit gate FAILED:
Unknown vulnerabilities (not in allowlist):
  - CVE-2025-3000  torch 2.12.0
Unused allowlist entries:
  - PYSEC-2022-42969 (py) — advisory not reported
```

## RCA per failure group

### `Security / audit-dependencies-extras` matrix (2 matrix legs × multiple PRs)

**Cause 1 — unknown vuln**: CVE-2025-3000 (alias [PYSEC-2025-194](https://github.com/pypa/advisory-database/blob/main/vulns/torch/PYSEC-2025-194.yaml)) is a memory-corruption advisory against PyTorch's `torch.jit.script`. OSV publishes the affected range as `introduced=0` / `last_affected=2.6.0-NA` with **no fixed version**, so pip-audit conservatively flags **every** installed torch version, including the 2.12.0 that `[media]` and `[dedup-image]` resolve to today. The gate's "unknown vulnerabilities" rule fires and the matrix job fails.

**Cause 2 — stale allowlist entry**: pip-audit's vulnerability database has dropped PYSEC-2022-42969 for the installed `py` version. The gate's "advisory not reported" rule (#163) fires on the now-unused allowlist entry as a hard failure — by design, to prevent accepted risks from lingering after upstream remediation.

Classification: **deterministic config drift** (CVE database change, not a code regression). Not flaky.

## Fix implemented and rationale

### `.github/accepted-risks-extras.yml`

* **Added** CVE-2025-3000 (torch) with `version_spec: ">=0"` (the only safe bound given OSV's `last_affected=2.6.0-NA` with no fixed version) and `expires_on: 2026-12-13` (the 6-month policy ceiling).
* **Rationale**: torch is pulled in by `[media]` (faster-whisper) and `[dedup-image]` (imagededup). Neither code path uses `torch.jit.script` — verified with:
    ```bash
    rg "torch\.jit|jit\.script" src/   # → no matches
    ```
* **Removed** PYSEC-2022-42969 (py). pip-audit no longer reports the advisory for the installed version; the gate's "advisory not reported" rule was correctly flagging it for cleanup.

## Scope note

The initial revision of this PR also dropped the `docker` package-ecosystem block from `.github/dependabot.yml` (the weekly Dependabot docker run has been failing with `No Dockerfiles nor Kubernetes YAML found in /`). That change has been **reverted** — the project guardrail `tests/ci/test_workflows.py::TestDependabotConfig::test_dependabot_has_docker_ecosystem` deliberately asserts the docker ecosystem must remain declared, so the entry is intentional policy. The Dockerfile-less weekly failure is a separate concern from the matrix CI failure and is out of scope for this PR.

## Trade-offs

* **Why not pin torch below 2.6.0?** OSV's `last_affected: 2.6.0-NA` is a sentinel meaning "no known upper bound / no patch" — pip-audit will flag any torch version against the advisory, including older ones. There is no safer-pin option today.
* **Why not bypass the gate with `--ignore-vuln`?** The allowlist is auditable, expiry-gated, and re-evaluated automatically by `pip_audit_gate.py` — `--ignore-vuln` would hide the risk from the gate's "stale after remediation" check. The allowlist is the project's documented mechanism for this exact case.
* **Test coverage**: not adding a dedicated round-trip test for `accepted-risks-extras.yml` — out of scope for a CI unblock.

## Verification steps performed

* `python3 -c yaml.safe_load(...)` parses the modified file cleanly.
* Replay of the failing audit payload through `scripts/pip_audit_gate.py` with the new allowlist returns `failed=False`.
* Forward-compatibility cases also exercised:
    * If upstream torch ships a fix and the advisory drops from pip-audit → gate fails with "advisory not reported" on torch entry (correct).
    * After 2026-12-13 expiry → gate fails with `stale_entries` (correct).
* `pytest tests/scripts/test_pip_audit_gate.py` — **20 / 20 pass** locally.

## Impacted areas/modules

* `.github/accepted-risks-extras.yml` (allowlist content only; schema unchanged)
* No production code changed; no behavior change on any installed environment.

## Before / after

| Workflow | Before this PR | After this PR |
|---|---|---|
| `Security / audit-dependencies-extras (ubuntu-latest)` | ❌ `pip-audit gate FAILED` | ✅ expected pass |
| `Security / audit-dependencies-extras (macos-latest)` | ❌ `pip-audit gate FAILED` | ✅ expected pass |
| `CI Full Matrix` (main) | ✅ pass | ✅ pass (unaffected) |
| `lint` guardrail tests | ✅ pass | ✅ pass (after revert of docker change) |

## Test plan
- [ ] Watch `Security / audit-dependencies-extras (ubuntu-latest)` go green on this PR
- [ ] Watch `Security / audit-dependencies-extras (macos-latest)` go green on this PR
- [ ] Verify `pytest tests/scripts/test_pip_audit_gate.py` still passes in PR CI
- [ ] Verify `lint` (pytest CI guardrails) passes after the docker-revert

https://claude.ai/code/session_01AzWSC44Gy4chZqQGy1DqhQ