### PR TITLE
Fix: Resolve Matrix CI Failures (torch CVE allowlist + coverage flake)

### DIFF
--- a/.github/accepted-risks-extras.yml
+++ b/.github/accepted-risks-extras.yml
@@ -30,15 +30,19 @@ allowlist:
       patched release as of 2026-04-23; re-evaluate when diskcache ships
       a 5.6.x+ that addresses the advisory.
     expires_on: 2026-10-23
-  - advisory_id: PYSEC-2022-42969
-    package: py
-    version_spec: "<=1.11.0"
+  - advisory_id: CVE-2025-3000
+    package: torch
+    version_spec: ">=2.6.0"
     reason: >-
-      Transitive via pytest (``[dev]`` / ``[all]`` test extras). The
-      advisory is a ReDoS in ``py.path.svnwc`` — SVN working-copy handling
-      that fo-core never invokes. Our pytest usage is limited to the core
-      test runner; no SVN-adjacent helpers are imported. The ``py``
-      package is effectively unmaintained (last release 2022-11) so no
-      upstream fix is expected. Re-evaluate when pytest drops the ``py``
-      dependency entirely (upstream tracking issue pytest-dev/pytest#10462).
-    expires_on: 2026-10-23
+      Memory corruption in ``torch.jit.script`` (CVSS 5.3, local attack
+      vector). Transitive via ``faster-whisper`` (``[media]`` extra) and
+      ``imagededup`` (``[dedup-image]`` extra). fo-core's torch usage is
+      limited to two device-detection probes — ``torch.cuda.is_available()``
+      in ``src/services/audio/transcriber.py`` and ``src/models/audio_transcriber.py``,
+      plus ``torch.backends.mps.is_available()`` in ``audio_transcriber.py``.
+      The vulnerable ``torch.jit.script`` code path is never invoked by
+      fo-core, and the transitive callers (faster-whisper, imagededup) JIT
+      only their own internal model code — no fo-core input flows into
+      ``torch.jit.script``. No upstream fix is published as of 2026-06-16;
+      re-evaluate when pytorch ships a patched release.
+    expires_on: 2026-12-16

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -47,9 +47,22 @@ jobs:
         # by [dev,search] and would fail at collection.  The exception is
         # test_extras_dedup_text.py: its deps (numpy, scikit-learn) ARE provided by
         # [dev,search], so we run it here for broader matrix coverage.
+        #
+        # `coverage erase` and the explicit `--cov-branch` / `--cov-config` flags
+        # defend against an intermittent xdist+pytest-cov race where a worker
+        # would write a statement-only `.coverage.*` file (no branch arcs),
+        # then the master's `cov.combine()` would fail with:
+        #   "Can't combine statement coverage data with branch data"
+        # Observed on the 06-14 daily run (Linux/py3.12): the rerun on 06-15
+        # passed on the same SHA, confirming a transient race. Passing
+        # `--cov-branch` explicitly propagates branch-mode to every worker
+        # regardless of config-load timing; `--cov-config=pyproject.toml`
+        # pins the config path; `coverage erase` clears any stray data files
+        # before the run.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          coverage erase
           pytest tests/ \
             --ignore=tests/extras/test_extras_cad.py \
             --ignore=tests/extras/test_extras_dedup_image.py \
@@ -61,6 +74,8 @@ jobs:
             --dist=loadgroup \
             --timeout=60 \
             --cov=src \
+            --cov-branch \
+            --cov-config=pyproject.toml \
             --cov-report= \
             --override-ini="addopts="
           mv .coverage .coverage.py${{ matrix.python-version }}


### PR DESCRIPTION
## Summary

Addresses two distinct Matrix CI failures detected on the most recent runs of `main`.

| # | Workflow | Job(s) | Status | Root cause |
|---|----------|--------|--------|------------|
| 1 | **Security** (matrix `os`) | `audit-dependencies-extras (ubuntu-latest)`, `audit-dependencies-extras (macos-latest)` | Failing on every scheduled run since the torch CVE landed | New CVE-2025-3000 against torch 2.12.0, plus a stale `PYSEC-2022-42969` allowlist entry that `pip_audit_gate.py` was flagging as "advisory not reported" (hard-fail rule) |
| 2 | **CI Full Matrix** (matrix `python-version`) | `Test Linux (py3.12)` | Intermittent — failed 06-14 on `89b6019a`, passed on 06-15 rerun (same SHA) | xdist + pytest-cov race: one worker wrote a statement-only `.coverage.*` file, master's `cov.combine()` raised `DataError: Can't combine statement coverage data with branch data` |

Failing runs:
- Security: [run 27532134748](https://github.com/curdriceaurora/fo-core/actions/runs/27532134748) ([ubuntu job](https://github.com/curdriceaurora/fo-core/actions/runs/27532134748/job/81372554555), [macos job](https://github.com/curdriceaurora/fo-core/actions/runs/27532134748/job/81372554532))
- CI Full Matrix: [run 27492312283](https://github.com/curdriceaurora/fo-core/actions/runs/27492312283) ([Linux py3.12 job](https://github.com/curdriceaurora/fo-core/actions/runs/27492312283/job/81259705368))

## RCA per failure group

### 1. Security gate — `audit-dependencies-extras` matrix

Both runners produced identical gate output across all 3 retry attempts:

```
pip-audit gate FAILED:
Unknown vulnerabilities (not in allowlist):
  - CVE-2025-3000  torch 2.12.0
Unused allowlist entries:
  - PYSEC-2022-42969 (py) — advisory not reported
```

`scripts/pip_audit_gate.py` rule 4 fails the build for any installed-but-no-longer-reported allowlist entry, so the stale `py` entry alone would already trip the gate; the `torch` CVE adds the unknown-vulnerability fail-path.

**CVE-2025-3000**: memory corruption in `torch.jit.script` (CVSS 5.3, local attack vector). PyTorch ≥ 2.6.0 affected; no upstream fix published as of 2026-06-16.

**fo-core reachability**: `rg "torch\.jit"` returns zero hits across `src/` and `tests/`. The only torch surface in fo-core is two device-detection probes:

| File | Call | Purpose |
|------|------|---------|
| `src/services/audio/transcriber.py:176` | `torch.cuda.is_available()` | CUDA device pick |
| `src/models/audio_transcriber.py:203` | `torch.cuda.is_available()` | CUDA device pick |
| `src/models/audio_transcriber.py:213` | `torch.backends.mps.is_available()` | MPS device pick |

The transitive callers (`faster-whisper`, `imagededup`) JIT only their own packaged model code; no fo-core input flows into the vulnerable function.

### 2. CI Full Matrix — `Test Linux (py3.12)` coverage combine

From the failing job log:

```
==== 18014 passed, 82 skipped, 1 xfailed, 15 warnings in 331.55s (0:05:31) =====
INTERNALERROR> coverage.exceptions.DataError: Can't combine statement coverage data with branch data
INTERNALERROR>   File ".../pytest_cov/engine.py", line 351, in finish
INTERNALERROR>     self.cov.combine()
##[error]Process completed with exit code 3.
```

All 18014 tests passed. Failure is purely the teardown combine. The 06-15 rerun on the same SHA succeeded, confirming a transient xdist worker race rather than a code regression.

`coverage.exceptions.DataError` at `combine_parallel_data` fires when one `.coverage.X.Y` file in the working directory has `has_arcs() == True` (branch coverage) and another has `has_arcs() == False`. `pyproject.toml` already declares `branch = true` under `[tool.coverage.run]`, so this points at a worker that didn't pick up the config — or a stray data file from an earlier step.

## Fix implemented and rationale

### 1. `.github/accepted-risks-extras.yml`

- **Remove** `PYSEC-2022-42969 (py)` — pip-audit no longer reports it; the gate's "unused entry" rule was tripping on it.
- **Add** `CVE-2025-3000 / torch (>=2.6.0)` with the unreachability justification above. `expires_on: 2026-12-16` (6 months, per policy).

### 2. `.github/workflows/ci-full.yml` — `test-linux-full` job

Added three defensive flags to the `Run full test suite` step:

```yaml
coverage erase                            # clear any stray .coverage.* files
pytest tests/ \
  ...
  --cov=src \
  --cov-branch \                          # force branch-mode on every worker
  --cov-config=pyproject.toml \           # pin config path; no default-search fallback
  --cov-report= \
  --override-ini="addopts="
```

- `coverage erase` ensures no leftover `.coverage.*` files from earlier steps could leak into the combine set.
- `--cov-branch` makes branch-mode an explicit pytest-cov flag, propagated to every xdist worker regardless of when each worker loads the config.
- `--cov-config=pyproject.toml` pins the config path so a worker can't fall back to a `.coveragerc` search miss.

These are pure CI configuration changes — no source/test changes.

## Trade-offs

- **No torch bump.** No upstream pytorch release fixes CVE-2025-3000 as of 2026-06-16. Allowlisting with a 6-month expiry is the policy-compliant action; the entry will re-prompt review on expiry.
- **Coverage-flake fix is defensive, not root-cause.** The underlying xdist+pytest-cov race in coverage.py 7.x is upstream behaviour; the three-flag belt-and-braces approach is the cheapest defensible mitigation without a code-level change. If the same combine error recurs after this lands, the next step is to bisect the test that's spawning a child Python process inheriting `COVERAGE_FILE` env without `--cov-branch`.

## Verification

- Locally validated the new allowlist against a synthetic audit JSON simulating the failing pip-audit output (torch 2.12.0 / CVE-2025-3000 + diskcache 5.6.3 / CVE-2025-69872, platform=linux, today=2026-06-16): `pip_audit_gate.evaluate()` returns `failed=False`, `unknown_vulns=[]`, `unused_entries=[]`, `stale_entries=[]`.
- YAML parse on both edited files passes (`yaml.safe_load`).
- `tests/ci/test_workflows.py` structural assertions for `ci-full.yml` preserved:
  - `test-linux-full` job present with `python-version: ["3.11", "3.12"]` matrix
  - `coverage-gate` job still depends on `test-linux-full`
  - Artifact naming contract intact (`daily-coverage-*` prefix)
  - `test-macos` / `test-windows` still contain no `--cov` flag
- Local Python env is broken (`pyo3` panic on `cryptography` import), so the full test suite was not exercised locally; the changes touch CI config + YAML only, so the GitHub-side CI run is the authoritative verification.

## Impacted areas

- `.github/workflows/ci-full.yml` — `test-linux-full` job only; macOS/Windows/coverage-gate jobs untouched.
- `.github/accepted-risks-extras.yml` — one entry replaced; diskcache entry unchanged.

## Before / after behavior

| | Before | After |
|--|--------|-------|
| `audit-dependencies-extras (ubuntu-latest)` | Fail — 2 gate findings | Pass — torch CVE matched, stale entry removed |
| `audit-dependencies-extras (macos-latest)` | Fail — 2 gate findings | Pass |
| `Test Linux (py3.12)` combine | Intermittent fail (worker race) | Defensive flags + `coverage erase` reduce race window |
| `Test Linux (py3.11)` | Pass | Pass (same defensive flags applied) |
| `Test macOS (Python 3.12)` | Pass (no --cov) | Pass (no change) |
| `Test Windows (Python 3.12)` | Pass (no --cov) | Pass (no change) |

## Test plan

- [ ] CI Full Matrix scheduled run (or `workflow_dispatch`) — `Test Linux (py3.12)` completes the combine cleanly under xdist
- [ ] Security workflow run — both `audit-dependencies-extras` matrix legs pass the gate
- [ ] No regression in `Test Linux (py3.11)` (same step gained the defensive flags)
- [ ] Existing `tests/ci/test_workflows.py` continues to pass
- [ ] Existing `tests/scripts/test_pip_audit_gate.py` continues to pass

https://claude.ai/code/session_01BqnSAfSizvW6k2CN3jrtEp

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqnSAfSizvW6k2CN3jrtEp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security vulnerability allowlist management, removing outdated entries and adding new constraints with version tracking and expiration dates for improved risk governance.
  * Enhanced CI/CD test coverage infrastructure with improved initialization sequence and explicit configuration handling to prevent race conditions and ensure reliable coverage reporting across test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->