### PR TITLE
Fix: CI Full Matrix coverage-combine DataError on Linux py3.12

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -41,12 +41,25 @@ jobs:
             set -euo pipefail
             pip install -e ".[dev,search]"
             pip install "pytest-asyncio>=0.23.0" faker --no-cache-dir
+      - name: Erase stale coverage data
+        # coverage erase clears .coverage; find removes ALL .coverage.* files
+        # (any depth) that xdist workers write.  Stale branch-vs-statement
+        # mismatches cause DataError on combine (#302, #309) — surfaced again
+        # on the 2026-06-14 nightly Linux py3.12 run (run 27492312283).
+        # Same guard as ci.yml `test` step; required here too because pytest-cov
+        # + xdist worker shutdown can leave behind partial .coverage.* files.
+        run: |
+          coverage erase
+          find . -name ".coverage.*" -delete
       - name: Run full test suite
         # tests/extras/ contains canary suites for ci-extras.yml.  Most hard-import
         # optional deps (cv2, torch, imagededup, ezdxf, h5py) that aren't installed
         # by [dev,search] and would fail at collection.  The exception is
         # test_extras_dedup_text.py: its deps (numpy, scikit-learn) ARE provided by
         # [dev,search], so we run it here for broader matrix coverage.
+        # --cov-branch is passed explicitly (matching ci.yml) so the branch
+        # setting cannot drift between worker init and the combine step even
+        # though `branch = true` is already in pyproject.toml.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -61,6 +74,7 @@ jobs:
             --dist=loadgroup \
             --timeout=60 \
             --cov=src \
+            --cov-branch \
             --cov-report= \
             --override-ini="addopts="
           mv .coverage .coverage.py${{ matrix.python-version }}


### PR DESCRIPTION
## Summary

The nightly **`CI Full Matrix`** job ([run 27492312283](https://github.com/curdriceaurora/fo-core/actions/runs/27492312283), 2026-06-14) failed on the **Linux py3.12** matrix leg with:

```
INTERNALERROR> coverage.exceptions.DataError:
Can't combine statement coverage data with branch data
==== 18014 passed, 82 skipped, 1 xfailed, 15 warnings in 331.55s (0:05:31) =====
##[error]Process completed with exit code 3.
```

All 18 014 tests passed — the failure is entirely in pytest-cov's post-test `cov_controller.finish()` → `cov.combine()` step, when worker `.coverage.*` files have mismatched `has_arcs` (branch vs. statement) settings. Linux py3.11, macOS, and Windows in the **same matrix run** all succeeded.

## Failure Classification

| Job | Result | Notes |
|---|---|---|
| Test Linux (py3.11) | ✅ success | Same command, same OS |
| **Test Linux (py3.12)** | ❌ **failure** | DataError on combine |
| Test macOS (Python 3.12) | ✅ success | Different command (smoke subset, no coverage) |
| Test Windows (Python 3.12) | ✅ success | Different command (smoke subset, no coverage) |

This is the **flaky coverage-combine race** signature, not a deterministic code regression — the SUT passed all assertions.

## Root Cause Analysis

The identical symptom was already diagnosed and fixed for the `ci.yml` `test` job in commit `c45b98a` (referencing issues **#302, #309**) by erasing stale `.coverage` / `.coverage.*` files before running pytest. The comment in `ci.yml` reads:

> coverage erase clears .coverage; find removes ALL .coverage.* files
> (any depth) that xdist workers write.  Stale branch-vs-statement
> mismatches cause DataError on combine (#302, #309).

That guard was **never propagated** to `ci-full.yml`. Additionally, every other coverage-running step in the repo (`ci.yml` test, `ci.yml` test-full, `ci.yml` test-integration, `pr-integration.yml`) passes `--cov-branch` explicitly on the command line, but `ci-full.yml` relied solely on `[tool.coverage.run] branch = true` in `pyproject.toml`. When pytest-cov + xdist + worker shutdown race, the branch setting can drift between worker init and the combine step.

## Fix

Two small, targeted hardenings to `.github/workflows/ci-full.yml`, both copied verbatim from existing precedents in `ci.yml`:

1. **Add "Erase stale coverage data" step** before "Run full test suite":
   ```yaml
   - name: Erase stale coverage data
     run: |
       coverage erase
       find . -name ".coverage.*" -delete
   ```
2. **Add `--cov-branch` to the pytest command** (defense in depth — explicit beats implicit):
   ```diff
        --cov=src \
   +    --cov-branch \
        --cov-report= \
   ```

## Trade-offs

- **No test was weakened.** All 18 014 tests already passed; the fix targets the coverage-combine race only.
- **No flaky-skip / xfail / retry.** This is the project-canonical prophylactic fix used in `ci.yml`.
- **Workflow-only change.** No source or test code touched, so no local test-suite re-run is meaningful — `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci-full.yml'))"` validates the YAML structure cleanly.

## Verification

- ✅ YAML parses cleanly via `yaml.safe_load`.
- ✅ Job step ordering verified: `Install dependencies → Erase stale coverage data → Run full test suite → Upload coverage data`.
- ✅ `coverage` is already installed by `pip install -e ".[dev,search]"` (it's a pytest-cov dep) so `coverage erase` is available in the install step's environment.
- ⏳ Live verification will run when the next nightly `CI Full Matrix` triggers (workflow-only change — there's no PR trigger for `CI Full Matrix`; it's `schedule: '0 6 * * *'` + `workflow_dispatch`). Recommend a `workflow_dispatch` after merge to confirm green before next scheduled run.

## Impacted Areas

- `.github/workflows/ci-full.yml` — `test-linux-full` job (Linux py3.11 & py3.12)
- No runtime / source / test changes
- `coverage-gate`, `test-macos`, `test-windows` jobs untouched

## Links

- Failing run: https://github.com/curdriceaurora/fo-core/actions/runs/27492312283
- Failing job: https://github.com/curdriceaurora/fo-core/actions/runs/27492312283/job/81259705368
- Prior fix this mirrors: `c45b98a` (referenced in `.github/workflows/ci.yml:213-219`)
- Related issues: #302, #309


---
_Generated by [Claude Code](https://claude.ai/code/session_013Vxr6x8ckyju9KUaniqmMG)_