### PR TITLE
fix(ci): add --cov-branch to CI Full Matrix Linux full-suite run

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -61,6 +61,7 @@ jobs:
             --dist=loadgroup \
             --timeout=60 \
             --cov=src \
+            --cov-branch \
             --cov-report= \
             --override-ini="addopts="
           mv .coverage .coverage.py${{ matrix.python-version }}


### PR DESCRIPTION
## Summary

The daily **CI Full Matrix** Linux py3.12 job ([run 27492312283, 2026-06-14](https://github.com/curdriceaurora/fo-core/actions/runs/27492312283)) failed with:

```
Plugin: _cov, Hook: pytest_runtestloop
DataError: Can't combine statement coverage data with branch data
==== 18014 passed, 82 skipped, 1 xfailed, 15 warnings in 331.55s ====
##[error]Process completed with exit code 3.
```

**All 18,014 tests passed.** The job exited with code 3 only because pytest-cov's xdist combine failed.

## Failure Classification

**Flaky/intermittent dependency-config race.** The same commit (`89b6019`) succeeded the day before ([run 27460359072, 2026-06-13](https://github.com/curdriceaurora/fo-core/actions/runs/27460359072)). macOS 3.12, Windows 3.12, and Linux 3.11 all passed in the failed run.

## RCA

The pytest command in `test-linux-full` passes `--cov=src` but **not** `--cov-branch`, relying on `[tool.coverage.run] branch = true` in `pyproject.toml`:

```yaml
# .github/workflows/ci-full.yml (before)
pytest tests/ \
    ... \
    -n auto --dist=loadgroup \
    --cov=src \
    --cov-report= \
    --override-ini="addopts="
```

Under `-n auto --dist=loadgroup`, this implicit configuration occasionally fails to propagate to one xdist worker — that worker writes a statement-only `.coverage.<pid>` file. At session teardown, `pytest_cov.engine.finish` calls `coverage.combine()`, and `coverage/sqldata.py:706` rejects merging branch + statement files:

```
File ".../pytest_cov/engine.py", line 351, in finish
    self.cov.combine()
File ".../coverage/control.py", line 907, in combine
    combine_parallel_data(...)
File ".../coverage/data.py", line 216, in combine_parallel_data
    data.update(new_data, map_path=map_path)
File ".../coverage/sqldata.py", line 706, in update
    raise DataError(...)
coverage.exceptions.DataError: Can't combine statement coverage data with branch data
```

The Linux 3.11 job (same workflow) avoided the race only because `pytest-randomly`'s seed produced a different worker schedule; macOS and Windows don't collect coverage at all.

## Fix

Add `--cov-branch` explicitly to the pytest invocation. This forces pytest-cov to set branch coverage at the CLI level, which propagates to every xdist worker reliably (instead of relying on each worker re-reading `pyproject.toml`).

```diff
             --cov=src \
+            --cov-branch \
             --cov-report= \
```

**Precedent in the same repository:** `ci.yml` already uses `--cov-branch` explicitly on every pytest invocation (lines 223, 281, 489). This brings `ci-full.yml` into alignment — the single asymmetry between the two workflows was the root cause.

## Trade-offs

None. `--cov-branch` only makes explicit what is already declared in `[tool.coverage.run] branch = true`. Behavior is identical when configuration loads correctly; the flag closes the race window when it doesn't.

## Verification

- ✅ YAML parses cleanly
- ✅ `pytest tests/ci/test_workflows.py` — all 42 workflow tests pass
- ✅ `pytest tests/ci/` — 755 passed (1 unrelated env-missing-binary skip)
- ✅ Diff is a single added line; no test changes, no dependency changes, no behavior changes for the success path

## Impacted Areas

- `.github/workflows/ci-full.yml` — `test-linux-full` job step "Run full test suite"

Other jobs (`test-macos`, `test-windows`, `coverage-gate`) are untouched.

## Before / After

**Before:** `18014 passed, 82 skipped, 1 xfailed → exit 3 (DataError on combine)`
**After (expected):** `18014 passed, 82 skipped, 1 xfailed → exit 0`

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHd19f4cjpGFrG3CPtsau1)_